### PR TITLE
Move custom goodbye message code to redux

### DIFF
--- a/plugin-hrm-form/src/dualWrite/br.ts
+++ b/plugin-hrm-form/src/dualWrite/br.ts
@@ -1,21 +1,21 @@
-import { ITask } from '@twilio/flex-ui';
+import { ITask, Manager } from '@twilio/flex-ui';
 
 import { saveContactToSaferNet } from '../services/ServerlessService';
 import { getConfig } from '../HrmFormPlugin';
 import { getMessage } from '../utils/pluginHelpers';
-import { setCustomGoodbyeMessage, getTaskLanguage } from '../utils/setUpActions';
+import { getTaskLanguage } from '../utils/setUpActions';
+import { setCustomGoodbyeMessage } from '../states/dualWrite/actions';
 
 const saveContact = async (task: ITask, payload: any) => {
   const { channelSid } = task.attributes;
   if (!channelSid) return;
 
   const postSurveyUrl = await saveContactToSaferNet(payload);
-
   const { helplineLanguage } = getConfig();
   const language = getTaskLanguage({ helplineLanguage })({ task });
   const message = await getMessage('SaferNet-CustomGoodbyeMsg')(language);
-
-  setCustomGoodbyeMessage(`${message} ${postSurveyUrl}`);
+  const customGoodbyeMessage = `${message} ${postSurveyUrl}`;
+  Manager.getInstance().store.dispatch(setCustomGoodbyeMessage(task.taskSid, customGoodbyeMessage));
 };
 
 export default saveContact;

--- a/plugin-hrm-form/src/states/dualWrite/actions.ts
+++ b/plugin-hrm-form/src/states/dualWrite/actions.ts
@@ -1,0 +1,12 @@
+import * as t from './types';
+
+export const setCustomGoodbyeMessage = (taskId: string, message: string): t.DualWriteActionType => ({
+  type: t.SET_CUSTOM_GOODBYE_MESSAGE,
+  taskId,
+  message,
+});
+
+export const clearCustomGoodbyeMessage = (taskId: string): t.DualWriteActionType => ({
+  type: t.CLEAR_CUSTOM_GOODBYE_MESSAGE,
+  taskId,
+});

--- a/plugin-hrm-form/src/states/dualWrite/reducer.ts
+++ b/plugin-hrm-form/src/states/dualWrite/reducer.ts
@@ -1,0 +1,52 @@
+import { omit } from 'lodash';
+
+import * as t from './types';
+import { GeneralActionType, REMOVE_CONTACT_STATE } from '../types';
+
+type DualWriteState = {
+  tasks: {
+    [taskId: string]: {
+      customGoodbyeMessage?: string;
+    };
+  };
+};
+
+const initialState: DualWriteState = { tasks: {} };
+
+// eslint-disable-next-line import/no-unused-modules
+export function reduce(state = initialState, action: t.DualWriteActionType | GeneralActionType): DualWriteState {
+  switch (action.type) {
+    case t.SET_CUSTOM_GOODBYE_MESSAGE:
+      return {
+        ...state,
+        tasks: {
+          ...state.tasks,
+          [action.taskId]: {
+            ...[action.taskId],
+            customGoodbyeMessage: action.message,
+          },
+        },
+      };
+
+    case t.CLEAR_CUSTOM_GOODBYE_MESSAGE:
+      return {
+        ...state,
+        tasks: {
+          ...state.tasks,
+          [action.taskId]: {
+            ...[action.taskId],
+            customGoodbyeMessage: null,
+          },
+        },
+      };
+
+    case REMOVE_CONTACT_STATE:
+      return {
+        ...state,
+        tasks: omit(state.tasks, action.taskId),
+      };
+
+    default:
+      return state;
+  }
+}

--- a/plugin-hrm-form/src/states/dualWrite/reducer.ts
+++ b/plugin-hrm-form/src/states/dualWrite/reducer.ts
@@ -13,7 +13,6 @@ type DualWriteState = {
 
 const initialState: DualWriteState = { tasks: {} };
 
-// eslint-disable-next-line import/no-unused-modules
 export function reduce(state = initialState, action: t.DualWriteActionType | GeneralActionType): DualWriteState {
   switch (action.type) {
     case t.SET_CUSTOM_GOODBYE_MESSAGE:

--- a/plugin-hrm-form/src/states/dualWrite/types.ts
+++ b/plugin-hrm-form/src/states/dualWrite/types.ts
@@ -1,0 +1,15 @@
+export const SET_CUSTOM_GOODBYE_MESSAGE = 'SET_CUSTOM_GOODBYE_MESSAGE';
+export const CLEAR_CUSTOM_GOODBYE_MESSAGE = 'CLEAR_CUSTOM_GOODBYE_MESSAGE';
+
+type SetCustomGoodbyeMessageAction = {
+  type: typeof SET_CUSTOM_GOODBYE_MESSAGE;
+  taskId: string;
+  message: string;
+};
+
+type ClearCustomGoodbyeMessageAction = {
+  type: typeof CLEAR_CUSTOM_GOODBYE_MESSAGE;
+  taskId: string;
+};
+
+export type DualWriteActionType = SetCustomGoodbyeMessageAction | ClearCustomGoodbyeMessageAction;

--- a/plugin-hrm-form/src/states/index.ts
+++ b/plugin-hrm-form/src/states/index.ts
@@ -7,6 +7,7 @@ import { reduce as ConnectedCaseReducer } from './case/reducer';
 import { reduce as QueuesStatusReducer } from './queuesStatus/reducer';
 import { reduce as ConfigurationReducer } from './configuration/reducer';
 import { reduce as RoutingReducer } from './routing/reducer';
+import { reduce as DualWriteReducer } from './dualWrite/reducer';
 
 // Register your redux store under a unique namespace
 export const namespace = 'plugin-hrm-form';
@@ -16,6 +17,7 @@ export const connectedCaseBase = 'connectedCase';
 export const queuesStatusBase = 'queuesStatusState';
 export const configurationBase = 'configuration';
 export const routingBase = 'routing';
+export const dualWriteBase = 'dualWrite';
 
 const reducers = {
   [contactFormsBase]: ContactStateReducer,
@@ -24,6 +26,7 @@ const reducers = {
   [connectedCaseBase]: ConnectedCaseReducer,
   [configurationBase]: ConfigurationReducer,
   [routingBase]: RoutingReducer,
+  [dualWriteBase]: DualWriteReducer,
 };
 
 // Combine the reducers

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 // eslint-disable-next-line no-unused-vars
 import { Manager, TaskHelper, Actions as FlexActions, StateHelper, ChatOrchestrator } from '@twilio/flex-ui';
 
@@ -162,7 +163,7 @@ const sendSystemMessageOfKey = messageKey => setupObject => async payload => {
   await sendSystemMessage({ taskSid: payload.task.taskSid, message, from: 'Bot' });
 };
 
-const sendSystemCustomGoodyeMessage = customGoodbyeMessage => () => async payload => {
+const sendSystemCustomGoodbyeMessage = customGoodbyeMessage => () => async payload => {
   const { taskSid } = payload.task;
   Manager.getInstance().store.dispatch(clearCustomGoodbyeMessage(taskSid));
   await sendSystemMessage({ taskSid, message: customGoodbyeMessage, from: 'Bot' });
@@ -170,10 +171,13 @@ const sendSystemCustomGoodyeMessage = customGoodbyeMessage => () => async payloa
 
 const sendWelcomeMessage = sendMessageOfKey('WelcomeMsg');
 const sendGoodbyeMessage = taskSid => {
-  const customGoodbyeMessage = Manager.getInstance().store.getState()[namespace][dualWriteBase].tasks[taskSid]
-    ?.customGoodbyeMessage;
+  const { enable_dual_write } = getConfig().featureFlags;
+
+  const customGoodbyeMessage =
+    enable_dual_write &&
+    Manager.getInstance().store.getState()[namespace][dualWriteBase].tasks[taskSid]?.customGoodbyeMessage;
   return customGoodbyeMessage
-    ? sendSystemCustomGoodyeMessage(customGoodbyeMessage)
+    ? sendSystemCustomGoodbyeMessage(customGoodbyeMessage)
     : sendSystemMessageOfKey('GoodbyeMsg');
 };
 


### PR DESCRIPTION
Primary Reviewer: @GPaoloni 

## Description
This PR moves code related to the custom goodbye message into redux. Since this feature is part of the `dualWrite` feature, I've created the `dualWrite` **reducer**.

This new code also fixes some potential bugs, because previously the `customGoodbyeMessage` was a single variable that was used by all the tasks. Now, each task has its own `customGoodbyeMessage` on redux (same structure as contacts or cases reducer), so there's no way one task could interfere with another task's `customGoodbyeMessage`.

### Verification steps
This is not trivial to run locally to test. I'm happy with you looking only at the code. But in case you want to see the behavior, you'd have to:
1) Run serverless locally
2) Edit flex-plugins getConfig so that it uses SaferNet configs:
    - helpline
    - helplineLanguage
    - featureFlags: enable_dual_write
3) Point `ServerlessService.saveContactToSaferNet` to call your local serverless
4) Send a message from Facebook to [Safernet Staging
](https://www.facebook.com/Safernet_Stg-104153648721033/)