### PR TITLE
Pre-survey information and helpline passed through to Flex on non-data calls

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -36,6 +36,7 @@ test('saveInsightsData for non-data callType', async () => {
     conversations: {
       content: 'content',
     },
+    helpline: 'helpline',
   };
 
   const twilioTask = {
@@ -45,20 +46,35 @@ test('saveInsightsData for non-data callType', async () => {
 
   const contactForm = {
     callType: 'Abusive',
+    callerInformation: {
+      age: '26',
+      gender: 'Girl',
+    },
+    childInformation: {
+      age: '18',
+      gender: 'Boy',
+      language: 'language',
+    },
   };
 
   await saveInsightsData(twilioTask, contactForm);
 
   const expectedNewAttributes = {
-    taskSid: 'task-sid',
-    channelType: 'sms',
+    ...previousAttributes,
     conversations: {
       content: 'content',
       conversation_attribute_2: 'Abusive',
       conversation_attribute_5: null,
       communication_channel: 'SMS',
+      conversation_attribute_3: contactForm.callerInformation.age,
+      conversation_attribute_4: contactForm.callerInformation.gender,
+      conversation_attribute_8: previousAttributes.helpline,
+      language: contactForm.childInformation.language,
     },
-    customers: {},
+    customers: {
+      year_of_birth: contactForm.childInformation.age,
+      gender: contactForm.childInformation.gender,
+    },
   };
 
   expect(twilioTask.setAttributes).toHaveBeenCalledWith(expectedNewAttributes);
@@ -87,6 +103,11 @@ test('saveInsightsData for data callType', async () => {
     childInformation: {
       age: '13-15',
       gender: 'Boy',
+      language: 'language',
+    },
+    callerInformation: {
+      age: '26',
+      gender: 'Girl',
     },
     caseInformation: {},
     categories: [
@@ -148,6 +169,11 @@ test('Handles contactless tasks', async () => {
     childInformation: {
       age: '3',
       gender: 'Unknown',
+      language: 'language',
+    },
+    callerInformation: {
+      age: '26',
+      gender: 'Girl',
     },
     caseInformation: {},
     categories: ['categories.Violence.Unspecified/Other'],

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -80,6 +80,57 @@ test('saveInsightsData for non-data callType', async () => {
   expect(twilioTask.setAttributes).toHaveBeenCalledWith(expectedNewAttributes);
 });
 
+test('saveInsightsData for non-data callType (test that fields are sanitized)', async () => {
+  const previousAttributes = {
+    taskSid: 'task-sid',
+    channelType: 'sms',
+    conversations: {
+      content: 'content',
+    },
+    helpline: 'helpline',
+  };
+
+  const twilioTask = {
+    attributes: previousAttributes,
+    setAttributes: jest.fn(),
+  };
+
+  const contactForm = {
+    callType: 'Abusive',
+    callerInformation: {
+      age: '',
+      gender: '',
+    },
+    childInformation: {
+      age: '',
+      gender: '',
+      language: '',
+    },
+  };
+
+  await saveInsightsData(twilioTask, contactForm);
+
+  const expectedNewAttributes = {
+    ...previousAttributes,
+    conversations: {
+      content: 'content',
+      conversation_attribute_2: 'Abusive',
+      conversation_attribute_5: null,
+      communication_channel: 'SMS',
+      conversation_attribute_3: null,
+      conversation_attribute_4: null,
+      conversation_attribute_8: previousAttributes.helpline,
+      language: null,
+    },
+    customers: {
+      year_of_birth: null,
+      gender: null,
+    },
+  };
+
+  expect(twilioTask.setAttributes).toHaveBeenCalledWith(expectedNewAttributes);
+});
+
 test('saveInsightsData for data callType', async () => {
   const previousAttributes = {
     taskSid: 'task-sid',

--- a/plugin-hrm-form/src/formDefinitions/v1/insights/oneToOneConfigSpec.json
+++ b/plugin-hrm-form/src/formDefinitions/v1/insights/oneToOneConfigSpec.json
@@ -4,14 +4,6 @@
       {
         "name": "relationshipToChild",
         "insights": ["conversations", "initiated_by"]
-      },
-      {
-        "name": "gender",
-        "insights": ["conversations", "conversation_attribute_4"]
-      },
-      {
-        "name": "age",
-        "insights": ["conversations", "conversation_attribute_3"]
       }
     ],
     "childInformation": [
@@ -22,18 +14,6 @@
       {
         "name": "postalCode",
         "insights": ["customers", "zip"]
-      },
-      {
-        "name": "gender",
-        "insights": ["customers", "gender"]
-      },
-      {
-        "name": "age",
-        "insights": ["customers", "year_of_birth"]
-      },
-      {
-        "name": "language",
-        "insights": ["conversations", "language"]
       },
       {
         "name": "ethnicity",

--- a/plugin-hrm-form/src/formDefinitions/za-v1/insights/oneToManyConfigSpecs.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/insights/oneToManyConfigSpecs.json
@@ -7,10 +7,5 @@
       "contactForm.childInformation.municipality",
       "contactForm.childInformation.district"
     ]
-  },
-  {
-    "attributeName": "conversation_attribute_8",
-    "insightsObject": "conversations",
-    "paths": ["taskAttributes.helpline"]
   }
 ]

--- a/plugin-hrm-form/src/formDefinitions/za-v1/insights/oneToOneConfigSpec.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/insights/oneToOneConfigSpec.json
@@ -4,14 +4,6 @@
       {
         "name": "relationshipToChild",
         "insights": ["conversations", "initiated_by"]
-      },
-      {
-        "name": "gender",
-        "insights": ["conversations", "conversation_attribute_4"]
-      },
-      {
-        "name": "age",
-        "insights": ["conversations", "conversation_attribute_3"]
       }
     ],
     "childInformation": [
@@ -22,18 +14,6 @@
       {
         "name": "postalCode",
         "insights": ["customers", "zip"]
-      },
-      {
-        "name": "gender",
-        "insights": ["customers", "gender"]
-      },
-      {
-        "name": "age",
-        "insights": ["customers", "year_of_birth"]
-      },
-      {
-        "name": "language",
-        "insights": ["conversations", "language"]
       },
       {
         "name": "race",

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -75,8 +75,6 @@ export const baseUpdates: InsightsUpdateFunction = (
   caseForm: Case,
 ): InsightsAttributes => {
   const { callType } = contactForm;
-  const hasCustomerData = !isNonDataCallType(callType);
-
   const communication_channel = taskAttributes.isContactlessTask
     ? mapChannelForInsights(
         typeof contactForm.contactlessTask.channel === 'string'
@@ -97,12 +95,20 @@ export const baseUpdates: InsightsUpdateFunction = (
        */
       conversation_attribute_5: null,
       communication_channel,
+      /**
+       * Fields that should always be populated, whether it is a data contact or not.
+       */
+      conversation_attribute_3: contactForm.childInformation.age.toString(),
+      conversation_attribute_4: contactForm.childInformation.gender.toString(),
+      conversation_attribute_8: taskAttributes.helpline,
+      language: contactForm.childInformation.language.toString(),
     },
   };
 
-  if (!hasCustomerData) {
+  if (isNonDataCallType(callType)) {
     return coreAttributes;
   }
+
   return {
     conversations: {
       ...coreAttributes.conversations,

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -69,6 +69,58 @@ type InsightsUpdateFunction = (
   caseForm: Case,
 ) => InsightsAttributes;
 
+const sanitizeInsightsValue = (value: string | boolean) => {
+  if (typeof value === 'string' && value) return value;
+
+  if (typeof value === 'boolean') return value.toString();
+
+  return null;
+};
+
+const COMMUNICATION_CHANNEL = 'communication_channel';
+const SUBCATEGORIES = 'conversation_attribute_1';
+const CALLTYPE = 'conversation_attribute_2';
+const CALLER_AGE = 'conversation_attribute_3';
+const CALLER_GENDER = 'conversation_attribute_4';
+const HELPLINE = 'conversation_attribute_8';
+const LANGUAGE = 'language';
+const CHILD_AGE = 'year_of_birth';
+const CHILD_GENDER = 'gender';
+
+/**
+ * This are the core attributes that should be present for all kind of contacts, returned by baseUpdates function
+ */
+type CoreAttributes = {
+  conversations: {
+    conversation_attribute_5: null; // This field is cleared for later use
+    [COMMUNICATION_CHANNEL]: string;
+    [SUBCATEGORIES]?: string;
+    [CALLTYPE]: string;
+    [CALLER_AGE]: string;
+    [CALLER_GENDER]: string;
+    [HELPLINE]: string;
+    [LANGUAGE]: string;
+  };
+  customers: {
+    [CHILD_AGE]: string;
+    [CHILD_GENDER]: string;
+  };
+};
+
+/**
+ * Updates that will be performed for every helpline, using a bunch of fixed Insights fields. The fields that should not be added to the custom mapping are:
+ * Conversations object:
+ *  - communication_channel
+ *  - conversation_attribute_1
+ *  - conversation_attribute_2
+ *  - conversation_attribute_3
+ *  - conversation_attribute_4
+ *  - conversation_attribute_8
+ *  - language
+ * Customers object:
+ *  - year_of_birth
+ *  - gender
+ */
 export const baseUpdates: InsightsUpdateFunction = (
   taskAttributes: TaskAttributes,
   contactForm: TaskEntry,
@@ -84,9 +136,8 @@ export const baseUpdates: InsightsUpdateFunction = (
     : mapChannelForInsights(taskAttributes.channelType);
 
   // First add the data we add whether or not there's contact form data
-  const coreAttributes: InsightsAttributes = {
+  const coreAttributes: CoreAttributes = {
     conversations: {
-      conversation_attribute_2: callType.toString(),
       /*
        * By default, Twilio populates attribute 5 with the Task ID, but we
        * overwrite it for data contacts so we want it null for non-data contacts.
@@ -94,18 +145,19 @@ export const baseUpdates: InsightsUpdateFunction = (
        * and then let other updates overwrite again later for data contacts.
        */
       conversation_attribute_5: null,
-      communication_channel,
       /**
        * Fields that should always be populated, whether it is a data contact or not.
        */
-      conversation_attribute_3: contactForm.callerInformation.age.toString(),
-      conversation_attribute_4: contactForm.callerInformation.gender.toString(),
-      conversation_attribute_8: taskAttributes.helpline,
-      language: contactForm.childInformation.language.toString(),
+      [COMMUNICATION_CHANNEL]: communication_channel,
+      [CALLTYPE]: sanitizeInsightsValue(callType),
+      [CALLER_AGE]: sanitizeInsightsValue(contactForm.callerInformation.age),
+      [CALLER_GENDER]: sanitizeInsightsValue(contactForm.callerInformation.gender),
+      [HELPLINE]: sanitizeInsightsValue(taskAttributes.helpline),
+      [LANGUAGE]: sanitizeInsightsValue(contactForm.childInformation.language),
     },
     customers: {
-      year_of_birth: contactForm.childInformation.age.toString(),
-      gender: contactForm.childInformation.gender.toString(),
+      [CHILD_AGE]: sanitizeInsightsValue(contactForm.childInformation.age),
+      [CHILD_GENDER]: sanitizeInsightsValue(contactForm.childInformation.gender),
     },
   };
 
@@ -117,7 +169,7 @@ export const baseUpdates: InsightsUpdateFunction = (
     ...coreAttributes,
     conversations: {
       ...coreAttributes.conversations,
-      conversation_attribute_1: getSubcategories(contactForm).toString(),
+      [SUBCATEGORIES]: getSubcategories(contactForm),
     },
   };
 };

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -88,7 +88,8 @@ const CHILD_AGE = 'year_of_birth';
 const CHILD_GENDER = 'gender';
 
 /**
- * This are the core attributes that should be present for all kind of contacts, returned by baseUpdates function
+ * This are the core attributes that should be present for all kind of contacts, returned by baseUpdates function.
+ * Note this is a specialization of the InsightsAttributes type
  */
 type CoreAttributes = {
   conversations: {
@@ -125,7 +126,7 @@ export const baseUpdates: InsightsUpdateFunction = (
   taskAttributes: TaskAttributes,
   contactForm: TaskEntry,
   caseForm: Case,
-): InsightsAttributes => {
+): CoreAttributes => {
   const { callType } = contactForm;
   const communication_channel = taskAttributes.isContactlessTask
     ? mapChannelForInsights(

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -98,10 +98,14 @@ export const baseUpdates: InsightsUpdateFunction = (
       /**
        * Fields that should always be populated, whether it is a data contact or not.
        */
-      conversation_attribute_3: contactForm.childInformation.age.toString(),
-      conversation_attribute_4: contactForm.childInformation.gender.toString(),
+      conversation_attribute_3: contactForm.callerInformation.age.toString(),
+      conversation_attribute_4: contactForm.callerInformation.gender.toString(),
       conversation_attribute_8: taskAttributes.helpline,
       language: contactForm.childInformation.language.toString(),
+    },
+    customers: {
+      year_of_birth: contactForm.childInformation.age.toString(),
+      gender: contactForm.childInformation.gender.toString(),
     },
   };
 
@@ -110,6 +114,7 @@ export const baseUpdates: InsightsUpdateFunction = (
   }
 
   return {
+    ...coreAttributes,
     conversations: {
       ...coreAttributes.conversations,
       conversation_attribute_1: getSubcategories(contactForm).toString(),


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-279.

This PR:
- Maps caller age, caller gender, task helpline attribute, child language, child age and child gender to corresponding insights fields for non data & data call types (previously only data call types behave like this). This is achieved by moving this updates on the insights object to be part of the `coreAttributes` of `baseUpdates` function.
- Removed above updates from custom insights mappings.
- Sanitized empty string values to be `null` instead as suggested in https://github.com/techmatters/flex-plugins/pull/444#issuecomment-842662511.
- Added some type information to make code easier to follow as suggested in https://github.com/techmatters/flex-plugins/pull/444#discussion_r634470439.

Questions for @dee-luo (SOLVED):
- ~Because of the way the forms works, if there is no "caller age" (for example), this will impact in insights as empty string in `conversation_attribute_3`. Do we want it to be `null` instead? I ignore if empty string vs `null` affects insights, but maybe you know.~
- ~Previously only ZA was recording `helpline` in `conversation_attribute_8`, but we want all of the helplines to record it, right?~

Note:
Because of this new fields being added to `coreAttributes`, if any subsequent update of insights object changes one of the already assigned fields, it will be overwritten. For example, if in three months from now we add "is child at risk" to be stored in `conversation_attribute_3` from one of our "customizable insights maps", caller age won't be part of any `conversation_attribute_X`. This is not an issue as long as we remember what fields should not be customizable for the insights mapping.