### PR TITLE
Fullstory devMode configuration option set to true

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -250,8 +250,7 @@ export default class HrmFormPlugin extends FlexPlugin {
   init(flex, manager) {
     loadCSS('https://use.fontawesome.com/releases/v5.15.1/css/solid.css');
 
-    if (process.env.NODE_ENV !== 'development')
-      setUpMonitoring(this, manager.workerClient, manager.serviceConfiguration);
+    setUpMonitoring(this, manager.workerClient, manager.serviceConfiguration);
 
     console.log(`Welcome to ${PLUGIN_NAME}`);
     this.registerReducers(manager);

--- a/plugin-hrm-form/src/utils/setUpMonitoring.js
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.js
@@ -84,7 +84,7 @@ function setUpRollbarLogger(plugin, workerClient, monitoringEnv) {
 function setUpFullStory() {
   FullStory.init({
     orgId: fullStoryId,
-    devMode: true,
+    devMode: process.env.NODE_ENV === 'development',
   });
   console.log('Fullstory monitoring is enabled');
 }

--- a/plugin-hrm-form/src/utils/setUpMonitoring.js
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.js
@@ -84,7 +84,7 @@ function setUpRollbarLogger(plugin, workerClient, monitoringEnv) {
 function setUpFullStory() {
   FullStory.init({
     orgId: fullStoryId,
-    devMode: false,
+    devMode: true,
   });
   console.log('Fullstory monitoring is enabled');
 }

--- a/plugin-hrm-form/src/utils/setUpMonitoring.js
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.js
@@ -84,11 +84,13 @@ function setUpRollbarLogger(plugin, workerClient, monitoringEnv) {
 function setUpFullStory() {
   FullStory.init({
     orgId: fullStoryId,
+    devMode: false,
   });
   console.log('Fullstory monitoring is enabled');
 }
+
 /**
- * Identifies and usage by Twilio Account ID (accountSid) in FullStory
+ * Identifies helpline usage by Twilio Account ID (accountSid) in FullStory
  * @param workerClient
  */
 function helplineIdentifierFullStory(workerClient) {
@@ -99,8 +101,11 @@ function helplineIdentifierFullStory(workerClient) {
 export default function setUpMonitoring(plugin, workerClient, serviceConfiguration) {
   const monitoringEnv = serviceConfiguration.attributes.monitoringEnv || 'staging';
 
-  setUpDatadogRum(workerClient, monitoringEnv);
-  setUpRollbarLogger(plugin, workerClient, monitoringEnv);
+  if (process.env.NODE_ENV !== 'development'){
+    setUpDatadogRum(workerClient, monitoringEnv);
+    setUpRollbarLogger(plugin, workerClient, monitoringEnv);
+  }
+
   if (serviceConfiguration.attributes.feature_flags.enable_fullstory_monitoring) {
     setUpFullStory();
     helplineIdentifierFullStory(workerClient);

--- a/plugin-hrm-form/src/utils/setUpMonitoring.js
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.js
@@ -101,7 +101,7 @@ function helplineIdentifierFullStory(workerClient) {
 export default function setUpMonitoring(plugin, workerClient, serviceConfiguration) {
   const monitoringEnv = serviceConfiguration.attributes.monitoringEnv || 'staging';
 
-  if (process.env.NODE_ENV !== 'development'){
+  if (process.env.NODE_ENV !== 'development') {
     setUpDatadogRum(workerClient, monitoringEnv);
     setUpRollbarLogger(plugin, workerClient, monitoringEnv);
   }


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
- Bug fix that will stop throwing this Fullstory related error - `Failed to send Form Error event Error: FullStory is not loaded, please ensure the init function is invoked before calling FullStory API functions`
- FullStory recording can be configured to true or false for devMode usage. Currently, it is set as true.

### Related Issues
Fixes [https://bugs.benetech.org/browse/CHI-1027](https://bugs.benetech.org/browse/CHI-1027)

### Verification steps
1. FullStory recording will be turned off in development environment and the following message will logged in the console: `FullStory is in dev mode and is not recording: event method not executed`
2. Check that deployed versions with this change are able to record events for FullStory