### PR TITLE
Custom goodbye message for SaferNet

### DIFF
--- a/plugin-hrm-form/src/dualWrite/br.ts
+++ b/plugin-hrm-form/src/dualWrite/br.ts
@@ -1,6 +1,9 @@
-import { Actions as FlexActions, ITask } from '@twilio/flex-ui';
+import { ITask } from '@twilio/flex-ui';
 
 import { saveContactToSaferNet } from '../services/ServerlessService';
+import { getConfig } from '../HrmFormPlugin';
+import { getMessage } from '../utils/pluginHelpers';
+import { setCustomGoodbyeMessage } from '../utils/setUpActions';
 
 const saveContact = async (task: ITask, payload: any) => {
   const { channelSid } = task.attributes;
@@ -8,11 +11,11 @@ const saveContact = async (task: ITask, payload: any) => {
 
   const postSurveyUrl = await saveContactToSaferNet(payload);
 
-  // TODO: Pre-pend something like 'Please answer the following survey: '
-  await FlexActions.invokeAction('SendMessage', {
-    body: postSurveyUrl,
-    channelSid,
-  });
+  const { helplineLanguage } = getConfig();
+  const language = task.attributes.language || helplineLanguage;
+  const message = await getMessage('SaferNet-CustomGoodbyeMsg')(language);
+
+  setCustomGoodbyeMessage(`${message} ${postSurveyUrl}`);
 };
 
 export default saveContact;

--- a/plugin-hrm-form/src/dualWrite/br.ts
+++ b/plugin-hrm-form/src/dualWrite/br.ts
@@ -3,7 +3,7 @@ import { ITask } from '@twilio/flex-ui';
 import { saveContactToSaferNet } from '../services/ServerlessService';
 import { getConfig } from '../HrmFormPlugin';
 import { getMessage } from '../utils/pluginHelpers';
-import { setCustomGoodbyeMessage } from '../utils/setUpActions';
+import { setCustomGoodbyeMessage, getTaskLanguage } from '../utils/setUpActions';
 
 const saveContact = async (task: ITask, payload: any) => {
   const { channelSid } = task.attributes;
@@ -12,7 +12,7 @@ const saveContact = async (task: ITask, payload: any) => {
   const postSurveyUrl = await saveContactToSaferNet(payload);
 
   const { helplineLanguage } = getConfig();
-  const language = task.attributes.language || helplineLanguage;
+  const language = getTaskLanguage({ helplineLanguage })({ task });
   const message = await getMessage('SaferNet-CustomGoodbyeMsg')(language);
 
   setCustomGoodbyeMessage(`${message} ${postSurveyUrl}`);

--- a/plugin-hrm-form/src/translations/en-US/messages.json
+++ b/plugin-hrm-form/src/translations/en-US/messages.json
@@ -1,4 +1,6 @@
 {
   "WelcomeMsg": "Hi, this is the counsellor. How can I help you?",
-  "GoodbyeMsg": "The counsellor has left the chat. Thank you for reaching out. Please contact us again if you need more help."
+  "GoodbyeMsg": "The counsellor has left the chat. Thank you for reaching out. Please contact us again if you need more help.",
+
+  "SaferNet-CustomGoodbyeMsg": "This chat has ended. Thank you for reaching out. Please help us improve by rating your experience through the following link: "
 }

--- a/plugin-hrm-form/src/translations/pt-BR/messages.json
+++ b/plugin-hrm-form/src/translations/pt-BR/messages.json
@@ -1,4 +1,6 @@
 {
   "WelcomeMsg": "Olá, sou da equipe da SaferNet, precisa de ajuda?",
-  "GoodbyeMsg": "Essa conversa foi finalizada. Obrigada por nos contatar. Por favor, nos ajude a melhorar o canal avaliando a orientação que recebeu clicando no link ao lado: "
+  "GoodbyeMsg": "O conselheiro saiu do chat. Obrigado por nos contactar. Por favor, entre em contato novamente se precisar de mais ajuda",
+
+  "SaferNet-CustomGoodbyeMsg": "Essa conversa foi finalizada. Obrigada por nos contatar. Por favor, nos ajude a melhorar o canal avaliando a orientação que recebeu clicando no link ao lado: "
 }


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-926
Primary reviewer: @GPaoloni 

This PR changes the Goodbye message to a custom one for when successfully saving a contact at SaferNet's backend. When it fails, it will fallback to the default goodbye message.

This should not affect other helplines

~~[WIP]: I was getting `Twilio: Error while setting LastConsumedMessageIndex` when saving a contact. Not sure if it was due to the Twilio Flex instability on Friday evening, or if it's something to fix. Gonna double check that on Monday.~~ This is happening in Aselo development as well, so it's not related to this PR.