### PR TITLE
Added adult as a possible non data calltype

### DIFF
--- a/hrm-form-definitions/src/formDefinition/callTypes.ts
+++ b/hrm-form-definitions/src/formDefinition/callTypes.ts
@@ -7,6 +7,7 @@ export const callTypes = {
   hangup: 'Hang up',
   wrongnumber: 'Wrong Number',
   abusive: 'Abusive',
+  adult: 'Adult Contact',
   test: 'test',
 } as const;
 


### PR DESCRIPTION
## Description
Adds `adult` as a possible key for call types. This allows `jm-v1` custom button setup to work properly.

### Verification steps
- Change the used `definitionVersion` to be `jm-v1` by changing the return of `getConfig` (`src/HrmFormPlugin.js`) to be
```
  /**
   * @type {any}
   */
   definitionVersion: 'jm-v1',
```
- Start local server (`npm run dev`).
- Submit offline and webchat based contacts using the `Adult Contact` call type button.