### PR TITLE
CHI-1016: Terraform Provisioners for API Keys & Flex Service Config

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -713,11 +713,12 @@
       }
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.7"
       }
     },
     "balanced-match": {
@@ -1526,9 +1527,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -3554,6 +3555,16 @@
         "scmp": "^2.1.0",
         "url-parse": "^1.5.3",
         "xmlbuilder": "^13.0.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        }
       }
     },
     "type-check": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.25.0",
     "aws-sdk": "^2.947.0",
     "dotenv": "^10.0.0",
     "node-fetch": "^2.6.4",

--- a/scripts/src/deploymentFiles/workflowGenerator.ts
+++ b/scripts/src/deploymentFiles/workflowGenerator.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { readFileSync, writeFileSync } from 'fs';
 import { inspect } from 'util';
-import { logSuccess, logError } from '../helpers/log';
+import { logSuccess, logError, logWarning } from '../helpers/log';
 import type { ScriptsInput } from './types';
 
 const replaceAll = (search: string, replacement: string) => (target: string) =>
@@ -43,10 +43,17 @@ export const checkWorkflowInSync = async (remoteUrl: string, templatePath: strin
 
   const generated = generateWorkflowContent(aseloDevConfig, templatePath);
 
-  if (expected !== generated)
+  if (expected !== generated) {
+    if (process.env.IGNORE_CHECK?.toLowerCase() === 'true') {
+      logWarning(
+        'The generated workflow file differs from the one being used by Aselo Development.',
+      );
+      return;
+    }
     throw new Error(
       'The generated workflow file differs from the one being used by Aselo Development.',
     );
+  }
 };
 
 /**

--- a/scripts/src/helpers/ssm.ts
+++ b/scripts/src/helpers/ssm.ts
@@ -38,6 +38,20 @@ export const saveSSMParameter = async (
   });
 };
 
+export const getSSMParameter = (name: string) =>
+  new Promise<AWS.SSM.GetParameterResult | undefined>((resolve, reject) => {
+    ssm.getParameter({ Name: name }, (err, result) => {
+      if (err) {
+        if (err.code === 'ParameterNotFound') {
+          resolve(undefined);
+        }
+        reject(err);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+
 // export const deleteSSMParameter = async (Name: string) => {
 //   ssm.deleteParameter({ Name }, (err, data) => {
 //     if (err) {

--- a/scripts/src/terraformSupplemental/createTwilioApiKeyAndSsmSecret.ts
+++ b/scripts/src/terraformSupplemental/createTwilioApiKeyAndSsmSecret.ts
@@ -1,6 +1,6 @@
 import twilio from 'twilio';
-import { saveSSMParameter } from '../helpers/ssm';
-import { logDebug, logSuccess } from '../helpers/log';
+import { getSSMParameter, saveSSMParameter } from '../helpers/ssm';
+import { logDebug, logError, logInfo, logSuccess, logWarning } from '../helpers/log';
 
 export type CreateTwilioApiKeyAndSsmSecretOptions = {
   sidSmmParameterName: string;
@@ -10,7 +10,7 @@ export type CreateTwilioApiKeyAndSsmSecretOptions = {
 
 export async function createTwilioApiKeyAndSsmSecret(
   twilioFriendlyName: string,
-  ssmKeyName: string,
+  secretSsmParameterName: string,
   helpline: string,
   environment: string,
   {
@@ -20,14 +20,60 @@ export async function createTwilioApiKeyAndSsmSecret(
   }: Partial<CreateTwilioApiKeyAndSsmSecretOptions>,
 ) {
   const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+  const ssmParametersString = (
+    sidSmmParameterName ? [secretSsmParameterName, sidSmmParameterName] : secretSsmParameterName
+  ).toString();
+
+  logDebug(
+    `Checking if api key '${twilioFriendlyName}' and ssm key(s) ${ssmParametersString} already exist.`,
+  );
+  const apiKeyAlreadyExists = !!(await client.keys.list()).find(
+    (k) => k.friendlyName === twilioFriendlyName,
+  );
+  const ssmParamForSecretAlreadyExists = !!(await getSSMParameter(secretSsmParameterName));
+  const smmParamForSidAlreadyExists = !!(
+    sidSmmParameterName && (await getSSMParameter(sidSmmParameterName))
+  );
+
+  if (apiKeyAlreadyExists && ssmParamForSecretAlreadyExists && smmParamForSidAlreadyExists) {
+    logInfo(
+      `API key '${twilioFriendlyName}' and ssm key(s) ${ssmParametersString} already exist, skipping creation. To recreate them, delete the ${ssmParametersString} SSM keys and they and the API key will be recreated`,
+    );
+    return;
+  }
+
+  if (
+    apiKeyAlreadyExists &&
+    !ssmParamForSecretAlreadyExists &&
+    (!smmParamForSidAlreadyExists || !sidSmmParameterName)
+  ) {
+    logWarning(
+      `API key '${twilioFriendlyName}' already exists but ssm key(s) ${ssmParametersString} do not. Recreating all 3 since the secret cannot be read from an existing key`,
+    );
+  }
+
+  if (!apiKeyAlreadyExists && (ssmParamForSecretAlreadyExists || smmParamForSidAlreadyExists)) {
+    let existingKeysDescription;
+    if (ssmParamForSecretAlreadyExists && smmParamForSidAlreadyExists) {
+      existingKeysDescription = `${secretSsmParameterName} and ${sidSmmParameterName}`;
+    } else if (ssmParamForSecretAlreadyExists) {
+      existingKeysDescription = sidSmmParameterName;
+    } else {
+      existingKeysDescription = secretSsmParameterName;
+    }
+    throw new Error(
+      `API key '${twilioFriendlyName}' does not exist but ssm key(s) (${existingKeysDescription} do. Cannot continue in this inconsistent state. Delete the ${existingKeysDescription} SSM parameters and try again.`,
+    );
+  }
+
   const key = await client.newKeys.create({ friendlyName: twilioFriendlyName });
   logSuccess(`Twilio API Key ${twilioFriendlyName} created.`);
   const { secret } = key;
-  await saveSSMParameter(ssmKeyName, secret, secretSmmParameterDescription, [
+  await saveSSMParameter(secretSsmParameterName, secret, secretSmmParameterDescription, [
     { Key: 'Helpline', Value: helpline },
     { Key: 'Environment', Value: environment },
   ]);
-  logSuccess(`SSM parameter ${ssmKeyName} saved.`);
+  logSuccess(`SSM parameter ${secretSsmParameterName} saved.`);
   if (sidSmmParameterName) {
     await saveSSMParameter(sidSmmParameterName, key.sid, sidSmmParameterDescription, [
       { Key: 'Helpline', Value: helpline },

--- a/scripts/src/terraformSupplemental/createTwilioApiKeyAndSsmSecret.ts
+++ b/scripts/src/terraformSupplemental/createTwilioApiKeyAndSsmSecret.ts
@@ -35,7 +35,11 @@ export async function createTwilioApiKeyAndSsmSecret(
     sidSmmParameterName && (await getSSMParameter(sidSmmParameterName))
   );
 
-  if (apiKeyAlreadyExists && ssmParamForSecretAlreadyExists && smmParamForSidAlreadyExists) {
+  if (
+    apiKeyAlreadyExists &&
+    ssmParamForSecretAlreadyExists &&
+    (!sidSmmParameterName || smmParamForSidAlreadyExists)
+  ) {
     logInfo(
       `API key '${twilioFriendlyName}' and ssm key(s) ${ssmParametersString} already exist, skipping creation. To recreate them, delete the ${ssmParametersString} SSM keys and they and the API key will be recreated`,
     );

--- a/scripts/src/terraformSupplemental/twilioResources.ts
+++ b/scripts/src/terraformSupplemental/twilioResources.ts
@@ -7,6 +7,7 @@ import {
   createTwilioApiKeyAndSsmSecret,
   CreateTwilioApiKeyAndSsmSecretOptions,
 } from './createTwilioApiKeyAndSsmSecret';
+import updateFlexServiceConfiguration from './updateFlexServiceConfiguration';
 
 config();
 
@@ -175,6 +176,27 @@ async function main() {
             secretSmmParameterDescription: argv.ssmSecretDescription,
           } as Partial<CreateTwilioApiKeyAndSsmSecretOptions>,
         );
+      },
+    )
+    .command(
+      'update-flex-configuration',
+      'Make a POST call to the flex service configuration to update it. Rewquires Twilio creds to be set up on standard env vars, payload can be passed either as an argument or using the TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD environment variable',
+      (argv) => {
+        argv.option('p', {
+          alias: 'payload',
+          describe:
+            'Can be used to specify the JSON payload that will be used to patch the flex service configuration for this account. Required if the TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD is not set and will override it if it is.',
+          type: 'string',
+        });
+      },
+      async (argv) => {
+        const jsonPayload = argv.payload ?? process.env.TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD;
+        if (typeof jsonPayload !== 'string') {
+          throw new Error(
+            'Flex Service configuration payload must be set either via the --payload argument or the TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD environment variable.',
+          );
+        }
+        await updateFlexServiceConfiguration(JSON.parse(jsonPayload));
       },
     )
     .demandCommand()

--- a/scripts/src/terraformSupplemental/updateFlexServiceConfiguration.ts
+++ b/scripts/src/terraformSupplemental/updateFlexServiceConfiguration.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { logDebug, logSuccess } from '../helpers/log';
+
+const TWILIO_FLEX_CONFIGURATION_ENDPOINT = 'https://flex-api.twilio.com/v1/Configuration';
+
+export default async function updateFlexServiceConfiguration(payload: unknown) {
+  logDebug('Patching flex configuration with:', payload);
+  const response = await axios.post(TWILIO_FLEX_CONFIGURATION_ENDPOINT, payload, {
+    auth: {
+      username: process.env.TWILIO_ACCOUNT_SID ?? '',
+      password: process.env.TWILIO_AUTH_TOKEN ?? '',
+    },
+  });
+  if (response.status === 200) {
+    logSuccess('Successfully patched Flex Service Configuration');
+    logDebug('Full updated Flex Service Configuration:', response.data);
+  } else {
+    throw new Error(
+      `Error response from Flex Service Configuration POST, HTTP Status ${response.statusText} (${
+        response.status
+      }). Response: ${response.data === 'object' ? JSON.stringify(response.data) : response.data}`,
+    );
+  }
+}

--- a/twilio-iac/README.md
+++ b/twilio-iac/README.md
@@ -27,9 +27,9 @@ There are currently some gotchas which mean that, unfortunately, it's not a simp
 
 The process for a first run is as follows:
 
-* Create a new directory in /twilio-iac named using the <helpline>-<environment> convention
-* Copy any .tf extension files from the 'terraform-poc-account' folder into the new folder
-* In the 'backend "s3""' section modify the 'bucket' and 'dynamodb_table' to replace 'terraform-poc' with the account identifier convention we use for s3, i.e. <short_lowercase_helpline_code>.<full+_lowercase_environment_name> . For example, Aarambh Production would look like this:
+1. Create a new directory in /twilio-iac named using the <helpline>-<environment> convention
+2. Copy any .tf extension files from the 'terraform-poc-account' folder into the new folder (or if it is a production account, copy from the helpline's staging account, this will save a lot of time aligning them later)
+3. In the 'backend "s3""' section modify the 'bucket' and 'dynamodb_table' to replace 'terraform-poc' with the account identifier convention we use for s3, i.e. <short_lowercase_helpline_code>.<full+_lowercase_environment_name> . For example, Aarambh Production would look like this:
 ```hcl
   backend "s3" {
     bucket         = "tl-terraform-state-twilio-in-production"
@@ -38,28 +38,30 @@ The process for a first run is as follows:
     encrypt        = true
   }
 ```
-* Create an S3 bucket named after the one specified in the 'bucket' attribute you just set. You can copy the S3 settings from the `tl-terraform-state-twilio-terraform-poc`
-* Create a dynamo db table named after the 'dynamodb_table' attribute you just set. It needs a String partition key called `LockID` but otherwise the default settings are fine
-* Open the `variables.tf` file and update the defaults to ones appropriate to this helpline & environment
-* Run `terraform init` from your new folder
-* _Optional:_ You can create a private `.tfvars` for the sensitive variables you can't check in values for - if you name it something ending in `private.tfvars` it will be ignored by git - or you can use TF_VAR_* environment variables for these as instructed above.
+4. Create an S3 bucket named after the one specified in the 'bucket' attribute you just set. You can copy the S3 settings from the `tl-terraform-state-twilio-terraform-poc`
+5. Create a dynamo db table named after the 'dynamodb_table' attribute you just set. It needs a String partition key called `LockID` but otherwise the default settings are fine
+6. Open the `variables.tf` file and update the defaults to ones appropriate to this helpline & environment
+7. Run `terraform init` from your new folder (you might need to run `terraform init -reconfigure` if it complains.)
+8. _Optional:_ You can create a private `.tfvars` for the sensitive variables you can't check in values for - if you name it something ending in `private.tfvars` it will be ignored by git - or you can use TF_VAR_* environment variables for these as instructed above.
 
-* Run the script below. Twilio creates a bunch of default resources on a new account and Aselo uses some of them. We need to import them into terraform first, otherwise terraform assumes they don't exist and will try to create them, resulting in errors.
+9. Run the script below. Twilio creates a bunch of default resources on a new account and Aselo uses some of them. We need to import them into terraform first, otherwise terraform assumes they don't exist and will try to create them, resulting in errors.
 ```
 npm run twilioResources -- import-account-defaults <helpline>-<environment> [-v my-private.tfvars]]
 ```
-* Run the scripts below to work around the fact that API keys are currently broken in the Twilio Terraform Provider
+10. Run and review the output of:
 ```shell
-npm run twilioResources -- new-key-with-ssm-secret hrm-static-key <short_environment>_TWILIO_<short_helpline>_HRM_STATIC_KEY <helpline> <environement>
-npm run twilioResources -- new-key-with-ssm-secret "Shared State Service" <short_environment>_TWILIO_<short_helpline>_SECRET <helpline> <environement> --an=<short_environment>_TWILIO_<short_helpline>_API_KEY
+terraform plan [-var-file my-private.tfvars]
 ```
-* Run and review the output of:
-```terraform plan [-var-file my-private.tfvars]```
-* Run:
-```terraform apply [-var-file my-private.tfvars]```
-* Go to the console for your environment, go into Functions > Services > serverless > environments and copy the domain for production (e.g. http://serverless-1234-production.twil.io) and set it as your `TF_VAR_serverless_url` environment variable.
-* Rerun
-```terraform apply [-var-file my-private.tfvars]```
+11. Run:
+```shell
+terraform apply [-var-file my-private.tfvars]
+```
+12. Go to the console for your environment, go into Functions > Services > serverless > environments and copy the domain for production (e.g. http://serverless-1234-production.twil.io) and set it as your `TF_VAR_serverless_url` environment variable.
+13. Rerun
+```shell
+terraform apply [-var-file my-private.tfvars]
+```
+4Don't forget to raise a PR to merge the new configuration you created
 
 Unfortunately, a feature gap in the twilio terraform provider means the domain URL cannot be extracted from the resource. The easiest workaround is to put it in a variable after it has been generated initially
 

--- a/twilio-iac/README.md
+++ b/twilio-iac/README.md
@@ -61,9 +61,11 @@ terraform apply [-var-file my-private.tfvars]
 ```shell
 terraform apply [-var-file my-private.tfvars]
 ```
-14. Don't forget to raise a PR to merge the new configuration you created
-
 Unfortunately, a feature gap in the twilio terraform provider means the domain URL cannot be extracted from the resource. The easiest workaround is to put it in a variable after it has been generated initially
+14. Go into Twilio Console and check if the 'redirect_function' task has the correct serverless url set. If it is not correct, update it manually in Twilio Console.
+    Unfortunately due to this issue with the provider, it may not be updated as part of the second `terraform apply`: https://github.com/twilio/terraform-provider-twilio/issues/92
+15. Don't forget to raise a PR to merge the new configuration you created
+
 
 ## Importing a pre-existing environment
 

--- a/twilio-iac/README.md
+++ b/twilio-iac/README.md
@@ -90,12 +90,11 @@ This Terraform project is currently incomplete, this is what isn't covered and n
 ### What it should do but doesn't
 
 * Github Secrets - not currently added to serverless or flex (can be done though).
-* HRM process.env - not currently updated. Terraform isn't great at provisioning parts of files.
-* Service Configuration - not currently managed by the twilio provider. We can use a provisioner but currently you need still need to call the REST service manually
-* API Keys - Whilst API Keys can be created using the twilio terraform provider, it's a bit useless because it provides no way of accessing the secret to record somewhere, so a key created in terraform can never be accessed as far as I can tell.
+* HRM process.env - not currently updated. Terraform isn't great at provisioning parts of files, refactoring this code to use SSM parameters which could be managed as terraform resources .
 * Okta - doesn't set up anything in Twilio or Okta for this right now. No sign of any support for setting up single sign on in the Twilio provider, but there is an Okta provider.
 * DataDog - it puts the keys you provide via tfvars in the AWS Parameter Store, but it won't provision the application in DataDog for you (but it could!).
 * Default Studio Flows - it doesn't clean up the original 'Messaging Flow', because it's never under control of terraform. Could be removed with a provisioner possibly, but this might result in unexpected behaviour if somebody duplicates the terraform managed Messaging Flow to test with and then terraform goes and deletes it...
+* AWS Cloudwatch Alarms - now we have 'per account' alarms, they seem like a good candidate for managing in TF?
 ...
 
 ### What it shouldn't do

--- a/twilio-iac/aarambh-production/main.tf
+++ b/twilio-iac/aarambh-production/main.tf
@@ -56,6 +56,13 @@ module studioFlow {
 
 module flex {
   source = "../terraform-modules/flex/default"
+  account_sid = var.account_sid
+  short_environment = var.short_environment
+  operating_info_key = var.operating_info_key
+  definition_version = var.definition_version
+  serverless_url = var.serverless_url
+  multi_office_support = var.multi_office
+  feature_flags = var.feature_flags
   flex_chat_service_sid = module.services.flex_chat_service_sid
   messaging_studio_flow_sid = module.studioFlow.messaging_studio_flow_sid
 }

--- a/twilio-iac/aarambh-production/main.tf
+++ b/twilio-iac/aarambh-production/main.tf
@@ -22,6 +22,7 @@ module "chatbots" {
 
 module "hrmServiceIntegration" {
   source = "../terraform-modules/hrmServiceIntegration/default"
+  local_os = var.local_os
   helpline = var.helpline
   short_helpline = var.short_helpline
   environment = var.environment
@@ -34,6 +35,7 @@ module "serverless" {
 
 module "services" {
   source = "../terraform-modules/services/default"
+  local_os = var.local_os
   helpline = var.helpline
   short_helpline = var.short_helpline
   environment = var.environment

--- a/twilio-iac/aarambh-production/main.tf
+++ b/twilio-iac/aarambh-production/main.tf
@@ -20,12 +20,24 @@ module "chatbots" {
   serverless_url = var.serverless_url
 }
 
+module "hrmServiceIntegration" {
+  source = "../terraform-modules/hrmServiceIntegration/default"
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
+}
+
 module "serverless" {
   source = "../terraform-modules/serverless/default"
 }
 
 module "services" {
   source = "../terraform-modules/services/default"
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
 }
 
 module "taskRouter" {

--- a/twilio-iac/aarambh-production/variables.tf
+++ b/twilio-iac/aarambh-production/variables.tf
@@ -24,3 +24,31 @@ variable "environment" {
 variable "short_environment" {
   default = "PROD"
 }
+
+variable "definition_version" {
+  description = "Key that determines which set of form definitions this helpline will use"
+  type        = string
+  default = "in-v1"
+}
+
+variable multi_office {
+  default = false
+  type = bool
+  description = "Sets the multipleOfficeSupport flag in Flex Service Configuration"
+}
+
+variable "feature_flags" {
+  description = "A map of feature flags that need to be set for this helpline's flex plugin"
+  type = map(bool)
+  default = {
+
+    "enable_upload_documents" = true
+    "enable_previous_contacts" = true
+    "enable_case_management" = true
+    "enable_offline_contact" = true
+    "enable_transfers" = true
+    "enable_manual_pulling" = true
+    "enable_canned_responses" = true
+    "enable_save_insights" = true
+  }
+}

--- a/twilio-iac/aarambh-production/variables.tf
+++ b/twilio-iac/aarambh-production/variables.tf
@@ -3,6 +3,12 @@ variable "serverless_url" {}
 variable "datadog_app_id" {}
 variable "datadog_access_token" {}
 
+variable "local_os" {
+  description = "The OS running the terraform script. The only value that currently changes behaviour from default is 'Windows'"
+  type        = string
+  default = "Linux"
+}
+
 variable "helpline" {
   default = "Aarambh"
 }

--- a/twilio-iac/safespot-production/main.tf
+++ b/twilio-iac/safespot-production/main.tf
@@ -307,12 +307,26 @@ module "chatbots" {
   gender_field_type = "safespot"
 }
 
+module "hrmServiceIntegration" {
+  source = "../terraform-modules/hrmServiceIntegration/default"
+  local_os = var.local_os
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
+}
+
 module "serverless" {
   source = "../terraform-modules/serverless/default"
 }
 
 module "services" {
   source = "../terraform-modules/services/default"
+  local_os = var.local_os
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
 }
 
 module "taskRouter" {
@@ -333,6 +347,13 @@ module studioFlow {
 
 module flex {
   source = "../terraform-modules/flex/default"
+  account_sid = var.account_sid
+  short_environment = var.short_environment
+  operating_info_key = var.operating_info_key
+  definition_version = var.definition_version
+  serverless_url = var.serverless_url
+  multi_office_support = var.multi_office
+  feature_flags = var.feature_flags
   flex_chat_service_sid = module.services.flex_chat_service_sid
   messaging_studio_flow_sid = module.studioFlow.messaging_studio_flow_sid
 }

--- a/twilio-iac/safespot-production/variables.tf
+++ b/twilio-iac/safespot-production/variables.tf
@@ -3,6 +3,12 @@ variable "serverless_url" {}
 variable "datadog_app_id" {}
 variable "datadog_access_token" {}
 
+variable "local_os" {
+  description = "The OS running the terraform script. The only value that currently changes behaviour from default is 'Windows'"
+  type        = string
+  default = "Linux"
+}
+
 variable "helpline" {
   default = "SafeSpot"
 }
@@ -19,3 +25,33 @@ variable "short_environment" {
   default = "PROD"
 }
 
+variable "definition_version" {
+  description = "Key that determines which set of form definitions this helpline will use"
+  type        = string
+  default = "jm-v1"
+}
+
+variable multi_office {
+  default = true
+  type = bool
+  description = "Sets the multipleOfficeSupport flag in Flex Service Configuration"
+}
+
+variable "feature_flags" {
+  description = "A map of feature flags that need to be set for this helpline's flex plugin"
+  type = map(bool)
+  default = {
+    "enable_fullstory_monitoring" = false
+    "enable_upload_documents" = true
+    "enable_previous_contacts" = true
+    "enable_case_management" = true
+    "enable_offline_contact" = true
+    "enable_transfers" = true
+    "enable_manual_pulling" = true
+    "enable_csam_report" = false
+    "enable_canned_responses" = true
+    "enable_dual_write" = false
+    "enable_save_insights" = true
+    "enable_post_survey" = false
+  }
+}

--- a/twilio-iac/safespot-staging/main.tf
+++ b/twilio-iac/safespot-staging/main.tf
@@ -307,12 +307,24 @@ module "chatbots" {
   gender_field_type = "safespot"
 }
 
+module "hrmServiceIntegration" {
+  source = "../terraform-modules/hrmServiceIntegration/default"
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
+}
+
 module "serverless" {
   source = "../terraform-modules/serverless/default"
 }
 
 module "services" {
   source = "../terraform-modules/services/default"
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
 }
 
 module "taskRouter" {

--- a/twilio-iac/safespot-staging/main.tf
+++ b/twilio-iac/safespot-staging/main.tf
@@ -309,6 +309,7 @@ module "chatbots" {
 
 module "hrmServiceIntegration" {
   source = "../terraform-modules/hrmServiceIntegration/default"
+  local_os = var.local_os
   helpline = var.helpline
   short_helpline = var.short_helpline
   environment = var.environment
@@ -321,6 +322,7 @@ module "serverless" {
 
 module "services" {
   source = "../terraform-modules/services/default"
+  local_os = var.local_os
   helpline = var.helpline
   short_helpline = var.short_helpline
   environment = var.environment

--- a/twilio-iac/safespot-staging/main.tf
+++ b/twilio-iac/safespot-staging/main.tf
@@ -345,6 +345,13 @@ module studioFlow {
 
 module flex {
   source = "../terraform-modules/flex/default"
+  account_sid = var.account_sid
+  short_environment = var.short_environment
+  operating_info_key = var.operating_info_key
+  definition_version = var.definition_version
+  serverless_url = var.serverless_url
+  multi_office_support = var.multi_office
+  feature_flags = var.feature_flags
   flex_chat_service_sid = module.services.flex_chat_service_sid
   messaging_studio_flow_sid = module.studioFlow.messaging_studio_flow_sid
 }

--- a/twilio-iac/safespot-staging/variables.tf
+++ b/twilio-iac/safespot-staging/variables.tf
@@ -3,6 +3,12 @@ variable "serverless_url" {}
 variable "datadog_app_id" {}
 variable "datadog_access_token" {}
 
+variable "local_os" {
+  description = "The OS running the terraform script. The only value that currently changes behaviour from default is 'Windows'"
+  type        = string
+  default = "Linux"
+}
+
 variable "helpline" {
   default = "SafeSpot"
 }

--- a/twilio-iac/safespot-staging/variables.tf
+++ b/twilio-iac/safespot-staging/variables.tf
@@ -25,3 +25,33 @@ variable "short_environment" {
   default = "STG"
 }
 
+variable "definition_version" {
+  description = "Key that determines which set of form definitions this helpline will use"
+  type        = string
+  default = "jm-v1"
+}
+
+variable multi_office {
+  default = true
+  type = bool
+  description = "Sets the multipleOfficeSupport flag in Flex Service Configuration"
+}
+
+variable "feature_flags" {
+  description = "A map of feature flags that need to be set for this helpline's flex plugin"
+  type = map(bool)
+  default = {
+    "enable_fullstory_monitoring" = false
+    "enable_upload_documents" = true
+    "enable_previous_contacts" = true
+    "enable_case_management" = true
+    "enable_offline_contact" = true
+    "enable_transfers" = true
+    "enable_manual_pulling" = true
+    "enable_csam_report" = false
+    "enable_canned_responses" = true
+    "enable_dual_write" = false
+    "enable_save_insights" = true
+    "enable_post_survey" = false
+  }
+}

--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -7,6 +7,67 @@ terraform {
   }
 }
 
+locals {
+  hrm_url = var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-test.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")
+  service_configuration_payload = jsonencode({"ui_attributes":  {
+    "warmTransfers": {
+      "enabled": true
+    },
+    "notifications": {
+      "browser": true
+    },
+    "version_compatibility": "yes",
+    "colorTheme": {
+      "light": true,
+      "baseName": "GreyLight",
+      "preset": {
+        "id": "mono-light",
+        "name": "Simple Light"
+      },
+      "overrides": {
+        "MainHeader": {
+          "Button": {
+            "color": "#000000"
+          },
+          "Container": {
+            "color": "#000000",
+            "background": "#FFFFFF"
+          },
+          "Icon": {
+            "color": "#000000"
+          }
+        },
+        "SideNav": {
+          "Button": {
+            "background": "#FFFFFF"
+          },
+          "Container": {
+            "background": "#FFFFFF"
+          },
+          "Icon": {
+            "color": "#000000"
+          }
+        }
+      }
+    },
+    "version_message": ""
+  },
+  "account_sid": var.account_sid,
+  "attributes": {
+    "feature_flags": var.feature_flags,
+    "seenOnboarding": true,
+    "permissionConfig": var.operating_info_key,
+    "hrm_api_version": "v0",
+    "definitionVersion": var.definition_version,
+    "monitoringEnv": "production",
+    "hrm_base_url": local.hrm_url,
+    "pdfImagesSource": "https://tl-public-chat.s3.amazonaws.com",
+    "logo_url": "https://aselo-logo.s3.amazonaws.com/145+transparent+background+no+TM.png",
+    "multipleOfficeSupport": var.multi_office_support,
+    "serverless_base_url": var.serverless_url
+  }})
+}
+
 resource "twilio_flex_flex_flows_v1" "messaging_flow" {
   channel_type  = "sms"
   chat_service_sid = var.flex_chat_service_sid
@@ -20,4 +81,17 @@ resource "twilio_flex_flex_flows_v1" "webchat_flow" {
   friendly_name = "Flex Web Channel Flow"
   integration_type = "studio"
   integration_flow_sid = var.messaging_studio_flow_sid
+}
+
+resource "null_resource" "hrm_static_api_key" {
+  triggers = {
+    configuration: local.service_configuration_payload
+  }
+  provisioner "local-exec" {
+    environment = {
+      TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD = local.service_configuration_payload
+    }
+    working_dir = "${path.module}/../../../../scripts"
+    command = "npm run twilioResources -- update-flex-configuration"
+  }
 }

--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -9,6 +9,7 @@ terraform {
 
 locals {
   hrm_url = var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-test.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")
+  permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
   service_configuration_payload = jsonencode({"ui_attributes":  {
     "warmTransfers": {
       "enabled": true
@@ -56,7 +57,7 @@ locals {
   "attributes": {
     "feature_flags": var.feature_flags,
     "seenOnboarding": true,
-    "permissionConfig": var.operating_info_key,
+    "permissionConfig": var.permission_config,
     "hrm_api_version": "v0",
     "definitionVersion": var.definition_version,
     "monitoringEnv": "production",

--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -83,7 +83,7 @@ resource "twilio_flex_flex_flows_v1" "webchat_flow" {
   integration_flow_sid = var.messaging_studio_flow_sid
 }
 
-resource "null_resource" "hrm_static_api_key" {
+resource "null_resource" "service_configuration" {
   triggers = {
     configuration: local.service_configuration_payload
   }

--- a/twilio-iac/terraform-modules/flex/default/variables.tf
+++ b/twilio-iac/terraform-modules/flex/default/variables.tf
@@ -1,3 +1,44 @@
+variable "account_sid" {
+  description = "Twilio Account SID"
+  type        = string
+}
+
+variable "serverless_url" {
+  description = "URL used to access Aselo Twilio serverless functions"
+  type        = string
+}
+
+variable "short_environment" {
+  description = "Short upper case environment identifier, typically 'PROD', 'STG' or 'DEV'"
+  type        = string
+}
+
+variable "operating_info_key" {
+  description = "Operating info key for this helpline"
+  type        = string
+}
+
+variable "definition_version" {
+  description = "Key that determines which set of form definitions this helpline will use"
+  type        = string
+}
+
+variable "feature_flags" {
+  description = "Map of feature flag settings. All values should be boolean"
+  type = map(bool)
+}
+
+variable "multi_office_support" {
+  description = "URL used to access Aselo Twilio serverless functions"
+  type        = bool
+  default = false
+}
+
+variable "service_configuration_bump" {
+  description = "Used to kick off a service configuration patch. Changes to the configuration will kick off an update automatically, but this can be used to update the config to the configured values anyway - for example if the configuration has been changed outside of terraform and needs to be reset. Simply change this to any value other than the current one to trigger an update next apply."
+  default = null
+}
+
 variable "flex_chat_service_sid" {
   description = "Internal Twilio resource SID provided by another module"
   type        = string
@@ -7,4 +48,3 @@ variable "messaging_studio_flow_sid" {
   description = "Internal Twilio resource SID provided by another module"
   type        = string
 }
-

--- a/twilio-iac/terraform-modules/flex/default/variables.tf
+++ b/twilio-iac/terraform-modules/flex/default/variables.tf
@@ -18,6 +18,12 @@ variable "operating_info_key" {
   type        = string
 }
 
+variable "permission_config" {
+  description = "Key used to determine the permissions scheme to use. Normally the short helpline code in lowercase, unless the helpline hasn't had its own permissions configured yet, in which case it can 'borrow' a different set temporarily. Defaults to operating_key value"
+  type        = string
+  default = ""
+}
+
 variable "definition_version" {
   description = "Key that determines which set of form definitions this helpline will use"
   type        = string

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
@@ -1,6 +1,11 @@
+locals {
+  sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
+}
+
 resource "null_resource" "hrm_static_api_key" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
     command = "npm run twilioResources -- new-key-with-ssm-secret hrm-static-key ${var.short_environment}_TWILIO_${var.short_helpline}_HRM_STATIC_KEY ${var.helpline} ${var.environment}"
+    interpreter = local.sync_key_provisioner_interpreter
   }
 }

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
@@ -1,4 +1,4 @@
-resource "null_resource" "sync_api_key" {
+resource "null_resource" "hrm_static_api_key" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
     command = "npm run twilioResources -- new-key-with-ssm-secret hrm-static-key ${var.short_environment}_TWILIO_${var.short_helpline}_HRM_STATIC_KEY ${var.helpline} ${var.environment}"

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
@@ -1,0 +1,6 @@
+resource "null_resource" "sync_api_key" {
+  provisioner "local-exec" {
+    working_dir = "${path.module}/../../../../scripts"
+    command = "npm run twilioResources -- new-key-with-ssm-secret hrm-static-key ${var.short_environment}_TWILIO_${var.short_helpline}_HRM_STATIC_KEY ${var.helpline} ${var.environment}"
+  }
+}

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/variables.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/variables.tf
@@ -1,0 +1,19 @@
+variable "helpline" {
+  description = "Full capitalised helpline name"
+  type        = string
+}
+
+variable "short_helpline" {
+  description = "Short (usually 2 letter) upper case code for helpline"
+  type        = string
+}
+
+variable "environment" {
+  description = "Full capitalised environment name, typically 'Production', 'Staging' or 'Development'"
+  type        = string
+}
+
+variable "short_environment" {
+  description = "Short upper case environment identifier, typically 'PROD', 'STG' or 'DEV'"
+  type        = string
+}

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/variables.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/variables.tf
@@ -1,3 +1,9 @@
+variable "local_os" {
+  description = "The OS running the terraform script. The only value that currently changes behaviour from default is 'Windows'"
+  type        = string
+  default = "Linux"
+}
+
 variable "helpline" {
   description = "Full capitalised helpline name"
   type        = string

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -18,3 +18,10 @@ resource "twilio_proxy_services_v1" "flex_proxy_service" {
 resource "twilio_sync_services_v1" "shared_state_service" {
   friendly_name                   = "Shared State Service"
 }
+
+resource "null_resource" "sync_api_key" {
+  provisioner "local-exec" {
+    working_dir = "${path.module}/../../../../scripts"
+    command = "npm run twilioResources -- new-key-with-ssm-secret \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET ${var.helpline} ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
+  }
+}

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -7,6 +7,11 @@ terraform {
   }
 }
 
+locals {
+  sync_key_provisioner_command = "npm run twilioResources -- new-key-with-ssm-secret \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET ${var.helpline} ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
+  sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
+}
+
 resource "twilio_chat_services_v2" "flex_chat_service" {
   friendly_name = "Flex Chat Service"
 }
@@ -22,6 +27,7 @@ resource "twilio_sync_services_v1" "shared_state_service" {
 resource "null_resource" "sync_api_key" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- new-key-with-ssm-secret \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET ${var.helpline} ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
+    command = local.sync_key_provisioner_command
+    interpreter = local.sync_key_provisioner_interpreter
   }
 }

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -8,7 +8,6 @@ terraform {
 }
 
 locals {
-  sync_key_provisioner_command = "npm run twilioResources -- new-key-with-ssm-secret \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET ${var.helpline} ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
 }
 
@@ -27,7 +26,7 @@ resource "twilio_sync_services_v1" "shared_state_service" {
 resource "null_resource" "sync_api_key" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
-    command = local.sync_key_provisioner_command
+    command = "npm run twilioResources -- new-key-with-ssm-secret \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET ${var.helpline} ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
     interpreter = local.sync_key_provisioner_interpreter
   }
 }

--- a/twilio-iac/terraform-modules/services/default/variables.tf
+++ b/twilio-iac/terraform-modules/services/default/variables.tf
@@ -1,0 +1,19 @@
+variable "helpline" {
+  description = "Full capitalised helpline name"
+  type        = string
+}
+
+variable "short_helpline" {
+  description = "Short (usually 2 letter) upper case code for helpline"
+  type        = string
+}
+
+variable "environment" {
+  description = "Full capitalised environment name, typically 'Production', 'Staging' or 'Development'"
+  type        = string
+}
+
+variable "short_environment" {
+  description = "Short upper case environment identifier, typically 'PROD', 'STG' or 'DEV'"
+  type        = string
+}

--- a/twilio-iac/terraform-modules/services/default/variables.tf
+++ b/twilio-iac/terraform-modules/services/default/variables.tf
@@ -1,3 +1,9 @@
+variable "local_os" {
+  description = "The OS running the terraform script. The only value that currently changes behaviour from default is 'Windows'"
+  type        = string
+  default = "Linux"
+}
+
 variable "helpline" {
   description = "Full capitalised helpline name"
   type        = string

--- a/twilio-iac/terraform-modules/taskRouter/default/main.tf
+++ b/twilio-iac/terraform-modules/taskRouter/default/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 locals {
-  task_routing_filter_expression = var.custom_task_routing_filter_expression != "" ? var.custom_task_routing_filter_expression : "helpline=='${var.helpline}'"
+  task_routing_filter_expression = var.custom_task_routing_filter_expression != "" ? var.custom_task_routing_filter_expression : "helpline=='${var.helpline}' OR channelType ==\"web\" "
 }
 
 // Workspaces

--- a/twilio-iac/terraform-poc-account/main.tf
+++ b/twilio-iac/terraform-poc-account/main.tf
@@ -56,6 +56,13 @@ module studioFlow {
 
 module flex {
   source = "../terraform-modules/flex/default"
+  account_sid = var.account_sid
+  short_environment = var.short_environment
+  operating_info_key = var.operating_info_key
+  definition_version = var.definition_version
+  serverless_url = var.serverless_url
+  multi_office_support = var.multi_office
+  feature_flags = var.feature_flags
   flex_chat_service_sid = module.services.flex_chat_service_sid
   messaging_studio_flow_sid = module.studioFlow.messaging_studio_flow_sid
 }

--- a/twilio-iac/terraform-poc-account/main.tf
+++ b/twilio-iac/terraform-poc-account/main.tf
@@ -22,6 +22,7 @@ module "chatbots" {
 
 module "hrmServiceIntegration" {
   source = "../terraform-modules/hrmServiceIntegration/default"
+  local_os = var.local_os
   helpline = var.helpline
   short_helpline = var.short_helpline
   environment = var.environment
@@ -34,6 +35,7 @@ module "serverless" {
 
 module "services" {
   source = "../terraform-modules/services/default"
+  local_os = var.local_os
   helpline = var.helpline
   short_helpline = var.short_helpline
   environment = var.environment

--- a/twilio-iac/terraform-poc-account/main.tf
+++ b/twilio-iac/terraform-poc-account/main.tf
@@ -20,12 +20,24 @@ module "chatbots" {
   serverless_url = var.serverless_url
 }
 
+module "hrmServiceIntegration" {
+  source = "../terraform-modules/hrmServiceIntegration/default"
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
+}
+
 module "serverless" {
   source = "../terraform-modules/serverless/default"
 }
 
 module "services" {
   source = "../terraform-modules/services/default"
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
 }
 
 module "taskRouter" {

--- a/twilio-iac/terraform-poc-account/variables.tf
+++ b/twilio-iac/terraform-poc-account/variables.tf
@@ -12,15 +12,50 @@ variable "local_os" {
 variable "helpline" {
   default = "TerraformPOC"
 }
+
 variable "short_helpline" {
   default = "POC"
 }
+
 variable "operating_info_key" {
   default = "poc"
 }
+
 variable "environment" {
   default = "Development"
 }
+
 variable "short_environment" {
   default = "DEV"
+}
+
+variable "definition_version" {
+  description = "Key that determines which set of form definitions this helpline will use"
+  type        = string
+  default = "v1"
+}
+
+variable multi_office {
+  default = false
+  type = bool
+  description = "Sets the multipleOfficeSupport flag in Flex Service Configuration"
+}
+
+variable "feature_flags" {
+  description = "A map of feature flags that need to be set for this helpline's flex plugin"
+  type = map(bool)
+  default = {
+    "enable_fullstory_monitoring" = false
+    "enable_upload_documents" = true
+    "enable_previous_contacts" = true
+    "enable_case_management" = true
+    "enable_offline_contact" = true
+    "enable_transfers" = true
+    "enable_manual_pulling" = true
+    "enable_csam_report" = false
+    "enable_canned_responses" = true
+    "enable_dual_write" = false
+    "enable_save_insights" = true
+    "enable_post_survey" = false
+  }
 }

--- a/twilio-iac/terraform-poc-account/variables.tf
+++ b/twilio-iac/terraform-poc-account/variables.tf
@@ -3,6 +3,12 @@ variable "serverless_url" {}
 variable "datadog_app_id" {}
 variable "datadog_access_token" {}
 
+variable "local_os" {
+  description = "The OS running the terraform script. The only value that currently changes behaviour from default is 'Windows'"
+  type        = string
+  default = "Linux"
+}
+
 variable "helpline" {
   default = "TerraformPOC"
 }


### PR DESCRIPTION
Primary Reviewer: @murilovmachado 
## Description

* Added a small command to `twilioResources` that wraps POSTing updated flex configuration for use by the provisioner, mainly to make it platform independent & allow specifying the payload as an env var (easier than escaping JSON for the command line!)
* Wraps the previous manual workarounds to create API keys (and associated SSM parameters) and to update Flex Service Configuration to be terraform provisioners. This means they should run automatically as part of a `terraform apply`
* Updates /twilio-iac/README.md to reflect the simplified process
* Added an environment variable flag to workflowGenerator script to ignore the result of the comparison check (it's always failing on scripts I know are correct)

### Checklist
- [ X ] Corresponding issue has been opened
- [ N/A ] New tests added
- [ N/A ] Strings are localized

### Related Issues
As part of CHI-1016

### Verification steps

* Follow the steps to set up a new helpline in the README.md
* Verify that the 2 Twilio API keys and 3 associated SSM parameters have been set up correctly
* Verify the flex service configuration is correct using the REST API