### PR TITLE
CSAM Report UI cleanup II

### DIFF
--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormScreen.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormScreen.tsx
@@ -49,7 +49,7 @@ const CSAMReportFormScreen: React.FC<Props> = ({
       <RegularText>
         <Template code="CSAMReportForm-ContactDetailsDescription" />
       </RegularText>
-      <Box padding="15px 15px 15px 20px">{formElements.anonymous}</Box>
+      <Box padding="15px 15px 0 15px">{formElements.anonymous}</Box>
 
       {/** Conditional part of the form only shown if contact is not anon */}
       {renderContactDetails && (

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportStatusScreen.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportStatusScreen.tsx
@@ -2,21 +2,21 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Template } from '@twilio/flex-ui';
-import CheckCircleTwoToneIcon from '@material-ui/icons/CheckCircleTwoTone';
-import FileCopyOutlined from '@material-ui/icons/FileCopyOutlined';
 import Close from '@material-ui/icons/Close';
-import CheckCircle from '@material-ui/icons/CheckCircle';
 
 import { BottomButtonBar, Box, HiddenText, Row, StyledNextStepButton, HeaderCloseButton } from '../../styles/HrmStyles';
 import {
   CSAMReportContainer,
   CSAMReportLayout,
+  SuccessReportIcon,
   BoldDescriptionText,
   RegularText,
   CenterContent,
   ReportCodeText,
   ButtonText,
   CopyCodeButton,
+  StyledCheckCircle,
+  StyledFileCopyOutlined,
 } from '../../styles/CSAMReport';
 import type { CSAMReportStatus } from '../../states/csam-report/types';
 
@@ -34,7 +34,7 @@ const CSAMReportStatusScreen: React.FC<Props> = ({ reportStatus, onClickClose, o
     setCopied(true);
   };
 
-  const CopyCodeButtonIcon = copied ? CheckCircle : FileCopyOutlined;
+  const CopyCodeButtonIcon = copied ? StyledCheckCircle : StyledFileCopyOutlined;
   const CopyCodeButtonText = copied ? 'Copied' : 'CopyCode';
 
   return (
@@ -51,7 +51,7 @@ const CSAMReportStatusScreen: React.FC<Props> = ({ reportStatus, onClickClose, o
           <CenterContent>
             <Row>
               <Box marginRight="10px">
-                <CheckCircleTwoToneIcon nativeColor="#00884C" width="24px" height="24px" />
+                <SuccessReportIcon />
               </Box>
               <BoldDescriptionText fontSize="16px">
                 <Template code="CSAMReportForm-ReportSent" />
@@ -67,9 +67,8 @@ const CSAMReportStatusScreen: React.FC<Props> = ({ reportStatus, onClickClose, o
                 <ReportCodeText>#{reportStatus.responseData}</ReportCodeText>
               </Box>
               <CopyCodeButton secondary roundCorners onClick={onCopyCode} data-testid="CSAMReport-CopyCodeButton">
-                <Box marginRight="5px">
-                  <CopyCodeButtonIcon width="20px" height="20px" />
-                </Box>
+                <CopyCodeButtonIcon />
+                <div style={{ width: 10 }} />
                 <ButtonText>
                   <Template code={CopyCodeButtonText} />
                 </ButtonText>

--- a/plugin-hrm-form/src/styles/CSAMReport/index.tsx
+++ b/plugin-hrm-form/src/styles/CSAMReport/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'react-emotion';
 import { withStyles } from '@material-ui/core';
 import AttachFile from '@material-ui/icons/AttachFile';
+import CheckCircle from '@material-ui/icons/CheckCircle';
+import FileCopyOutlined from '@material-ui/icons/FileCopyOutlined';
 
 import { FontOpenSans, StyledNextStepButton } from '../HrmStyles';
 
@@ -89,3 +91,25 @@ export const CSAMAttachmentIcon = withStyles({
   },
 })(AttachFile);
 CSAMAttachmentIcon.displayName = 'CSAMAttachmentIcon';
+
+export const SuccessReportIcon = withStyles({
+  root: {
+    width: '24px',
+    height: '24px',
+    fill: '#00884C',
+  },
+})(CheckCircle);
+SuccessReportIcon.displayName = 'SuccessReportIcon';
+
+const styleCopyCodeIcon = withStyles({
+  root: {
+    width: '20px',
+    height: '20px',
+  },
+});
+
+export const StyledCheckCircle = styleCopyCodeIcon(CheckCircle);
+StyledCheckCircle.displayName = 'StyledCheckCircle';
+
+export const StyledFileCopyOutlined = styleCopyCodeIcon(FileCopyOutlined);
+StyledFileCopyOutlined.displayName = 'StyledFileCopyOutlined';

--- a/plugin-hrm-form/src/styles/GlobalOverrides.js
+++ b/plugin-hrm-form/src/styles/GlobalOverrides.js
@@ -38,4 +38,10 @@ injectGlobal`
   a.link-text-decoration-none:hover { text-decoration: none; color: #1874e1; }
   a.link-text-decoration-none:focus { text-decoration: none; color: #1874e1; }
   a.link-text-decoration-none:active { text-decoration: none; color: #1874e1; }
+
+  span.ContactDetailsInfo-open-in-new-icon {
+    width: 16px;
+    height: 16px;
+    font-size: 16px;
+  }
 `;

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -269,7 +269,6 @@ export const StyledNextStepButton = styled(Button)<StyledNextStepButtonProps>`
     )};
 
   &&:focus {
-    outline-color: #4d90fe;
     outline-style: auto;
     outline-width: initial;
   }
@@ -860,8 +859,7 @@ export const FormCheckbox = styled(CheckboxBase)`
   }
 
   &[type='checkbox']:focus:not(:focus-visible) {
-    outline: rgb(0, 95, 204) 2px solid;
-    outline-offset: 2px;
+    outline: auto;
   }
 `;
 FormCheckbox.displayName = 'FormCheckbox';

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -729,9 +729,11 @@ export const FormRadioInput = styled('input')<FormInputProps>`
     -moz-appearance: none;
     appearance: none;
 
-    width: 24px;
-    height: 24px;
-    margin-right: 5px;
+    box-sizing: content-box;
+    padding: 0;
+    margin: 0 5px 0 0;
+    width: 12px;
+    height: 12px;
     border: 2px solid #080808;
     background-color: ${props => props.theme.colors.inputBackgroundColor};
     border-radius: 50%;
@@ -741,8 +743,8 @@ export const FormRadioInput = styled('input')<FormInputProps>`
 
   &[type='radio']:checked:after {
     display: block;
-    width: 12px;
-    height: 12px;
+    width: 6px;
+    height: 6px;
     border-radius: 50%;
     content: '';
     position: relative;

--- a/plugin-hrm-form/src/styles/callTypeButtons/index.tsx
+++ b/plugin-hrm-form/src/styles/callTypeButtons/index.tsx
@@ -105,7 +105,6 @@ export const ConfirmButton = styled(Button)<ConfirmButtonProps>`
   ${p => getBackgroundWithHoverCSS(p.theme.colors.declineColor, true, false, p.disabled)};
 
   &:focus {
-    outline-color: #4d90fe;
     outline-style: auto;
     outline-width: initial;
   }

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -333,7 +333,7 @@
   "CSAMReportForm-ContactDetails": "Contact details",
   "CSAMReportForm-ContactDetailsDescription": "Reports can be filed anonymously or with contact details if the caller would like to follow up or be available to provide further details to IWF.",
   "CSAMReportForm-LearnMore": "Learn more",
-  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\">UK Data Protection Act</a>",
+  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>",
   "CSAMReportForm-ReportSent": "CSAM Report Sent!",
   "CSAMReportForm-CopyCode": "Copy confirmation code for sharing",
   "CSAMReportForm-Attachment": "CSAM Report has been filled",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -333,7 +333,7 @@
   "CSAMReportForm-ContactDetails": "Contact details",
   "CSAMReportForm-ContactDetailsDescription": "Reports can be filed anonymously or with contact details if the caller would like to follow up or be available to provide further details to IWF.",
   "CSAMReportForm-LearnMore": "Learn more",
-  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>",
+  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>.   <span class=\"ContactDetailsInfo-open-in-new-icon material-icons\">open_in_new</span>",
   "CSAMReportForm-ReportSent": "CSAM Report Sent!",
   "CSAMReportForm-CopyCode": "Copy confirmation code for sharing",
   "CSAMReportForm-Attachment": "CSAM Report has been filled",


### PR DESCRIPTION
## Description
This PR addresses the second round of feedback on the CSAM UI.

Note: easier to review commit by commit.

### Checklist
- [ ] Corresponding issue has been opened https://bugs.benetech.org/browse/CHI-1062
- [N/A] New tests added
- [ ] Strings are localized

### Verification steps
- Run local server like `npm run dev`.
- Confirm that the comments on the above Jira issue looks like expected (or that there is a comment explaining why it does not).

What to look at:
- Radio buttons shrinked
  ![Screenshot from 2022-02-11 16-50-28](https://user-images.githubusercontent.com/15805319/153659881-ea99a696-0436-4d52-9a10-e5785e9cbf59.png)

- Reduced blank space between radio buttons and next elements
  ![Screenshot from 2022-02-11 16-51-01](https://user-images.githubusercontent.com/15805319/153659964-4e60d132-2a20-4a10-ae9d-d028f1bb2b20.png)

- Clicking on the UK data protection act opens a new tab. Also added an icon at the end of the string. All of this is done in the same localizable string (wording, link and icon). This way, the style will be the same no matter the language (hence the phrase lenght).
  ![Screenshot from 2022-02-11 16-51-33](https://user-images.githubusercontent.com/15805319/153660030-1a5ec715-9436-4937-93b5-e8d13bbe61e0.png)

- Outline is black (`auto`) across the entire app. Agreed with Jana to standardize in black, later on we'll change the color of the outline app-wide (changing to #009DFF for this screen only will make the rest of the app inconsistent).
  ![Screenshot from 2022-02-11 16-53-10](https://user-images.githubusercontent.com/15805319/153661397-20a46e13-2275-43f1-bbff-8fcb41ca3ab6.png)


- Success icon matches the mocks
  ![Screenshot from 2022-02-11 16-54-35](https://user-images.githubusercontent.com/15805319/153660427-7c6d2226-35dc-492c-94a0-d3c223229e71.png)

- Copy button icons shrinked
  ![Screenshot from 2022-02-11 16-55-00](https://user-images.githubusercontent.com/15805319/153660664-69f71e81-ad13-4c66-b64e-654805a64cf3.png)


Jana's comments not addressed in the PR:
> 6. When I typed “www.something” as the url, I was able to save it without an error message. Next I tried “2222” and got an error message, so it is doing some validation. I do think we should require a .com or a .org, or something of the sort to validate it.

After discussing with Jana and Dee, advanced validation attempts might exclude lots of valid urls. We will do basic validation and let the IWF one reject urls that makes no sense (if there's such a thing).

> 9. This is probably out of scope, but I was able to hit the button “send another report” without saving the original CSAM report I was working on. I’d like us to show the alert dialog when we have a chance to add this in.

Will be addressed after the dialog is implemented (in edit case feature).