### PR TITLE
Prepopulate form: chatbot to form definition mappings

### DIFF
--- a/hrm-form-definitions/form-definitions/jm-v1/PrepopulateKeys.json
+++ b/hrm-form-definitions/form-definitions/jm-v1/PrepopulateKeys.json
@@ -1,0 +1,1 @@
+{ "ChildInformationTab": ["parish"], "CallerInformationTab": ["parish"] }

--- a/hrm-form-definitions/package-lock.json
+++ b/hrm-form-definitions/package-lock.json
@@ -1752,9 +1752,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
       "dev": true
     },
     "@types/prettier": {

--- a/hrm-form-definitions/package.json
+++ b/hrm-form-definitions/package.json
@@ -14,6 +14,7 @@
     "@babel/preset-env": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",
     "@types/jest": "^27.0.3",
+    "@types/node": "^17.0.8",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
     "babel-core": "^6.26.3",

--- a/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -1,3 +1,5 @@
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
 import {
   CallTypeButtonsDefinitions,
   CannedResponsesDefinitions,
@@ -22,7 +24,7 @@ export enum DefinitionVersionId {
 // Using a variable for the root of the dynamic import confuses webpack :-(
 // const DEFINITION_JSON_ROOT = '../../form-definitions/';
 
-export async function loadDefinition(version: DefinitionVersionId) {
+export async function loadDefinition(version: DefinitionVersionId): Promise<DefinitionVersion> {
   /*
    * Unfortuntately I could not get lazy loading to work, which would have been nice because only the form definitions used by that helpline would be loeded.
    * It appears to be an issue with the module loader, when the bundle was split across multiple files for lazy loading, the additional bundle JS files were not loaded at runtime.
@@ -80,6 +82,13 @@ export async function loadDefinition(version: DefinitionVersionId) {
     /* webpackMode: "eager" */ `../../form-definitions/${version}/CaseStatus.json`
   );
 
+  let prepopulateKeys;
+  try {
+    prepopulateKeys = require(`../../form-definitions/${version}/PrepopulateKeys.json`);
+  } catch (err) {
+    prepopulateKeys = [];
+  }
+
   const { helplines } = helplineInformationModule.default;
   const defaultHelpline =
     helplineInformationModule.default.helplines.find((helpline: HelplineEntry) => helpline.default)
@@ -110,5 +119,6 @@ export async function loadDefinition(version: DefinitionVersionId) {
       oneToManyConfigSpecs: oneToManyConfigSpecsModule.default as OneToManyConfigSpecs,
     },
     caseStatus: caseStatusModule.default as DefinitionVersion['caseStatus'],
+    prepopulateKeys,
   };
 }

--- a/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -86,7 +86,7 @@ export async function loadDefinition(version: DefinitionVersionId): Promise<Defi
   try {
     prepopulateKeys = require(`../../form-definitions/${version}/PrepopulateKeys.json`);
   } catch (err) {
-    prepopulateKeys = [];
+    prepopulateKeys = { ChildInformationTab: [], CallerInformationTab: [] };
   }
 
   const { helplines } = helplineInformationModule.default;

--- a/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -84,7 +84,9 @@ export async function loadDefinition(version: DefinitionVersionId): Promise<Defi
 
   let prepopulateKeys;
   try {
-    prepopulateKeys = require(`../../form-definitions/${version}/PrepopulateKeys.json`);
+    prepopulateKeys = await import(
+      /* webpackMode: "eager" */ `../../form-definitions/${version}/PrepopulateKeys.json`
+    );
   } catch (err) {
     prepopulateKeys = { ChildInformationTab: [], CallerInformationTab: [] };
   }

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -188,5 +188,5 @@ export type DefinitionVersion = {
   caseStatus: {
     [status: string]: StatusInfo;
   };
-  prepopulateKeys: string[];
+  prepopulateKeys: { ChildInformationTab: string[]; CallerInformationTab: string[] };
 };

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -188,4 +188,5 @@ export type DefinitionVersion = {
   caseStatus: {
     [status: string]: StatusInfo;
   };
+  prepopulateKeys: string[];
 };

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -11,7 +11,10 @@ const getUnknownOption = (key: string, definition: FormDefinition) => {
   const inputDef = definition.find(e => e.name === key);
 
   if (inputDef && inputDef.type === 'select') {
-    return inputDef.unknownOption || inputDef.options.find(e => e.value === 'Unknown').value;
+    const unknownOption = inputDef.unknownOption || inputDef.options.find(e => e.value === 'Unknown');
+    if (unknownOption && unknownOption.value) return unknownOption.value;
+
+    console.error(`getUnknownOption couldn't determine a valid unknown option for key ${key}.`);
   }
 
   return 'Unknown';

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -73,7 +73,7 @@ const getValuesFromAnswers = (
   task: ITask,
   answers: any,
   tabFormDefinition: FormDefinition,
-  prepopulateKeys: DefinitionVersion['prepopulateKeys'],
+  prepopulateKeys: string[],
 ) => {
   // Get values from task attributes
   const { firstName, language } = task.attributes;
@@ -114,8 +114,11 @@ export const prepopulateForm = (task: ITask) => {
     const isAboutSelf = answers.about_self.answer === 'Yes';
     const callType = isAboutSelf ? callTypes.child : callTypes.caller;
     const tabFormDefinition = isAboutSelf ? ChildInformationTab : CallerInformationTab;
+    const prepopulateKeys = isAboutSelf
+      ? currentDefinitionVersion.prepopulateKeys.ChildInformationTab
+      : currentDefinitionVersion.prepopulateKeys.CallerInformationTab;
 
-    const values = getValuesFromAnswers(task, answers, tabFormDefinition, currentDefinitionVersion.prepopulateKeys);
+    const values = getValuesFromAnswers(task, answers, tabFormDefinition, prepopulateKeys);
 
     Manager.getInstance().store.dispatch(prepopulateFormAction(callType, values, task.taskSid));
 

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -1,6 +1,6 @@
 import { ITask, Manager } from '@twilio/flex-ui';
 import { capitalize } from 'lodash';
-import { callTypes, FormDefinition } from 'hrm-form-definitions';
+import { callTypes, FormDefinition, DefinitionVersion } from 'hrm-form-definitions';
 
 import { mapAge, mapGenericOption } from './mappers';
 import * as RoutingActions from '../states/routing/actions';
@@ -32,12 +32,11 @@ const getSelectOptions = (key: string) => (definition: FormDefinition) => {
   return [];
 };
 
-type PrePopulateAnswers = 'age' | 'gender' | 'ethnicity';
 type MapperFunction = (options: string[]) => (value: string) => string;
 
 const getAnswerOrUnknown = (
   answers: any,
-  key: PrePopulateAnswers,
+  key: string,
   definition: FormDefinition,
   mapperFunction: MapperFunction = mapGenericOption,
 ) => {
@@ -47,21 +46,59 @@ const getAnswerOrUnknown = (
   // This prevents setting redux state with the 'Unknown' value for a property that is not asked by the pre-survey
   if (!isRequiredKey && !answers[key]) return null;
 
+  const itemDefinition = definition.find(e => e.name === key);
+
   // This prevents setting redux state with the 'Unknown' value for a property that is not present on the definition
-  if (!definition.find(e => e.name === key)) {
+  if (!itemDefinition) {
     console.error(`${key} does not exist in the current definition`);
     return null;
   }
 
-  const unknown = getUnknownOption(key, definition);
-  const isUnknownAnswer = answers[key].error || answers[key].answer === unknown;
+  if (itemDefinition.type === 'select') {
+    const unknown = getUnknownOption(key, definition);
+    const isUnknownAnswer = answers[key].error || answers[key].answer === unknown;
 
-  if (isUnknownAnswer) return unknown;
+    if (isUnknownAnswer) return unknown;
 
-  const options = getSelectOptions(key)(definition);
-  const result = mapperFunction(options)(answers[key].answer);
+    const options = getSelectOptions(key)(definition);
+    const result = mapperFunction(options)(answers[key].answer);
 
-  return result === 'Unknown' ? unknown : result;
+    return result === 'Unknown' ? unknown : result;
+  }
+
+  return answers[key].answer;
+};
+
+const getValuesFromAnswers = (
+  task: ITask,
+  answers: any,
+  tabFormDefinition: FormDefinition,
+  prepopulateKeys: DefinitionVersion['prepopulateKeys'],
+) => {
+  // Get values from task attributes
+  const { firstName, language } = task.attributes;
+
+  // Get required values from bot's memory
+  const age = getAnswerOrUnknown(answers, 'age', tabFormDefinition, mapAge);
+  const gender = getAnswerOrUnknown(answers, 'gender', tabFormDefinition);
+
+  // This field is not required yet it's bundled here as if it were. Leaving it from now but should we move it to prepopulateKeys where it's used?
+  const ethnicity = getAnswerOrUnknown(answers, 'ethnicity', tabFormDefinition);
+
+  // Get the customizable values from the bot's memory if there's any value (defined in PrepopulateKeys.json)
+  const customizableValues = prepopulateKeys.reduce((accum, key) => {
+    const value = getAnswerOrUnknown(answers, key, tabFormDefinition);
+    return value ? { ...accum, [key]: value } : accum;
+  }, {});
+
+  return {
+    ...(firstName && { firstName }),
+    ...(gender && { gender }),
+    ...(age && { age }),
+    ...(ethnicity && { ethnicity }),
+    ...(language && { language: capitalize(language) }),
+    ...customizableValues,
+  };
 };
 
 export const prepopulateForm = (task: ITask) => {
@@ -72,23 +109,13 @@ export const prepopulateForm = (task: ITask) => {
     // If can't know if call is child or caller, do nothing here
     if (!answers.about_self || !['Yes', 'No'].includes(answers.about_self.answer)) return;
 
-    const { CallerInformationTab, ChildInformationTab } = getDefinitionVersions().currentDefinitionVersion.tabbedForms;
+    const { currentDefinitionVersion } = getDefinitionVersions();
+    const { CallerInformationTab, ChildInformationTab } = currentDefinitionVersion.tabbedForms;
     const isAboutSelf = answers.about_self.answer === 'Yes';
     const callType = isAboutSelf ? callTypes.child : callTypes.caller;
-    const definitionForm = isAboutSelf ? ChildInformationTab : CallerInformationTab;
+    const tabFormDefinition = isAboutSelf ? ChildInformationTab : CallerInformationTab;
 
-    const { firstName, language } = task.attributes;
-    const age = getAnswerOrUnknown(answers, 'age', definitionForm, mapAge);
-    const gender = getAnswerOrUnknown(answers, 'gender', definitionForm);
-    const ethnicity = getAnswerOrUnknown(answers, 'ethnicity', definitionForm);
-
-    const values = {
-      ...(firstName && { firstName }),
-      ...(gender && { gender }),
-      ...(age && { age }),
-      ...(ethnicity && { ethnicity }),
-      ...(language && { language: capitalize(language) }),
-    };
+    const values = getValuesFromAnswers(task, answers, tabFormDefinition, currentDefinitionVersion.prepopulateKeys);
 
     Manager.getInstance().store.dispatch(prepopulateFormAction(callType, values, task.taskSid));
 


### PR DESCRIPTION
## Description
This PR introduces a new customization file available for the helplines: `PrepopulateKeys.json`. It should be part of the root of the definition, and it's an object with two arrays of strings where each key represents an answer we want to grab from the bot's memory and drop n the form, one represents the values to grab if the contact is "child calling about self" type, the other if it's "caller". Obviously this keys must exist in the form definition for the according tab (child or caller). This file is not required, so if a definition version does not have it, nothing goes wrong, but if it does the file must be an array. An example to address the JM needs (grab the `parish` from the survey) is like `{ "ChildInformationTab": ["parish"], "CallerInformationTab": ["parish"] }` as the entire content of this `PrepopulateKeys.json` file.

### Checklist
- [x] Corresponding issue has been opened: https://bugs.benetech.org/browse/CHI-1003
- [WIP] New tests added
- [N/A] Strings are localized

### Verification steps
- Create a new `PrepopulateKeys.json` file in the corresponding form definition you are using (remember this now lives in `flex-plugins/hrm-form-definitions/` so the entire path for `jm-v1` will look like `flex-plugins/hrm-form-definitions/form-definitions/jm-v1/PrepopulateKeys.json`). Fill it with the fields you want to include in the prepopulate process (like `{ "ChildInformationTab": ["phone1"], "CallerInformationTab": ["phone2"] }`).
- Send a new chat task and reserve it but don't accept it yet. Note that in this step, the survey must be answered (at least the first question with `Yes` or `No`).
- Go to Twilio console, locate the task and edit it's attributes to mimic the bot answers to contain one that matches what you expect, under the `collected_data` property of the memory. You can add something like `"phone1":{"answer":"123"}`.
- Now accept the task, and the answer from above should be pasted in the corresponding form field.
- Repeat the above to check the other call type.

@dee-luo Does this format makes sense? What do the rest of the team thinks? I don't consider this behavior to belong anywhere else in the form definitions so that's why a new file is introduced, but let me know if you think differently.