### PR TITLE
Removed end chat button if dual write is on

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -188,7 +188,7 @@ const setUpComponents = setupObject => {
   if (!Boolean(helpline)) Components.setUpDeveloperComponents(setupObject); // utilities for developers only
 
   // remove dynamic components
-  Components.removeActionsIfWrapping();
+  Components.removeTaskCanvasHeaderActions(setupObject);
   Components.setLogo(setupObject.logoUrl);
   if (featureFlags.enable_transfers) {
     Components.removeDirectoryButton();

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -361,12 +361,14 @@ export const setUpStandaloneSearch = () => {
 };
 
 /**
- * Removes the actions buttons from TaskCanvasHeaders if the task is wrapping
+ * Removes the actions buttons from TaskCanvasHeaders if the task is wrapping or if dual write is on (temporary prevents bug)
+ * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
  */
-export const removeActionsIfWrapping = () => {
+export const removeTaskCanvasHeaderActions = setupObject => {
+  const { featureFlags } = setupObject;
   // Must use submit buttons in CRM container to complete task
   Flex.TaskCanvasHeader.Content.remove('actions', {
-    if: props => props.task && props.task.status === 'wrapping',
+    if: props => (props.task && props.task.status === 'wrapping') || featureFlags.enable_dual_write,
   });
 };
 


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

## Description
This PR removes the "end chat" button if the helpline has dual write enabled. 
![Screenshot from 2021-12-21 15-26-52](https://user-images.githubusercontent.com/15805319/146980994-d2e0403d-f0d4-4255-acf4-7736472dfa2f.png)

### Checklist
- [:negative_squared_cross_mark: ] Corresponding issue has been opened (should I?).
- [:negative_squared_cross_mark:] New tests added (this files does not have tests, moving to TS and testing them may be a good idea).
- [ N/A] Strings are localized
- [:heavy_check_mark:] Verified for chat
- [N/A] Verified for calls

### Verification steps
- Set `enable_dual_write` flag in service configuration
- `npm run dev` to start dev server
- Send and accept a new chat contact