### PR TITLE
Do not fallback to defaultFrom when there's no IP

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.js
@@ -231,6 +231,7 @@ describe('saveToHrm() (isContactlessTask)', () => {
       defaultFrom,
       attributes: {
         isContactlessTask: false,
+        ip: '', // Studio makes it empty string
       },
     };
     const form = createForm({ callType: callTypes.child, childFirstName: 'Jill' });

--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.js
@@ -223,7 +223,7 @@ describe('saveToHrm() (isContactlessTask)', () => {
     mockedFetch.mockClear();
   });
 
-  test('save defaultFrom when IP is null from web calltype', async () => {
+  test('save empty string when IP is null from web calltype', async () => {
     const defaultFrom = 'Anonymous';
     const webTaskWithoutIP = {
       queueName: 'queueName',
@@ -240,7 +240,7 @@ describe('saveToHrm() (isContactlessTask)', () => {
     await saveToHrm(webTaskWithoutIP, form, workerSid, uniqueIdentifier);
 
     const numberFromPOST = getNumberFromPOST(mockedFetch);
-    expect(numberFromPOST).toEqual(defaultFrom);
+    expect(numberFromPOST).toEqual('');
 
     mockedFetch.mockClear();
   });

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -63,7 +63,7 @@ export function getNumberFromTask(task: ITask) {
   } else if (task.channelType === channelTypes.whatsapp) {
     return task.defaultFrom.replace('whatsapp:', '');
   } else if (task.channelType === channelTypes.web) {
-    return task.attributes.ip || task.defaultFrom;
+    return task.attributes.ip;
   }
 
   return task.defaultFrom;


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-739
Primary reviewer: @GPaoloni 

Very simple PR that removes the fallback to `defaultFrom` when there's no IP.
The rest of the code already takes care of not showing the previous contact feature in this situation.