### PR TITLE
[Breaking change] Moved offline contact routing info to serverless

### DIFF
--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -115,6 +115,9 @@ export const getDefinitionVersionsList = async (missingDefinitionVersions: strin
     }),
   );
 
+/**
+ * Creates a new task (offline contact) in behalf of targetSid worker with finalTaskAttributes. Other attributes for routing are added to the task in the implementation of assignOfflineContact serverless function
+ */
 export const assignOfflineContact = async (targetSid: string, finalTaskAttributes: ITask['attributes']) => {
   const body = {
     targetSid,

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -43,8 +43,7 @@ export const submitContactForm = async (task: CustomITask, contactForm: Contact,
 
   if (isOfflineContactTask(task)) {
     const targetSid = contactForm.contactlessTask.createdOnBehalfOf as string;
-    const initialAttributes = { helpline, channelType: 'default', isContactlessTask: true, isInMyBehalf: true };
-    const finalAttributes = buildInsightsData(initialAttributes, contactForm, caseForm);
+    const finalAttributes = buildInsightsData({}, contactForm, caseForm);
     const inBehalfTask = await assignOfflineContact(targetSid, finalAttributes);
     return saveToHrm(task, contactForm, workerSid, helpline, inBehalfTask.sid);
   }

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -130,6 +130,9 @@ export function isOfflineContactTask(task: CustomITask): task is OfflineContactT
   return task.taskSid === offlineContactTaskSid;
 }
 
+/**
+ * Checks if the task is issued by someone else to avoid showing certain things in the UI. This is done by checking isInMyBehalf task attribute (attached while creating offline contacts)
+ */
 export function isInMyBehalfITask(task: CustomITask): task is InMyBehalfITask {
   return task.attributes && task.attributes.isContactlessTask && (task.attributes as any).isInMyBehalf;
 }


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/serverless/pull/58.

IMPORTANT: This PR contains a breaking change. Do not merge until above change in serverless has been deployed to all environments.

This PR removes the `initialAttributes` from the frontend when creating an offline contact, leaving the responsibility for the offline contact routing info to `assignOfflineContact` serverless function.