### PR TITLE
CHI-627: Upgrade all workflows to build with node 14

### DIFF
--- a/.github/workflows/aarambh_production.yml
+++ b/.github/workflows/aarambh_production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/aarambh_staging.yml
+++ b/.github/workflows/aarambh_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/aselo_beta.yml
+++ b/.github/workflows/aselo_beta.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/canada_staging.yml
+++ b/.github/workflows/canada_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/ecpat_philippines_staging.yml
+++ b/.github/workflows/ecpat_philippines_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/ethiopia_production.yml
+++ b/.github/workflows/ethiopia_production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/ethiopia_staging.yml
+++ b/.github/workflows/ethiopia_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/jamaica_production.yml
+++ b/.github/workflows/jamaica_production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/jamaica_staging.yml
+++ b/.github/workflows/jamaica_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/malawi_production.yml
+++ b/.github/workflows/malawi_production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/malawi_staging.yml
+++ b/.github/workflows/malawi_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/safernet_production.yml
+++ b/.github/workflows/safernet_production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/safernet_staging.yml
+++ b/.github/workflows/safernet_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/south_africa_production.yml
+++ b/.github/workflows/south_africa_production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/south_africa_staging.yml
+++ b/.github/workflows/south_africa_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/zambia_production.yml
+++ b/.github/workflows/zambia_production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/.github/workflows/zambia_staging.yml
+++ b/.github/workflows/zambia_staging.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/scripts/templates/flex-plugins-workflow-template
+++ b/scripts/templates/flex-plugins-workflow-template
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Call main-action to compile and deploy
       - name: Executing main-action
         uses: ./.github/actions/main-action

--- a/scripts/templates/serverless-workflow-template
+++ b/scripts/templates/serverless-workflow-template
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       # Setup credentials to access AWS for parameters
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Description

* Update current workflow files to build using Node 14
* Update templates to generate new workflows that use Node 14

### Checklist
- [ X ] Corresponding issue has been opened
- [ N/A ] New tests added
- [ N/A ] Strings are localized

### Related Issues
Fixes CHI-627

### Verification steps

* Run release build