### PR TITLE
Added PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
+Primary reviewer:
+
+## Description
+<!--
+- What this pull request does.
+- Bug fix, new feature, documentation change, etc.
+-->
+
+### Checklist
+- [ ] Corresponding issue has been opened
+- [ ] New tests added
+- [ ] Strings are localized
+- [ ] Tested for chat contacts
+- [ ] Tested for call contacts
+
+### Related Issues
+Fixes #....
+
+### Verification steps
+<!--
+Describe how to validate your changes.
+- Include screen shots if applicable.
+- Note if migrations are required.
+-->


### PR DESCRIPTION
## Description
Adds a PR template for this repo. Is mostly the same as the [organization one](https://github.com/techmatters/.github/blob/main/.github/pull_request_template.md), but includes primary reviewer, chat and calls tests. 


### Checklist
- [x] Corresponding issue has been opened ([Jira](https://bugs.benetech.org/browse/CHI-964))
- [ ] N/A New tests added
- [ ] N/A Strings are localized