### PR TITLE
Fix: Ethnicity field autopopulates to Unknown

### DIFF
--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -39,13 +39,17 @@ const getAnswerOrUnknown = (
   definition: FormDefinition,
   mapperFunction: MapperFunction = mapGenericOption,
 ) => {
+  // This prevents setting redux state with the 'Unknown' value for a property that is not asked by the pre-survey
+  if (!answers[key]) return null;
+
+  // This prevents setting redux state with the 'Unknown' value for a property that is not present on the definition
   if (!definition.find(e => e.name === key)) {
     console.error(`${key} does not exist in the current definition`);
-    return undefined; // This prevents saving at redux a property that is not present on the definition with the 'Unknown' value
+    return null;
   }
 
   const unknown = getUnknownOption(key, definition);
-  const isUnknownAnswer = !answers[key] || answers[key].error || answers[key].answer === unknown;
+  const isUnknownAnswer = answers[key].error || answers[key].answer === unknown;
 
   if (isUnknownAnswer) return unknown;
 
@@ -74,11 +78,11 @@ export const prepopulateForm = (task: ITask) => {
     const ethnicity = getAnswerOrUnknown(answers, 'ethnicity', definitionForm);
 
     const values = {
-      firstName,
-      gender,
-      age,
-      ethnicity,
-      language: capitalize(language),
+      ...(firstName && { firstName }),
+      ...(gender && { gender }),
+      ...(age && { age }),
+      ...(ethnicity && { ethnicity }),
+      ...(language && { language: capitalize(language) }),
     };
 
     Manager.getInstance().store.dispatch(prepopulateFormAction(callType, values, task.taskSid));

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -39,8 +39,11 @@ const getAnswerOrUnknown = (
   definition: FormDefinition,
   mapperFunction: MapperFunction = mapGenericOption,
 ) => {
+  // This keys must be set with 'Unknown' value even if there's no answer
+  const isRequiredKey = key === 'age' || key === 'gender';
+
   // This prevents setting redux state with the 'Unknown' value for a property that is not asked by the pre-survey
-  if (!answers[key]) return null;
+  if (!isRequiredKey && !answers[key]) return null;
 
   // This prevents setting redux state with the 'Unknown' value for a property that is not present on the definition
   if (!definition.find(e => e.name === key)) {


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-862
Primary reviewer: @murilovmachado 

This PR:
- Changes `getAnswerOrUnknown` function to return `null` if a requested `key` is not part of the `answers` object (bot's memory). By request, `age` and `gender` are excepted: `Unknown` is returned even if there's no answer.
- Before dispatching `prepopulateFormAction`, fill the `values` argument object only with the keys of pre-survey that actually contains a value (a [truthy value](https://developer.mozilla.org/en-US/docs/Glossary/Truthy)). The edge case for `"0"` works fine because is not an integer, but a non-empty string.

What to test here:
- Pre survey continues to work as expected.
- Pre survey does not fills ethnicity for ZM, as it's not part of the questions (thus `answers['ethnicity']` is undefined).
- Pre survey does fills ethnicity for BR. To easily test this, you can modify the task attributes while it is still pending to include a value for `answers['ethnicity']`, mimicking the behavior if this question would have been part of pre survey. When accepting the task, this value should be taken into consideration.

Note: it would be great at some point, have a little time to include unit tests for this piece of code.