### PR TITLE
Sends taskLanguage when calling initPostSurvey

### DIFF
--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -138,7 +138,11 @@ export const getWorkerAttributes = async (workerSid: string) => {
   return response;
 };
 
-export const postSurveyInit = async (body: { channelSid: string; taskSid: string }): Promise<any> => {
+export const postSurveyInit = async (body: {
+  channelSid: string;
+  taskSid: string;
+  taskLanguage?: string;
+}): Promise<any> => {
   const response = await fetchProtectedApi('/postSurveyInit', body);
   return response;
 };

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -316,12 +316,11 @@ export const setUpPostSurvey = setupObject => {
 
 /**
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
- * @returns {import('@twilio/flex-ui').ActionFunction}
+ * @param {{ task: import('@twilio/flex-ui').ITask }} payload
  */
-const triggerPostSurvey = setupObject => async payload => {
+const triggerPostSurvey = async (setupObject, payload) => {
   const { task } = payload;
 
-  // if (featureFlags.enable_post_survey) {
   if (TaskHelper.isChatBasedTask(task)) {
     const { taskSid } = task;
     const channelSid = TaskHelper.getTaskChatChannelSid(task);
@@ -331,7 +330,6 @@ const triggerPostSurvey = setupObject => async payload => {
 
     await postSurveyInit(body);
   }
-  // }
 };
 
 /**
@@ -342,7 +340,7 @@ export const afterCompleteTask = setupObject => async payload => {
   const { featureFlags } = setupObject;
 
   if (featureFlags.enable_post_survey) {
-    await triggerPostSurvey(setupObject)(payload);
+    await triggerPostSurvey(setupObject, payload);
   }
 
   removeContactForm(payload);


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-829
This PR is related to https://github.com/techmatters/serverless/pull/168

This PR adds an optional parameter (`taskLanguage`) to the `postSurveyInit` call.
To test this, point to `dev` environment of serverless, start a webchat task and edit it's attributes to contain a property like `"language": "pt-BR"`.  Any other language should result in an error log and the default English message being sent.

![Screenshot from 2021-12-08 18-42-33](https://user-images.githubusercontent.com/15805319/145293093-1cee359b-e2ba-4aaf-8cf6-1ae79869b768.png)
