### PR TITLE
Upgrade @twilio/flex-ui to 1.28.1

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -1647,9 +1647,9 @@
       }
     },
     "@gooddata/typings": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@gooddata/typings/-/typings-2.28.0.tgz",
-      "integrity": "sha512-v8nk8b2aIy2A6h88m3ec37TSbZk8CbBQ0FSLES5zu1cGka2z/JCGgKUNnAy46z/ieuR+/8c8QzXKwXPC1t5DkQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@gooddata/typings/-/typings-2.29.0.tgz",
+      "integrity": "sha512-kGcrgPjpj+56Ygym8+Vg2iglSxim7njEx2cwGE18KO5kd+LZGUJyuPkfXb/wNyJ2VOBCRBnCKRaB49FZLbPYEA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.11"
@@ -2977,9 +2977,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.17",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-          "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
+          "version": "2.6.19",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
+          "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
           "dev": true
         },
         "deepmerge": {
@@ -3352,78 +3352,31 @@
       "dev": true
     },
     "@twilio/flex-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.6.0.tgz",
-      "integrity": "sha512-g7JTAug6g0oJk5xx1m5IRovkbkRHNcr3v40YTqKVNRljdw8/zJRxVjbm/SUBdtSP6KSYb2SEkJtN49Y6cDjopQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.8.1.tgz",
+      "integrity": "sha512-LftPU/ld05mKA1OMMMYT1/J/TV8tbwSqNiPCD05R0qAtbG0lBLhA1V4vBj8NFUXcMVIvBGfSatYRip7RN69cBQ==",
       "dev": true,
       "requires": {
         "core-js": "^3.9.1",
         "inversify": "^5.0.1",
         "lodash": "^4.17.21",
         "loglevel": "^1.7.0",
-        "node-fetch": "^2.6.1",
         "reflect-metadata": "^0.1.13",
-        "twilio-sync": "^0.13.0",
         "twilsock": "^0.8.3"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.16.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
-          "integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
+          "version": "3.20.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
           "dev": true
-        },
-        "twilio-sync": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/twilio-sync/-/twilio-sync-0.13.0.tgz",
-          "integrity": "sha512-3SfV2zQh6B2g+Tl7McYvcLH4/2IEZShXN7Lm/7GDkNnBSCtmX8cJLd5uOE1Vrj2pCXVXD9Ty2dxJlE4cDwBwlg==",
-          "dev": true,
-          "requires": {
-            "loglevel": "^1.6.3",
-            "operation-retrier": "^3.0.0",
-            "platform": "^1.3.6",
-            "twilio-notifications": "^0.5.11",
-            "twilsock": "^0.6.1",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "twilsock": {
-              "version": "0.6.2",
-              "resolved": "https://registry.npmjs.org/twilsock/-/twilsock-0.6.2.tgz",
-              "integrity": "sha512-Wk60XZxwFR5ooLkSLO5CGtBBXLT7VRbyPcg49D9icUqeAgm9McVZPPDq0kxVW4R4c3k4cppd1EvuhtUEejezCw==",
-              "dev": true,
-              "requires": {
-                "javascript-state-machine": "^3.0.1",
-                "loglevel": "^1.6.3",
-                "operation-retrier": "^3.0.0",
-                "platform": "^1.3.6",
-                "uuid": "^3.2.1",
-                "ws": "^5.1.0"
-              }
-            }
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        },
-        "ws": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
-          "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
         }
       }
     },
     "@twilio/flex-ui": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.27.0.tgz",
-      "integrity": "sha512-5jhdL+WA7377jKF2P7uWCCaDkjrOx2q2ehOA1+oCiMwFLl1czZJcLpPagA0uvtGEMCWiXABGGzac9Lk6YOcuRQ==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.28.1.tgz",
+      "integrity": "sha512-LgvDlIGi0roCCEPQW/bkF47Mr5NYLTUaIEPPEr70CHdwQzzFisjh1ritW5dRUWPOM+p1CaidirZUvllYOFZuvA==",
       "dev": true,
       "requires": {
         "@gooddata/gooddata-js": "13.2.0",
@@ -3431,8 +3384,8 @@
         "@material-ui/lab": "3.0.0-alpha.30",
         "@twilio/flex-insights-identity-client-js": "2.0.6",
         "@twilio/flex-insights-player": "2.3.1",
-        "@twilio/flex-sdk": "^0.6.0",
-        "@twilio/flex-ui-core": "0.52.0",
+        "@twilio/flex-sdk": "^0.8.0",
+        "@twilio/flex-ui-core": "0.53.0",
         "@twilio/player": "1.0.1",
         "@types/deep-diff": "^1.0.0",
         "@types/react-select": "2.0.19",
@@ -3445,9 +3398,11 @@
         "eventemitter3": "4.0.0",
         "history": "4.7.2",
         "hoist-non-react-statics": "3.3.1",
+        "jwt-decode": "^3.1.2",
         "lodash.debounce": "4.0.8",
         "lodash.isequal": "4.5.0",
         "lodash.merge": "4.6.2",
+        "lodash.snakecase": "4.1.1",
         "lodash.throttle": "4.1.1",
         "loglevel": "1.6.7",
         "query-string": "6.2.0",
@@ -3474,9 +3429,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.16.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
-          "integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
+          "version": "3.20.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
           "dev": true
         },
         "eventemitter3": {
@@ -3516,14 +3471,13 @@
       }
     },
     "@twilio/flex-ui-core": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.52.0.tgz",
-      "integrity": "sha512-Cf2jNbr5kQ7vc3qRZCL4vfj6ThOJbswfwupWbeOXsgylDSkLnP6inWEYdWA9r1wmOKEydXf75o5c7QIgDgO83A==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.53.0.tgz",
+      "integrity": "sha512-zoj4H+4ris8MowPmnFhhT0KD1L72lkb6Joh4TY9CFls/2N0DsMZriQJxpDC0RR07vKncg0j08bTIQ45JwiXbsA==",
       "dev": true,
       "requires": {
         "@material-ui/core": "3.9.4",
         "@material-ui/icons": "2.0.3",
-        "@twilio/flex-sdk": "^0.6.0",
         "core-js": "^3.0.1",
         "create-emotion-styled": "^9.2.6",
         "emotion": "9.2.6",
@@ -3549,9 +3503,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.16.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
-          "integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
+          "version": "3.20.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
           "dev": true
         },
         "hoist-non-react-statics": {
@@ -3831,9 +3785,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.17",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-          "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
+          "version": "2.6.19",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
+          "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
           "dev": true
         }
       }
@@ -6890,9 +6844,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.17",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-          "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
+          "version": "2.6.19",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
+          "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
           "dev": true
         }
       }
@@ -9595,9 +9549,9 @@
       }
     },
     "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
       "dev": true,
       "requires": {
         "core-js": "^1.0.0",
@@ -9606,7 +9560,7 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "ua-parser-js": "^0.7.30"
       },
       "dependencies": {
         "core-js": {
@@ -17617,10 +17571,16 @@
         "object.assign": "^4.1.2"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+      "dev": true
+    },
     "keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg==",
       "dev": true
     },
     "keytar": {
@@ -17900,6 +17860,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
       "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
+      "dev": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
       "dev": true
     },
     "lodash.some": {
@@ -23553,26 +23519,15 @@
       }
     },
     "twilio-taskrouter": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.5.4.tgz",
-      "integrity": "sha512-EV7MV1911d2mCn3e64S4UVwnj9Nm/13bxfAhyYD1IPJ4rSTVz94NHFfFppYH3dHdyerLmxvQHlXQN9XSqw3VSw==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.5.7.tgz",
+      "integrity": "sha512-YMz6Pi/UxGP5PuWCiqideXKiWdilH5LYrHvfRYKEzu6aaDguQWUPEpsVEOmDAnOCHwwRGmeaXvCR8goQEkFM0g==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5",
         "loglevel": "^1.4.1",
-        "ws": "^5.1.0",
+        "ws": "^7.4.6",
         "xmlhttprequest": "^1.8.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
-          "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
       }
     },
     "twilsock": {
@@ -23665,15 +23620,15 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
-      "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.0.tgz",
+      "integrity": "sha512-x+xdeDWq7FiORDvyIJ0q/waWd4PhjBNOm5dQUOq2AKC0IEjxOS66Ha9tctiVDGcRQuh69K7fgU5oRuTK4cysSg==",
       "dev": true,
       "optional": true
     },

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -41,7 +41,7 @@
     "@testing-library/dom": "^7.21.0",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^10.4.7",
-    "@twilio/flex-ui": "1.27.0",
+    "@twilio/flex-ui": "1.28.1",
     "@types/jest": "^26.0.20",
     "@types/react-redux": "^7.1.16",
     "@typescript-eslint/parser": "^3.8.0",


### PR DESCRIPTION
## Description
This PR updates Twilio from **1.27.0** to **1.28.1**.
There are newer versions, but they make our tests break.

### Related Issues
Fixes https://bugs.benetech.org/browse/CHI-1028

### Verification steps

1. fetch code
2. remove `node_modules/`
3. run `UNBUNDLED_REACT=true npm ci`
4. Check the Aselo still works fine
