### PR TITLE
Clear categories redux state when selecting a different helpline

### DIFF
--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -56,15 +56,9 @@ const TaskView: React.FC<Props> = props => {
   // Set contactForm.helpline for all contacts on the first run. React to helpline changes for offline contacts only
   React.useEffect(() => {
     const setHelpline = async () => {
-      console.log('>>>>> 1) setHelpline called');
       if (task && !isStandaloneITask(task)) {
-        console.log('>>>>> 2) conditions met, checking helpline to save');
         const helplineToSave = await getHelplineToSave(task, contactlessTask || {});
-        console.log('>> helpline is: ', helpline);
-        console.log('>> helplineToSave is: ', helplineToSave);
-        console.log('>> contactlessTask.helpline is: ', contactlessTask?.helpline);
         if (helpline !== helplineToSave) {
-          console.log('>>>>> 3) Updating helpline!!');
           updateHelpline(task.taskSid, helplineToSave);
         }
       }

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -49,28 +49,35 @@ const TaskView: React.FC<Props> = props => {
     };
   }, [task]);
 
+  const contactInitialized = Boolean(contactForm);
   const helpline = contactForm?.helpline;
   const contactlessTask = contactForm?.contactlessTask;
-  const firstRunHelplineEffect = React.useRef(true);
 
   // Set contactForm.helpline for all contacts on the first run. React to helpline changes for offline contacts only
   React.useEffect(() => {
     const setHelpline = async () => {
+      console.log('>>>>> 1) setHelpline called');
       if (task && !isStandaloneITask(task)) {
+        console.log('>>>>> 2) conditions met, checking helpline to save');
         const helplineToSave = await getHelplineToSave(task, contactlessTask || {});
+        console.log('>> helpline is: ', helpline);
+        console.log('>> helplineToSave is: ', helplineToSave);
+        console.log('>> contactlessTask.helpline is: ', contactlessTask?.helpline);
         if (helpline !== helplineToSave) {
+          console.log('>>>>> 3) Updating helpline!!');
           updateHelpline(task.taskSid, helplineToSave);
         }
       }
     };
 
-    // Only run setHelpline if is the first time this effect is called or if contactlessTask.helpline has changed
+    // Only run setHelpline if a) contactForm.helpline is not set or b) if the task is an offline contact and contactlessTask.helpline has changed
     const helplineChanged = contactlessTask?.helpline && helpline !== contactlessTask.helpline;
-    if (firstRunHelplineEffect.current || helplineChanged) {
-      firstRunHelplineEffect.current = false;
+    const shouldSetHelpline = contactInitialized && (!helpline || (isOfflineContactTask(task) && helplineChanged));
+
+    if (shouldSetHelpline) {
       setHelpline();
     }
-  }, [contactlessTask, helpline, task, updateHelpline]);
+  }, [contactlessTask, contactInitialized, helpline, task, updateHelpline]);
 
   // If this task is not the active task, or if the task is not accepted yet, hide it
   const show =

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -56,14 +56,9 @@ const TaskView: React.FC<Props> = props => {
   // Set contactForm.helpline for all contacts on the first run. React to helpline changes for offline contacts only
   React.useEffect(() => {
     const setHelpline = async () => {
-      console.log('>>>> 1: setHelpline is invoked');
       if (task && !isStandaloneITask(task)) {
-        console.log('>>>> 2: setHelpline is doing something');
         const helplineToSave = await getHelplineToSave(task, contactlessTask || {});
-        console.log('helpline is:', helpline);
-        console.log('helplineToSave is:', helplineToSave);
         if (helpline !== helplineToSave) {
-          console.log('>>>> 3: updating helpline!!');
           updateHelpline(task.taskSid, helplineToSave);
         }
       }

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -49,18 +49,33 @@ const TaskView: React.FC<Props> = props => {
     };
   }, [task]);
 
-  const contactlessTask = contactForm && contactForm.contactlessTask;
+  const helpline = contactForm?.helpline;
+  const contactlessTask = contactForm?.contactlessTask;
+  const firstRunHelplineEffect = React.useRef(true);
 
+  // Set contactForm.helpline for all contacts on the first run. React to helpline changes for offline contacts only
   React.useEffect(() => {
-    const fetchHelpline = async () => {
-      if (task && contactlessTask && !isStandaloneITask(task)) {
+    const setHelpline = async () => {
+      console.log('>>>> 1: setHelpline is invoked');
+      if (task && !isStandaloneITask(task)) {
+        console.log('>>>> 2: setHelpline is doing something');
         const helplineToSave = await getHelplineToSave(task, contactlessTask || {});
-        updateHelpline(task.taskSid, helplineToSave);
+        console.log('helpline is:', helpline);
+        console.log('helplineToSave is:', helplineToSave);
+        if (helpline !== helplineToSave) {
+          console.log('>>>> 3: updating helpline!!');
+          updateHelpline(task.taskSid, helplineToSave);
+        }
       }
     };
 
-    fetchHelpline();
-  }, [task, contactlessTask, updateHelpline]);
+    // Only run setHelpline if is the first time this effect is called or if contactlessTask.helpline has changed
+    const helplineChanged = contactlessTask?.helpline && helpline !== contactlessTask.helpline;
+    if (firstRunHelplineEffect.current || helplineChanged) {
+      firstRunHelplineEffect.current = false;
+      setHelpline();
+    }
+  }, [contactlessTask, helpline, task, updateHelpline]);
 
   // If this task is not the active task, or if the task is not accepted yet, hide it
   const show =

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -14,7 +14,7 @@ import { updateCallType, updateForm } from '../../states/contacts/actions';
 import { searchResultToContactForm } from '../../services/ContactService';
 import { removeOfflineContact } from '../../services/formSubmissionHelpers';
 import { changeRoute } from '../../states/routing/actions';
-import type { TaskEntry } from '../../states/contacts/reducer';
+import { TaskEntry, emptyCategories } from '../../states/contacts/reducer';
 import { TabbedFormSubroutes, NewCaseSubroutes } from '../../states/routing/types';
 import { CustomITask, isOfflineContactTask, SearchContact } from '../../types/types';
 import { TabbedFormsContainer, Box, StyledTabs } from '../../styles/HrmStyles';
@@ -82,6 +82,16 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, task, contactForm, cu
     shouldFocusError: false,
     mode: 'onChange',
   });
+
+  const { setValue } = methods;
+  const { helpline } = contactForm;
+
+  /**
+   * Clear some parts of the form state when helpline changes.
+   */
+  React.useEffect(() => {
+    setValue('categories', emptyCategories);
+  }, [helpline, setValue]);
 
   if (routing.route !== 'tabbed-forms') return null;
 
@@ -153,7 +163,6 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, task, contactForm, cu
 
   const isDataCallType = !isNonDataCallType(contactForm.callType);
   const showSubmitButton = !isEmptyCallType(contactForm.callType) && tabIndex === tabs.length - 1;
-  const { helpline } = contactForm;
 
   return (
     <FormProvider {...methods}>

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -69,7 +69,7 @@ export const createNewTaskEntry = (definitions: DefinitionVersion) => (recreated
   const contactlessTask = initialContactlessTaskTabDefinition.reduce(createStateItem, {});
 
   return {
-    helpline: defaultHelpline,
+    helpline: '',
     callType: '',
     childInformation: initialChildInformation,
     callerInformation: initialCallerInformation,

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -37,7 +37,7 @@ type ContactsState = {
   };
 };
 
-const emptyCategories = [];
+export const emptyCategories = [];
 
 // eslint-disable-next-line import/no-unused-modules
 export const createNewTaskEntry = (definitions: DefinitionVersion) => (recreated: boolean): TaskEntry => {

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -37,6 +37,8 @@ type ContactsState = {
   };
 };
 
+const emptyCategories = [];
+
 // eslint-disable-next-line import/no-unused-modules
 export const createNewTaskEntry = (definitions: DefinitionVersion) => (recreated: boolean): TaskEntry => {
   const initialChildInformation = definitions.tabbedForms.ChildInformationTab.reduce(createStateItem, {});
@@ -73,7 +75,7 @@ export const createNewTaskEntry = (definitions: DefinitionVersion) => (recreated
     callerInformation: initialCallerInformation,
     caseInformation: initialCaseInformation,
     contactlessTask,
-    categories: [],
+    categories: emptyCategories,
     metadata,
   };
 };
@@ -217,6 +219,7 @@ export function reduce(state = initialState, action: t.ContactsActionType | Gene
           [action.taskId]: {
             ...state.tasks[action.taskId],
             helpline: action.helpline,
+            categories: emptyCategories,
           },
         },
       };


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-754
Primary reviewer: @murilovmachado 

This PR:
- Cleans categories form state on `UPDATE_HELPLINE` action. I think this is the cleanest way to do this, as it's part of the same action. The alternative would be to dispatch a second action to clear the categories after helpline changes.
- Renamed `fetchHelpline` to `setHelpline` (`TaskView` component) to empathize that it changes some state.
- Rework on `TaskView` effect that triggers ~`fetchHelpline`~ `setHelpline`: 
  While working on this issue, I've realized:
  - This effect was called each time _any_ value of `contactForm.contactlessTask` changed (cause it's in the dependencies array). While this is fine, the function ~`fetchHelpline`~ `setHelpline` was also invoked each time the effect executed. This is not a good behavior IMO as  ~`fetchHelpline`~ `setHelpline` is an async function that also dispatches a Redux action, we should call it when required only. 
  - The initial form state included `defaultHelpline` as the `contactForm.helpline` value. This was later on modified by the sequential calls to ~`fetchHelpline`~ `setHelpline` which lead to the right value, but I think is cleaner to start empty (`''`) and then set the proper value.
  
  Both of the above are addressed by:
  - `contactForm.helpline` initializes as empty string, then is properly set. Should we add some kind of check here to at least warn us if `helpline` is ever empty when the form is submitted?
  - Including conditions that need to be met in order to call ~`fetchHelpline`~ `setHelpline`.
  - ~`fetchHelpline`~ `setHelpline` will actually dispatch the `UPDATE_HELPLINE` action only if really needed (`helpline !== helplineToSave`).

Please take a deep review of this PR, as `helpline` is a critical piece of our system. Feel free to provide feedback if you think any of this changes is unnecessary/could be easier/whatever suggestion.

Note: You can checkout to [this commit](https://github.com/techmatters/flex-plugins/pull/539/commits/5a1f8a8438eb105c876d1217c41414339480bc75) that includes some `console.log`s prefixed with `>>>>>` to make easier spotting when ~`fetchHelpline`~ `setHelpline` runs and when it changes some value.
What to test in this PR?:
-  The initial issue is solved (categories are cleaned when helpline changes).
- `contactForm.helpline` starts empty but then is always set for all kind of tasks.
- ~`fetchHelpline`~ `setHelpline` runs only when required. That is if a) `contactForm.helpline` is not set or b) if the task is an offline contact and `contactForm.contactlessTask.helpline` changed.
- The correct `contactForm.helpline` is carried all the lifetime of the contact, being the one submitted with the form when the counselor saves it.