### PR TITLE
CHI-863: Add Full Story element identifiers

### DIFF
--- a/plugin-hrm-form/.eslintrc.json
+++ b/plugin-hrm-form/.eslintrc.json
@@ -17,6 +17,7 @@
     "no-alert": "off",
     "import/no-extraneous-dependencies": "off",
     "jsx-a11y/tabindex-no-positive": "off",
-    "sonarjs/no-duplicate-string": "off"
+    "sonarjs/no-duplicate-string": "off",
+    "prettier/prettier": ["error", {"endOfLine": "auto"}]
   }
 }

--- a/plugin-hrm-form/.eslintrc.json
+++ b/plugin-hrm-form/.eslintrc.json
@@ -17,7 +17,6 @@
     "no-alert": "off",
     "import/no-extraneous-dependencies": "off",
     "jsx-a11y/tabindex-no-positive": "off",
-    "sonarjs/no-duplicate-string": "off",
-    "prettier/prettier": ["error", {"endOfLine": "auto"}]
+    "sonarjs/no-duplicate-string": "off"
   }
 }

--- a/plugin-hrm-form/.prettierrc.json
+++ b/plugin-hrm-form/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "arrowParens": "avoid",
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "auto"
 }

--- a/plugin-hrm-form/src/components/ManualPullButton/index.tsx
+++ b/plugin-hrm-form/src/components/ManualPullButton/index.tsx
@@ -59,6 +59,7 @@ const ManualPullButton: React.FC<Props> = ({ queuesStatusState, chatChannelCapac
       disabled={disabled}
       isLoading={isWaitingNewTask}
       label="ManualPullButtonText"
+      data-fs-id="Task-AnotherTask-Button"
     />
   );
 };

--- a/plugin-hrm-form/src/components/OfflineContact/AddOfflineContactButton.tsx
+++ b/plugin-hrm-form/src/components/OfflineContact/AddOfflineContactButton.tsx
@@ -26,7 +26,7 @@ const AddOfflineContactButton: React.FC<Props> = ({
     await reRenderAgentDesktop();
   };
 
-  return <AddTaskButton onClick={onClick} disabled={isAddingOfflineContact} label="OfflineContactButtonText" />;
+  return <AddTaskButton data-fs-id="Task-AddOfflineContact-Button" onClick={onClick} disabled={isAddingOfflineContact} label="OfflineContactButtonText" />;
 };
 
 AddOfflineContactButton.displayName = 'AddOfflineContactButton';

--- a/plugin-hrm-form/src/components/OfflineContact/AddOfflineContactButton.tsx
+++ b/plugin-hrm-form/src/components/OfflineContact/AddOfflineContactButton.tsx
@@ -28,10 +28,10 @@ const AddOfflineContactButton: React.FC<Props> = ({
 
   return (
     <AddTaskButton
-      data-fs-id="Task-AddOfflineContact-Button"
       onClick={onClick}
       disabled={isAddingOfflineContact}
       label="OfflineContactButtonText"
+      data-fs-id="Task-AddOfflineContact-Button"
     />
   );
 };

--- a/plugin-hrm-form/src/components/OfflineContact/AddOfflineContactButton.tsx
+++ b/plugin-hrm-form/src/components/OfflineContact/AddOfflineContactButton.tsx
@@ -26,7 +26,14 @@ const AddOfflineContactButton: React.FC<Props> = ({
     await reRenderAgentDesktop();
   };
 
-  return <AddTaskButton data-fs-id="Task-AddOfflineContact-Button" onClick={onClick} disabled={isAddingOfflineContact} label="OfflineContactButtonText" />;
+  return (
+    <AddTaskButton
+      data-fs-id="Task-AddOfflineContact-Button"
+      onClick={onClick}
+      disabled={isAddingOfflineContact}
+      label="OfflineContactButtonText"
+    />
+  );
 };
 
 AddOfflineContactButton.displayName = 'AddOfflineContactButton';

--- a/plugin-hrm-form/src/components/callTypeButtons/NonDataCallTypeDialog.jsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/NonDataCallTypeDialog.jsx
@@ -28,7 +28,7 @@ const NonDataCallTypeDialog = ({ isOpen, isCallTask, isInWrapupMode, handleConfi
         </CloseTaskDialogText>
         <Box marginBottom="32px">
           <Row>
-            <ConfirmButton autoFocus tabIndex={1} onClick={handleConfirm}>
+            <ConfirmButton data-fs-id="Task-EndCallOrChat-Button" autoFocus tabIndex={1} onClick={handleConfirm}>
               {/* eslint-disable react/jsx-max-depth,no-nested-ternary */}
               <Template
                 code={isInWrapupMode ? 'CallType-CloseContact' : isCallTask ? 'TaskHeaderEndCall' : 'TaskHeaderEndChat'}

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -540,7 +540,7 @@ const Case: React.FC<Props> = props => {
                     <Template code="BottomBar-Cancel" />
                   </StyledNextStepButton>
                 </Box>
-                <StyledNextStepButton roundCorners onClick={handleSaveAndEnd}>
+                <StyledNextStepButton roundCorners onClick={handleSaveAndEnd} data-fs-id="Case-SaveAndEnd-Button">
                   <Template code="BottomBar-SaveAndEnd" />
                 </StyledNextStepButton>
               </>

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
@@ -122,11 +122,13 @@ class BottomBar extends Component {
             Icon={FolderOpenIcon}
             text={<Template code="BottomBar-OpenNewCase" />}
             onClick={handleSubmitIfValid(this.handleOpenNewCase, this.onError)}
+            data-fs-id="Contact-OpenNewCase-Button"
           />
           <MenuItem
             Icon={AddIcon}
             text={<Template code="BottomBar-AddToExistingCase" />}
             onClick={this.handleMockedMessage}
+            data-fs-id="Contact-AddToExistingCase-Button"
           />
         </Menu>
 
@@ -155,6 +157,7 @@ class BottomBar extends Component {
                     secondary
                     onClick={this.toggleCaseMenu}
                     disabled={isSubmitting}
+                    data-fs-id="ContactForm-SaveAndAddToCase"
                   >
                     <FolderIcon style={{ fontSize: '16px', marginRight: '10px' }} />
                     <Template code="BottomBar-SaveAndAddToCase" />
@@ -165,6 +168,7 @@ class BottomBar extends Component {
                 roundCorners={true}
                 onClick={handleSubmitIfValid(this.handleSubmit, this.onError)}
                 disabled={isSubmitting}
+                data-fs-id="Contact-SaveContact-Button"
               >
                 {isSubmitting ? <CircularProgress size={12} /> : <Template code="BottomBar-SaveContact" />}
               </StyledNextStepButton>

--- a/plugin-hrm-form/src/components/transfer/TransferButton.tsx
+++ b/plugin-hrm-form/src/components/transfer/TransferButton.tsx
@@ -13,6 +13,7 @@ const TransferButton: React.FC<Props> = ({ theme }) => {
       color={theme.colors.secondaryButtonTextColor}
       background={theme.colors.secondaryButtonColor}
       onClick={() => Actions.invokeAction('ShowDirectory')}
+      data-fs-id="Task-Transfer-Button"
     >
       <Template code="Transfer-TransferButton" />
     </TransferStyledButton>

--- a/scripts/.prettierrc
+++ b/scripts/.prettierrc
@@ -3,5 +3,6 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "tabWidth": 2
+  "tabWidth": 2,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
* Added requested identifiers as `data-fs-id` attributes, to keep them separate from HTML IDs and reduce the chance of developers breaking them with updates
* Used naming convention `Category-ElementFunction-ControlType` where Category would be a high level functional area like 'Contact' or 'Case', ElementFunction would be what the element is supposed to do 'EndCallOrChat', 'Transfer', and ControlType is what the control is, 'Button', 'DropDown' etc.
* Changed some linter settings to not get upset about windows line endings.

There are 2 elements specified in CHI-863 that have not had attributes explicitly added to them: 
* The 'Accept' button, this is not part of our plugin but part of the Twlio core UI. There is not a simple reliable wauy of adding extra attributes to this markup as far as we are aware. The suggested alternative would be to use a class based CSS selector for the event capturing clicks of these buttons in Full Story - `button.Twilio-TaskButton-Accept` and `button.Twilio-IncomingTask-Accept` for the All Tasks panel and Incoming Task panel versions of this button respectively 
TODO - add data element to 'Accept' button, which is defined in flex rather than the plugin