### PR TITLE
In stg update 02.18.2022

### DIFF
--- a/hrm-form-definitions/form-definitions/in-v1/LayoutDefinitions.json
+++ b/hrm-form-definitions/form-definitions/in-v1/LayoutDefinitions.json
@@ -6,15 +6,12 @@
       "splitFormAt": 15
     },
     "caseInformation": {
-      "splitFormAt": 4
     }
   },
   "case": {
     "households": {
-      "splitFormAt": 7
     },
     "perpetrators": {
-      "splitFormAt": 7
     },
     "incidents": {
       "previewFields": ["date", "duration", "location"],
@@ -29,8 +26,7 @@
         "location":  {
           "includeLabel": true
         }
-      },
-      "splitFormAt": 13
+      }
     },
     "referrals": {
       "splitFormAt": 2

--- a/hrm-form-definitions/form-definitions/in-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/in-v1/tabbedForms/CaseInformationTab.json
@@ -82,19 +82,8 @@
     ]
   },
   {
-    "name": "keepConfidential",
-    "label": "Keep confidential?",
-    "type": "checkbox",
-    "initialChecked": true
-  },
-  {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "mixed-checkbox"
-  },
-  {
-    "name": "didYouDiscussRightsWithTheChild",
-    "label": "Did you discuss rights with the child?",
     "type": "mixed-checkbox"
   },
   {


### PR DESCRIPTION
## Description
- Remove 'keepConfidential' and 'didDiscussRightsWithChild' from CaseInformationTab.json
- Adjust LayoutDefinitions.json to adjust Summary form, Perpetrator, Household and Incident forms.

### Checklist
- [ N/A ] Corresponding issue has been opened
- [ N/A ] New tests added
- [x] Strings are localized

<!-- Uncomment for web client-related PRs
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->


### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
