### PR TITLE
CSAM: Expose/update services

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/CSAMReport/CSAMReport.test.js
+++ b/plugin-hrm-form/src/___tests__/components/CSAMReport/CSAMReport.test.js
@@ -1,0 +1,300 @@
+/* eslint-disable sonarjs/no-identical-functions */
+import React from 'react';
+import { configureAxe, toHaveNoViolations } from 'jest-axe';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { mount } from 'enzyme';
+import { StorelessThemeProvider } from '@twilio/flex-ui';
+import '@testing-library/jest-dom/extend-expect';
+
+import '../../mockGetConfig';
+
+import * as ServerlessService from '../../../services/ServerlessService';
+import * as CSAMReportService from '../../../services/CSAMReportService';
+import { CSAMReportScreen } from '../../../components/CSAMReport/CSAMReport';
+import { initialValues } from '../../../components/CSAMReport/CSAMReportFormDefinition';
+import HrmTheme from '../../../styles/HrmTheme';
+
+jest.mock('../../../services/ServerlessService');
+jest.mock('../../../services/CSAMReportService');
+
+console.error = () => undefined;
+expect.extend(toHaveNoViolations);
+
+const themeConf = {
+  colorTheme: HrmTheme,
+};
+
+const taskSid = 'task-sid';
+const workerSid = 'worker-sid';
+
+test("Form renders but can't be submitted empty", async () => {
+  const alertSpy = jest.spyOn(window, 'alert');
+
+  const updateFormAction = jest.fn();
+  const updateStatusAction = jest.fn();
+  const clearCSAMReportAction = jest.fn();
+  const changeRoute = jest.fn();
+  const addCSAMReportEntry = jest.fn();
+  const csamReportState = { form: initialValues };
+  const routing = { route: 'csam-report', subroute: 'form' };
+  const counselorsHash = { workerSid };
+
+  render(
+    <StorelessThemeProvider themeConf={themeConf}>
+      <CSAMReportScreen
+        taskSid={taskSid}
+        updateFormAction={updateFormAction}
+        updateStatusAction={updateStatusAction}
+        clearCSAMReportAction={clearCSAMReportAction}
+        changeRoute={changeRoute}
+        addCSAMReportEntry={addCSAMReportEntry}
+        csamReportState={csamReportState}
+        routing={routing}
+        counselorsHash={counselorsHash}
+      />
+    </StorelessThemeProvider>,
+  );
+
+  expect(screen.getByTestId('CSAMReport-FormScreen')).toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-StatusScreen')).not.toBeInTheDocument();
+
+  const submitButton = screen.getByTestId('CSAMReport-SubmitButton');
+  expect(submitButton).toBeInTheDocument();
+
+  fireEvent.click(submitButton);
+
+  expect(await screen.findAllByText('RequiredFieldError')).not.toHaveLength(0);
+  expect(alertSpy).toHaveBeenCalled();
+});
+
+test('Form can be submitted if valid (anonymous)', async () => {
+  const updateFormAction = jest.fn();
+  const updateStatusAction = jest.fn();
+  const clearCSAMReportAction = jest.fn();
+  const changeRoute = jest.fn();
+  const addCSAMReportEntry = jest.fn();
+  const csamReportState = { form: initialValues };
+  const routing = { route: 'csam-report', subroute: 'form' };
+  const counselorsHash = { workerSid };
+
+  const reportToIWFSpy = jest.spyOn(ServerlessService, 'reportToIWF').mockImplementationOnce(() =>
+    Promise.resolve({
+      'IWFReportService1.0': { responseData: {} },
+    }),
+  );
+  const createCSAMReportSpy = jest.spyOn(CSAMReportService, 'createCSAMReport').mockImplementationOnce(() =>
+    Promise.resolve({
+      csamReportId: 'report-sid',
+    }),
+  );
+
+  render(
+    <StorelessThemeProvider themeConf={themeConf}>
+      <CSAMReportScreen
+        taskSid={taskSid}
+        updateFormAction={updateFormAction}
+        updateStatusAction={updateStatusAction}
+        clearCSAMReportAction={clearCSAMReportAction}
+        changeRoute={changeRoute}
+        addCSAMReportEntry={addCSAMReportEntry}
+        csamReportState={csamReportState}
+        routing={routing}
+        counselorsHash={counselorsHash}
+      />
+    </StorelessThemeProvider>,
+  );
+
+  expect(screen.getByTestId('CSAMReport-FormScreen')).toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-StatusScreen')).not.toBeInTheDocument();
+
+  const submitButton = screen.getByTestId('CSAMReport-SubmitButton');
+  expect(submitButton).toBeInTheDocument();
+
+  const webAddressInput = screen.getByTestId('webAddress');
+  expect(webAddressInput).toBeInTheDocument();
+
+  fireEvent.change(webAddressInput, {
+    target: {
+      value: 'some-url',
+    },
+  });
+
+  fireEvent.click(submitButton);
+
+  await waitFor(() => expect(screen.queryAllByText('RequiredFieldError')).toHaveLength(0));
+
+  expect(changeRoute).toHaveBeenCalled();
+  expect(reportToIWFSpy).toHaveBeenCalled();
+  expect(createCSAMReportSpy).toHaveBeenCalled();
+  expect(updateStatusAction).toHaveBeenCalled();
+  expect(addCSAMReportEntry).toHaveBeenCalled();
+});
+
+test('Form can be submitted if valid (non-anonymous)', async () => {
+  const updateFormAction = jest.fn();
+  const updateStatusAction = jest.fn();
+  const clearCSAMReportAction = jest.fn();
+  const changeRoute = jest.fn();
+  const addCSAMReportEntry = jest.fn();
+  const csamReportState = { form: initialValues };
+  const routing = { route: 'csam-report', subroute: 'form' };
+  const counselorsHash = { workerSid };
+
+  const reportToIWFSpy = jest.spyOn(ServerlessService, 'reportToIWF').mockImplementationOnce(() =>
+    Promise.resolve({
+      'IWFReportService1.0': { responseData: {} },
+    }),
+  );
+  const createCSAMReportSpy = jest.spyOn(CSAMReportService, 'createCSAMReport').mockImplementationOnce(() =>
+    Promise.resolve({
+      csamReportId: 'report-sid',
+    }),
+  );
+
+  render(
+    <StorelessThemeProvider themeConf={themeConf}>
+      <CSAMReportScreen
+        taskSid={taskSid}
+        updateFormAction={updateFormAction}
+        updateStatusAction={updateStatusAction}
+        clearCSAMReportAction={clearCSAMReportAction}
+        changeRoute={changeRoute}
+        addCSAMReportEntry={addCSAMReportEntry}
+        csamReportState={csamReportState}
+        routing={routing}
+        counselorsHash={counselorsHash}
+      />
+    </StorelessThemeProvider>,
+  );
+
+  expect(screen.getByTestId('CSAMReport-FormScreen')).toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-StatusScreen')).not.toBeInTheDocument();
+
+  const submitButton = screen.getByTestId('CSAMReport-SubmitButton');
+  expect(submitButton).toBeInTheDocument();
+
+  const webAddressInput = screen.getByTestId('webAddress');
+  expect(webAddressInput).toBeInTheDocument();
+
+  fireEvent.change(webAddressInput, {
+    target: {
+      value: 'some-url',
+    },
+  });
+
+  const anonymousInput = screen.getByTestId('anonymous');
+  expect(anonymousInput).toBeInTheDocument();
+
+  fireEvent.click(anonymousInput);
+
+  const firstNameInput = screen.getByTestId('firstName');
+  expect(firstNameInput).toBeInTheDocument();
+  const lastNameInput = screen.getByTestId('lastName');
+  expect(lastNameInput).toBeInTheDocument();
+  const emailInput = screen.getByTestId('email');
+  expect(emailInput).toBeInTheDocument();
+
+  fireEvent.change(emailInput, {
+    target: {
+      value: 'some@email.com',
+    },
+  });
+
+  fireEvent.click(submitButton);
+  await waitFor(() => expect(screen.queryAllByText('RequiredFieldError')).toHaveLength(0));
+
+  expect(changeRoute).toHaveBeenCalled();
+  expect(reportToIWFSpy).toHaveBeenCalled();
+  expect(createCSAMReportSpy).toHaveBeenCalled();
+  expect(updateStatusAction).toHaveBeenCalled();
+  expect(addCSAMReportEntry).toHaveBeenCalled();
+});
+
+test('Loading screen renders', async () => {
+  const updateFormAction = jest.fn();
+  const updateStatusAction = jest.fn();
+  const clearCSAMReportAction = jest.fn();
+  const changeRoute = jest.fn();
+  const addCSAMReportEntry = jest.fn();
+  const csamReportState = { form: initialValues };
+  const routing = { route: 'csam-report', subroute: 'loading' };
+  const counselorsHash = { workerSid };
+
+  render(
+    <StorelessThemeProvider themeConf={themeConf}>
+      <CSAMReportScreen
+        taskSid={taskSid}
+        updateFormAction={updateFormAction}
+        updateStatusAction={updateStatusAction}
+        clearCSAMReportAction={clearCSAMReportAction}
+        changeRoute={changeRoute}
+        addCSAMReportEntry={addCSAMReportEntry}
+        csamReportState={csamReportState}
+        routing={routing}
+        counselorsHash={counselorsHash}
+      />
+    </StorelessThemeProvider>,
+  );
+
+  expect(screen.getByTestId('CSAMReport-Loading')).toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-FormScreen')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-StatusScreen')).not.toBeInTheDocument();
+});
+
+test('Report Status screen renders + copy button works', async () => {
+  const updateFormAction = jest.fn();
+  const updateStatusAction = jest.fn();
+  const clearCSAMReportAction = jest.fn();
+  const changeRoute = jest.fn();
+  const addCSAMReportEntry = jest.fn();
+  const csamReportState = {
+    form: initialValues,
+    reportStatus: {
+      responseCode: 'responseCode',
+      responseData: 'responseData',
+      responseDescription: 'responseDescription',
+    },
+  };
+  const routing = { route: 'csam-report', subroute: 'status' };
+  const counselorsHash = { workerSid };
+
+  Object.assign(navigator, {
+    clipboard: {
+      writeText: async () => undefined,
+    },
+  });
+
+  const copySpy = jest.spyOn(navigator.clipboard, 'writeText');
+
+  render(
+    <StorelessThemeProvider themeConf={themeConf}>
+      <CSAMReportScreen
+        taskSid={taskSid}
+        updateFormAction={updateFormAction}
+        updateStatusAction={updateStatusAction}
+        clearCSAMReportAction={clearCSAMReportAction}
+        changeRoute={changeRoute}
+        addCSAMReportEntry={addCSAMReportEntry}
+        csamReportState={csamReportState}
+        routing={routing}
+        counselorsHash={counselorsHash}
+      />
+    </StorelessThemeProvider>,
+  );
+
+  expect(screen.getByTestId('CSAMReport-StatusScreen')).toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-FormScreen')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
+
+  const copyCodeButton = screen.getByTestId('CSAMReport-CopyCodeButton');
+  expect(copyCodeButton).toBeInTheDocument();
+
+  await act(async () => {
+    fireEvent.click(copyCodeButton);
+  });
+
+  expect(copySpy).toHaveBeenCalledWith(csamReportState.reportStatus.responseData);
+});

--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -9,6 +9,8 @@ import { UnconnectedPreviousContactsBanner } from '../../components/PreviousCont
 import { channelTypes } from '../../states/DomainConstants';
 import { SearchPages } from '../../states/search/types';
 
+jest.mock('../../components/CSAMReport/CSAMReportFormDefinition');
+
 expect.extend(toHaveNoViolations);
 
 const ip = 'task-ip';

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
@@ -12,6 +12,8 @@ import QueueCard from '../../../components/queuesStatus/QueueCard';
 import { WaitTimeValue } from '../../../styles/queuesStatus';
 import { ErrorText } from '../../../styles/HrmStyles';
 
+jest.mock('../../../components/CSAMReport/CSAMReportFormDefinition');
+
 expect.extend(toHaveNoViolations);
 const mockStore = configureMockStore([]);
 

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
@@ -6,6 +6,8 @@ import { InnerQueuesStatusWriter as QueuesStatusWriter } from '../../../componen
 import { channelTypes } from '../../../states/DomainConstants';
 import { newQueueEntry, initializeQueuesStatus, getNewQueuesStatus } from '../../../components/queuesStatus/helpers';
 
+jest.mock('../../../components/CSAMReport/CSAMReportFormDefinition');
+
 jest.mock('../../../services/ServerlessService', () => ({
   listWorkerQueues: async ({ workerSid }) => {
     if (workerSid === 'worker-admin')

--- a/plugin-hrm-form/src/___tests__/components/tabbedForms/IssueCategorizationTab.test.js
+++ b/plugin-hrm-form/src/___tests__/components/tabbedForms/IssueCategorizationTab.test.js
@@ -12,6 +12,8 @@ import { namespace, contactFormsBase } from '../../../states';
 import { setCategoriesGridView } from '../../../states/contacts/actions';
 import mockV1 from '../../../formDefinitions/v1';
 
+jest.mock('../../../components/CSAMReport/CSAMReportFormDefinition');
+
 const helpline = 'ChildLine Zambia (ZM)';
 const definition = mockV1.tabbedForms.IssueCategorizationTab(helpline);
 

--- a/plugin-hrm-form/src/___tests__/states/search/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/search/reducer.test.ts
@@ -12,6 +12,8 @@ import {
 } from '../../../states/types';
 import { reduce, newTaskEntry } from '../../../states/search/reducer';
 
+jest.mock('../../../components/CSAMReport/CSAMReportFormDefinition');
+
 // @ts-ignore
 Object.fromEntries = fromentries;
 

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
@@ -1,0 +1,182 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { CircularProgress } from '@material-ui/core';
+import { connect, ConnectedProps } from 'react-redux';
+
+import CSAMReportStatusScreen from './CSAMReportStatusScreen';
+import CSAMReportFormScreen from './CSAMReportFormScreen';
+import { CSAMReportContainer, CSAMReportLayout, CenterContent } from '../../styles/CSAMReport';
+import { FormItemDefinition } from '../common/forms/types';
+import { getInputType } from '../common/forms/formGenerators';
+import { definitionObject, keys, initialValues } from './CSAMReportFormDefinition';
+import type { CustomITask } from '../../types/types';
+import { getConfig } from '../../HrmFormPlugin';
+import * as actions from '../../states/csam-report/actions';
+import * as routingActions from '../../states/routing/actions';
+import * as contactsActions from '../../states/contacts/actions';
+import { RootState, csamReportBase, namespace, routingBase, configurationBase } from '../../states';
+import { reportToIWF } from '../../services/ServerlessService';
+import { createCSAMReport } from '../../services/CSAMReportService';
+import useFocus from '../../utils/useFocus';
+
+type OwnProps = {
+  taskSid: CustomITask['taskSid'];
+};
+
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
+  csamReportState: state[namespace][csamReportBase].tasks[ownProps.taskSid],
+  routing: state[namespace][routingBase].tasks[ownProps.taskSid],
+  counselorsHash: state[namespace][configurationBase].counselors.hash,
+});
+
+const mapDispatchToProps = {
+  updateFormAction: actions.updateFormAction,
+  updateStatusAction: actions.updateStatusAction,
+  clearCSAMReportAction: actions.clearCSAMReportAction,
+  changeRoute: routingActions.changeRoute,
+  addCSAMReportEntry: contactsActions.addCSAMReportEntry,
+};
+
+// eslint-disable-next-line no-use-before-define
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+// exported for test purposes
+export const CSAMReportScreen: React.FC<Props> = ({
+  updateFormAction,
+  updateStatusAction,
+  clearCSAMReportAction,
+  changeRoute,
+  addCSAMReportEntry,
+  taskSid,
+  csamReportState,
+  routing,
+  counselorsHash,
+}) => {
+  const [initialForm] = React.useState(csamReportState.form); // grab initial values in first render only. This value should never change or will ruin the memoization below
+  const methods = useForm();
+  const firstElementRef = useFocus();
+
+  const currentCounselor = React.useMemo(() => {
+    const { workerSid } = getConfig();
+    return counselorsHash[workerSid];
+  }, [counselorsHash]);
+
+  const formElements = React.useMemo(() => {
+    const onUpdateInput = () => {
+      const values = methods.getValues(Object.values(keys));
+      updateFormAction(values, taskSid);
+    };
+
+    const generateInput = (e: FormItemDefinition, index: number) => {
+      const generatedInput = getInputType([], onUpdateInput)(e);
+      const initialValue = initialForm[e.name] === undefined ? initialValues[e.name] : initialForm[e.name];
+
+      return index === 0 ? generatedInput(initialValue, firstElementRef) : generatedInput(initialValue);
+    };
+
+    // Function used to generate the inputs with a reduce
+    const reducerFunc = (
+      accum: { [k in keyof typeof definitionObject]: JSX.Element },
+      [k, e]: [string, FormItemDefinition],
+      index: number,
+    ) => ({
+      ...accum,
+      [k]: generateInput(e, index),
+    });
+
+    return Object.entries(definitionObject).reduce(reducerFunc, null);
+  }, [firstElementRef, initialForm, methods, taskSid, updateFormAction]);
+
+  if (routing.route !== 'csam-report') return null;
+
+  const onClickClose = () => {
+    clearCSAMReportAction(taskSid);
+    changeRoute({ route: 'tabbed-forms', subroute: 'caseInformation' }, taskSid);
+  };
+
+  switch (routing.subroute) {
+    case 'form': {
+      const onValid = async form => {
+        try {
+          changeRoute({ route: 'csam-report', subroute: 'loading' }, taskSid);
+          const report = await reportToIWF(form);
+          const storedReport = await createCSAMReport({
+            csamReportId: report['IWFReportService1.0'].responseData,
+            twilioWorkerId: getConfig().workerSid,
+          });
+
+          updateStatusAction(report['IWFReportService1.0'], taskSid);
+          addCSAMReportEntry(storedReport, taskSid);
+          changeRoute({ route: 'csam-report', subroute: 'status' }, taskSid);
+        } catch (err) {
+          console.error(err);
+          window.alert(getConfig().strings['Error-Backend']);
+          changeRoute({ route: 'csam-report', subroute: 'form' }, taskSid);
+        }
+      };
+
+      const onInvalid = () => {
+        window.alert(getConfig().strings['Error-Form']);
+      };
+
+      const onSendReport = methods.handleSubmit(onValid, onInvalid);
+
+      const anonymousWatch = methods.watch('anonymous');
+      const renderContactDetails =
+        anonymousWatch === false || (anonymousWatch === undefined && initialForm.anonymous === false);
+
+      return (
+        <FormProvider {...methods}>
+          <CSAMReportFormScreen
+            formElements={formElements}
+            renderContactDetails={renderContactDetails}
+            counselor={currentCounselor}
+            onClickClose={onClickClose}
+            onSendReport={onSendReport}
+          />
+        </FormProvider>
+      );
+    }
+    case 'loading': {
+      return (
+        <CSAMReportContainer data-testid="CSAMReport-Loading">
+          <CSAMReportLayout>
+            <CenterContent>
+              <CircularProgress />
+            </CenterContent>
+          </CSAMReportLayout>
+        </CSAMReportContainer>
+      );
+    }
+    case 'status': {
+      const onSendAnotherReport = () => {
+        clearCSAMReportAction(taskSid);
+        changeRoute({ route: 'csam-report', subroute: 'form' }, taskSid);
+      };
+
+      return (
+        <CSAMReportStatusScreen
+          reportStatus={csamReportState.reportStatus}
+          onClickClose={onClickClose}
+          onSendAnotherReport={onSendAnotherReport}
+        />
+      );
+    }
+    default: {
+      console.error('Error: unexpected route reached on CSAM Report: ', routing);
+
+      const { strings } = getConfig();
+      window.alert(strings['Error-Unexpected']);
+      onClickClose();
+      return null;
+    }
+  }
+};
+
+CSAMReportScreen.displayName = 'CSAMReportScreen';
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+const connected = connector(CSAMReportScreen);
+
+export default connected;

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormScreen.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormScreen.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { Template } from '@twilio/flex-ui';
+
+import ActionHeader from '../case/ActionHeader';
+import { BottomButtonBar, Box, StyledNextStepButton } from '../../styles/HrmStyles';
+import { CSAMReportContainer, CSAMReportLayout, BoldDescriptionText, RegularText } from '../../styles/CSAMReport';
+import { definitionObject } from './CSAMReportFormDefinition';
+
+type Props = {
+  formElements: { [k in keyof typeof definitionObject]: JSX.Element };
+  renderContactDetails: boolean;
+  counselor: string;
+  onClickClose: () => void;
+  onSendReport: () => void;
+};
+
+const CSAMReportFormScreen: React.FC<Props> = ({
+  formElements,
+  renderContactDetails,
+  counselor,
+  onClickClose,
+  onSendReport,
+}) => (
+  <CSAMReportContainer data-testid="CSAMReport-FormScreen">
+    <CSAMReportLayout>
+      <ActionHeader titleTemplate="CSAMReportForm-Header" onClickClose={onClickClose} counselor={counselor} />
+
+      {/** Website details */}
+      <Box marginTop="20px" marginBottom="5px">
+        <BoldDescriptionText>
+          <Template code="CSAMReportForm-WebsiteDetails" />
+        </BoldDescriptionText>
+      </Box>
+      <RegularText>
+        <Template code="CSAMReportForm-WebsiteDetailsDescription" />
+      </RegularText>
+      <Box padding="15px 15px 15px 20px">
+        {formElements.webAddress}
+        {formElements.description}
+      </Box>
+
+      {/** Contact details */}
+      <Box marginTop="20px" marginBottom="5px">
+        <BoldDescriptionText>
+          <Template code="CSAMReportForm-ContactDetails" />
+        </BoldDescriptionText>
+      </Box>
+      <RegularText>
+        <Template code="CSAMReportForm-ContactDetailsDescription" />
+      </RegularText>
+      <Box padding="15px 15px 15px 20px">{formElements.anonymous}</Box>
+
+      {/** Conditional part of the form only shown if contact is not anon */}
+      {renderContactDetails && (
+        <Box marginTop="20px" marginBottom="5px">
+          <RegularText>
+            <Template code="CSAMReportForm-ContactDetailsInfo" />
+          </RegularText>
+          <Box padding="15px 15px 15px 20px">
+            {formElements.firstName}
+            {formElements.lastName}
+            {formElements.email}
+          </Box>
+        </Box>
+      )}
+    </CSAMReportLayout>
+
+    <BottomButtonBar>
+      <Box marginRight="15px">
+        <StyledNextStepButton secondary roundCorners onClick={onClickClose}>
+          <Template code="BottomBar-Cancel" />
+        </StyledNextStepButton>
+      </Box>
+      <StyledNextStepButton roundCorners onClick={onSendReport} data-testid="CSAMReport-SubmitButton">
+        <Template code="BottomBar-SendReport" />
+      </StyledNextStepButton>
+    </BottomButtonBar>
+  </CSAMReportContainer>
+);
+
+CSAMReportFormScreen.displayName = 'CSAMReportFormScreen';
+
+export default CSAMReportFormScreen;

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportStatusScreen.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportStatusScreen.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable react/jsx-max-depth */
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { Template } from '@twilio/flex-ui';
+import { ButtonBase } from '@material-ui/core';
+import CheckCircleTwoToneIcon from '@material-ui/icons/CheckCircleTwoTone';
+import FileCopyOutlined from '@material-ui/icons/FileCopyOutlined';
+import Close from '@material-ui/icons/Close';
+import CheckCircle from '@material-ui/icons/CheckCircle';
+
+import { BottomButtonBar, Box, HiddenText, Row, StyledNextStepButton } from '../../styles/HrmStyles';
+import {
+  CSAMReportContainer,
+  CSAMReportLayout,
+  BoldDescriptionText,
+  RegularText,
+  CenterContent,
+  ReportCodeText,
+  ButtonText,
+  CopyCodeButton,
+} from '../../styles/CSAMReport';
+import type { CSAMReportStatus } from '../../states/csam-report/types';
+
+type Props = {
+  reportStatus: CSAMReportStatus;
+  onClickClose: () => void;
+  onSendAnotherReport: () => void;
+};
+
+const CSAMReportStatusScreen: React.FC<Props> = ({ reportStatus, onClickClose, onSendAnotherReport }) => {
+  const [copied, setCopied] = React.useState(false);
+
+  const onCopyCode = async () => {
+    await navigator.clipboard.writeText(reportStatus.responseData);
+    setCopied(true);
+  };
+
+  const CopyCodeButtonIcon = copied ? CheckCircle : FileCopyOutlined;
+  const CopyCodeButtonText = copied ? 'Copied' : 'CopyCode';
+
+  return (
+    // how should we handle possible IWF API error here? Show a screen, an alert & go back to form?
+    <CSAMReportContainer data-testid="CSAMReport-StatusScreen">
+      <CSAMReportLayout>
+        <ButtonBase onClick={onClickClose} style={{ marginLeft: 'auto' }} data-testid="Case-CloseCross">
+          <HiddenText>
+            <Template code="Case-CloseButton" />
+          </HiddenText>
+          <Close />
+        </ButtonBase>
+        <Box marginTop="15%" marginBottom="auto">
+          <CenterContent>
+            <Row>
+              <Box marginRight="10px">
+                <CheckCircleTwoToneIcon nativeColor="#00884C" width="24px" height="24px" />
+              </Box>
+              <BoldDescriptionText fontSize="16px">
+                <Template code="CSAMReportForm-ReportSent" />
+              </BoldDescriptionText>
+            </Row>
+            <Box marginTop="8%" marginBottom="3%">
+              <RegularText>
+                <Template code="CSAMReportForm-CopyCode" />
+              </RegularText>
+            </Box>
+            <Row>
+              <Box marginRight="5%">
+                <ReportCodeText>#{reportStatus.responseData}</ReportCodeText>
+              </Box>
+              <CopyCodeButton secondary roundCorners onClick={onCopyCode} data-testid="CSAMReport-CopyCodeButton">
+                <Box marginRight="5px">
+                  <CopyCodeButtonIcon width="20px" height="20px" />
+                </Box>
+                <ButtonText>
+                  <Template code={CopyCodeButtonText} />
+                </ButtonText>
+              </CopyCodeButton>
+            </Row>
+          </CenterContent>
+        </Box>
+      </CSAMReportLayout>
+
+      <BottomButtonBar>
+        <Box marginRight="15px">
+          <StyledNextStepButton secondary roundCorners onClick={onSendAnotherReport}>
+            <Template code="BottomBar-SendAnotherReport" />
+          </StyledNextStepButton>
+        </Box>
+        <StyledNextStepButton roundCorners onClick={onClickClose}>
+          <Template code="BottomBar-CloseView" />
+        </StyledNextStepButton>
+      </BottomButtonBar>
+    </CSAMReportContainer>
+  );
+};
+
+CSAMReportStatusScreen.displayName = 'CSAMReportStatusScreen';
+
+export default CSAMReportStatusScreen;

--- a/plugin-hrm-form/src/components/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/ContactDetails.tsx
@@ -58,7 +58,7 @@ const Details: React.FC<Props> = ({
   }, [definitionVersions, updateDefinitionVersion, version]);
 
   // Object destructuring on contact
-  const { overview, details, counselor } = contact;
+  const { overview, details, counselor, csamReports } = contact;
   const {
     dateTime,
     name: childName,
@@ -93,6 +93,12 @@ const Details: React.FC<Props> = ({
 
   const definitionVersion = definitionVersions[version];
   const addedBy = counselorsHash[createdBy];
+
+  const csamReportsAttached =
+    csamReports &&
+    csamReports
+      .map(r => `CSAM on ${format(new Date(r.createdAt), 'yyyy MM dd h:mm aaaaa')}m\n#${r.csamReportId}`)
+      .join('\n\n');
 
   if (!definitionVersion)
     return (
@@ -211,6 +217,13 @@ const Details: React.FC<Props> = ({
               definition={e}
             />
           ))}
+          {csamReportsAttached && (
+            <SectionEntry
+              key="CaseInformation-AttachedCSAMReports"
+              description={<Template code="CSAMReportForm-ReportsSubmitted" />}
+              value={csamReportsAttached}
+            />
+          )}
         </Section>
       )}
     </DetailsContainer>

--- a/plugin-hrm-form/src/components/HrmForm.tsx
+++ b/plugin-hrm-form/src/components/HrmForm.tsx
@@ -1,30 +1,30 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { withTaskContext, ITask } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 
 import { CaseLayout } from '../styles/case';
 import CallTypeButtons from './callTypeButtons';
 import TabbedForms from './tabbedForms';
 import Case from './case';
+import CSAMReport from './CSAMReport/CSAMReport';
 import { namespace, RootState, routingBase } from '../states';
-import * as RoutingActions from '../states/routing/actions';
 import type { CustomITask } from '../types/types';
 
 type OwnProps = {
   task: CustomITask;
+  featureFlags: { [flag: string]: boolean };
 };
 
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ReturnType<typeof mapStateToProps>;
 
-const HrmForm: React.FC<Props> = ({ routing, task }) => {
+const HrmForm: React.FC<Props> = ({ routing, task, featureFlags }) => {
   if (!routing) return null;
   const { route } = routing;
 
   switch (route) {
     case 'tabbed-forms':
-      return <TabbedForms task={task} />;
+      return <TabbedForms task={task} csamReportEnabled={featureFlags.enable_csam_report} />;
 
     case 'new-case':
       return (
@@ -32,6 +32,9 @@ const HrmForm: React.FC<Props> = ({ routing, task }) => {
           <Case task={task} isCreating={true} />
         </CaseLayout>
       );
+
+    case 'csam-report':
+      return <CSAMReport taskSid={task.taskSid} />;
 
     case 'select-call-type':
     default:
@@ -45,10 +48,6 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const routingState = state[namespace][routingBase];
 
   return { routing: routingState.tasks[ownProps.task.taskSid] };
-};
-
-const mapDispatchToProps = {
-  changeRoute: RoutingActions.changeRoute,
 };
 
 export default connect(mapStateToProps, null)(HrmForm);

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -88,7 +88,7 @@ const TaskView: React.FC<Props> = props => {
     <Flex flexDirection="column" height="100%">
       {featureFlags.enable_previous_contacts && <PreviousContactsBanner task={task} />}
       {!hasTaskControl(task) && <FormNotEditable />}
-      <HrmForm task={task} />
+      <HrmForm task={task} featureFlags={featureFlags} />
     </Flex>
   );
 };

--- a/plugin-hrm-form/src/components/case/ContactDetailsAdapter.js
+++ b/plugin-hrm-form/src/components/case/ContactDetailsAdapter.js
@@ -42,7 +42,7 @@ export const adaptContactToDetailsScreen = (contact, counselorName) => {
   const categories = retrieveCategories(caseInformation.categories);
   const notes = caseInformation.callSummary;
   const channelType = contact.channel;
-  const { conversationDuration } = contact;
+  const { conversationDuration, csamReports } = contact;
   const counselor = counselorName;
 
   return {
@@ -59,6 +59,7 @@ export const adaptContactToDetailsScreen = (contact, counselorName) => {
     },
     counselor,
     details: contact.rawJson,
+    csamReports,
   };
 };
 
@@ -72,6 +73,7 @@ export const adaptFormToContactDetails = (task, form, date, counselor) => {
   const notes = caseInformation.callSummary;
   const { channelType } = task;
   const conversationDuration = getConversationDuration(task, form.metadata);
+  const { csamReports } = form;
 
   return {
     overview: {
@@ -87,5 +89,6 @@ export const adaptFormToContactDetails = (task, form, date, counselor) => {
     },
     counselor,
     details,
+    csamReports,
   };
 };

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -39,6 +39,7 @@ export const getInitialValue = (def: FormItemDefinition) => {
   switch (def.type) {
     case 'input':
     case 'numeric-input':
+    case 'email':
     case 'textarea':
     case 'date-input':
     case 'time-input':
@@ -96,7 +97,7 @@ const bindCreateSelectOptions = (path: string) => (o: SelectOption) => (
  * @param {() => void} updateCallback Callback called to update form state. When is the callback called is specified in the input type.
  * @param {FormItemDefinition} def Definition for a single input.
  */
-const getInputType = (parents: string[], updateCallback: () => void, customHandlers?: CustomHandlers) => (
+export const getInputType = (parents: string[], updateCallback: () => void, customHandlers?: CustomHandlers) => (
   def: FormItemDefinition,
 ) => (
   initialValue: any, // TODO: restrict this type
@@ -123,6 +124,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                 </Row>
                 <FormInput
                   id={path}
+                  data-testid={path}
                   name={path}
                   error={Boolean(error)}
                   aria-invalid={Boolean(error)}
@@ -162,6 +164,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                 </Row>
                 <FormInput
                   id={path}
+                  data-testid={path}
                   name={path}
                   error={Boolean(error)}
                   aria-invalid={Boolean(error)}
@@ -178,6 +181,44 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                     })(innerRef);
                   }}
                   defaultValue={initialValue}
+                />
+                {error && (
+                  <FormError>
+                    <Template id={`${path}-error`} code={error.message} />
+                  </FormError>
+                )}
+              </FormLabel>
+            );
+          }}
+        </ConnectForm>
+      );
+    case 'email':
+      return (
+        <ConnectForm key={path}>
+          {({ errors, register }) => {
+            const error = get(errors, path);
+            return (
+              <FormLabel htmlFor={path}>
+                <Row>
+                  <Box marginBottom="8px">
+                    {labelTextComponent}
+                    {rules.required && <RequiredAsterisk />}
+                  </Box>
+                </Row>
+                <FormInput
+                  id={path}
+                  data-testid={path}
+                  name={path}
+                  error={Boolean(error)}
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={`${path}-error`}
+                  onBlur={updateCallback}
+                  innerRef={register({
+                    ...rules,
+                    pattern: { value: /\S+@\S+\.\S+/, message: 'Entered value does not match email format' },
+                  })}
+                  defaultValue={initialValue}
+                  type="email"
                 />
                 {error && (
                   <FormError>
@@ -207,6 +248,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                 <FormSelectWrapper>
                   <FormSelect
                     id={path}
+                    data-testid={path}
                     name={path}
                     error={Boolean(error)}
                     aria-invalid={Boolean(error)}
@@ -281,6 +323,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                 <FormSelectWrapper>
                   <FormSelect
                     id={path}
+                    data-testid={path}
                     name={path}
                     error={Boolean(error)}
                     aria-invalid={Boolean(error)}
@@ -320,6 +363,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                   <Box marginRight="5px">
                     <FormCheckbox
                       id={path}
+                      data-testid={path}
                       name={path}
                       type="checkbox"
                       aria-invalid={Boolean(error)}
@@ -372,6 +416,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                   <Box marginRight="5px">
                     <FormMixedCheckbox
                       id={path}
+                      data-testid={path}
                       type="checkbox"
                       className="mixed-checkbox"
                       aria-invalid={Boolean(error)}
@@ -418,6 +463,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                 </Row>
                 <FormTextArea
                   id={path}
+                  data-testid={path}
                   name={path}
                   error={Boolean(error)}
                   aria-invalid={Boolean(error)}
@@ -460,6 +506,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                 <FormTimeInput
                   type="time"
                   id={path}
+                  data-testid={path}
                   name={path}
                   error={Boolean(error)}
                   aria-invalid={Boolean(error)}
@@ -500,6 +547,7 @@ const getInputType = (parents: string[], updateCallback: () => void, customHandl
                 <FormDateInput
                   type="date"
                   id={path}
+                  data-testid={path}
                   name={path}
                   error={Boolean(error)}
                   aria-invalid={Boolean(error)}

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -47,6 +47,11 @@ type NumericInputDefinition = {
 } & ItemBase &
   RegisterOptions;
 
+type EmailInputDefinition = {
+  type: 'email';
+} & ItemBase &
+  RegisterOptions;
+
 export type SelectOption = { value: any; label: string };
 
 type SelectDefinition = {
@@ -108,6 +113,7 @@ type FileUploadDefinition = {
 export type FormItemDefinition =
   | InputDefinition
   | NumericInputDefinition
+  | EmailInputDefinition
   | SelectDefinition
   | DependentSelectDefinition
   | CheckboxDefinition

--- a/plugin-hrm-form/src/components/tabbedForms/CSAMAttachments.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/CSAMAttachments.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { Template } from '@twilio/flex-ui';
+
+import { Box, Column, Row } from '../../styles/HrmStyles';
+import { CSAMAttachmentText, CSAMAttachmentIcon } from '../../styles/CSAMReport';
+import { formatStringToDateAndTime } from '../../utils';
+import type { CSAMReportEntry } from '../../types/types';
+
+type Props = {
+  csamReports: CSAMReportEntry[];
+};
+
+const CSAMAttachments: React.FC<Props> = ({ csamReports }) => {
+  return (
+    <Box marginTop="10px">
+      <Column>
+        {csamReports.map(r => {
+          const formattedCreatedAt = formatStringToDateAndTime(r.createdAt);
+
+          return (
+            <Row key={r.csamReportId}>
+              <Box marginRight="5px" marginTop="5px" style={{ alignSelf: 'flex-start' }}>
+                <CSAMAttachmentIcon />
+                {/* <AttachFile fontSize="13px" opacity="0.6" /> */}
+              </Box>
+              <CSAMAttachmentText>
+                <Template code="CSAMReportForm-Attachment" />
+                <br />
+                {`${formattedCreatedAt}m #${r.csamReportId}`}
+              </CSAMAttachmentText>
+            </Row>
+          );
+        })}
+      </Column>
+    </Box>
+  );
+};
+
+CSAMAttachments.displayName = 'CSAMAttachments';
+
+export default CSAMAttachments;

--- a/plugin-hrm-form/src/components/tabbedForms/CSAMReportButton.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/CSAMReportButton.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { ButtonBase } from '@material-ui/core';
+import { Template } from '@twilio/flex-ui';
+import OpenInNew from '@material-ui/icons/OpenInNew';
+
+import { Row, CSAMReportButtonText, Box } from '../../styles/HrmStyles';
+
+type OwnProps = {
+  handleClick: () => void;
+};
+
+type Props = OwnProps;
+
+const CSAMReportButton: React.FC<Props> = ({ handleClick }) => {
+  return (
+    <Row>
+      <ButtonBase onClick={handleClick}>
+        <OpenInNew fontSize="inherit" style={{ marginRight: 5 }} />
+        <CSAMReportButtonText>
+          <Template code="TabbedForms-CSAMReportButton" />
+        </CSAMReportButtonText>
+      </ButtonBase>
+    </Row>
+  );
+};
+
+CSAMReportButton.displayName = 'CSAMReportButton';
+
+export default CSAMReportButton;

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedFormTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedFormTab.tsx
@@ -26,6 +26,7 @@ type OwnProps = {
   tabPath: keyof TaskEntry;
   initialValues: TaskEntry['callerInformation'] | TaskEntry['childInformation'] | TaskEntry['caseInformation'];
   autoFocus: boolean;
+  extraChildrenRight?: React.ReactNode;
 };
 
 // eslint-disable-next-line no-use-before-define
@@ -40,6 +41,7 @@ const TabbedFormTab: React.FC<Props> = ({
   initialValues,
   autoFocus,
   updateForm,
+  extraChildrenRight,
 }) => {
   const shouldFocusFirstElement = display && autoFocus;
   const firstElementRef = useFocus(shouldFocusFirstElement);
@@ -69,7 +71,10 @@ const TabbedFormTab: React.FC<Props> = ({
         <Box paddingBottom={`${BottomButtonBarHeight}px`}>
           <TwoColumnLayout>
             <ColumnarBlock>{l}</ColumnarBlock>
-            <ColumnarBlock>{r}</ColumnarBlock>
+            <ColumnarBlock>
+              {r}
+              {extraChildrenRight}
+            </ColumnarBlock>
           </TwoColumnLayout>
         </Box>
       </Container>

--- a/plugin-hrm-form/src/services/CSAMReportService.ts
+++ b/plugin-hrm-form/src/services/CSAMReportService.ts
@@ -1,0 +1,23 @@
+import fetchHrmApi from './fetchHrmApi';
+// import { CSAMReportEntry } from '../types/types';
+
+type CreateCSAMReportParams = {
+  csamReportId: string;
+  twilioWorkerId: string;
+  contactId?: number;
+};
+
+export const createCSAMReport = async ({ csamReportId, twilioWorkerId, contactId }: CreateCSAMReportParams) => {
+  const body = {
+    twilioWorkerId,
+    csamReportId,
+    contactId,
+  };
+
+  const options = {
+    method: 'POST',
+    body: JSON.stringify(body),
+  };
+
+  return fetchHrmApi('/csamReports', options);
+};

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -191,7 +191,7 @@ const saveContactToHrm = async (
   // This might change if isNonDataCallType, that's why we use rawForm
   const timeOfContact = getDateTime(rawForm.contactlessTask);
 
-  const { helpline } = form;
+  const { helpline, csamReports } = form;
   /*
    * We do a transform from the original and then add things.
    * Not sure if we should drop that all into one function or not.
@@ -219,6 +219,7 @@ const saveContactToHrm = async (
     taskId: uniqueIdentifier,
     channelSid,
     serviceSid,
+    csamReports,
   };
 
   const options = {
@@ -240,6 +241,7 @@ export const saveContact = async (
 ) => {
   const response = await saveContactToHrm(task, form, workerSid, uniqueIdentifier, shouldFillEndMillis);
 
+  // TODO: add catch clause to handle saving to Sync Doc
   try {
     await saveContactToExternalBackend(task, response.requestPayload);
   } finally {

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -6,6 +6,7 @@ import fetchProtectedApi from './fetchProtectedApi';
 import { getConfig } from '../HrmFormPlugin';
 import definitionVersions from '../formDefinitions';
 import type { DefinitionVersion } from '../components/common/forms/types';
+import type { CSAMReportForm } from '../states/csam-report/types';
 
 type PopulateCounselorsReturn = { sid: string; fullName: string }[];
 
@@ -167,6 +168,23 @@ export const getFileDownloadUrl = async (fileNameAtAws: string, fileName: string
 export const getFileUploadUrl = async (fileName: string, mimeType: string) => {
   const body = { fileName, mimeType };
   const response = await fetchProtectedApi('/getFileUploadUrl', body);
+  return response;
+};
+
+/**
+ * Send a CSAM report to IWF
+ */
+export const reportToIWF = async (form: CSAMReportForm) => {
+  const body = {
+    Reported_URL: form.webAddress,
+    Reporter_Description: form.description,
+    Reporter_Anonymous: form.anonymous ? 'Y' : 'N',
+    Reporter_First_Name: form.firstName,
+    Reporter_Last_Name: form.lastName,
+    Reporter_Email_ID: form.email,
+  };
+
+  const response = await fetchProtectedApi('/reportToIWF', body);
   return response;
 };
 

--- a/plugin-hrm-form/src/styles/CSAMReport/index.tsx
+++ b/plugin-hrm-form/src/styles/CSAMReport/index.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import styled from 'react-emotion';
+import { withStyles } from '@material-ui/core';
+import AttachFile from '@material-ui/icons/AttachFile';
+
+import { FontOpenSans, StyledNextStepButton } from '../HrmStyles';
+
+export const CSAMReportContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: #192b334d;
+  padding: 5px 10px;
+`;
+CSAMReportContainer.displayName = 'CSAMReportContainer';
+
+export const CSAMReportLayout = styled('div')`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  align-items: stretch;
+  overflow-y: scroll;
+  background-color: #ffffff;
+  border-radius: 4px 4px 0 0;
+  padding: 3% 4%;
+
+  /* Remove scrollbar */
+  ::-webkit-scrollbar {
+    width: 0;
+    background: transparent;
+  }
+`;
+CSAMReportLayout.displayName = 'CSAMReportLayout';
+
+export const CenterContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;
+CenterContent.displayName = 'CenterContent';
+
+export const CopyCodeButton = styled(StyledNextStepButton)`
+  padding: 7px;
+`;
+CopyCodeButton.displayName = 'CopyCodeButton';
+
+export const BoldDescriptionText = styled(FontOpenSans)<{ fontSize?: string }>`
+  color: #14171a;
+  font-size: ${({ fontSize }) => (fontSize ? fontSize : '14px')};
+  font-weight: 700;
+`;
+BoldDescriptionText.displayName = 'BoldDescriptionText';
+
+export const RegularText = styled(FontOpenSans)`
+  font-size: 13px;
+`;
+RegularText.displayName = 'RegularText';
+
+export const ReportCodeText = styled(FontOpenSans)`
+  color: #009dff;
+  font-size: 12px;
+  line-height: 14px;
+`;
+ReportCodeText.displayName = 'ReportCodeText';
+
+export const ButtonText = styled(FontOpenSans)`
+  color: ${props => props.theme.colors.defaultButtonColor};
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 24px;
+`;
+
+export const CSAMAttachmentText = styled(FontOpenSans)`
+  font-style: italic;
+  font-size: 13px;
+  color: ${props => props.theme.colors.defaultButtonColor};
+`;
+CSAMAttachmentText.displayName = 'CSAMAttachmentText';
+
+export const CSAMAttachmentIcon = withStyles({
+  root: {
+    width: 14,
+    height: 14,
+    color: '#080808',
+    opacity: 0.5,
+  },
+})(AttachFile);
+CSAMAttachmentIcon.displayName = 'CSAMAttachmentIcon';

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -11,10 +11,12 @@ export const BottomButtonBarHeight = 55;
 type BoxProps = {
   width?: string;
   height?: string;
+  margin?: string;
   marginTop?: string;
   marginBottom?: string;
   marginLeft?: string;
   marginRight?: string;
+  padding?: string;
   paddingTop?: string;
   paddingBottom?: string;
   paddingLeft?: string;
@@ -25,10 +27,12 @@ type BoxProps = {
 export const Box = styled('div')<BoxProps>`
   ${({ width }) => width && `width: ${width};`}
   ${({ height }) => height && `height: ${height};`}
+  ${({ margin }) => margin && `margin: ${margin}`}
   ${({ marginTop }) => marginTop && `margin-top: ${marginTop};`}
   ${({ marginBottom }) => marginBottom && `margin-bottom: ${marginBottom};`}
   ${({ marginLeft }) => marginLeft && `margin-left: ${marginLeft};`}
   ${({ marginRight }) => marginRight && `margin-right: ${marginRight};`}
+  ${({ padding }) => padding && `padding: ${padding}`}
   ${({ paddingTop }) => paddingTop && `padding-top: ${paddingTop};`}
   ${({ paddingBottom }) => paddingBottom && `padding-bottom: ${paddingBottom};`}
   ${({ paddingLeft }) => paddingLeft && `padding-left: ${paddingLeft};`}
@@ -372,6 +376,7 @@ export const StyledTab = withStyles({
     height: 35,
     minHeight: 35,
     minWidth: 120,
+    width: 120,
     backgroundColor: '#ecedf1',
     borderTopLeftRadius: 4,
     borderTopRightRadius: 4,
@@ -1011,6 +1016,13 @@ export const Bold = styled('span')`
 `;
 
 Bold.displayName = 'Bold';
+
+export const CSAMReportButtonText = styled(FontOpenSans)`
+  font-size: 12px;
+  color: ${props => props.theme.colors.hyperlinkColor};
+  font-weight: 600;
+`;
+CSAMReportButtonText.displayName = 'CSAMReportButtonText';
 
 export const StyledBackButton = styled(ButtonBase)`
   &:focus {

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -89,8 +89,7 @@
   "SharedStateSaveFormError": "The information stored in the form couldn't be saved. Task will be transferred anyway.",
   "SharedStateLoadFormError": "The information stored in the form by previous counsellor couldn't be retrieved. Starting current task with clear contact form.",
   "SharedStateSaveContactError": "Could not save pending contact at the Shared State.",
-  "SharedStateRetryPendingContactsError": "Could not retry saving the pending contacts from the Shared State.",
-
+  
   "Transfer-TransferButton": "Transfer",
   "Transfer-AcceptTransferButton": "Accept Transfer",
   "Transfer-RejectTransferButton": "Reject Transfer",
@@ -137,12 +136,14 @@
   "TabbedForms-AddCaseInfoTab": "Summary",
   "TabbedForms-AddContactInfoTab": "Contact Info",
   "TabbedForms-BackButton": "Categorize Contact Type",
+  "TabbedForms-CSAMReportButton": "File CSAM Report",
 
   "NotImplemented": "Not implemented yet!",
   "Error-Backend": "Error from backend system.",
   "Error-ContinueWithoutRecording": "Error from backend system.  Are you sure you want to end the task without recording?",
   "Error-Form": "There is a problem with your submission.  Please check the form for errors.",
   "Error-CategoryRequired": "Required 1 category minimum, 3 categories maximum",
+  "Error-Unexpected": "Unexpected error has occurred",
 
   "Case-CaseNumber": "Case #",
   "Case-TimelineSection": "Timeline",
@@ -317,6 +318,24 @@
   "PreviousContacts-OnlyShowRecordsFrom": "Only show records from",
 
   "UploadFile-ButtonText": "Upload File",
-  "DownloadFile-ButtonText": "Download File"
+  "DownloadFile-ButtonText": "Download File",
+  
+  "CSAMReportForm-Header": "File a Report: Child Sexual Abuse Material",
+  "CSAMReportForm-WebsiteDetails": "Website details",
+  "CSAMReportForm-WebsiteDetailsDescription": "Please provide details where the material was discovered.<br>To report more than one website do a separate report.",
+  "CSAMReportForm-ContactDetails": "Contact details",
+  "CSAMReportForm-ContactDetailsDescription": "Reports can be filed anonymously or with contact details if the caller would like to follow up or be available to provide further details to IWF.",
+  "CSAMReportForm-LearnMore": "Learn more",
+  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the UK Data Protection Act",
+  "CSAMReportForm-ReportSent": "CSAM Report Sent!",
+  "CSAMReportForm-CopyCode": "Copy confirmation code for sharing",
+  "CSAMReportForm-Attachment": "CSAM Report has been filled",
+  "CSAMReportForm-ReportsSubmitted": "Reports Submitted",
 
+  "SpecifyIfAnonymousOrNot": "Specify if this report is either anonymous or not",
+  "BottomBar-SendReport": "Send Report",
+  "BottomBar-SendAnotherReport": "Send Another Report",
+  "BottomBar-CloseView": "Close View",
+  "CopyCode": "Copy Code",
+  "Copied": "Copied!"
 }


### PR DESCRIPTION
This PR is part of "splitting https://github.com/techmatters/flex-plugins/pull/543 in smaller chunks".
Primary reviewer: @murilovmachado
Note: is easier to review commit-per-commit.

This PR:
- Adds `createCSAMReport` function to create csam reports in HRM (https://github.com/techmatters/hrm/pull/131).
- Includes `csamReports` when creating a new case in HRM (https://github.com/techmatters/hrm/pull/131).
- Exposes a function to call `reportToIWF` serverless endpoint (IWF API integration).

Note: CI failing due to lint. This will be fixed in subsequent PRs.