### PR TITLE
Fix Add Another Task button to wait for next task

### DIFF
--- a/plugin-hrm-form/src/components/ManualPullButton/index.tsx
+++ b/plugin-hrm-form/src/components/ManualPullButton/index.tsx
@@ -42,7 +42,15 @@ const ManualPullButton: React.FC<Props> = ({ queuesStatusState, chatChannelCapac
 
   const { maxMessageCapacity } = worker.attributes;
   const maxCapacityReached = chatChannelCapacity >= parseInt(maxMessageCapacity, 10);
-  const disabled = maxCapacityReached || !isAnyChatPending(queuesStatusState.queuesStatus) || isWaitingNewTask;
+  const { isAvailable } = worker.worker;
+  const noTasks = worker.tasks.size === 0;
+
+  const disabled =
+    !isAvailable ||
+    noTasks ||
+    maxCapacityReached ||
+    !isAnyChatPending(queuesStatusState.queuesStatus) ||
+    isWaitingNewTask;
 
   return (
     <AddTaskButton

--- a/plugin-hrm-form/src/components/ManualPullButton/index.tsx
+++ b/plugin-hrm-form/src/components/ManualPullButton/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React from 'react';
+import React, { useState } from 'react';
 import { Notifications } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 
@@ -16,15 +16,20 @@ type OwnProps = {
 type Props = OwnProps & ReturnType<typeof mapStateToProps>;
 
 const ManualPullButton: React.FC<Props> = ({ queuesStatusState, chatChannelCapacity, worker, workerClient }) => {
+  const [isWaitingNewTask, setWaitingNewTask] = useState(false);
+
   // Increase chat capacity, if no reservation is created within 5 seconds, capacity is decreased and shows a notification.
   const increaseChatCapacity = async () => {
+    setWaitingNewTask(true);
     let alertTimeout = null;
 
     const cancelTimeout = () => {
+      setWaitingNewTask(false);
       clearTimeout(alertTimeout);
     };
 
     alertTimeout = setTimeout(async () => {
+      setWaitingNewTask(false);
       workerClient.removeListener('reservationCreated', cancelTimeout);
       Notifications.showNotification('NoTaskAssignableNotification');
       await adjustChatCapacity('decrease');
@@ -37,9 +42,16 @@ const ManualPullButton: React.FC<Props> = ({ queuesStatusState, chatChannelCapac
 
   const { maxMessageCapacity } = worker.attributes;
   const maxCapacityReached = chatChannelCapacity >= parseInt(maxMessageCapacity, 10);
-  const disabled = maxCapacityReached || !isAnyChatPending(queuesStatusState.queuesStatus);
+  const disabled = maxCapacityReached || !isAnyChatPending(queuesStatusState.queuesStatus) || isWaitingNewTask;
 
-  return <AddTaskButton onClick={increaseChatCapacity} disabled={disabled} label="ManualPullButtonText" />;
+  return (
+    <AddTaskButton
+      onClick={increaseChatCapacity}
+      disabled={disabled}
+      isLoading={isWaitingNewTask}
+      label="ManualPullButtonText"
+    />
+  );
 };
 
 ManualPullButton.displayName = 'ManualPullButton';

--- a/plugin-hrm-form/src/components/common/AddTaskButton/index.tsx
+++ b/plugin-hrm-form/src/components/common/AddTaskButton/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Template } from '@twilio/flex-ui';
+import { CircularProgress } from '@material-ui/core';
 
 import {
   AddTaskButtonBase,
@@ -14,9 +15,10 @@ type Props = {
   onClick: (() => void) | (() => Promise<void>);
   disabled: boolean;
   label: string;
+  isLoading?: boolean;
 };
 
-const AddTaskButton: React.FC<Props> = ({ onClick, disabled, label }) => {
+const AddTaskButton: React.FC<Props> = ({ onClick, disabled, label, isLoading }) => {
   return (
     <AddTaskButtonBase
       onClick={onClick}
@@ -31,6 +33,7 @@ const AddTaskButton: React.FC<Props> = ({ onClick, disabled, label }) => {
         <AddTaskText>
           <Template code={label} />
         </AddTaskText>
+        {isLoading && <CircularProgress size={12} />}
       </AddTaskContent>
     </AddTaskButtonBase>
   );

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -565,6 +565,7 @@ export const AddTaskText = styled(FontOpenSans)`
   font-size: 12px;
   line-height: 16px;
   font-weight: 600;
+  margin-right: 5px;
 `;
 AddTaskText.displayName = 'AddTaskText';
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-841
Primary Reviewer: @GPaoloni 

This PR fixes the Add Another Task Button to be disabled (and shows a spinner) after clicking on it. It will only be clickable again after one of the following happens:
- A reservation to the user gets created, or;
- A reservation fails to be created after 5 seconds.
