### PR TITLE
Changed to use helplineLanguage in service configuration

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -247,7 +247,7 @@ export default class HrmFormPlugin extends FlexPlugin {
    * @param flex { typeof import('@twilio/flex-ui') }
    * @param manager { import('@twilio/flex-ui').Manager }
    */
-  init(flex, manager) {
+  async init(flex, manager) {
     loadCSS('https://use.fontawesome.com/releases/v5.15.1/css/solid.css');
 
     if (process.env.NODE_ENV !== 'development')
@@ -262,7 +262,7 @@ export default class HrmFormPlugin extends FlexPlugin {
      * localization setup (translates the UI if necessary)
      * WARNING: the way this is done right now is "hacky". More info in initLocalization declaration
      */
-    const { translateUI, getMessage } = setUpLocalization(config);
+    const { translateUI, getMessage } = await setUpLocalization(config);
 
     const setupObject = { ...config, translateUI, getMessage };
 

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -32,13 +32,13 @@ export const getConfig = () => {
   const logoUrl = manager.serviceConfiguration.attributes.logo_url;
   const chatServiceSid = manager.serviceConfiguration.chat_service_instance_sid;
   const workerSid = manager.workerClient.sid;
-  const { helpline, counselorLanguage, helplineLanguage } = manager.workerClient.attributes;
+  const { helpline, counselorLanguage } = manager.workerClient.attributes;
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
   const counselorName = manager.workerClient.attributes.full_name;
   const isSupervisor = manager.workerClient.attributes.roles.includes('supervisor');
   const {
-    configuredLanguage,
+    helplineLanguage,
     definitionVersion,
     pdfImagesSource,
     multipleOfficeSupport,
@@ -60,7 +60,6 @@ export const getConfig = () => {
     currentWorkspace,
     counselorLanguage,
     helplineLanguage,
-    configuredLanguage,
     identity,
     token,
     counselorName,
@@ -152,7 +151,7 @@ const setUpTransfers = setupObject => {
 const setUpLocalization = config => {
   const manager = Flex.Manager.getInstance();
 
-  const { counselorLanguage, helplineLanguage, configuredLanguage } = config;
+  const { counselorLanguage, helplineLanguage } = config;
 
   const twilioStrings = { ...manager.strings }; // save the originals
   const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
@@ -161,7 +160,7 @@ const setUpLocalization = config => {
     Flex.Actions.invokeAction('NavigateToView', { viewName: manager.store.getState().flex.view.activeView }); // force a re-render
   };
   const localizationConfig = { twilioStrings, setNewStrings, afterNewStrings };
-  const initialLanguage = counselorLanguage || helplineLanguage || configuredLanguage;
+  const initialLanguage = counselorLanguage || helplineLanguage;
 
   return initLocalization(localizationConfig, initialLanguage);
 };

--- a/plugin-hrm-form/src/___tests__/mockGetConfig.js
+++ b/plugin-hrm-form/src/___tests__/mockGetConfig.js
@@ -12,7 +12,6 @@ jest.mock('../HrmFormPlugin', () => ({
       currentWorkspace: '',
       counselorLanguage: '',
       helplineLanguage: '',
-      configuredLanguage: '',
       identity: '',
       token: '',
       counselorName: '',

--- a/plugin-hrm-form/src/utils/pluginHelpers.js
+++ b/plugin-hrm-form/src/utils/pluginHelpers.js
@@ -65,13 +65,14 @@ export const getMessage = messageKey => async language => {
  * @param {{ twilioStrings: any; setNewStrings: (newStrings: any) => void; afterNewStrings: (language: string) => void; }} localizationConfig
  * @param {string} initialLanguage
  */
-export const initLocalization = (localizationConfig, initialLanguage) => {
+export const initLocalization = async (localizationConfig, initialLanguage) => {
   const translateUI = initTranslateUI(localizationConfig);
 
-  const { setNewStrings } = localizationConfig;
-
-  setNewStrings(defaultTranslation);
-  if (initialLanguage && initialLanguage !== defaultLanguage) translateUI(initialLanguage);
+  if (initialLanguage && initialLanguage !== defaultLanguage) await translateUI(initialLanguage);
+  else {
+    const { setNewStrings } = localizationConfig;
+    setNewStrings(defaultTranslation);
+  }
 
   return {
     translateUI,

--- a/plugin-hrm-form/src/utils/pluginHelpers.js
+++ b/plugin-hrm-form/src/utils/pluginHelpers.js
@@ -68,11 +68,10 @@ export const getMessage = messageKey => async language => {
 export const initLocalization = async (localizationConfig, initialLanguage) => {
   const translateUI = initTranslateUI(localizationConfig);
 
+  const { setNewStrings } = localizationConfig;
+  setNewStrings(defaultTranslation);
+
   if (initialLanguage && initialLanguage !== defaultLanguage) await translateUI(initialLanguage);
-  else {
-    const { setNewStrings } = localizationConfig;
-    setNewStrings(defaultTranslation);
-  }
 
   return {
     translateUI,

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -132,8 +132,8 @@ const handleTransferredTask = async task => {
   await restoreFormIfTransfer(task);
 };
 
-const getTaskLanguage = ({ helplineLanguage, configuredLanguage }) => ({ task }) =>
-  task.attributes.language || helplineLanguage || configuredLanguage;
+const getTaskLanguage = ({ counselorLanguage, helplineLanguage }) => ({ task }) =>
+  task.attributes.language || counselorLanguage || helplineLanguage;
 
 /**
  * @param {string} messageKey


### PR DESCRIPTION
This PR removes the old `configuredLanguage` property and changes code to use `helplineLanguage` instead.
From this PR, the order of language that will be used is:
- `counselorLanguage` from worker attributes.
- `helplineLanguage` from service configuration.
- `defaultLanguage` hardcoded.

For messages sent to the person in contact, an attempt to retrieve `task.attributes.language` will be performed prior to the above.

The later commits changes the plugin `init` function to be `async` and allows fetching translations from remote source. In order for this to work properly we should add a component that indicates a loading state until the translation is complete. I can either finish this or merge only the first commit for the original changes, leaving the rest for a later one (if desired).