### PR TITLE
Changed to use helplineLanguage in service config

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -32,13 +32,13 @@ export const getConfig = () => {
   const logoUrl = manager.serviceConfiguration.attributes.logo_url;
   const chatServiceSid = manager.serviceConfiguration.chat_service_instance_sid;
   const workerSid = manager.workerClient.sid;
-  const { helpline, counselorLanguage, helplineLanguage } = manager.workerClient.attributes;
+  const { helpline, counselorLanguage } = manager.workerClient.attributes;
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
   const counselorName = manager.workerClient.attributes.full_name;
   const isSupervisor = manager.workerClient.attributes.roles.includes('supervisor');
   const {
-    configuredLanguage,
+    helplineLanguage,
     definitionVersion,
     pdfImagesSource,
     multipleOfficeSupport,
@@ -60,7 +60,6 @@ export const getConfig = () => {
     currentWorkspace,
     counselorLanguage,
     helplineLanguage,
-    configuredLanguage,
     identity,
     token,
     counselorName,
@@ -152,7 +151,7 @@ const setUpTransfers = setupObject => {
 const setUpLocalization = config => {
   const manager = Flex.Manager.getInstance();
 
-  const { counselorLanguage, helplineLanguage, configuredLanguage } = config;
+  const { counselorLanguage, helplineLanguage } = config;
 
   const twilioStrings = { ...manager.strings }; // save the originals
   const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
@@ -161,7 +160,7 @@ const setUpLocalization = config => {
     Flex.Actions.invokeAction('NavigateToView', { viewName: manager.store.getState().flex.view.activeView }); // force a re-render
   };
   const localizationConfig = { twilioStrings, setNewStrings, afterNewStrings };
-  const initialLanguage = counselorLanguage || helplineLanguage || configuredLanguage;
+  const initialLanguage = counselorLanguage || helplineLanguage;
 
   return initLocalization(localizationConfig, initialLanguage);
 };

--- a/plugin-hrm-form/src/___tests__/mockGetConfig.js
+++ b/plugin-hrm-form/src/___tests__/mockGetConfig.js
@@ -12,7 +12,6 @@ jest.mock('../HrmFormPlugin', () => ({
       currentWorkspace: '',
       counselorLanguage: '',
       helplineLanguage: '',
-      configuredLanguage: '',
       identity: '',
       token: '',
       counselorName: '',

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -19,6 +19,7 @@ import callTypes, { transferModes } from '../states/DomainConstants';
 import * as TransferHelpers from './transfer';
 import { saveFormSharedState, loadFormSharedState } from './sharedState';
 import { prepopulateForm } from './prepopulateForm';
+import { defaultLanguage } from './pluginHelpers';
 
 /**
  * @param {string} version
@@ -132,8 +133,7 @@ const handleTransferredTask = async task => {
   await restoreFormIfTransfer(task);
 };
 
-const getTaskLanguage = ({ helplineLanguage, configuredLanguage }) => ({ task }) =>
-  task.attributes.language || helplineLanguage || configuredLanguage;
+const getTaskLanguage = ({ helplineLanguage }) => ({ task }) => task.attributes.language || helplineLanguage;
 
 /**
  * @param {string} messageKey


### PR DESCRIPTION
This PR is an isolation of commit https://github.com/techmatters/flex-plugins/pull/548/commits/8bd94bfb25fc0fcf7581755e9b3344bdabe94931 from https://github.com/techmatters/flex-plugins/pull/548. 

This PR removes the old configuredLanguage property and changes code to use helplineLanguage instead.
From this PR, the order of language that will be used is:
- `counselorLanguage` from worker attributes.
- `helplineLanguage` from service configuration.
- `defaultLanguage` hardcoded.

For messages sent to the person in contact, we will look for the language like:
- `task.attributes.language`.
- `helplineLanguage`.

Note that this PR differs from https://github.com/techmatters/flex-plugins/pull/548:
Instead than doing
```
const getTaskLanguage = ({ counselorLanguage, helplineLanguage }) => ({ task }) =>
  task.attributes.language || counselorLanguage || helplineLanguage;
```

now we do 
```
const getTaskLanguage = ({ helplineLanguage }) => ({ task }) => task.attributes.language || helplineLanguage;
```

This is to not interfere with the work done in https://github.com/techmatters/flex-plugins/pull/557. @dee-luo Is this ok or we should use the `counselorLanguage` when calculating the task language?