### PR TITLE
[Don't merge] Added option to retrieve garbled translation

### DIFF
--- a/plugin-hrm-form/src/components/translator/index.jsx
+++ b/plugin-hrm-form/src/components/translator/index.jsx
@@ -48,6 +48,7 @@ class Translator extends React.PureComponent {
         >
           <MenuItem value="en-US">English</MenuItem>
           <MenuItem value="es">Español</MenuItem>
+          <MenuItem value="garbled">Garbled</MenuItem>
         </Select>
         {this.state.loading && <CircularProgress style={{ position: 'absolute', flex: 1 }} />}
       </FormControl>


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/serverless/pull/64. 

Adds an option to the translator to fetch garbled translation.