### PR TITLE
Unify helpline attribute to HRM and Insights

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -37,6 +37,7 @@ test('saveInsightsData for non-data callType', async () => {
       content: 'content',
     },
     helpline: 'helpline',
+    helplineToSave: 'helpline',
   };
 
   const twilioTask = {
@@ -88,6 +89,7 @@ test('saveInsightsData for non-data callType (test that fields are sanitized)', 
       content: 'content',
     },
     helpline: 'helpline',
+    helplineToSave: 'helpline',
   };
 
   const twilioTask = {

--- a/plugin-hrm-form/src/components/CustomCRMContainer.tsx
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.tsx
@@ -13,7 +13,11 @@ import { OfflineContactTask } from '../types/types';
 const offlineContactTask: OfflineContactTask = {
   taskSid: 'offline-contact-task-sid',
   channelType: 'default',
-  attributes: { isContactlessTask: true },
+  attributes: { isContactlessTask: true, channelType: 'default' },
+  setAttributes: async newAttributes => {
+    offlineContactTask.attributes = { ...offlineContactTask.attributes, ...newAttributes };
+    return offlineContactTask;
+  },
 };
 
 type OwnProps = {

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -160,14 +160,13 @@ export function transformForm(form: TaskEntry): ContactRawJson {
  * Function that saves the form to Contacts table.
  * If you don't intend to complete the twilio task, set shouldFillEndMillis=false
  *
- * @param  task
+ * @param task
  * @param form
  * @param workerSid
- * @param workerHelpline
  * @param uniqueIdentifier
  * @param shouldFillEndMillis
  */
-export async function saveToHrm(task, form, workerSid, workerHelpline, uniqueIdentifier, shouldFillEndMillis = true) {
+export async function saveToHrm(task, form, workerSid, uniqueIdentifier, shouldFillEndMillis = true) {
   // if we got this far, we assume the form is valid and ready to submit
   const metadata = shouldFillEndMillis ? fillEndMillis(form.metadata) : form.metadata;
   const conversationDuration = getConversationDuration(task, metadata);
@@ -199,8 +198,6 @@ export async function saveToHrm(task, form, workerSid, workerHelpline, uniqueIde
    */
   const formToSend = transformForm(rawForm);
 
-  const helplineToSend = (isOfflineContactTask(task) && form.contactlessTask?.helpline) || workerHelpline;
-
   let channelSid;
   let serviceSid;
 
@@ -215,7 +212,7 @@ export async function saveToHrm(task, form, workerSid, workerHelpline, uniqueIde
     queueName: task.queueName,
     channel: task.channelType,
     number,
-    helpline: helplineToSend,
+    helpline: task.attributes.helplineToSave,
     conversationDuration,
     timeOfContact,
     taskId: uniqueIdentifier,

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -153,7 +153,7 @@ export const baseUpdates: InsightsUpdateFunction = (
       [CALLTYPE]: sanitizeInsightsValue(callType),
       [CALLER_AGE]: sanitizeInsightsValue(contactForm.callerInformation.age),
       [CALLER_GENDER]: sanitizeInsightsValue(contactForm.callerInformation.gender),
-      [HELPLINE]: sanitizeInsightsValue(taskAttributes.helpline),
+      [HELPLINE]: sanitizeInsightsValue(taskAttributes.helplineToSave),
       [LANGUAGE]: sanitizeInsightsValue(contactForm.childInformation.language),
     },
     customers: {

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -127,3 +127,13 @@ export const assignOfflineContact = async (targetSid: string, finalTaskAttribute
   const response = await fetchProtectedApi('/assignOfflineContact', body);
   return response;
 };
+
+/**
+ * Gets the attributes of the target worker
+ */
+export const getWorkerAttributes = async (workerSid: string) => {
+  const body = { workerSid };
+
+  const response = await fetchProtectedApi('/getWorkerAttributes', body);
+  return response;
+};

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -1,13 +1,13 @@
 /* eslint-disable import/no-unused-modules */
 import { Actions, ITask, Manager } from '@twilio/flex-ui';
 
-import { getConfig, reRenderAgentDesktop } from '../HrmFormPlugin';
+import { getConfig } from '../HrmFormPlugin';
 import { TaskEntry as Contact } from '../states/contacts/reducer';
 import { Case, CustomITask, isOfflineContactTask, offlineContactTaskSid } from '../types/types';
 import { channelTypes } from '../states/DomainConstants';
 import { buildInsightsData } from './InsightsService';
 import { saveToHrm } from './ContactService';
-import { assignOfflineContact } from './ServerlessService';
+import { assignOfflineContact, getWorkerAttributes } from './ServerlessService';
 import { removeContactState } from '../states/actions';
 
 /**
@@ -38,16 +38,35 @@ export const completeContactlessTask = async (task: CustomITask) => {
 export const completeTask = (task: CustomITask) =>
   isOfflineContactTask(task) ? removeOfflineContact() : completeContactTask(task);
 
-export const submitContactForm = async (task: CustomITask, contactForm: Contact, caseForm: Case) => {
-  const { workerSid, helpline } = getConfig();
-
+/**
+ * Helper used to be the source of truth for the helpline value being passed to HRM and Insights
+ */
+export const getHelplineToSave = async (task: CustomITask, contactForm: Contact, caseForm: Case) => {
   if (isOfflineContactTask(task)) {
-    const targetSid = contactForm.contactlessTask.createdOnBehalfOf as string;
-    const initialAttributes = { helpline, channelType: 'default', isContactlessTask: true };
-    const finalAttributes = buildInsightsData(initialAttributes, contactForm, caseForm);
-    const inBehalfTask = await assignOfflineContact(targetSid, finalAttributes);
-    return saveToHrm(task, contactForm, workerSid, helpline, inBehalfTask.sid);
+    if (contactForm.contactlessTask.helpline) return contactForm.contactlessTask.helpline;
+
+    const targetWorkerSid = contactForm.contactlessTask.createdOnBehalfOf as string;
+    const targetWorkerAttributes = await getWorkerAttributes(targetWorkerSid);
+    return targetWorkerAttributes.helpline;
   }
 
-  return saveToHrm(task, contactForm, workerSid, helpline, task.taskSid);
+  const { helpline: thisWorkerHelpline } = getConfig();
+  return thisWorkerHelpline || task.attributes.helpline || '';
+};
+
+export const submitContactForm = async (task: CustomITask, contactForm: Contact, caseForm: Case) => {
+  const { workerSid } = getConfig();
+
+  const helplineToSave = await getHelplineToSave(task, contactForm, caseForm);
+  // Add helplineToSave so it's grabbed when saving to Insights (either in buildInsightsData for offline contacts or sendInsightsData for live contacts)
+  /* const updatedTask = */ await task.setAttributes({ ...task.attributes, helplineToSave });
+
+  if (isOfflineContactTask(task)) {
+    const targetWorkerSid = contactForm.contactlessTask.createdOnBehalfOf as string;
+    const finalAttributes = buildInsightsData(task.attributes, contactForm, caseForm);
+    const inBehalfTask = await assignOfflineContact(targetWorkerSid, finalAttributes);
+    return saveToHrm(task, contactForm, workerSid, inBehalfTask.sid);
+  }
+
+  return saveToHrm(task, contactForm, workerSid, task.taskSid);
 };

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -118,8 +118,11 @@ export type OfflineContactTask = {
   taskSid: typeof offlineContactTaskSid;
   attributes: {
     isContactlessTask: true;
+    channelType: 'default';
+    helplineToSave?: string;
   };
   channelType: 'default';
+  setAttributes: (attributes: {}) => Promise<OfflineContactTask>;
 };
 
 export type InMyBehalfITask = ITask & { attributes: { isContactlessTask: true; isInMyBehalf: true } };

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -306,7 +306,7 @@ const decreaseChatCapacity = setupObject => async payload => {
  * @returns {import('@twilio/flex-ui').ActionFunction}
  */
 export const beforeCompleteTask = setupObject => async payload => {
-  await sendInsightsData(setupObject)(payload);
+  await sendInsightsData(setupObject)(payload); // Having this behavior in here makes very opaque to the live task workflow what's saved into Insights. Should we move it?
   await decreaseChatCapacity(setupObject)(payload);
 };
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-719
This PR is related to https://github.com/techmatters/serverless/pull/80

This PR:
- Adds the option to extend offline contact task attributes, making them more "Twilio Task like".
- Adds `getWorkerAttributes` serverless service.
- Using above, unifies the source of truth for helpline value sent to HRM and Insights. This is done by updating the task to contain the expected `helplineToSend`, then grabbing this value from task attributes in both places (HRM & Insights saving functions).
