### PR TITLE
Fix es-IN translations for Aarambh

### DIFF
--- a/plugin-hrm-form/src/translations/en-IN/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-IN/flexUI.json
@@ -4,5 +4,5 @@
   "SearchForm-Counselor": "Case Worker",
   "CallTypeAndCounselor-Label": "Case Worker",
   "CaseList-THCounselor": "Case Worker",
-  "ContactDetails-GeneralDetails-Counselor": "Case Worker",
+  "ContactDetails-GeneralDetails-Counselor": "Case Worker"
 }

--- a/plugin-hrm-form/src/utils/pluginHelpers.js
+++ b/plugin-hrm-form/src/utils/pluginHelpers.js
@@ -9,14 +9,19 @@ const defaultMessages = require(`../translations/${defaultLanguage}/messages.jso
 const ptBRTranslation = require(`../translations/pt-BR/flexUI.json`);
 const ptBRMessages = require(`../translations/pt-BR/messages.json`);
 
+const enINTranslation = require(`../translations/en-IN/flexUI.json`);
+const enINMessages = require(`../translations/en-IN/messages.json`);
+
 const bundledTranslations = {
   [defaultLanguage]: defaultTranslation,
   'pt-BR': ptBRTranslation,
+  'en-IN': enINTranslation,
 };
 
 const bundledMessages = {
   [defaultLanguage]: defaultMessages,
   'pt-BR': ptBRMessages,
+  'en-IN': enINMessages,
 };
 
 const translationErrorMsg = 'Could not translate, using default';


### PR DESCRIPTION
## Description
This PR adds the missing `en-IN` translation in our map of bundled translations (missed this step before).

### Verification steps
- Edit the `helplineLanguage` to be 'en-IN' in `HrmFormPlugin.js` file (line 62).
- Start local server with `npm run dev`.
- Check that the intended translations are displayed in the UI.

Question for @dee-luo: I see that the strings in `messages.json` are still using the counsellor word. Should this be updated? If so, feel free to do in this very same PR.