### PR TITLE
Save pending contacts at the Sync Client

### DIFF
--- a/plugin-hrm-form/src/dualWrite/index.ts
+++ b/plugin-hrm-form/src/dualWrite/index.ts
@@ -1,6 +1,7 @@
 import { ITask } from '@twilio/flex-ui';
 
 import { getConfig } from '../HrmFormPlugin';
+import { savePendingContactToSharedState } from '../utils/sharedState';
 import saveContactToSaferNet from './br';
 
 type DualWriteFn = (task: ITask, payload: any) => Promise<void>;
@@ -19,6 +20,10 @@ export const saveContactToExternalBackend = async (task: ITask, payload: any) =>
 
   const saveContact = saveContactByDefinitionVersion[definitionVersion];
   if (saveContact) {
-    await saveContact(task, payload);
+    try {
+      await saveContact(task, payload);
+    } catch (err) {
+      savePendingContactToSharedState(task, payload, err);
+    }
   }
 };

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -240,7 +240,6 @@ export const saveContact = async (
 ) => {
   const response = await saveContactToHrm(task, form, workerSid, uniqueIdentifier, shouldFillEndMillis);
 
-  // TODO: add catch clause to handle saving to Sync Doc
   try {
     await saveContactToExternalBackend(task, response.requestPayload);
   } finally {

--- a/plugin-hrm-form/src/services/fetchProtectedApi.js
+++ b/plugin-hrm-form/src/services/fetchProtectedApi.js
@@ -28,7 +28,8 @@ const fetchProtectedApi = async (endPoint, body = {}) => {
   const responseJson = await response.json();
 
   if (!response.ok) {
-    throw new Error(responseJson.message);
+    const option = responseJson.stack ? { cause: responseJson.stack } : null;
+    throw new Error(responseJson.message, option);
   }
 
   return responseJson;

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -88,6 +88,8 @@
 
   "SharedStateSaveFormError": "The information stored in the form couldn't be saved. Task will be transferred anyway.",
   "SharedStateLoadFormError": "The information stored in the form by previous counsellor couldn't be retrieved. Starting current task with clear contact form.",
+  "SharedStateSaveContactError": "Could not save pending contact at the Shared State.",
+  "SharedStateRetryPendingContactsError": "Could not retry saving the pending contacts from the Shared State.",
 
   "Transfer-TransferButton": "Transfer",
   "Transfer-AcceptTransferButton": "Accept Transfer",

--- a/plugin-hrm-form/src/utils/sharedState.js
+++ b/plugin-hrm-form/src/utils/sharedState.js
@@ -1,4 +1,8 @@
 import { getConfig } from '../HrmFormPlugin';
+import { saveContactToExternalBackend } from '../dualWrite';
+
+const isSharedStateClientConnected = sharedStateClient =>
+  sharedStateClient && sharedStateClient.connectionState === 'connected';
 
 /**
  * Saves the actual form into the Sync Client
@@ -11,7 +15,7 @@ export const saveFormSharedState = async (form, task) => {
   if (!featureFlags.enable_transfers) return null;
 
   try {
-    if (sharedStateClient === undefined || sharedStateClient.connectionState !== 'connected') {
+    if (!isSharedStateClientConnected(sharedStateClient)) {
       console.error('Error with Sync Client conection. Sync Client object is: ', sharedStateClient);
       window.alert(strings.SharedStateSaveFormError);
       return null;
@@ -43,7 +47,7 @@ export const loadFormSharedState = async task => {
   if (!featureFlags.enable_transfers) return null;
 
   try {
-    if (sharedStateClient === undefined || sharedStateClient.connectionState !== 'connected') {
+    if (!isSharedStateClientConnected(sharedStateClient)) {
       console.error('Error with Sync Client conection. Sync Client object is: ', sharedStateClient);
       window.alert(strings.SharedStateLoadFormError);
       return null;
@@ -63,6 +67,75 @@ export const loadFormSharedState = async task => {
     return null;
   } catch (err) {
     console.error('Error while loading form from shared state', err);
+    return null;
+  }
+};
+
+/**
+ * This function creates an object with all parseable attributes from the original Twilio Task.
+ *
+ * The twilio task by itself cannot be passed directly to be store at the Shared State.
+ * This happens because, internally, it tries to parse the object but it fails because of circular dependencies.
+ *
+ * @param {*} task Twilio Task
+ * @returns Parseable copy of the Twilio Task
+ */
+const copyTask = task => {
+  const taskToReturn = {};
+  Object.keys(task._task).forEach(key => {
+    const value = task[key];
+    if (['object', 'string', 'number'].includes(typeof value)) {
+      taskToReturn[key] = task[key];
+    }
+  });
+
+  return taskToReturn;
+};
+
+/**
+ * This function receives an Error and returns an error object with the following attributes:
+ * - message: the Error.message
+ * - stack: the original stack trace (that's optionally store at Error.cause)
+ * @param {*} error an instance of Error
+ * @returns error object to be stored at the Sync Client
+ */
+const copyError = error => ({
+  message: error.message,
+  ...(error.cause && { stack: error.cause }),
+});
+
+/**
+ * Saves a pending contact into the Sync Client
+ * @param {import("@twilio/flex-ui").ITask} task task used to save the contact
+ * @param {*} payload payload used to save the contact
+ * @param {*} error error returned when trying to save contact to external backend
+ */
+export const savePendingContactToSharedState = async (task, payload, error) => {
+  const { featureFlags, sharedStateClient, strings } = getConfig();
+
+  if (!featureFlags.enable_dual_write) return null;
+  if (!task || !payload) return null;
+
+  try {
+    if (!isSharedStateClientConnected(sharedStateClient)) {
+      console.error('Error with Sync Client conection. Sync Client object is: ', sharedStateClient);
+      console.error(strings.SharedStateSaveContactError);
+      return null;
+    }
+
+    const list = await sharedStateClient.list('pending-contacts');
+
+    const taskToSave = copyTask(task);
+    const errorToSave = copyError(error);
+
+    const document = { task: taskToSave, payload, error: errorToSave, retries: 0 };
+    await list.push(document);
+
+    console.log('The following pending contact was saved at Shared State:');
+    console.log(document);
+  } catch (err) {
+    console.error('Error while saving pending contact to shared state', err);
+  } finally {
     return null;
   }
 };


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-879
Serverless: [WIP](Change in the error500 function)
Primary reviewer: @GPaoloni 

When a contact fails to be saved on the external backend, it will be saved at Twilio's Sync Client, in a list called `pending-contacts`. The format of a pending contact is:
- **retries**: number of retries
- **task**: the Twilio Task
- **payload**: the payload used to save the contact at Aselo backend
- **error**: the error received when trying to save at the external backend