### PR TITLE
Updated preinstall script

### DIFF
--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "preinstall": "cd ../hrm-form-definitions && npm run build",
+    "preinstall": "cd ../hrm-form-definitions && npm ci && npm run build",
     "postinstall": "flex-plugin pre-script-check",
     "prestart": "flex-plugin pre-start-check",
     "dev": "UNBUNDLED_REACT=true NO_MONITORING=true npm start",


### PR DESCRIPTION
## Description
Changes `plugin-hrm-form` `preinstall` script to bundle `hrm-form-definitions` dependencies prior to compiling.

This fixes this issue on our current presintall script.
![Screenshot from 2022-01-20 17-18-02](https://user-images.githubusercontent.com/15805319/150415516-b9b766cf-0b94-4e6d-b2b9-771c6707761b.png)

### Verification steps
- Delete `node_modules` folder from `hrm-form-definitions` and from `plugin-hrm-form`.
- Run `UNBUNDLED_REACT=true npm ci` in `plugin-hrm-form`.
- Confirm that everything is installed properly (and `hrm-form-definitions` compiles).
- Run `npm run dev` to check that the plugin is able to compile too.