### PR TITLE
CHI-838: Script tweaks from SaferNet Production environment setup

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,7 @@ To run the script:
 - Run `npm run setupNewAccount` on the root folder.
 
 To run this script we need to provide the following environment
+
 | Variable               | Description |
 |------------------------|-------------|
 | AWS_ACCESS_KEY_ID      | AWS script-user access key (or any other user with Parameter Store access) |
@@ -71,6 +72,7 @@ To run the script:
 - Run `npm run copyFlow` on the root folder.
 
 To run this script we need to provide the following environment
+
 | Variable               | Description |
 |------------------------|-------------|
 | TWILIO_ACCOUNT_SID_SOURCE | Twilio account sid of the account that contains the desired Studio Flow |

--- a/scripts/src/setupNewAccount/removeTwilioResource.ts
+++ b/scripts/src/setupNewAccount/removeTwilioResource.ts
@@ -1,0 +1,57 @@
+import { WorkspaceContext } from 'twilio/lib/rest/taskrouter/v1/workspace';
+import { Twilio } from 'twilio';
+import { logWarning } from '../helpers/log';
+
+/**
+ * Type aliases defined to work with different types of Twilio resource generically
+ * No such types exist in the Twilio API itself, they are all just unrelated types with the same stuff defined on them.
+ */
+type TwilioResource = { remove: () => void; sid: string; friendlyName: string };
+
+type ResourceListOptions = { limit: number | undefined };
+
+type ResourceListFunction<T extends TwilioResource> = (opts: ResourceListOptions) => Promise<T[]>;
+/**
+ * Generic function for removing a Twlio resource by searching for it by the friendly name used to create it
+ * @param resourceFriendlyName - the 'friendly name' used in the Twilio GUI - used to locate the specific resource from a list of all resources of that type.
+ * @param resourceTypeDescription - a string just used in logs to differentiate the resource from others in the script.
+ * @param resourceGetter - A function to return the resource type provided a workspace instance, e.g. () => client.sync.services
+ */
+export const removeResource = async <T extends TwilioResource>(
+  resourceFriendlyName: string,
+  resourceTypeDescription: string,
+  resourceGetter: () => { list: ResourceListFunction<T> },
+): Promise<void> => {
+  const resource = (await resourceGetter().list({ limit: 20 })).find(
+    (key) => key.friendlyName === resourceFriendlyName,
+  );
+  if (resource) {
+    await resource.remove();
+    logWarning(`Twilio resource: Successfully removed ${resourceTypeDescription} ${resource.sid}`);
+  }
+};
+
+/**
+ * Generic function for removing a resource that is part of the flex workspace
+ * @param client
+ * @param workspaceSid
+ * @param resourceFriendlyName - the 'friendly name' used in the Twilio GUI - used to try to locate the resource.
+ * @param resourceTypeDescription - a string just used in logs to differentiate the resource from others in the script.
+ * @param resourceGetter - A function to return the resource type provided a workspace instance, e.g. workspace => workspace.workflows
+ */
+export const removeWorkspaceResource = async <T extends TwilioResource>(
+  client: Twilio,
+  workspaceSid: string | undefined,
+  resourceFriendlyName: string,
+  resourceTypeDescription: string,
+  resourceGetter: (ws: WorkspaceContext) => { list: ResourceListFunction<T> },
+): Promise<void> => {
+  if (!workspaceSid)
+    throw new Error(
+      `Flex Task Assignment Workspace not found while trying to remove the ${resourceTypeDescription}.`,
+    );
+  const workspace = await client.taskrouter.workspaces(workspaceSid);
+  await removeResource<T>(resourceFriendlyName, resourceTypeDescription, () =>
+    resourceGetter(workspace),
+  );
+};

--- a/scripts/src/setupNewAccount/workflowGenerator.ts
+++ b/scripts/src/setupNewAccount/workflowGenerator.ts
@@ -32,7 +32,7 @@ type WorkflowConfig = {
 
 export const checkWorkflowInSync = async (remoteUrl: string, templatePath: string) => {
   const aseloBetaConfig = {
-    environment: 'Staging',
+    environment: 'Beta',
     shortEnvironment: 'STG',
     helpline: 'Aselo',
     shortHelpline: 'AS',
@@ -43,10 +43,13 @@ export const checkWorkflowInSync = async (remoteUrl: string, templatePath: strin
 
   const generated = generateWorkflowContent(aseloBetaConfig, templatePath);
 
-  if (expected !== generated)
+  if (expected !== generated) {
+    writeFileSync('./expected_serverless_workflow.yml', expected);
+    writeFileSync('./actual_serverless_workflow.yml', generated);
     throw new Error(
-      'The generated workflow file differs from the one being used by Aselo Development.',
+      `The generated workflow file (length ${generated.length}) differs from the one being used by Aselo Beta (length ${expected.length}). Diff expected_serverless_workflow.yml and actual_serverless_workflow.yml to see exact differences.`,
     );
+  }
 };
 
 /**

--- a/scripts/src/setupNewAccount/workflowGenerator.ts
+++ b/scripts/src/setupNewAccount/workflowGenerator.ts
@@ -31,9 +31,9 @@ type WorkflowConfig = {
 };
 
 export const checkWorkflowInSync = async (remoteUrl: string, templatePath: string) => {
-  const aseloDevConfig = {
-    environment: 'Development',
-    shortEnvironment: 'DEV',
+  const aseloBetaConfig = {
+    environment: 'Staging',
+    shortEnvironment: 'STG',
     helpline: 'Aselo',
     shortHelpline: 'AS',
   };
@@ -41,7 +41,7 @@ export const checkWorkflowInSync = async (remoteUrl: string, templatePath: strin
   const response = await fetch(remoteUrl);
   const expected = await response.text();
 
-  const generated = generateWorkflowContent(aseloDevConfig, templatePath);
+  const generated = generateWorkflowContent(aseloBetaConfig, templatePath);
 
   if (expected !== generated)
     throw new Error(

--- a/scripts/src/workflows/serverless.json
+++ b/scripts/src/workflows/serverless.json
@@ -1,5 +1,5 @@
 {
   "workflowTemplatePath": "templates/serverless-workflow-template",
   "fileName": "new-serverless-workflow.yml",
-  "remoteUrl": "https://raw.githubusercontent.com/techmatters/serverless/master/.github/workflows/aselo_development.yml"
+  "remoteUrl": "https://raw.githubusercontent.com/techmatters/serverless/master/.github/workflows/aselo_beta.yml"
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
+    "target": "es2019",
     "strict": true,
     "sourceMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Description

* createTwilioResources: An AWS Parameter already existing does not fail the script, it just moves on.
* createTwilioResources: Does not attempt to delete chatbots because that blocks the unique name from being reused for 30 days. Instead, on creation, if the bot is already found, it uses that instead
* createTwilioResources: Remove functions now attempt to remove resources even if they weren't created on this script run. This means they can fix things when previous cleanup attempts failed
* createTwilioResources: Refactored functioins to remove some copy & pasta
* Made Aselo Beta the baseline environment to verify generated workflows against. rather than Aselo Development,
* Various spelling & markdown corrections.

…script. Tries to remove resources even if not created that run. No longer removes bots and uses existing if they already exist. Uses Aselo Beta rather than Dev as compare baseline

### Checklist
[ X ] Corresponding issue has been opened
[ N/A ] New tests added
[ N/A ] Strings are localized

### Verification steps

Run these scripts setting up a new environment.
