### PR TITLE
fixed remaining localization strings

### DIFF
--- a/plugin-hrm-form/src/___tests__/search/SearchResults.test.js
+++ b/plugin-hrm-form/src/___tests__/search/SearchResults.test.js
@@ -183,7 +183,7 @@ describe('<SearchResults> with 1 result', () => {
     );
 
     expect(screen.getByTestId('SearchResultsCount')).toHaveTextContent('1 PreviousContacts-Case');
-    expect(screen.getByTestId('ContactsCount')).toHaveTextContent('1 SearchResultsIndex-Contacts');
+    expect(screen.getByTestId('ContactsCount')).toHaveTextContent('1 PreviousContacts-Contact');
   });
 
   test('on cases tab', () => {
@@ -203,7 +203,7 @@ describe('<SearchResults> with 1 result', () => {
     );
 
     expect(screen.getByTestId('SearchResultsCount')).toHaveTextContent('1 PreviousContacts-Contact');
-    expect(screen.getByTestId('CasesCount')).toHaveTextContent('1 SearchResultsIndex-Cases');
+    expect(screen.getByTestId('CasesCount')).toHaveTextContent('1 PreviousContacts-Case');
   });
 });
 

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -285,7 +285,8 @@ const SearchResults: React.FC<Props> = ({
                     <Template code="PreviousContacts-Case" />
                   ) : (
                     <Template code="SearchResultsIndex-Cases" />
-                  )}&nbsp;
+                  )}
+                  &nbsp;
                 </StyledCount>
                 <StyledFormControlLabel
                   control={<StyledSwitch checked={closedCases} onChange={handleToggleClosedCases} />}

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -186,45 +186,42 @@ const SearchResults: React.FC<Props> = ({
         <ScrollableList>
           <StyledResultsContainer>
             <StyledResultsText>
-              <BoldText data-testid="SearchResultsCount">
-                {/* Intentionally we must show the option different at the one currently selected */}
-                {currentPage === SearchPages.resultsContacts ? (
-                  <>
-                    {casesCount === 1 ? (
-                      <>
-                        <Template code="PreviousContacts-ThereIs" />
-                        &nbsp;
-                        {casesCount} <Template code="PreviousContacts-Case" />
-                      </>
-                    ) : (
-                      <>
-                        <Template code="PreviousContacts-ThereAre" />
-                        &nbsp;
-                        {casesCount} <Template code="PreviousContacts-Cases" />
-                      </>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    {contactsCount === 1 ? (
-                      <>
-                        <Template code="PreviousContacts-ThereIs" />
-                        &nbsp;
-                        {contactsCount} <Template code="PreviousContacts-Contact" />
-                      </>
-                    ) : (
-                      <>
-                        <Template code="PreviousContacts-ThereAre" />
-                        &nbsp;
-                        {contactsCount} <Template code="PreviousContacts-Contacts" />
-                      </>
-                    )}
-                  </>
-                )}
-              </BoldText>
+              {/* Intentionally we must show the option different at the one currently selected */}
+              {currentPage === SearchPages.resultsContacts ? (
+                <>
+                  {casesCount === 1 ? (
+                    <>
+                      <Template code="PreviousContacts-ThereIs" />
+                      &nbsp;<BoldText data-testid="SearchResultsCount">{casesCount}</BoldText>&nbsp;
+                      <Template code="PreviousContacts-Case" />
+                    </>
+                  ) : (
+                    <>
+                      <Template code="PreviousContacts-ThereAre" />
+                      &nbsp;<BoldText data-testid="SearchResultsCount">{casesCount}</BoldText>&nbsp;
+                      <Template code="PreviousContacts-Cases" />
+                    </>
+                  )}
+                </>
+              ) : (
+                <>
+                  {contactsCount === 1 ? (
+                    <>
+                      <Template code="PreviousContacts-ThereIs" />
+                      &nbsp;<BoldText data-testid="SearchResultsCount">{contactsCount}</BoldText>&nbsp;
+                      <Template code="PreviousContacts-Contact" />
+                    </>
+                  ) : (
+                    <>
+                      <Template code="PreviousContacts-ThereAre" />
+                      &nbsp; <BoldText data-testid="SearchResultsCount">{contactsCount}</BoldText>&nbsp;
+                      <Template code="PreviousContacts-Contacts" />
+                    </>
+                  )}
+                </>
+              )}
               &nbsp;
               <Template code="PreviousContacts-Returned" />
-              &nbsp;
             </StyledResultsText>
             <StyledLink onClick={toggleTabs} data-testid="ViewCasesLink">
               <Template
@@ -241,7 +238,7 @@ const SearchResults: React.FC<Props> = ({
             <>
               <StyledContactResultsHeader>
                 <StyledCount data-testid="ContactsCount">
-                  {contactsCount}{' '}
+                  {contactsCount}&nbsp;
                   {contactsCount === 1 ? (
                     <Template code="PreviousContacts-Contact" />
                   ) : (
@@ -283,12 +280,12 @@ const SearchResults: React.FC<Props> = ({
             <>
               <StyledCaseResultsHeader>
                 <StyledCount data-testid="CasesCount">
-                  {casesCount}{' '}
+                  {casesCount}&nbsp;
                   {casesCount === 1 ? (
                     <Template code="PreviousContacts-Case" />
                   ) : (
                     <Template code="SearchResultsIndex-Cases" />
-                  )}{' '}
+                  )}&nbsp;
                 </StyledCount>
                 <StyledFormControlLabel
                   control={<StyledSwitch checked={closedCases} onChange={handleToggleClosedCases} />}

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -186,42 +186,45 @@ const SearchResults: React.FC<Props> = ({
         <ScrollableList>
           <StyledResultsContainer>
             <StyledResultsText>
-              {/* Intentionally we must show the option different at the one currently selected */}
-              {currentPage === SearchPages.resultsContacts ? (
-                <>
-                  {casesCount === 1 ? (
-                    <>
-                      <Template code="PreviousContacts-ThereIs" />
-                      &nbsp;<BoldText data-testid="SearchResultsCount">{casesCount}</BoldText>&nbsp;
-                      <Template code="PreviousContacts-Case" />
-                    </>
-                  ) : (
-                    <>
-                      <Template code="PreviousContacts-ThereAre" />
-                      &nbsp;<BoldText data-testid="SearchResultsCount">{casesCount}</BoldText>&nbsp;
-                      <Template code="PreviousContacts-Cases" />
-                    </>
-                  )}
-                </>
-              ) : (
-                <>
-                  {contactsCount === 1 ? (
-                    <>
-                      <Template code="PreviousContacts-ThereIs" />
-                      &nbsp;<BoldText data-testid="SearchResultsCount">{contactsCount}</BoldText>&nbsp;
-                      <Template code="PreviousContacts-Contact" />
-                    </>
-                  ) : (
-                    <>
-                      <Template code="PreviousContacts-ThereAre" />
-                      &nbsp; <BoldText data-testid="SearchResultsCount">{contactsCount}</BoldText>&nbsp;
-                      <Template code="PreviousContacts-Contacts" />
-                    </>
-                  )}
-                </>
-              )}
+              <BoldText data-testid="SearchResultsCount">
+                {/* Intentionally we must show the option different at the one currently selected */}
+                {currentPage === SearchPages.resultsContacts ? (
+                  <>
+                    {casesCount === 1 ? (
+                      <>
+                        <Template code="PreviousContacts-ThereIs" />
+                        &nbsp;
+                        {casesCount} <Template code="PreviousContacts-Case" />
+                      </>
+                    ) : (
+                      <>
+                        <Template code="PreviousContacts-ThereAre" />
+                        &nbsp;
+                        {casesCount} <Template code="PreviousContacts-Cases" />
+                      </>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {contactsCount === 1 ? (
+                      <>
+                        <Template code="PreviousContacts-ThereIs" />
+                        &nbsp;
+                        {contactsCount} <Template code="PreviousContacts-Contact" />
+                      </>
+                    ) : (
+                      <>
+                        <Template code="PreviousContacts-ThereAre" />
+                        &nbsp;
+                        {contactsCount} <Template code="PreviousContacts-Contacts" />
+                      </>
+                    )}
+                  </>
+                )}
+              </BoldText>
               &nbsp;
               <Template code="PreviousContacts-Returned" />
+              &nbsp;
             </StyledResultsText>
             <StyledLink onClick={toggleTabs} data-testid="ViewCasesLink">
               <Template
@@ -238,7 +241,7 @@ const SearchResults: React.FC<Props> = ({
             <>
               <StyledContactResultsHeader>
                 <StyledCount data-testid="ContactsCount">
-                  {contactsCount}&nbsp;
+                  {contactsCount}{' '}
                   {contactsCount === 1 ? (
                     <Template code="PreviousContacts-Contact" />
                   ) : (
@@ -280,12 +283,12 @@ const SearchResults: React.FC<Props> = ({
             <>
               <StyledCaseResultsHeader>
                 <StyledCount data-testid="CasesCount">
-                  {casesCount}&nbsp;
+                  {casesCount}{' '}
                   {casesCount === 1 ? (
                     <Template code="PreviousContacts-Case" />
                   ) : (
                     <Template code="SearchResultsIndex-Cases" />
-                  )}&nbsp;
+                  )}{' '}
                 </StyledCount>
                 <StyledFormControlLabel
                   control={<StyledSwitch checked={closedCases} onChange={handleToggleClosedCases} />}

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -285,8 +285,7 @@ const SearchResults: React.FC<Props> = ({
                     <Template code="PreviousContacts-Case" />
                   ) : (
                     <Template code="SearchResultsIndex-Cases" />
-                  )}
-                  &nbsp;
+                  )}&nbsp;
                 </StyledCount>
                 <StyledFormControlLabel
                   control={<StyledSwitch checked={closedCases} onChange={handleToggleClosedCases} />}

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -153,14 +153,17 @@ const SearchResults: React.FC<Props> = ({
         <Row style={{ justifyContent: 'center' }}>
           <div style={{ width: '300px' }}>
             <StyledTabs selectedTabName={currentPage} onTabSelected={tabSelected}>
-              <TwilioTab label={<Template code="SearchResultsIndex-Contacts"/>} uniqueName={SearchPages.resultsContacts}>
+              <TwilioTab
+                label={<Template code="SearchResultsIndex-Contacts" />}
+                uniqueName={SearchPages.resultsContacts}
+              >
                 {[]}
               </TwilioTab>
               <TwilioTab
                 label={
                   <StyledTabLabel>
                     <StyledFolderIcon />
-                    <Template code="SearchResultsIndex-Cases"/>
+                    <Template code="SearchResultsIndex-Cases" />
                   </StyledTabLabel>
                 }
                 uniqueName={SearchPages.resultsCases}
@@ -189,14 +192,15 @@ const SearchResults: React.FC<Props> = ({
                   <>
                     {casesCount === 1 ? (
                       <>
-                      <Template code="PreviousContacts-ThereIs"/>&nbsp;
-                      {casesCount}{' '}
-                      <Template code="PreviousContacts-Case" />
+                        <Template code="PreviousContacts-ThereIs" />
+                        &nbsp;
+                        {casesCount} <Template code="PreviousContacts-Case" />
                       </>
-                    ) : (<>
-                      <Template code="PreviousContacts-ThereAre"/>&nbsp;
-                      {casesCount}{' '}
-                      <Template code="PreviousContacts-Cases" />
+                    ) : (
+                      <>
+                        <Template code="PreviousContacts-ThereAre" />
+                        &nbsp;
+                        {casesCount} <Template code="PreviousContacts-Cases" />
                       </>
                     )}
                   </>
@@ -204,15 +208,15 @@ const SearchResults: React.FC<Props> = ({
                   <>
                     {contactsCount === 1 ? (
                       <>
-                      <Template code="PreviousContacts-ThereIs"/>&nbsp;
-                      {contactsCount}{' '}
-                      <Template code="PreviousContacts-Contact" />
+                        <Template code="PreviousContacts-ThereIs" />
+                        &nbsp;
+                        {contactsCount} <Template code="PreviousContacts-Contact" />
                       </>
                     ) : (
                       <>
-                      <Template code="PreviousContacts-ThereAre"/>&nbsp;
-                      {contactsCount}{' '}
-                      <Template code="PreviousContacts-Contacts" />
+                        <Template code="PreviousContacts-ThereAre" />
+                        &nbsp;
+                        {contactsCount} <Template code="PreviousContacts-Contacts" />
                       </>
                     )}
                   </>
@@ -238,8 +242,11 @@ const SearchResults: React.FC<Props> = ({
               <StyledContactResultsHeader>
                 <StyledCount data-testid="ContactsCount">
                   {contactsCount}{' '}
-                  {contactsCount === 1 ? <Template code="PreviousContacts-Contact" />
-:<Template code="SearchResultsIndex-Contacts" />}
+                  {contactsCount === 1 ? (
+                    <Template code="PreviousContacts-Contact" />
+                  ) : (
+                    <Template code="SearchResultsIndex-Contacts" />
+                  )}
                 </StyledCount>
                 <StyledFormControlLabel
                   control={<StyledSwitch checked={!onlyDataContacts} onChange={handleToggleNonDataContact} />}
@@ -276,9 +283,13 @@ const SearchResults: React.FC<Props> = ({
             <>
               <StyledCaseResultsHeader>
                 <StyledCount data-testid="CasesCount">
-                {casesCount}{' '}
-                  {casesCount === 1 ? <Template code="PreviousContacts-Case" />
-:<Template code="SearchResultsIndex-Cases" />}                </StyledCount>
+                  {casesCount}{' '}
+                  {casesCount === 1 ? (
+                    <Template code="PreviousContacts-Case" />
+                  ) : (
+                    <Template code="SearchResultsIndex-Cases" />
+                  )}{' '}
+                </StyledCount>
                 <StyledFormControlLabel
                   control={<StyledSwitch checked={closedCases} onChange={handleToggleClosedCases} />}
                   label={

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -153,14 +153,14 @@ const SearchResults: React.FC<Props> = ({
         <Row style={{ justifyContent: 'center' }}>
           <div style={{ width: '300px' }}>
             <StyledTabs selectedTabName={currentPage} onTabSelected={tabSelected}>
-              <TwilioTab label="Contacts" uniqueName={SearchPages.resultsContacts}>
+              <TwilioTab label={<Template code="SearchResultsIndex-Contacts"/>} uniqueName={SearchPages.resultsContacts}>
                 {[]}
               </TwilioTab>
               <TwilioTab
                 label={
                   <StyledTabLabel>
                     <StyledFolderIcon />
-                    Cases
+                    <Template code="SearchResultsIndex-Cases"/>
                   </StyledTabLabel>
                 }
                 uniqueName={SearchPages.resultsCases}
@@ -183,26 +183,37 @@ const SearchResults: React.FC<Props> = ({
         <ScrollableList>
           <StyledResultsContainer>
             <StyledResultsText>
-              <Template code="PreviousContacts-ThereAre" />
-              &nbsp;
               <BoldText data-testid="SearchResultsCount">
                 {/* Intentionally we must show the option different at the one currently selected */}
                 {currentPage === SearchPages.resultsContacts ? (
                   <>
-                    {casesCount}{' '}
                     {casesCount === 1 ? (
+                      <>
+                      <Template code="PreviousContacts-ThereIs"/>&nbsp;
+                      {casesCount}{' '}
                       <Template code="PreviousContacts-Case" />
-                    ) : (
+                      </>
+                    ) : (<>
+                      <Template code="PreviousContacts-ThereAre"/>&nbsp;
+                      {casesCount}{' '}
                       <Template code="PreviousContacts-Cases" />
+                      </>
                     )}
                   </>
                 ) : (
                   <>
-                    {contactsCount}{' '}
                     {contactsCount === 1 ? (
+                      <>
+                      <Template code="PreviousContacts-ThereIs"/>&nbsp;
+                      {contactsCount}{' '}
                       <Template code="PreviousContacts-Contact" />
+                      </>
                     ) : (
+                      <>
+                      <Template code="PreviousContacts-ThereAre"/>&nbsp;
+                      {contactsCount}{' '}
                       <Template code="PreviousContacts-Contacts" />
+                      </>
                     )}
                   </>
                 )}
@@ -226,7 +237,9 @@ const SearchResults: React.FC<Props> = ({
             <>
               <StyledContactResultsHeader>
                 <StyledCount data-testid="ContactsCount">
-                  {contactsCount} <Template code="SearchResultsIndex-Contacts" />
+                  {contactsCount}{' '}
+                  {contactsCount === 1 ? <Template code="PreviousContacts-Contact" />
+:<Template code="SearchResultsIndex-Contacts" />}
                 </StyledCount>
                 <StyledFormControlLabel
                   control={<StyledSwitch checked={!onlyDataContacts} onChange={handleToggleNonDataContact} />}
@@ -263,8 +276,9 @@ const SearchResults: React.FC<Props> = ({
             <>
               <StyledCaseResultsHeader>
                 <StyledCount data-testid="CasesCount">
-                  {casesCount} <Template code="SearchResultsIndex-Cases" />
-                </StyledCount>
+                {casesCount}{' '}
+                  {casesCount === 1 ? <Template code="PreviousContacts-Case" />
+:<Template code="SearchResultsIndex-Cases" />}                </StyledCount>
                 <StyledFormControlLabel
                   control={<StyledSwitch checked={closedCases} onChange={handleToggleClosedCases} />}
                   label={

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -286,6 +286,7 @@
   "Anonymous": "Anonymous",
 
   "PreviousContacts-ThereAre": "There are",
+  "PreviousContacts-ThereIs": "There is",
   "PreviousContacts-Returned": "returned in this search.",
   "PreviousContacts-PreviousContacts": "previous contacts",
   "PreviousContacts-PreviousContact": "previous contact",


### PR DESCRIPTION
Jira: [https://bugs.benetech.org/browse/CHI-701](https://bugs.benetech.org/browse/CHI-701)

In this PR, the Cases and Contacts tabs in the search results are localizable. The results are also correctly singular/plural depending on the number of results.

<img width="587" alt="Screen Shot 2021-06-25 at 12 01 37 PM" src="https://user-images.githubusercontent.com/56773304/123453156-30388100-d5ad-11eb-97fa-95651652eff4.png">
