### PR TITLE
fixed pluralization on previous contacts banner

### DIFF
--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -71,7 +71,44 @@ const PreviousContactsBanner: React.FC<Props> = ({
   return (
     <YellowBanner data-testid="PreviousContacts-Container">
       {/* eslint-disable-next-line prettier/prettier */}
-      <pre><Template code="PreviousContacts-ThereAre" /> <Bold>{contactsCount} <Template code="PreviousContacts-PreviousContacts" /></Bold> and <Bold>{casesCount} <Template code="PreviousContacts-Cases" /></Bold> <Template code="PreviousContacts-From" /> <Template code={localizedSource[task.channelType]} /> <Bold>{contactNumber}</Bold>.</pre>
+      <pre>
+        <Template code="PreviousContacts-ThereAre" />
+        &nbsp;
+        {contactsCount === 1 ? (
+          <>
+            <Bold>
+              {contactsCount} <Template code="PreviousContacts-PreviousContact" />
+            </Bold>
+          </>
+        ) : (
+          <>
+            <Bold>
+              {contactsCount} <Template code="PreviousContacts-PreviousContacts" />
+            </Bold>
+          </>
+        )}
+        &nbsp;and&nbsp;
+        {casesCount === 1 ? (
+          <>
+            <Bold>
+              {casesCount} <Template code="PreviousContacts-Case" />
+            </Bold>
+          </>
+        ) : (
+          <>
+            <Bold>
+              {casesCount} <Template code="PreviousContacts-Cases" />
+            </Bold>
+          </>
+        )}
+        &nbsp;
+        <Template code="PreviousContacts-From" />
+        &nbsp;
+        <Template code={localizedSource[task.channelType]} />
+        &nbsp;
+        <Bold>{contactNumber}</Bold>.
+      </pre>
+
       <StyledLink underline data-testid="PreviousContacts-ViewRecords" onClick={handleClickViewRecords}>
         <Template code="PreviousContacts-ViewRecords" />
       </StyledLink>

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -75,31 +75,28 @@ const PreviousContactsBanner: React.FC<Props> = ({
         <Template code="PreviousContacts-ThereAre" />
         &nbsp;
         {contactsCount === 1 ? (
-          <>
             <Bold>
               {contactsCount} <Template code="PreviousContacts-PreviousContact" />
             </Bold>
-          </>
         ) : (
-          <>
+          
             <Bold>
               {contactsCount} <Template code="PreviousContacts-PreviousContacts" />
             </Bold>
-          </>
         )}
         &nbsp;and&nbsp;
         {casesCount === 1 ? (
-          <>
+          
             <Bold>
               {casesCount} <Template code="PreviousContacts-Case" />
             </Bold>
-          </>
+          
         ) : (
-          <>
+          
             <Bold>
               {casesCount} <Template code="PreviousContacts-Cases" />
             </Bold>
-          </>
+          
         )}
         &nbsp;
         <Template code="PreviousContacts-From" />

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -75,28 +75,23 @@ const PreviousContactsBanner: React.FC<Props> = ({
         <Template code="PreviousContacts-ThereAre" />
         &nbsp;
         {contactsCount === 1 ? (
-            <Bold>
-              {contactsCount} <Template code="PreviousContacts-PreviousContact" />
-            </Bold>
+          <Bold>
+            {contactsCount} <Template code="PreviousContacts-PreviousContact" />
+          </Bold>
         ) : (
-          
-            <Bold>
-              {contactsCount} <Template code="PreviousContacts-PreviousContacts" />
-            </Bold>
+          <Bold>
+            {contactsCount} <Template code="PreviousContacts-PreviousContacts" />
+          </Bold>
         )}
         &nbsp;and&nbsp;
         {casesCount === 1 ? (
-          
-            <Bold>
-              {casesCount} <Template code="PreviousContacts-Case" />
-            </Bold>
-          
+          <Bold>
+            {casesCount} <Template code="PreviousContacts-Case" />
+          </Bold>
         ) : (
-          
-            <Bold>
-              {casesCount} <Template code="PreviousContacts-Cases" />
-            </Bold>
-          
+          <Bold>
+            {casesCount} <Template code="PreviousContacts-Cases" />
+          </Bold>
         )}
         &nbsp;
         <Template code="PreviousContacts-From" />

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -280,7 +280,9 @@
 
   "PreviousContacts-ThereAre": "There are",
   "PreviousContacts-PreviousContacts": "previous contacts",
+  "PreviousContacts-PreviousContact": "previous contact",
   "PreviousContacts-Cases": "cases",
+  "PreviousContacts-Case": "case",
   "PreviousContacts-From": "from",
   "PreviousContacts-IPAddress": "IP address",
   "PreviousContacts-PhoneNumber": "phone number",


### PR DESCRIPTION
Jira: https://bugs.benetech.org/secure/RapidBoard.jspa?rapidView=19&view=detail&selectedIssue=CHI-667

In this PR:
- Previous contacts banner now shows 'contact' for single contact, and 'contacts' for multiple -- same with cases