### PR TITLE
CSAM reporting cleanup

### DIFF
--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -24,6 +24,14 @@ type EmailInputDefinition = {
   type: 'email';
 } & ItemBase;
 
+export type InputOption = { value: any; label: string };
+
+type RadioInputDefinition = {
+  type: 'radio-input';
+  options: InputOption[];
+  defaultOption?: InputOption['value'];
+} & ItemBase;
+
 export type SelectOption = { value: any; label: string };
 
 type SelectDefinition = {
@@ -83,6 +91,7 @@ export type FormItemDefinition =
   | InputDefinition
   | NumericInputDefinition
   | EmailInputDefinition
+  | RadioInputDefinition
   | SelectDefinition
   | DependentSelectDefinition
   | CheckboxDefinition

--- a/plugin-hrm-form/src/___tests__/components/CSAMReport/CSAMReport.test.js
+++ b/plugin-hrm-form/src/___tests__/components/CSAMReport/CSAMReport.test.js
@@ -27,17 +27,33 @@ const themeConf = {
 const taskSid = 'task-sid';
 const workerSid = 'worker-sid';
 
-test("Form renders but can't be submitted empty", async () => {
-  const alertSpy = jest.spyOn(window, 'alert');
+const setupProps = (subroute, csamReportState) => ({
+  alertSpy: jest.spyOn(window, 'alert'),
+  updateFormAction: jest.fn(),
+  updateStatusAction: jest.fn(),
+  clearCSAMReportAction: jest.fn(),
+  changeRoute: jest.fn(),
+  addCSAMReportEntry: jest.fn(),
+  csamReportState,
+  routing: { route: 'csam-report', subroute },
+  counselorsHash: { workerSid },
+});
 
-  const updateFormAction = jest.fn();
-  const updateStatusAction = jest.fn();
-  const clearCSAMReportAction = jest.fn();
-  const changeRoute = jest.fn();
-  const addCSAMReportEntry = jest.fn();
-  const csamReportState = { form: initialValues };
-  const routing = { route: 'csam-report', subroute: 'form' };
-  const counselorsHash = { workerSid };
+/**
+ * @param {: 'form' | 'loading' | 'status'} subroute
+ */
+const renderCSAMReportScreen = (subrouteParam = 'form', csamReportStateParam = { form: initialValues }) => {
+  const {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  } = setupProps(subrouteParam, csamReportStateParam);
 
   render(
     <StorelessThemeProvider themeConf={themeConf}>
@@ -54,6 +70,32 @@ test("Form renders but can't be submitted empty", async () => {
       />
     </StorelessThemeProvider>,
   );
+
+  return {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  };
+};
+
+test("Form renders but can't be submitted empty", async () => {
+  const {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  } = renderCSAMReportScreen();
 
   expect(screen.getByTestId('CSAMReport-FormScreen')).toBeInTheDocument();
   expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
@@ -69,33 +111,17 @@ test("Form renders but can't be submitted empty", async () => {
 });
 
 test("Form renders but can't be submitted on invalid url", async () => {
-  const alertSpy = jest.spyOn(window, 'alert');
-
-  const updateFormAction = jest.fn();
-  const updateStatusAction = jest.fn();
-  const clearCSAMReportAction = jest.fn();
-  const changeRoute = jest.fn();
-  const addCSAMReportEntry = jest.fn();
-  const csamReportState = { form: initialValues };
-  const routing = { route: 'csam-report', subroute: 'form' };
-  const counselorsHash = { workerSid };
-
-  render(
-    <StorelessThemeProvider themeConf={themeConf}>
-      <CSAMReportScreen
-        taskSid={taskSid}
-        updateFormAction={updateFormAction}
-        updateStatusAction={updateStatusAction}
-        clearCSAMReportAction={clearCSAMReportAction}
-        changeRoute={changeRoute}
-        addCSAMReportEntry={addCSAMReportEntry}
-        csamReportState={csamReportState}
-        routing={routing}
-        counselorsHash={counselorsHash}
-      />
-    </StorelessThemeProvider>,
-  );
-
+  const {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  } = renderCSAMReportScreen();
   expect(screen.getByTestId('CSAMReport-FormScreen')).toBeInTheDocument();
   expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
   expect(screen.queryByTestId('CSAMReport-StatusScreen')).not.toBeInTheDocument();
@@ -119,17 +145,6 @@ test("Form renders but can't be submitted on invalid url", async () => {
 });
 
 test("Form can't be submitted if anonymous value is undefined", async () => {
-  const alertSpy = jest.spyOn(window, 'alert');
-
-  const updateFormAction = jest.fn();
-  const updateStatusAction = jest.fn();
-  const clearCSAMReportAction = jest.fn();
-  const changeRoute = jest.fn();
-  const addCSAMReportEntry = jest.fn();
-  const csamReportState = { form: initialValues };
-  const routing = { route: 'csam-report', subroute: 'form' };
-  const counselorsHash = { workerSid };
-
   const reportToIWFSpy = jest.spyOn(ServerlessService, 'reportToIWF').mockImplementationOnce(() =>
     Promise.resolve({
       'IWFReportService1.0': { responseData: {} },
@@ -141,21 +156,17 @@ test("Form can't be submitted if anonymous value is undefined", async () => {
     }),
   );
 
-  render(
-    <StorelessThemeProvider themeConf={themeConf}>
-      <CSAMReportScreen
-        taskSid={taskSid}
-        updateFormAction={updateFormAction}
-        updateStatusAction={updateStatusAction}
-        clearCSAMReportAction={clearCSAMReportAction}
-        changeRoute={changeRoute}
-        addCSAMReportEntry={addCSAMReportEntry}
-        csamReportState={csamReportState}
-        routing={routing}
-        counselorsHash={counselorsHash}
-      />
-    </StorelessThemeProvider>,
-  );
+  const {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  } = renderCSAMReportScreen();
 
   expect(screen.getByTestId('CSAMReport-FormScreen')).toBeInTheDocument();
   expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
@@ -180,15 +191,6 @@ test("Form can't be submitted if anonymous value is undefined", async () => {
 });
 
 test('Form can be submitted if valid (anonymous)', async () => {
-  const updateFormAction = jest.fn();
-  const updateStatusAction = jest.fn();
-  const clearCSAMReportAction = jest.fn();
-  const changeRoute = jest.fn();
-  const addCSAMReportEntry = jest.fn();
-  const csamReportState = { form: initialValues };
-  const routing = { route: 'csam-report', subroute: 'form' };
-  const counselorsHash = { workerSid };
-
   const reportToIWFSpy = jest.spyOn(ServerlessService, 'reportToIWF').mockImplementationOnce(() =>
     Promise.resolve({
       'IWFReportService1.0': { responseData: {} },
@@ -200,21 +202,17 @@ test('Form can be submitted if valid (anonymous)', async () => {
     }),
   );
 
-  render(
-    <StorelessThemeProvider themeConf={themeConf}>
-      <CSAMReportScreen
-        taskSid={taskSid}
-        updateFormAction={updateFormAction}
-        updateStatusAction={updateStatusAction}
-        clearCSAMReportAction={clearCSAMReportAction}
-        changeRoute={changeRoute}
-        addCSAMReportEntry={addCSAMReportEntry}
-        csamReportState={csamReportState}
-        routing={routing}
-        counselorsHash={counselorsHash}
-      />
-    </StorelessThemeProvider>,
-  );
+  const {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  } = renderCSAMReportScreen();
 
   expect(screen.getByTestId('CSAMReport-FormScreen')).toBeInTheDocument();
   expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
@@ -251,15 +249,6 @@ test('Form can be submitted if valid (anonymous)', async () => {
 });
 
 test('Form can be submitted if valid (non-anonymous)', async () => {
-  const updateFormAction = jest.fn();
-  const updateStatusAction = jest.fn();
-  const clearCSAMReportAction = jest.fn();
-  const changeRoute = jest.fn();
-  const addCSAMReportEntry = jest.fn();
-  const csamReportState = { form: initialValues };
-  const routing = { route: 'csam-report', subroute: 'form' };
-  const counselorsHash = { workerSid };
-
   const reportToIWFSpy = jest.spyOn(ServerlessService, 'reportToIWF').mockImplementationOnce(() =>
     Promise.resolve({
       'IWFReportService1.0': { responseData: {} },
@@ -271,21 +260,17 @@ test('Form can be submitted if valid (non-anonymous)', async () => {
     }),
   );
 
-  render(
-    <StorelessThemeProvider themeConf={themeConf}>
-      <CSAMReportScreen
-        taskSid={taskSid}
-        updateFormAction={updateFormAction}
-        updateStatusAction={updateStatusAction}
-        clearCSAMReportAction={clearCSAMReportAction}
-        changeRoute={changeRoute}
-        addCSAMReportEntry={addCSAMReportEntry}
-        csamReportState={csamReportState}
-        routing={routing}
-        counselorsHash={counselorsHash}
-      />
-    </StorelessThemeProvider>,
-  );
+  const {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  } = renderCSAMReportScreen();
 
   expect(screen.getByTestId('CSAMReport-FormScreen')).toBeInTheDocument();
   expect(screen.queryByTestId('CSAMReport-Loading')).not.toBeInTheDocument();
@@ -334,30 +319,17 @@ test('Form can be submitted if valid (non-anonymous)', async () => {
 });
 
 test('Loading screen renders', async () => {
-  const updateFormAction = jest.fn();
-  const updateStatusAction = jest.fn();
-  const clearCSAMReportAction = jest.fn();
-  const changeRoute = jest.fn();
-  const addCSAMReportEntry = jest.fn();
-  const csamReportState = { form: initialValues };
-  const routing = { route: 'csam-report', subroute: 'loading' };
-  const counselorsHash = { workerSid };
-
-  render(
-    <StorelessThemeProvider themeConf={themeConf}>
-      <CSAMReportScreen
-        taskSid={taskSid}
-        updateFormAction={updateFormAction}
-        updateStatusAction={updateStatusAction}
-        clearCSAMReportAction={clearCSAMReportAction}
-        changeRoute={changeRoute}
-        addCSAMReportEntry={addCSAMReportEntry}
-        csamReportState={csamReportState}
-        routing={routing}
-        counselorsHash={counselorsHash}
-      />
-    </StorelessThemeProvider>,
-  );
+  const {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  } = renderCSAMReportScreen('loading');
 
   expect(screen.getByTestId('CSAMReport-Loading')).toBeInTheDocument();
   expect(screen.queryByTestId('CSAMReport-FormScreen')).not.toBeInTheDocument();
@@ -365,22 +337,6 @@ test('Loading screen renders', async () => {
 });
 
 test('Report Status screen renders + copy button works', async () => {
-  const updateFormAction = jest.fn();
-  const updateStatusAction = jest.fn();
-  const clearCSAMReportAction = jest.fn();
-  const changeRoute = jest.fn();
-  const addCSAMReportEntry = jest.fn();
-  const csamReportState = {
-    form: initialValues,
-    reportStatus: {
-      responseCode: 'responseCode',
-      responseData: 'responseData',
-      responseDescription: 'responseDescription',
-    },
-  };
-  const routing = { route: 'csam-report', subroute: 'status' };
-  const counselorsHash = { workerSid };
-
   Object.assign(navigator, {
     clipboard: {
       writeText: async () => undefined,
@@ -389,21 +345,24 @@ test('Report Status screen renders + copy button works', async () => {
 
   const copySpy = jest.spyOn(navigator.clipboard, 'writeText');
 
-  render(
-    <StorelessThemeProvider themeConf={themeConf}>
-      <CSAMReportScreen
-        taskSid={taskSid}
-        updateFormAction={updateFormAction}
-        updateStatusAction={updateStatusAction}
-        clearCSAMReportAction={clearCSAMReportAction}
-        changeRoute={changeRoute}
-        addCSAMReportEntry={addCSAMReportEntry}
-        csamReportState={csamReportState}
-        routing={routing}
-        counselorsHash={counselorsHash}
-      />
-    </StorelessThemeProvider>,
-  );
+  const {
+    alertSpy,
+    updateFormAction,
+    updateStatusAction,
+    clearCSAMReportAction,
+    changeRoute,
+    addCSAMReportEntry,
+    csamReportState,
+    routing,
+    counselorsHash,
+  } = renderCSAMReportScreen('status', {
+    form: initialValues,
+    reportStatus: {
+      responseCode: 'responseCode',
+      responseData: 'responseData',
+      responseDescription: 'responseDescription',
+    },
+  });
 
   expect(screen.getByTestId('CSAMReport-StatusScreen')).toBeInTheDocument();
   expect(screen.queryByTestId('CSAMReport-FormScreen')).not.toBeInTheDocument();

--- a/plugin-hrm-form/src/___tests__/mockStyled.js
+++ b/plugin-hrm-form/src/___tests__/mockStyled.js
@@ -162,7 +162,6 @@ jest.mock('../styles/case', () => ({
   CaseActionContainer: 'CaseActionContainer',
   CaseActionFormContainer: 'CaseActionFormContainer',
   CaseAddButton: 'CaseAddButton',
-  CaseActionCloseButton: 'CaseActionCloseButton',
   CenteredContainer: 'CenteredContainer',
   CaseSectionFont: 'CaseSectionFont',
   ViewButton: 'ViewButton',

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
@@ -54,7 +54,7 @@ export const CSAMReportScreen: React.FC<Props> = ({
   counselorsHash,
 }) => {
   const [initialForm] = React.useState(csamReportState.form); // grab initial values in first render only. This value should never change or will ruin the memoization below
-  const methods = useForm();
+  const methods = useForm({ reValidateMode: 'onChange' });
   const firstElementRef = useFocus();
 
   const currentCounselor = React.useMemo(() => {
@@ -126,7 +126,8 @@ export const CSAMReportScreen: React.FC<Props> = ({
 
       const anonymousWatch = methods.watch('anonymous');
       const renderContactDetails =
-        anonymousWatch === false || (anonymousWatch === undefined && initialForm.anonymous === false);
+        anonymousWatch === 'non-anonymous' ||
+        (anonymousWatch === undefined && initialForm.anonymous === 'non-anonymous');
 
       return (
         <FormProvider {...methods}>

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
@@ -8,7 +8,7 @@ import { FormItemDefinition } from 'hrm-form-definitions';
 import CSAMReportStatusScreen from './CSAMReportStatusScreen';
 import CSAMReportFormScreen from './CSAMReportFormScreen';
 import { CSAMReportContainer, CSAMReportLayout, CenterContent } from '../../styles/CSAMReport';
-import { getInputType } from '../common/forms/formGenerators';
+import { addMargin, getInputType } from '../common/forms/formGenerators';
 import { definitionObject, keys, initialValues } from './CSAMReportFormDefinition';
 import type { CustomITask } from '../../types/types';
 import { getConfig } from '../../HrmFormPlugin';
@@ -82,7 +82,7 @@ export const CSAMReportScreen: React.FC<Props> = ({
       index: number,
     ) => ({
       ...accum,
-      [k]: generateInput(e, index),
+      [k]: addMargin(5)(generateInput(e, index)),
     });
 
     return Object.entries(definitionObject).reduce(reducerFunc, null);

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
@@ -90,16 +90,18 @@ export const CSAMReportScreen: React.FC<Props> = ({
 
   if (routing.route !== 'csam-report') return null;
 
+  const { previousRoute } = routing;
+
   const onClickClose = () => {
     clearCSAMReportAction(taskSid);
-    changeRoute({ route: 'tabbed-forms', subroute: 'caseInformation' }, taskSid);
+    changeRoute({ ...previousRoute }, taskSid);
   };
 
   switch (routing.subroute) {
     case 'form': {
       const onValid = async form => {
         try {
-          changeRoute({ route: 'csam-report', subroute: 'loading' }, taskSid);
+          changeRoute({ route: 'csam-report', subroute: 'loading', previousRoute }, taskSid);
           const report = await reportToIWF(form);
           const storedReport = await createCSAMReport({
             csamReportId: report['IWFReportService1.0'].responseData,
@@ -108,11 +110,11 @@ export const CSAMReportScreen: React.FC<Props> = ({
 
           updateStatusAction(report['IWFReportService1.0'], taskSid);
           addCSAMReportEntry(storedReport, taskSid);
-          changeRoute({ route: 'csam-report', subroute: 'status' }, taskSid);
+          changeRoute({ route: 'csam-report', subroute: 'status', previousRoute }, taskSid);
         } catch (err) {
           console.error(err);
           window.alert(getConfig().strings['Error-Backend']);
-          changeRoute({ route: 'csam-report', subroute: 'form' }, taskSid);
+          changeRoute({ route: 'csam-report', subroute: 'form', previousRoute }, taskSid);
         }
       };
 
@@ -152,7 +154,7 @@ export const CSAMReportScreen: React.FC<Props> = ({
     case 'status': {
       const onSendAnotherReport = () => {
         clearCSAMReportAction(taskSid);
-        changeRoute({ route: 'csam-report', subroute: 'form' }, taskSid);
+        changeRoute({ route: 'csam-report', subroute: 'form', previousRoute }, taskSid);
       };
 
       return (

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
@@ -16,7 +16,7 @@ type CSAMFormDefinitionObject = {
 };
 
 // eslint-disable-next-line prefer-named-capture-group
-const urlRegex = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/g;
+const urlRegex = /(https?:\/\/)?([\w\-])+\.{1}([a-zA-Z]{2,63})([\/\w-]*)*\/?\??([^#\n\r]*)?#?([^\n\r]*)/g;
 
 export const definitionObject: CSAMFormDefinitionObject = {
   webAddress: {
@@ -38,9 +38,13 @@ export const definitionObject: CSAMFormDefinitionObject = {
   },
   anonymous: {
     name: 'anonymous',
-    label: 'File anonymously',
-    type: 'checkbox',
-    initialChecked: true,
+    label: '',
+    type: 'radio-input',
+    options: [
+      { value: 'anonymous', label: 'File anonymously' },
+      { value: 'non-anonymous', label: 'Provide contact details' },
+    ],
+    required: { value: true, message: 'RequiredFieldError' },
   },
   firstName: {
     name: 'firstName',

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
@@ -24,7 +24,7 @@ export const definitionObject: CSAMFormDefinitionObject = {
     label: 'Web address',
     type: 'input',
     required: { value: true, message: 'RequiredFieldError' },
-    maxLength: 1000,
+    maxLength: { value: 1000, message: '1000 characters max.' },
     validate: data => {
       if (!data.match(urlRegex)) return 'NotURLFieldError';
       return null;
@@ -34,7 +34,7 @@ export const definitionObject: CSAMFormDefinitionObject = {
     name: 'description',
     label: 'Description (500 characters)',
     type: 'textarea',
-    maxLength: 500,
+    maxLength: { value: 500, message: '500 characters max.' },
   },
   anonymous: {
     name: 'anonymous',
@@ -50,20 +50,20 @@ export const definitionObject: CSAMFormDefinitionObject = {
     name: 'firstName',
     label: "Reporter's First Name",
     type: 'input',
-    maxLength: 50,
+    maxLength: { value: 50, message: '50 characters max.' },
   },
   lastName: {
     name: 'lastName',
     label: "Reporter's Last Name",
     type: 'input',
-    maxLength: 50,
+    maxLength: { value: 50, message: '50 characters max.' },
   },
   email: {
     name: 'email',
     label: 'Email Address',
     type: 'email',
     required: { value: true, message: 'RequiredFieldError' },
-    maxLength: 100,
+    maxLength: { value: 100, message: '100 characters max.' },
   },
 };
 

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
@@ -25,9 +25,9 @@ export const definitionObject: CSAMFormDefinitionObject = {
     type: 'input',
     required: { value: true, message: 'RequiredFieldError' },
     maxLength: 1000,
-    pattern: {
-      value: urlRegex,
-      message: 'NotURLFieldError',
+    validate: data => {
+      if (!data.match(urlRegex)) return 'NotURLFieldError';
+      return null;
     },
   },
   description: {

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
@@ -15,6 +15,9 @@ type CSAMFormDefinitionObject = {
   [k in keyof typeof keys]: FormItemDefinition;
 };
 
+// eslint-disable-next-line prefer-named-capture-group
+const urlRegex = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/g;
+
 export const definitionObject: CSAMFormDefinitionObject = {
   webAddress: {
     name: 'webAddress',
@@ -22,6 +25,10 @@ export const definitionObject: CSAMFormDefinitionObject = {
     type: 'input',
     required: { value: true, message: 'RequiredFieldError' },
     maxLength: 1000,
+    pattern: {
+      value: urlRegex,
+      message: 'NotURLFieldError',
+    },
   },
   description: {
     name: 'description',

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportStatusScreen.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportStatusScreen.tsx
@@ -2,13 +2,12 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Template } from '@twilio/flex-ui';
-import { ButtonBase } from '@material-ui/core';
 import CheckCircleTwoToneIcon from '@material-ui/icons/CheckCircleTwoTone';
 import FileCopyOutlined from '@material-ui/icons/FileCopyOutlined';
 import Close from '@material-ui/icons/Close';
 import CheckCircle from '@material-ui/icons/CheckCircle';
 
-import { BottomButtonBar, Box, HiddenText, Row, StyledNextStepButton } from '../../styles/HrmStyles';
+import { BottomButtonBar, Box, HiddenText, Row, StyledNextStepButton, HeaderCloseButton } from '../../styles/HrmStyles';
 import {
   CSAMReportContainer,
   CSAMReportLayout,
@@ -42,12 +41,12 @@ const CSAMReportStatusScreen: React.FC<Props> = ({ reportStatus, onClickClose, o
     // how should we handle possible IWF API error here? Show a screen, an alert & go back to form?
     <CSAMReportContainer data-testid="CSAMReport-StatusScreen">
       <CSAMReportLayout>
-        <ButtonBase onClick={onClickClose} style={{ marginLeft: 'auto' }} data-testid="Case-CloseCross">
+        <HeaderCloseButton onClick={onClickClose} data-testid="Case-CloseCross">
           <HiddenText>
             <Template code="Case-CloseButton" />
           </HiddenText>
           <Close />
-        </ButtonBase>
+        </HeaderCloseButton>
         <Box marginTop="15%" marginBottom="auto">
           <CenterContent>
             <Row>

--- a/plugin-hrm-form/src/components/case/ActionHeader.tsx
+++ b/plugin-hrm-form/src/components/case/ActionHeader.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { Template } from '@twilio/flex-ui';
 import { Close } from '@material-ui/icons';
 
-import { Row, HiddenText } from '../../styles/HrmStyles';
-import { CaseActionTitle, CaseActionDetailFont, CaseActionCloseButton } from '../../styles/case';
+import { Row, HiddenText, HeaderCloseButton } from '../../styles/HrmStyles';
+import { CaseActionTitle, CaseActionDetailFont } from '../../styles/case';
 import { formatDateTime } from '../../utils/formatters';
 
 type OwnProps = {
@@ -25,12 +25,12 @@ const ActionHeader: React.FC<Props> = ({ titleTemplate, onClickClose, added, cou
         <CaseActionTitle style={{ marginTop: 'auto' }}>
           <Template code={titleTemplate} />
         </CaseActionTitle>
-        <CaseActionCloseButton onClick={onClickClose} data-testid="Case-CloseCross">
+        <HeaderCloseButton onClick={onClickClose} data-testid="Case-CloseCross">
           <HiddenText>
             <Template code="Case-CloseButton" />
           </HiddenText>
           <Close />
-        </CaseActionCloseButton>
+        </HeaderCloseButton>
       </Row>
       <Row style={{ width: '100%' }}>
         <CaseActionDetailFont style={{ marginRight: 20 }} data-testid="Case-ActionHeaderAdded">

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -635,12 +635,13 @@ export const createFormFromDefinition = (definition: FormDefinition) => (parents
   });
 };
 
-export const disperseInputs = (margin: number) => (formItems: JSX.Element[]) =>
-  formItems.map(i => (
-    <Box key={`${i.key}-wrapping-box`} marginTop={`${margin.toString()}px`} marginBottom={`${margin.toString()}px`}>
-      {i}
-    </Box>
-  ));
+export const addMargin = (margin: number) => (i: JSX.Element) => (
+  <Box key={`${i.key}-wrapping-box`} marginTop={`${margin.toString()}px`} marginBottom={`${margin.toString()}px`}>
+    {i}
+  </Box>
+);
+
+export const disperseInputs = (margin: number) => (formItems: JSX.Element[]) => formItems.map(addMargin(margin));
 
 export const splitInHalf = (formItems: JSX.Element[]) => {
   const m = Math.ceil(formItems.length / 2);

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -265,7 +265,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
                     </Box>
                   </Row>
                 )}
-                {def.options.map(({ value, label }) => (
+                {def.options.map(({ value, label }, index) => (
                   <Box key={`${path}-${value}`} marginBottom="15px">
                     <FormLabel htmlFor={`${path}-${value}`}>
                       <Row>
@@ -276,7 +276,14 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
                           type="radio"
                           value={value}
                           onChange={updateCallback}
-                          innerRef={register(rules)}
+                          innerRef={innerRef => {
+                            // If autofocus is pertinent, focus first radio input
+                            if (index === 0 && htmlElRef) {
+                              htmlElRef.current = innerRef;
+                            }
+
+                            register(rules)(innerRef);
+                          }}
                           checked={currentValue === value}
                         />
                         <Template code={label} className=".fullstory-unmask" />

--- a/plugin-hrm-form/src/components/tabbedForms/CSAMAttachments.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/CSAMAttachments.tsx
@@ -27,7 +27,7 @@ const CSAMAttachments: React.FC<Props> = ({ csamReports }) => {
               <CSAMAttachmentText>
                 <Template code="CSAMReportForm-Attachment" />
                 <br />
-                {`${formattedCreatedAt}m #${r.csamReportId}`}
+                {`${formattedCreatedAt} #${r.csamReportId}`}
               </CSAMAttachmentText>
             </Row>
           );

--- a/plugin-hrm-form/src/components/tabbedForms/CSAMReportButton.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/CSAMReportButton.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { ButtonBase } from '@material-ui/core';
 import { Template } from '@twilio/flex-ui';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 
-import { Row, CSAMReportButtonText, Box } from '../../styles/HrmStyles';
+import { Row, CSAMReportButtonText, StyledCSAMReportButton } from '../../styles/HrmStyles';
 
 type OwnProps = {
   handleClick: () => void;
@@ -15,12 +14,12 @@ type Props = OwnProps;
 const CSAMReportButton: React.FC<Props> = ({ handleClick }) => {
   return (
     <Row>
-      <ButtonBase onClick={handleClick}>
+      <StyledCSAMReportButton onClick={handleClick}>
         <OpenInNew fontSize="inherit" style={{ marginRight: 5 }} />
         <CSAMReportButtonText>
           <Template code="TabbedForms-CSAMReportButton" />
         </CSAMReportButtonText>
-      </ButtonBase>
+      </StyledCSAMReportButton>
     </Row>
   );
 };

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -186,7 +186,7 @@ const TabbedForms: React.FC<Props> = ({
       <Row>
         <SearchResultsBackButton handleBack={handleBackButton} text={<Template code="TabbedForms-BackButton" />} />
         {csamReportEnabled && (
-          <Box marginLeft="auto">
+          <Box marginLeft="auto" marginRight="15px">
             <CSAMReportButton
               handleClick={() =>
                 dispatch(changeRoute({ route: 'csam-report', subroute: 'form', previousRoute: routing }, taskId))

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -188,7 +188,9 @@ const TabbedForms: React.FC<Props> = ({
         {csamReportEnabled && (
           <Box marginLeft="auto">
             <CSAMReportButton
-              handleClick={() => dispatch(changeRoute({ route: 'csam-report', subroute: 'form' }, taskId))}
+              handleClick={() =>
+                dispatch(changeRoute({ route: 'csam-report', subroute: 'form', previousRoute: routing }, taskId))
+              }
             />
           </Box>
         )}

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -182,7 +182,7 @@ export const reportToIWF = async (form: CSAMReportForm) => {
   const body = {
     Reported_URL: form.webAddress,
     Reporter_Description: form.description,
-    Reporter_Anonymous: form.anonymous ? 'Y' : 'N',
+    Reporter_Anonymous: form.anonymous === 'anonymous' ? 'Y' : 'N',
     Reporter_First_Name: form.firstName,
     Reporter_Last_Name: form.lastName,
     Reporter_Email_ID: form.email,

--- a/plugin-hrm-form/src/states/csam-report/types.ts
+++ b/plugin-hrm-form/src/states/csam-report/types.ts
@@ -6,7 +6,7 @@ export const CLEAR_CSAM_REPORT = 'csam-report/CLEAR_CSAM_REPORT';
 export type CSAMReportForm = {
   webAddress: string;
   description: string;
-  anonymous: boolean;
+  anonymous: string;
   firstName: string;
   lastName: string;
   email: string;

--- a/plugin-hrm-form/src/states/routing/types.ts
+++ b/plugin-hrm-form/src/states/routing/types.ts
@@ -47,6 +47,7 @@ export type AppRoutesWithCase =
 export type CSAMReportRoute = {
   route: 'csam-report';
   subroute: 'form' | 'loading' | 'status';
+  previousRoute: AppRoutes;
 };
 
 type OtherRoutes = CSAMReportRoute;

--- a/plugin-hrm-form/src/styles/CSAMReport/index.tsx
+++ b/plugin-hrm-form/src/styles/CSAMReport/index.tsx
@@ -59,8 +59,9 @@ export const RegularText = styled(FontOpenSans)`
 RegularText.displayName = 'RegularText';
 
 export const ReportCodeText = styled(FontOpenSans)`
-  color: #009dff;
+  color: #0074d8;
   font-size: 12px;
+  font-weight: 600;
   line-height: 14px;
 `;
 ReportCodeText.displayName = 'ReportCodeText';

--- a/plugin-hrm-form/src/styles/GlobalOverrides.js
+++ b/plugin-hrm-form/src/styles/GlobalOverrides.js
@@ -32,4 +32,10 @@ injectGlobal`
   button.Twilio-MessageInput-SendButton {
     background: rgba(216, 27, 96, 0.8);
   }
+
+  a.link-text-decoration-none { text-decoration: none; color: #1874e1; }
+  a.link-text-decoration-none:visited { text-decoration: none; color: #1874e1; }
+  a.link-text-decoration-none:hover { text-decoration: none; color: #1874e1; }
+  a.link-text-decoration-none:focus { text-decoration: none; color: #1874e1; }
+  a.link-text-decoration-none:active { text-decoration: none; color: #1874e1; }
 `;

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -1024,10 +1024,15 @@ export const CSAMReportButtonText = styled(FontOpenSans)`
 `;
 CSAMReportButtonText.displayName = 'CSAMReportButtonText';
 
-export const StyledBackButton = styled(ButtonBase)`
+const TabbedFormsHeaderButton = styled(ButtonBase)`
   &:focus {
     outline: auto;
   }
 `;
+TabbedFormsHeaderButton.displayName = 'TabbedFormsHeaderButton';
 
+export const StyledBackButton = TabbedFormsHeaderButton;
 StyledBackButton.displayName = 'StyledBackButton';
+
+export const StyledCSAMReportButton = TabbedFormsHeaderButton;
+StyledCSAMReportButton.displayName = 'StyledCSAMReportButton';

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -1036,3 +1036,14 @@ StyledBackButton.displayName = 'StyledBackButton';
 
 export const StyledCSAMReportButton = TabbedFormsHeaderButton;
 StyledCSAMReportButton.displayName = 'StyledCSAMReportButton';
+
+export const HeaderCloseButton = styled(ButtonBase)`
+  && {
+    margin-left: auto;
+  }
+
+  :focus {
+    outline: auto;
+  }
+`;
+HeaderCloseButton.displayName = 'HeaderCloseButton';

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -654,6 +654,13 @@ export const FormLabel = styled('label')`
 `;
 FormLabel.displayName = 'FormLabel';
 
+export const FormFieldset = styled('fieldset')<FormInputProps>`
+  display: flex;
+  flex-direction: column;
+  border: ${props => (props.error ? '1px solid #CB3232' : 'none')};
+`;
+FormFieldset.displayName = 'FormFieldset';
+
 export const UploadFileLabel = styled(Flex)`
   font-size: 14px;
   letter-spacing: 0;
@@ -715,6 +722,35 @@ export const FormInput = styled('input')<FormInputProps>`
   }
 `;
 FormInput.displayName = 'FormInput';
+
+export const FormRadioInput = styled('input')<FormInputProps>`
+  &[type='radio'] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+
+    width: 24px;
+    height: 24px;
+    margin-right: 5px;
+    border: 2px solid #080808;
+    background-color: ${props => props.theme.colors.inputBackgroundColor};
+    border-radius: 50%;
+    display: grid;
+    place-content: center;
+  }
+
+  &[type='radio']:checked:after {
+    display: block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    content: '';
+    position: relative;
+    background: #080808;
+    background-color: #080808;
+  }
+`;
+FormRadioInput.displayName = 'FormRadioInput';
 
 export const FormDateInput = styled(FormInput)`
   &[type='date']::-webkit-clear-button,

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -127,17 +127,6 @@ export const CaseActionTitle = styled(FontOpenSans)`
 `;
 CaseActionTitle.displayName = 'CaseActionTitle';
 
-export const CaseActionCloseButton = styled(ButtonBase)`
-  && {
-    margin-left: auto;
-  }
-
-  :focus {
-    outline: auto;
-  }
-`;
-CaseActionCloseButton.displayName = 'CaseActionCloseButton';
-
 export const CaseActionDetailFont = styled(FontOpenSans)`
   font-style: italic;
   font-size: 12px;

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -437,6 +437,9 @@ export const ScrollableList = styled('div')`
 export const StyledButtonBase = withStyles({
   root: {
     margin: 5,
+    '&:focus': {
+      outline: 'auto',
+    },
   },
   disabled: {
     color: 'rgba(0, 0, 0, 0.26)',

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -327,7 +327,7 @@
   "CSAMReportForm-ContactDetails": "Contact details",
   "CSAMReportForm-ContactDetailsDescription": "Reports can be filed anonymously or with contact details if the caller would like to follow up or be available to provide further details to IWF.",
   "CSAMReportForm-LearnMore": "Learn more",
-  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the UK Data Protection Act",
+  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\">UK Data Protection Act</a>",
   "CSAMReportForm-ReportSent": "CSAM Report Sent!",
   "CSAMReportForm-CopyCode": "Copy confirmation code for sharing",
   "CSAMReportForm-Attachment": "CSAM Report has been filled",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -287,6 +287,7 @@
   "YouMustBeAvailableToPerformThisOp": "You must be available to perform this operation.",
 
   "RequiredFieldError": "This field is required.",
+  "NotURLFieldError": "This field only accepts URLs.",
   "DateCantBeGreaterThanToday": "Date can't be greater than today.",
   "DateCantBeLesserThanEpoch": "Date can't be lesser than 00:00:00 UTC on 1 January 1970.",
   "TimeCantBeGreaterThanNow": "Time can't be greater than now.",


### PR DESCRIPTION
Primary reviewer: @stephenhand 
Note: easier to review commit by commit.

## Description
This PR is a UI/UX cleanup of the CSAM report components.
Please read the below linked Jira card for the full detail on this changes. Other than those, the only really relevant change is the inclusion of a new input type radio.

Special considerations:
- One of the items of the ticket is "The italic font on the summary screen should pull the real italic font, not the oblique version of it". After investigating, it looks like we will need to import a new font family just to address this, and after a small talk with Dee she's ok leaving it as they are.
- The regex validation for url is not the most exact one, but I couldn't find a valid url that's not accepted. The inverse might be true tho (not restrictive enough). Happy to get some help if someone has more expertise in rexeg.
- I'm hiding the overall label for the radio button set to match the designs. This is not very accessible tho. Happy to change if the design is reviewed.

### Checklist
- [x] Corresponding issue has been opened https://bugs.benetech.org/browse/CHI-977
- [x] New tests added
- [x] Strings are localized

### Verification steps
- Run Flex locally (`npm run dev`).
- Open a new CSAM report (top right button of the contact form).
- Confirm that behavior is the expected, validations are as described in the ticket and the functionality to submit reports is still working.