### PR TITLE
Auto retry saving pending contacts

### DIFF
--- a/plugin-hrm-form/src/dualWrite/br.ts
+++ b/plugin-hrm-form/src/dualWrite/br.ts
@@ -6,11 +6,13 @@ import { getMessage } from '../utils/pluginHelpers';
 import { getTaskLanguage } from '../utils/setUpActions';
 import { setCustomGoodbyeMessage } from '../states/dualWrite/actions';
 
-const saveContact = async (task: ITask, payload: any) => {
+const saveContact = async (task: ITask, payload: any, isAutoRetry = false) => {
   const { channelSid } = task.attributes;
   if (!channelSid) return;
 
   const postSurveyUrl = await saveContactToSaferNet(payload);
+  if (isAutoRetry) return; // TODO: here we will try opening a facebok chat to send back the post-survey url
+
   const { helplineLanguage } = getConfig();
   const language = getTaskLanguage({ helplineLanguage })({ task });
   const message = await getMessage('SaferNet-CustomGoodbyeMsg')(language);

--- a/plugin-hrm-form/src/dualWrite/index.ts
+++ b/plugin-hrm-form/src/dualWrite/index.ts
@@ -4,7 +4,7 @@ import { getConfig } from '../HrmFormPlugin';
 import { savePendingContactToSharedState, autoRetrySavingPendingContacts } from '../utils/sharedState';
 import saveContactToSaferNet from './br';
 
-type DualWriteFn = (task: ITask, payload: any) => Promise<void>;
+type DualWriteFn = (task: ITask, payload: any, isAutoRetry?: boolean) => Promise<void>;
 
 type SaveContactByDefinitionVersion = {
   [definitionVersion: string]: DualWriteFn;

--- a/plugin-hrm-form/src/dualWrite/index.ts
+++ b/plugin-hrm-form/src/dualWrite/index.ts
@@ -1,7 +1,7 @@
 import { ITask } from '@twilio/flex-ui';
 
 import { getConfig } from '../HrmFormPlugin';
-import { savePendingContactToSharedState } from '../utils/sharedState';
+import { savePendingContactToSharedState, autoRetrySavingPendingContacts } from '../utils/sharedState';
 import saveContactToSaferNet from './br';
 
 type DualWriteFn = (task: ITask, payload: any) => Promise<void>;
@@ -22,6 +22,7 @@ export const saveContactToExternalBackend = async (task: ITask, payload: any) =>
   if (saveContact) {
     try {
       await saveContact(task, payload);
+      autoRetrySavingPendingContacts(saveContact);
     } catch (err) {
       savePendingContactToSharedState(task, payload, err);
     }

--- a/plugin-hrm-form/src/utils/sharedState.js
+++ b/plugin-hrm-form/src/utils/sharedState.js
@@ -1,5 +1,4 @@
 import { getConfig } from '../HrmFormPlugin';
-import { saveContactToExternalBackend } from '../dualWrite';
 import { recordBackendError } from '../fullStory';
 
 const isSharedStateClientConnected = sharedStateClient =>
@@ -145,7 +144,7 @@ export const savePendingContactToSharedState = async (task, payload, error) => {
 
 /**
  * Loops through the pending contacts and try saving them to the external backend.
- * When a pending contact is successfully saved to the external backend, it's removed from the pending contacts list.
+ * When a pending contact is successfully saved on the external backend, it's removed from the pending contacts list.
  * When a pending contact fails to be saved on the external backend, its 'retries' attribute is incremented.
  * @param {*} saveContactFn Function that saves a contact to the external backend
  */

--- a/plugin-hrm-form/src/utils/sharedState.js
+++ b/plugin-hrm-form/src/utils/sharedState.js
@@ -180,7 +180,7 @@ export const autoRetrySavingPendingContacts = async saveContactFn => {
       const { task, payload } = value;
 
       try {
-        await saveContactFn(task, payload);
+        await saveContactFn(task, payload, true);
         successfulRetriesIndexes.push(index);
       } catch (e) {
         failedRetriesIndexes.push(index);
@@ -199,6 +199,10 @@ export const autoRetrySavingPendingContacts = async saveContactFn => {
   } catch (e) {
     console.error('Error while auto retrying to save pending contacts', e);
   } finally {
-    await pendingContactsLock.set({ isLocked: false });
+    try {
+      await pendingContactsLock.set({ isLocked: false });
+    } catch (e) {
+      console.error('Error releasing pending-contacts-lock', e);
+    }
   }
 };


### PR DESCRIPTION
Primary reviewer: @GPaoloni 
Jira: https://bugs.benetech.org/browse/CHI-880

## Description
This PR implements auto-retry for the pending contacts:
- The auto-retry is triggered when any contact succeeds to be saved on the external backend.
- When a pending contact is successfully saved on the external backend, it's removed from the pending contacts list.
- When a pending contact fails to be saved on the external backend, its 'retries' attribute is incremented.
- `pending-contacts-lock` is used to ~prevent~ minimize concurrency issues


### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added [WIP]

### Verification steps
Testing this PR is not trivial because it involves a lot of setups. I'm writing unit tests to make sure `autoRetrySavingPendingContacts()` works as intended.
