### PR TITLE
Factour out saveInsightsData for live contacts

### DIFF
--- a/plugin-hrm-form/src/___tests__/mockGetConfig.js
+++ b/plugin-hrm-form/src/___tests__/mockGetConfig.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import mockV1 from '../formDefinitions/v1';
 
 jest.mock('../HrmFormPlugin', () => ({
@@ -24,6 +25,10 @@ jest.mock('../HrmFormPlugin', () => ({
         'TabbedForms-AddChildInfoTab': 'Child Information',
         'TabbedForms-CategoriesTab': 'Categories',
         'TabbedForms-AddCaseInfoTab': 'Summary',
+      },
+      featureFlags: {
+        enable_transfers: true,
+        enable_save_insights: true,
       },
     };
   },

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -24,9 +24,9 @@ const zambiaUpdates = (attributes, contactForm, caseForm) => {
   return attsToReturn;
 };
 
-const expectWithV1Zambia = (attributes, contactForm, caseForm, submissionContext) =>
+const expectWithV1Zambia = (attributes, contactForm, caseForm, extraParameters) =>
   [baseUpdates, contactlessTaskUpdates, zambiaUpdates]
-    .map(f => f(attributes, contactForm, caseForm, submissionContext))
+    .map(f => f(attributes, contactForm, caseForm, extraParameters))
     .reduce((acc, curr) => mergeAttributes(acc, curr), { ...attributes });
 
 test('Insights Data for non-data callType', async () => {
@@ -173,11 +173,11 @@ test('Insights Data for data callType', async () => {
     id: 123,
   };
 
-  const submissionContext = { helplineToSave: previousAttributes.helpline };
+  const extraParameters = { helplineToSave: previousAttributes.helpline };
 
-  const expectedNewAttributes = expectWithV1Zambia(twilioTask.attributes, contactForm, caseForm, submissionContext);
+  const expectedNewAttributes = expectWithV1Zambia(twilioTask.attributes, contactForm, caseForm, extraParameters);
 
-  const result = buildInsightsData(twilioTask, contactForm, caseForm, submissionContext);
+  const result = buildInsightsData(twilioTask, contactForm, caseForm, extraParameters);
 
   /*
    * const expectedNewAttributes = {
@@ -237,11 +237,11 @@ test('Handles contactless tasks', async () => {
     id: 123,
   };
 
-  const submissionContext = { helplineToSave: previousAttributes.helpline };
+  const extraParameters = { helplineToSave: previousAttributes.helpline };
 
-  const expectedNewAttributes = expectWithV1Zambia(twilioTask.attributes, contactForm, caseForm, submissionContext);
+  const expectedNewAttributes = expectWithV1Zambia(twilioTask.attributes, contactForm, caseForm, extraParameters);
 
-  const result = buildInsightsData(twilioTask, contactForm, caseForm, submissionContext);
+  const result = buildInsightsData(twilioTask, contactForm, caseForm, extraParameters);
 
   /*
    * const expectedNewAttributes = {

--- a/plugin-hrm-form/src/components/CustomCRMContainer.tsx
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.tsx
@@ -14,10 +14,6 @@ const offlineContactTask: OfflineContactTask = {
   taskSid: 'offline-contact-task-sid',
   channelType: 'default',
   attributes: { isContactlessTask: true, channelType: 'default' },
-  setAttributes: async newAttributes => {
-    offlineContactTask.attributes = { ...offlineContactTask.attributes, ...newAttributes };
-    return offlineContactTask;
-  },
 };
 
 type OwnProps = {

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -22,6 +22,7 @@ import {
   SearchContactResult,
   isOfflineContactTask,
   isTwilioTask,
+  SubmissionContext,
 } from '../types/types';
 
 /**
@@ -159,14 +160,15 @@ export function transformForm(form: TaskEntry): ContactRawJson {
 /**
  * Function that saves the form to Contacts table.
  * If you don't intend to complete the twilio task, set shouldFillEndMillis=false
- *
- * @param task
- * @param form
- * @param workerSid
- * @param uniqueIdentifier
- * @param shouldFillEndMillis
  */
-export async function saveToHrm(task, form, workerSid, uniqueIdentifier, shouldFillEndMillis = true) {
+export async function saveToHrm(
+  task,
+  form,
+  submissionContext: SubmissionContext,
+  workerSid: string,
+  uniqueIdentifier: string,
+  shouldFillEndMillis = true,
+) {
   // if we got this far, we assume the form is valid and ready to submit
   const metadata = shouldFillEndMillis ? fillEndMillis(form.metadata) : form.metadata;
   const conversationDuration = getConversationDuration(task, metadata);
@@ -212,7 +214,7 @@ export async function saveToHrm(task, form, workerSid, uniqueIdentifier, shouldF
     queueName: task.queueName,
     channel: task.channelType,
     number,
-    helpline: task.attributes.helplineToSave,
+    helpline: submissionContext.helplineToSave,
     conversationDuration,
     timeOfContact,
     taskId: uniqueIdentifier,

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -22,7 +22,7 @@ import {
   SearchContactResult,
   isOfflineContactTask,
   isTwilioTask,
-  SubmissionContext,
+  ExtraParameters,
 } from '../types/types';
 
 /**
@@ -164,7 +164,7 @@ export function transformForm(form: TaskEntry): ContactRawJson {
 export async function saveToHrm(
   task,
   form,
-  submissionContext: SubmissionContext,
+  extraParameters: ExtraParameters,
   workerSid: string,
   uniqueIdentifier: string,
   shouldFillEndMillis = true,
@@ -214,7 +214,7 @@ export async function saveToHrm(
     queueName: task.queueName,
     channel: task.channelType,
     number,
-    helpline: submissionContext.helplineToSave,
+    helpline: extraParameters.helplineToSave,
     conversationDuration,
     timeOfContact,
     taskId: uniqueIdentifier,

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -58,16 +58,16 @@ export const submitContactForm = async (task: CustomITask, contactForm: Contact,
   const { workerSid } = getConfig();
 
   const helplineToSave = await getHelplineToSave(task, contactForm);
-  const submissionContext = { helplineToSave };
+  const extraParameters = { helplineToSave };
 
   if (isOfflineContactTask(task)) {
     const targetWorkerSid = contactForm.contactlessTask.createdOnBehalfOf as string;
-    const finalAttributes = buildInsightsData(task, contactForm, caseForm, submissionContext);
+    const finalAttributes = buildInsightsData(task, contactForm, caseForm, extraParameters);
     const inBehalfTask = await assignOfflineContact(targetWorkerSid, finalAttributes);
-    return saveToHrm(task, contactForm, submissionContext, workerSid, inBehalfTask.sid);
+    return saveToHrm(task, contactForm, extraParameters, workerSid, inBehalfTask.sid);
   }
 
-  const finalAttributes = buildInsightsData(task, contactForm, caseForm, submissionContext);
+  const finalAttributes = buildInsightsData(task, contactForm, caseForm, extraParameters);
   await task.setAttributes(finalAttributes);
-  return saveToHrm(task, contactForm, submissionContext, workerSid, task.taskSid);
+  return saveToHrm(task, contactForm, extraParameters, workerSid, task.taskSid);
 };

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -122,7 +122,6 @@ export type OfflineContactTask = {
     helplineToSave?: string;
   };
   channelType: 'default';
-  setAttributes: (attributes: {}) => Promise<OfflineContactTask>;
 };
 
 export type InMyBehalfITask = ITask & { attributes: { isContactlessTask: true; isInMyBehalf: true } };
@@ -143,3 +142,7 @@ export function isInMyBehalfITask(task: CustomITask): task is InMyBehalfITask {
 export function isTwilioTask(task: CustomITask): task is ITask {
   return task && !isOfflineContactTask(task) && !isInMyBehalfITask(task);
 }
+
+export type SubmissionContext = {
+  helplineToSave: string;
+};

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -142,7 +142,9 @@ export function isInMyBehalfITask(task: CustomITask): task is InMyBehalfITask {
 export function isTwilioTask(task: CustomITask): task is ITask {
   return task && !isOfflineContactTask(task) && !isInMyBehalfITask(task);
 }
-
-export type SubmissionContext = {
+/**
+ * This type is used within the context of a form submission, to share values between HRM & Insights
+ */
+export type ExtraParameters = {
   helplineToSave: string;
 };


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-722

Note: better reviewed commit by commit.

This PR moves the "sending data to Insights for live contacts" logic out of the `beforeCompleteTask` event (addressing [this](https://github.com/techmatters/flex-plugins/pull/472#discussion_r666515823) and [this](https://github.com/techmatters/flex-plugins/pull/472#discussion_r666534390) comments). Instead this process will be in the same function that it is for offline contacts (`submitContactForm` function under `src/services/formSubmissionHelpers.ts`). This way, all of the process of saving to HRM and to Insights is handled in a single place, reducing the complexity, making easier to be consistent in both places and eliminating the need of API calls to keep in sync.
Also the `setAttributes` method is reverted (and removed) from offline contacts as now it has no utility.

All the combinations mentioned [here](https://github.com/techmatters/flex-plugins/pull/472#discussion_r666517839)  were tested, but please test them again in case I'm missing something.