### PR TITLE
[DON'T MERGE] Block IP address display

### DIFF
--- a/plugin-hrm-form/src/utils/formatters.ts
+++ b/plugin-hrm-form/src/utils/formatters.ts
@@ -119,7 +119,7 @@ export const formatNumberFromTask = task => {
     return getNumberFromTask(task).replace(/[0-9]/g, 'x');
   }
   return getNumberFromTask(task);
-}
+};
 
 /**
  * Removes the prefixed milliseconds from the fileName saved at AWS and returns only the original fileName


### PR DESCRIPTION
This change blocks the user's IP address from display to the counselor. Since our upcoming presentation will be recorded and published on the internet forever, I didn't want our IPs to be visible.

This is branched off of the currently deployed commit to Beta (`1cd5799`). I plan to just deploy Beta, and then revert afterward.

I'm not bothering with blocking other identifiers, since they are app-scoped and also appear in the task list.

cc @dee-luo 

![image](https://user-images.githubusercontent.com/10714292/137553868-e3149a92-91cd-4ca8-925f-394f24743fe8.png)
