### PR TITLE
[FULLSTORY] Added Fullstory id to all deploy files

### DIFF
--- a/.github/workflows/aselo_beta.yml
+++ b/.github/workflows/aselo_beta.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"           
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$PROD_DATADOG_AS_ACCESS_TOKEN';
           export const datadogApplicationID = '$PROD_DATADOG_AS_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  

--- a/.github/workflows/ethiopia_production.yml
+++ b/.github/workflows/ethiopia_production.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"            
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$PROD_DATADOG_ET_ACCESS_TOKEN';
           export const datadogApplicationID = '$PROD_DATADOG_ET_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  

--- a/.github/workflows/ethiopia_staging.yml
+++ b/.github/workflows/ethiopia_staging.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"            
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$STG_DATADOG_ET_ACCESS_TOKEN';
           export const datadogApplicationID = '$STG_DATADOG_ET_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  

--- a/.github/workflows/malawi_production.yml
+++ b/.github/workflows/malawi_production.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"            
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$PROD_DATADOG_MW_ACCESS_TOKEN';
           export const datadogApplicationID = '$PROD_DATADOG_MW_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  

--- a/.github/workflows/malawi_staging.yml
+++ b/.github/workflows/malawi_staging.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"            
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$STG_DATADOG_MW_ACCESS_TOKEN';
           export const datadogApplicationID = '$STG_DATADOG_MW_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  

--- a/.github/workflows/south_africa_production.yml
+++ b/.github/workflows/south_africa_production.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"           
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$PROD_DATADOG_ZA_ACCESS_TOKEN';
           export const datadogApplicationID = '$PROD_DATADOG_ZA_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  

--- a/.github/workflows/south_africa_staging.yml
+++ b/.github/workflows/south_africa_staging.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"           
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$STG_DATADOG_ZA_ACCESS_TOKEN';
           export const datadogApplicationID = '$STG_DATADOG_ZA_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  

--- a/.github/workflows/zambia_production.yml
+++ b/.github/workflows/zambia_production.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"            
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$PROD_DATADOG_ZM_ACCESS_TOKEN';
           export const datadogApplicationID = '$PROD_DATADOG_ZM_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  

--- a/.github/workflows/zambia_staging.yml
+++ b/.github/workflows/zambia_staging.yml
@@ -47,7 +47,12 @@ jobs:
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "ROLLBAR_ACCESS_TOKEN"
-          env_variable_name: "ROLLBAR_ACCESS_TOKEN"            
+          env_variable_name: "ROLLBAR_ACCESS_TOKEN"
+      - name: Set Fullstory org id
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "FULLSTORY_ID"
+          env_variable_name: "FULLSTORY_ID"
       # Create temporal files for the release
       - name: Create appConfig.js
         run: cp ./public/appConfig.example.js ./public/appConfig.js
@@ -69,6 +74,7 @@ jobs:
           export const rollbarAccessToken = '$ROLLBAR_ACCESS_TOKEN';
           export const datadogAccessToken = '$STG_DATADOG_ZM_ACCESS_TOKEN';
           export const datadogApplicationID = '$STG_DATADOG_ZM_APP_ID';
+          export const fullStoryId = '$FULLSTORY_ID';
           EOT
         working-directory: ./plugin-hrm-form
       # Runs a single command using the runners shell  


### PR DESCRIPTION
This PR adds Fullstory id to all the deploy actions except for Aselo Development (done at https://github.com/techmatters/flex-plugins/pull/512).

IMPORTANT: This PR should be merged only after https://github.com/techmatters/flex-plugins/pull/512 and when we are sure we want to start using Fullstory in the rest of the environments.