### PR TITLE
[PoC] First implementation Worker Availability

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -198,6 +198,9 @@ const setUpComponents = setupObject => {
   Components.setUpStandaloneSearch();
 
   if (featureFlags.enable_canned_responses) Components.setupCannedResponses();
+
+  // set feature flag here
+  if (true) Components.setUpWorkerStatusHandler();
 };
 
 /**

--- a/plugin-hrm-form/src/components/WorkerStatusHandler/WorkerStatusHandler.tsx
+++ b/plugin-hrm-form/src/components/WorkerStatusHandler/WorkerStatusHandler.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+
+import type { RootState } from '../../states';
+
+type OwnProps = {
+  workerClient: import('@twilio/flex-ui').Manager['workerClient'];
+};
+
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
+  const { worker } = state.flex;
+
+  return { worker };
+};
+
+const connector = connect(mapStateToProps);
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+const WorkerStatusHandler: React.FC<Props> = ({ worker, workerClient }) => {
+  const [availableActivity, offlineActivity] = React.useMemo(() => {
+    const activitiesArray = Array.from(workerClient.activities);
+    const [, available] = activitiesArray.find(([k, v]) => v.name === 'Available');
+    const [, offline] = activitiesArray.find(([k, v]) => v.name === 'Offline');
+    return [available, offline];
+  }, [workerClient.activities]);
+
+  const noTasks = worker.tasks.size === 0;
+  const { available } = worker.activity;
+  const { attributes } = worker;
+  const isSomeTaskPending = Array.from(worker.tasks).some(([, t]) => t.status === 'pending');
+
+  const shouldSetAvailable = noTasks && !available; // here we want to also consider a worker attribute to indicate if should stay offline or if it's "ready to work"
+  const shouldSetOffline = available && !noTasks && !worker.attributes.keepAvailable && !isSomeTaskPending;
+
+  console.log('>>>> shouldSetAvailable', shouldSetAvailable);
+  console.log('>>>> shouldSetOffline', shouldSetOffline);
+
+  React.useEffect(() => {
+    const handleActivities = async () => {
+      if (shouldSetAvailable) {
+        console.log('>>>> setting available');
+        await availableActivity.setAsCurrent();
+      } else if (shouldSetOffline) {
+        console.log('>>>> setting offline');
+        await offlineActivity.setAsCurrent();
+      }
+    };
+
+    try {
+      handleActivities();
+    } catch (err) {
+      console.log('>>>> err on handleActivities', err);
+    }
+  }, [availableActivity, offlineActivity, shouldSetAvailable, shouldSetOffline]);
+
+  return null;
+};
+WorkerStatusHandler.displayName = 'WorkerStatusHandler';
+
+export default connector(WorkerStatusHandler);

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -8,6 +8,7 @@ import * as TransferHelpers from './transfer';
 import CannedResponses from '../components/CannedResponses';
 import QueuesStatusWriter from '../components/queuesStatus/QueuesStatusWriter';
 import QueuesStatus from '../components/queuesStatus';
+import WorkerStatusHandler from '../components/WorkerStatusHandler/WorkerStatusHandler';
 import CustomCRMContainer from '../components/CustomCRMContainer';
 import LocalizationContext from '../contexts/LocalizationContext';
 import Translator from '../components/translator';
@@ -87,6 +88,19 @@ export const setUpQueuesStatusWriter = setupObject => {
       key="queue-status-writer"
       workerSid={workerSid}
     />,
+    {
+      sortOrder: -1,
+      align: 'start',
+    },
+  );
+};
+
+/**
+ * Add an "invisible" component that tracks the state of the worker, setting the status activity accordingly
+ */
+export const setUpWorkerStatusHandler = () => {
+  Flex.MainContainer.Content.add(
+    <WorkerStatusHandler workerClient={Flex.Manager.getInstance().workerClient} key="worker-status-handler" />,
     {
       sortOrder: -1,
       align: 'start',


### PR DESCRIPTION
## Description
This PR is a proof of concept of the Option 1 for worker's availability, as described in https://benetech.app.box.com/notes/902771185700.
 
### Checklist
- [ ] Corresponding issue has been opened: https://bugs.benetech.org/browse/CHI-982
[N/A] New tests added
[N/A] Strings are localized

### Verification steps
Keep an eye to the worker status activity at every time while doing this. On top of that, you can open the browser console and find the logs prefixed with `>>>>` that are intentionally included here, to check when the calculation is run and what the values are.
- Run this branch locally with `npm run dev`.
- Try chat based contacts and manual pull for extra tasks.

Required work on top of this:
- Proper handling for transferred tasks to a particular worker (direct transfers). This should be handled in the corresponding Serverless function (set `keepAvailable`) when the transferred task is created and in Flex UI (unset `keepAvailable`) when the transferred task is accepted or rejected.
- Proper handling for offline contacts. This should be handled in the corresponding Serverless function (set & unset `keepAvailable`).
- Define a new flag to indicate when a worker is "ready" to accept tasks vs when it's not, probably using task attributes (something like `isReady`). This flag should be taken into consideration to set Available to allow tasks come in, but it's probably not required to be part of the task assignment rules.
- Define if we want more statuses other than "Ready" and "Not Ready" (analogous to Available and Offline).
- UI (this will partially depend on above item):
  - Top right corner of worker view.
  
    ![Screenshot from 2022-01-12 15-34-01](https://user-images.githubusercontent.com/15805319/149201074-7f9c8f0b-139f-42e8-b37e-fbf016d8615d.png)

  - No tasks view of worker's view.
  
    ![Screenshot from 2022-01-12 15-34-54](https://user-images.githubusercontent.com/15805319/149201178-87badff8-dc3d-4b16-a761-e97c576daae8.png)

  - Workers statuses of supervisor's view.
  
    ![Screenshot from 2022-01-12 15-36-27](https://user-images.githubusercontent.com/15805319/149201363-8cc344dc-bd38-4665-a461-9c9234b28cbb.png)

- How can we deal with the lost information of worker's reports in Insights? Custom timestamps? Fullstory?
