### PR TITLE
Added optional id to AddTaskButton

### DIFF
--- a/plugin-hrm-form/src/components/ManualPullButton/index.tsx
+++ b/plugin-hrm-form/src/components/ManualPullButton/index.tsx
@@ -54,6 +54,7 @@ const ManualPullButton: React.FC<Props> = ({ queuesStatusState, chatChannelCapac
 
   return (
     <AddTaskButton
+      id="ManualPullButton"
       onClick={increaseChatCapacity}
       disabled={disabled}
       isLoading={isWaitingNewTask}

--- a/plugin-hrm-form/src/components/common/AddTaskButton/index.tsx
+++ b/plugin-hrm-form/src/components/common/AddTaskButton/index.tsx
@@ -16,11 +16,13 @@ type Props = {
   disabled: boolean;
   label: string;
   isLoading?: boolean;
+  id?: string;
 };
 
-const AddTaskButton: React.FC<Props> = ({ onClick, disabled, label, isLoading }) => {
+const AddTaskButton: React.FC<Props> = ({ onClick, disabled, label, isLoading, id }) => {
   return (
     <AddTaskButtonBase
+      id={id}
       onClick={onClick}
       className="Twilio-TaskListBaseItem-UpperArea css-xz5ie1"
       disabled={disabled}


### PR DESCRIPTION
This PR:
- Adds an option id prop to `AddTaskButton`.
- Adds `id=ManualPullButton` as the id for `ManualPullButton` (makes usage of the above).