### PR TITLE
Added validation to prevent offline contacts dates be lesser than EPOCH

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -54,7 +54,15 @@ export const createContactlessTaskTabDefinition = (
       required: { value: true, message: 'RequiredFieldError' },
       validate: date => {
         const [y, m, d] = splitDate(date);
-        return isFuture(new Date(y, m - 1, d)) ? 'DateCantBeGreaterThanToday' : null;
+        const inputDate = new Date(y, m - 1, d);
+
+        // Date is lesser than Unix epoch (00:00:00 UTC on 1 January 1970)
+        if (inputDate.getTime() < 0) return 'DateCantBeLesserThanEpoch';
+
+        // Date is greater than "today"
+        if (isFuture(inputDate)) return 'DateCantBeGreaterThanToday';
+
+        return null;
       },
     },
     {

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -285,6 +285,7 @@
 
   "RequiredFieldError": "This field is required.",
   "DateCantBeGreaterThanToday": "Date can't be greater than today.",
+  "DateCantBeLesserThanEpoch": "Date can't be lesser than 00:00:00 UTC on 1 January 1970.",
   "TimeCantBeGreaterThanNow": "Time can't be greater than now.",
   "NoCaseSummary": "No case summary",
   "CannedResponses": "Canned Responses",


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-840

This PR prevents the user to input a date older than Unix epoch (00:00:00 UTC on 1 January 1970) in the offline contact date input.

![Screenshot from 2021-10-27 17-48-19](https://user-images.githubusercontent.com/15805319/139146026-4a6712ad-8aa0-4948-a72d-603f4d03b993.png)
