### PR TITLE
Remove metadata from ContactRawJson

### DIFF
--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -145,7 +145,6 @@ export function transformForm(form: TaskEntry): ContactRawJson {
     callType,
     callerInformation,
     childInformation,
-    metadata,
     caseInformation: {
       ...transformedValues.caseInformation,
       categories,

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -81,11 +81,6 @@ export type ContactRawJson = {
   callerInformation: InformationObject;
   caseInformation: { categories: {} } & { [key: string]: string | boolean | {} }; // // having {} makes type looser here because of this https://github.com/microsoft/TypeScript/issues/17867. Possible/future solution https://github.com/microsoft/TypeScript/pull/29317
   contactlessTask: { [key: string]: string | boolean };
-  metadata: {
-    startMillis: number;
-    endMillis: number;
-    recreated: boolean;
-  };
 };
 
 // Information about a single contact, as expected from search contacts endpoint (we might want to reuse this type in backend) - (is this a correct placement for this?)


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-808
Primary reviewer: @GPaoloni 

This PR removes metadata from ContactRawJson. All the metadata data that we need is already being sent as **timeOfContact** and **conversationDuration** columns.