### PR TITLE
Add Helpline Select on ZM offline contact form

### DIFF
--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -189,6 +189,7 @@ export type DefinitionVersion = {
   };
   // TODO: change this property to contactForms to be consistent (though that may create confusion with the component name)
   tabbedForms: {
+    ContactlessTaskTab?: FormDefinition;
     CallerInformationTab: FormDefinition;
     CaseInformationTab: FormDefinition;
     ChildInformationTab: FormDefinition;

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
@@ -13,17 +13,26 @@ import type { TaskEntry } from '../../states/contacts/reducer';
 import { createFormDefinition } from './ContactlessTaskTabDefinition';
 import { splitDate, splitTime } from '../../utils/helpers';
 import type { OfflineContactTask } from '../../types/types';
+import type { FormDefinition } from '../common/forms/types';
 
 type OwnProps = {
   task: OfflineContactTask;
   display: boolean;
+  definition?: FormDefinition;
   initialValues: TaskEntry[keyof TaskEntry];
 };
 
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task, initialValues, counselorsList }) => {
+const ContactlessTaskTab: React.FC<Props> = ({
+  dispatch,
+  display,
+  task,
+  definition,
+  initialValues,
+  counselorsList,
+}) => {
   const [initialForm] = React.useState(initialValues); // grab initial values in first render only. This value should never change or will ruin the memoization below
 
   const { getValues, register, setError, setValue, watch, errors } = useFormContext();
@@ -34,12 +43,14 @@ const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task, initialV
       dispatch(updateForm(task.taskSid, 'contactlessTask', rest));
     };
 
-    const formDefinition = createFormDefinition(counselorsList);
+    const formDefinition = definition
+      ? [...createFormDefinition(counselorsList), ...definition]
+      : createFormDefinition(counselorsList);
 
     const tab = createFormFromDefinition(formDefinition)(['contactlessTask'])(initialForm)(updateCallBack);
 
     return disperseInputs(5)(tab);
-  }, [counselorsList, dispatch, getValues, initialForm, task.taskSid]);
+  }, [counselorsList, dispatch, getValues, definition, initialForm, task.taskSid]);
 
   // Add invisible field that errors if date + time are future (triggered by validaiton)
   React.useEffect(() => {

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -173,6 +173,7 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, currentD
                 <ContactlessTaskTab
                   task={task}
                   display={subroute === 'contactlessTask'}
+                  definition={currentDefinitionVersion.tabbedForms.ContactlessTaskTab}
                   initialValues={contactForm.contactlessTask}
                 />
               )}

--- a/plugin-hrm-form/src/formDefinitions/v1/index.ts
+++ b/plugin-hrm-form/src/formDefinitions/v1/index.ts
@@ -4,6 +4,7 @@ import IncidentForm from './caseForms/IncidentForm.json';
 import NoteForm from './caseForms/NoteForm.json';
 import PerpetratorForm from './caseForms/PerpetratorForm.json';
 import ReferralForm from './caseForms/ReferralForm.json';
+import ContactlessTaskTab from './tabbedForms/ContactlessTaskTab.json';
 import CallerInformationTab from './tabbedForms/CallerInformationTab.json';
 import CaseInformationTab from './tabbedForms/CaseInformationTab.json';
 import ChildInformationTab from './tabbedForms/ChildInformationTab.json';
@@ -31,6 +32,7 @@ const version: DefinitionVersion = {
     ReferralForm: ReferralForm as FormDefinition,
   },
   tabbedForms: {
+    ContactlessTaskTab: ContactlessTaskTab as FormDefinition,
     CallerInformationTab: CallerInformationTab as FormDefinition,
     CaseInformationTab: CaseInformationTab as FormDefinition,
     ChildInformationTab: ChildInformationTab as FormDefinition,

--- a/plugin-hrm-form/src/formDefinitions/v1/tabbedForms/ContactlessTaskTab.json
+++ b/plugin-hrm-form/src/formDefinitions/v1/tabbedForms/ContactlessTaskTab.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "helpline",
+    "label": "Helpline",
+    "type": "select",
+    "options": [
+      { "value": "Unknown", "label": "" },
+      { "value": "ChildLine", "label": "ChildLine" },
+      { "value": "LifeLine", "label": "LifeLine" }
+    ],
+    "required": { "value": true, "message": "RequiredFieldError" }
+  }
+]

--- a/plugin-hrm-form/src/formDefinitions/v1/tabbedForms/ContactlessTaskTab.json
+++ b/plugin-hrm-form/src/formDefinitions/v1/tabbedForms/ContactlessTaskTab.json
@@ -3,8 +3,8 @@
     "name": "helpline",
     "label": "Helpline",
     "type": "select",
+    "defaultOption": "ChildLine",
     "options": [
-      { "value": "Unknown", "label": "" },
       { "value": "ChildLine", "label": "ChildLine" },
       { "value": "LifeLine", "label": "LifeLine" }
     ],

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -16,7 +16,7 @@ import type {
   FormDefinition,
   FormItemDefinition,
 } from '../components/common/forms/types';
-import { InformationObject, ContactRawJson, SearchContactResult, isOfflineContactTask, CustomITask } from '../types/types';
+import { InformationObject, ContactRawJson, SearchContactResult, isOfflineContactTask } from '../types/types';
 
 /**
  * Un-nests the information (caller/child) as it comes from DB, to match the form structure

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -16,7 +16,7 @@ import type {
   FormDefinition,
   FormItemDefinition,
 } from '../components/common/forms/types';
-import { InformationObject, ContactRawJson, SearchContactResult, isOfflineContactTask } from '../types/types';
+import { InformationObject, ContactRawJson, SearchContactResult, isOfflineContactTask, CustomITask } from '../types/types';
 
 /**
  * Un-nests the information (caller/child) as it comes from DB, to match the form structure
@@ -193,13 +193,15 @@ export async function saveToHrm(task, form, workerSid, helpline, uniqueIdentifie
    */
   const formToSend = transformForm(rawForm);
 
+  const helplineToSend = (isOfflineContactTask(task) && form.contactlessTask.helpline) || helpline;
+
   const body = {
     form: formToSend,
     twilioWorkerId,
     queueName: task.queueName,
     channel: task.channelType,
     number,
-    helpline,
+    helpline: helplineToSend,
     conversationDuration,
     timeOfContact,
     taskId: uniqueIdentifier,

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -157,11 +157,11 @@ export function transformForm(form: TaskEntry): ContactRawJson {
  * @param  task
  * @param form
  * @param workerSid
- * @param helpline
+ * @param workerHelpline
  * @param uniqueIdentifier
  * @param shouldFillEndMillis
  */
-export async function saveToHrm(task, form, workerSid, helpline, uniqueIdentifier, shouldFillEndMillis = true) {
+export async function saveToHrm(task, form, workerSid, workerHelpline, uniqueIdentifier, shouldFillEndMillis = true) {
   // if we got this far, we assume the form is valid and ready to submit
   const metadata = shouldFillEndMillis ? fillEndMillis(form.metadata) : form.metadata;
   const conversationDuration = getConversationDuration(task, metadata);
@@ -193,7 +193,7 @@ export async function saveToHrm(task, form, workerSid, helpline, uniqueIdentifie
    */
   const formToSend = transformForm(rawForm);
 
-  const helplineToSend = (isOfflineContactTask(task) && form.contactlessTask.helpline) || helpline;
+  const helplineToSend = (isOfflineContactTask(task) && form.contactlessTask?.helpline) || workerHelpline;
 
   const body = {
     form: formToSend,


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-633

This PR adds a **Helpline** select on **Contact Info** Tab when creating an **offline contact** on **ZM**.

P.S.: The easiest way to test this is to edit **HrmFormPlugin** line 68 to be `definitionVersion: 'v1',` because **dev** environment is configured on Twilio to use ZA definitions. 

![image](https://user-images.githubusercontent.com/1504544/121560260-407a2900-ca0f-11eb-952c-ea4c4c596d02.png)
