### PR TITLE
CHI-997: Safespot Chat Survey TF Customisations

### DIFF
--- a/twilio-iac/safespot-staging/variables.tf
+++ b/twilio-iac/safespot-staging/variables.tf
@@ -10,7 +10,7 @@ variable "short_helpline" {
   default = "JM"
 }
 variable "operating_info_key" {
-  default = "aselo-dev"
+  default = "jm"
 }
 variable "environment" {
   default = "Staging"

--- a/twilio-iac/terraform-modules/chatbots/terraform-modules/pre-survey-task/default/main.tf
+++ b/twilio-iac/terraform-modules/chatbots/terraform-modules/pre-survey-task/default/main.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_providers {
+    twilio = {
+      source  = "twilio/twilio"
+      version = "0.11.1"
+    }
+  }
+}
+
+resource "twilio_autopilot_assistants_tasks_v1" "survey" {
+  unique_name = "survey"
+  assistant_sid = var.bot_sid
+  actions = jsonencode({
+    "actions" : [
+      {
+        "remember" : { "at" : "survey" }
+      },
+      {
+        "say" : "Thank you. You can say 'prefer not to answer' (or type X) to any question."
+      },
+      {
+        "collect" : {
+          "on_complete" : {
+            "redirect" : "task://redirect_function"
+          },
+          "name" : "collect_survey",
+          "questions" : [
+            {
+              "type" : "Age",
+              "validate" : {
+                "on_failure" : {
+                  "repeat_question" : true,
+                  "messages" : [
+                    {
+                      "say" : "Sorry, I didn't understand that. Please respond with a number."
+                    },
+                    {
+                      "say" : "Sorry, I still didn't get that."
+                    }
+                  ]
+                },
+                "max_attempts" : {
+                  "redirect" : "task://redirect_function",
+                  "num_attempts" : 2
+                }
+              },
+              "question" : "How old are you?",
+              "name" : "age"
+            },
+            {
+              "type" : "Gender",
+              "validate" : {
+                "on_failure" : {
+                  "repeat_question" : true,
+                  "messages" : [
+                    {
+                      "say" : "Sorry, I didn't understand that. Please try again."
+                    },
+                    {
+                      "say" : "Sorry, I still didn't get that."
+                    }
+                  ]
+                },
+                "max_attempts" : {
+                  "redirect" : "task://redirect_function",
+                  "num_attempts" : 2
+                }
+              },
+              "question" : "What is your gender?",
+              "name" : "gender"
+            }
+          ]
+        }
+      }
+    ]
+  })
+}

--- a/twilio-iac/terraform-modules/chatbots/terraform-modules/pre-survey-task/default/variables.tf
+++ b/twilio-iac/terraform-modules/chatbots/terraform-modules/pre-survey-task/default/variables.tf
@@ -1,0 +1,4 @@
+variable "bot_sid" {
+  description = "SID of the Twilio assistant (chatbot) that will use the survey task."
+  type        = string
+}

--- a/twilio-iac/terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/main.tf
+++ b/twilio-iac/terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/main.tf
@@ -1,0 +1,195 @@
+terraform {
+  required_providers {
+    twilio = {
+      source  = "twilio/twilio"
+      version = "0.11.1"
+    }
+  }
+}
+
+resource "twilio_autopilot_assistants_tasks_v1" "survey" {
+  unique_name = "survey"
+  assistant_sid = var.bot_sid
+  actions = jsonencode({
+    "actions": [
+      {
+        "remember": {
+          "at": "survey"
+        }
+      },
+      {
+        "say": "Thank you. You can say 'prefer not to answer' (or type X) to any question."
+      },
+      {
+        "collect": {
+          "name": "collect_survey",
+          "questions": [
+            {
+              "question": "How old are you?",
+              "name": "age",
+              "type": "Age",
+              "validate": {
+                "on_failure": {
+                  "messages": [
+                    {
+                      "say": "Sorry, I didn't understand that. Please respond with a number."
+                    },
+                    {
+                      "say": "Sorry, I still didn't get that."
+                    }
+                  ],
+                  "repeat_question": true
+                },
+                "max_attempts": {
+                  "redirect": "task://redirect_function",
+                  "num_attempts": 2
+                }
+              }
+            },
+            {
+              "question": "What is your gender?",
+              "name": "gender",
+              "type": "Gender",
+              "validate": {
+                "on_failure": {
+                  "messages": [
+                    {
+                      "say": "Sorry, I didn't understand that. Please try again."
+                    },
+                    {
+                      "say": "Sorry, I still didn't get that."
+                    }
+                  ],
+                  "repeat_question": true
+                },
+                "max_attempts": {
+                  "redirect": "task://redirect_function",
+                  "num_attempts": 2
+                }
+              }
+            },
+            {
+              "question": "What parish are you located in?",
+              "name": "parish",
+              "type": "Parish",
+              "validate": {
+                "on_failure": {
+                  "messages": [
+                    {
+                      "say": "Sorry, I didn't understand that. Please try again."
+                    },
+                    {
+                      "say": "Sorry, I still didn't get that."
+                    }
+                  ],
+                  "repeat_question": true
+                },
+                "max_attempts": {
+                  "redirect": "task://redirect_function",
+                  "num_attempts": 2
+                }
+              }
+            }
+          ],
+          "on_complete": {
+            "redirect": "task://redirect_function"
+          }
+        }
+      }
+    ]
+  })
+}
+
+
+resource "twilio_autopilot_assistants_field_types_v1" "parish" {
+  unique_name = "Parish"
+  assistant_sid = var.bot_sid
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_group" {
+  for_each = toset(["Unknown", "Portland", "St. Mary", "St. Ann", "Trelawny", "St. James", "Hanover", "Westmoreland", "St. Elizabeth", "Manchester", "Clarendon", "St. Catherine", "St. Thomas", "St. Andrew", "Kingston"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_unknown_synonym_group" {
+  depends_on = [twilio_autopilot_assistants_field_types_field_values_v1.parish_group] //Synonym creation fails if not created after what they alias
+  for_each = toset(["no", "x"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+  synonym_of = "Unknown"
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_stmary_synonym_group" {
+  depends_on = [twilio_autopilot_assistants_field_types_field_values_v1.parish_group] //Synonym creation fails if not created after what they alias
+  for_each = toset(["s mary", "stm ary", "st mary", "stmary"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+  synonym_of = "St. Mary"
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_stann_synonym_group" {
+  depends_on = [twilio_autopilot_assistants_field_types_field_values_v1.parish_group] //Synonym creation fails if not created after what they alias
+  for_each = toset(["s ann", "sta nn", "st ann", "stann"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+  synonym_of = "St. Ann"
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_stjames_synonym_group" {
+  depends_on = [twilio_autopilot_assistants_field_types_field_values_v1.parish_group] //Synonym creation fails if not created after what they alias
+  for_each = toset(["s james", "stj ames", "st james", "stjames"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+  synonym_of = "St. James"
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_stelizabeth_synonym_group" {
+  depends_on = [twilio_autopilot_assistants_field_types_field_values_v1.parish_group] //Synonym creation fails if not created after what they alias
+  for_each = toset(["s elizabeth", "se lizabeth", "st elizabeth", "stelizabeth"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+  synonym_of = "St. Elizabeth"
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_stcatherine_synonym_group" {
+  depends_on = [twilio_autopilot_assistants_field_types_field_values_v1.parish_group] //Synonym creation fails if not created after what they alias
+  for_each = toset(["s catherine", "sc atherine", "st catherine", "stcatherine"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+  synonym_of = "St. Catherine"
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_stthomas_synonym_group" {
+  depends_on = [twilio_autopilot_assistants_field_types_field_values_v1.parish_group] //Synonym creation fails if not created after what they alias
+  for_each = toset(["s thomas", "st homas", "st thomas", "stthomas", "thomas"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+  synonym_of = "St. Thomas"
+}
+
+resource "twilio_autopilot_assistants_field_types_field_values_v1" "parish_standrew_synonym_group" {
+  depends_on = [twilio_autopilot_assistants_field_types_field_values_v1.parish_group] //Synonym creation fails if not created after what they alias
+  for_each = toset(["s andrew", "sa ndrew", "st andrew", "standrew", "andrew"])
+  assistant_sid = var.bot_sid
+  field_type_sid = twilio_autopilot_assistants_field_types_v1.parish.sid
+  value = each.key
+  language = "en-US"
+  synonym_of = "St. Andrew"
+}

--- a/twilio-iac/terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/variables.tf
+++ b/twilio-iac/terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/variables.tf
@@ -1,0 +1,4 @@
+variable "bot_sid" {
+  description = "SID of the Twilio assistant (chatbot) that will use the survey task."
+  type        = string
+}


### PR DESCRIPTION
Primary reviewer @murilovmachado 

## Description

* Moved the 'survey' task for the pre survey bot into its own module
* Created customised 'survey' task for JM including the parish question & associated field resources

### Checklist
- [ X ] Corresponding issue has been opened
- [ N/A ] New tests added
- [ N/A ] Strings are localized

### Related Issues
Preparation for CHI-997

### Verification steps

Run `terraform plan` & review output

