### PR TITLE
Modified Fullstory to allow recording single field errors

### DIFF
--- a/plugin-hrm-form/src/fullStory/index.ts
+++ b/plugin-hrm-form/src/fullStory/index.ts
@@ -56,7 +56,7 @@ function transformErrorObj(errorObj: any) {
  */
 export function recordFormValidationError(origin: string, formError: FieldValues): void {
   let errorJson: string = '{}';
-  let errorArr: any;
+  let errorArr: any[] = [];
   try {
     errorJson = JSON.stringify(serializableFormValidationError(formError));
     errorArr = transformErrorObj(serializableFormValidationError(formError));

--- a/plugin-hrm-form/src/fullStory/index.ts
+++ b/plugin-hrm-form/src/fullStory/index.ts
@@ -36,8 +36,10 @@ export function recordEvent(eventType: string, payload: any) {
 function getFieldErrorObj(tabName: string, fieldName: string, object: any): any[] {
   if (object.hasOwnProperty('type') && object.hasOwnProperty('message')) {
     return [{ [fieldName]: { tab: tabName, ...object } }];
+  } else if (typeof object === 'object') {
+    return Object.keys(object).flatMap(child => getFieldErrorObj(tabName, child, object[child]));
   }
-  return Object.keys(object).flatMap(child => getFieldErrorObj(tabName, child, object[child]));
+  return [];
 }
 /**
  * Transforms a form error object into single field errors - returns an array of all the field errors at error object for a form

--- a/plugin-hrm-form/src/fullStory/index.ts
+++ b/plugin-hrm-form/src/fullStory/index.ts
@@ -28,20 +28,38 @@ export function recordEvent(eventType: string, payload: any) {
 }
 
 /**
+ * Recursive function that checks the error object(branch) for type and message properties(leaf) and returns an array of objects based on the nested nature of the branch or leaf.
+ * @param tabName - the tab or section at which the fields are present
+ * @param fieldName - the name of the field (i.e., - firstname, age)
+ * @param object - the error object
+ */
+function getFieldErrorObj(tabName: string, fieldName: string, object: any): any[] {
+  if (object.hasOwnProperty('type') && object.hasOwnProperty('message')) {
+    return [{ [fieldName]: { tab: tabName, ...object } }];
+  }
+  return Object.keys(object).flatMap(child => getFieldErrorObj(tabName, child, object[child]));
+}
+/**
+ * Transforms a form error object into single field errors - returns an array of all the field errors at error object for a form
+ * @param errorObj - the error object after clean up with serializableFormValidationError
+ */
+function transformErrorObj(errorObj: any) {
+  return Object.keys(errorObj).flatMap(tab => getFieldErrorObj(tab, tab, errorObj[tab]));
+}
+
+/**
  * Sends form validation errors to fullstory.com, under the event name 'Form Error'
  * Specvific form error information is sent as a JSON blob in a single property for now because I'm not sure how much fullstory likes dynamic payloads
- * In addition to 'Form Error', a custom 'Single Field Error' event is also sent which will separate the Form Error into specific field errors.
- * To achieve 'Single Field Error', the original error is cleaned up with serializableFormValidationError method and flattened into the errorArr which holds all the error objects in an array.
+ * In addition to 'Form Error', several 'Custom Error' events are also sent which are separated into specific field errors. The original error is cleaned up with serializableFormValidationError method and flattened into the errorArr
  * @param origin - A string identifying the form the error originated from
  * @param formError - The error object produced by the form validation (i.e. the first parameter of the error handler)
  */
 export function recordFormValidationError(origin: string, formError: FieldValues): void {
   let errorJson: string = '{}';
-  let errorObj: object = {};
+  let errorArr: any;
   try {
     errorJson = JSON.stringify(serializableFormValidationError(formError));
-
-    errorObj = serializableFormValidationError(formError);
+    errorArr = transformErrorObj(serializableFormValidationError(formError));
   } catch (serializeError) {
     console.warn(
       `Error serializing error data for form validation error from ${origin}, sending event with no data`,
@@ -55,16 +73,12 @@ export function recordFormValidationError(origin: string, formError: FieldValues
     errors_str: errorJson,
   });
 
-  const errorArr = Object.values(errorObj)
-    .flatMap(obj => Object.entries(obj))
-    .map(([key, value]) => ({ [key]: value }));
-
-  errorArr.map(error => {
+  errorArr.forEach(error => {
     return recordEvent('Custom Error', {
       // eslint-disable-next-line camelcase
       form_str: origin,
       // eslint-disable-next-line camelcase
-      field_str: `${Object.keys(error)}`,
+      field_str: Object.keys(error)[0],
       // eslint-disable-next-line camelcase
       error_str: JSON.stringify(error),
     });

--- a/plugin-hrm-form/src/fullStory/index.ts
+++ b/plugin-hrm-form/src/fullStory/index.ts
@@ -37,14 +37,11 @@ export function recordEvent(eventType: string, payload: any) {
  */
 export function recordFormValidationError(origin: string, formError: FieldValues): void {
   let errorJson: string = '{}';
-
-  const errorObj = serializableFormValidationError(formError);
-  const errorArr = Object.values(errorObj)
-    .flatMap(obj => Object.entries(obj))
-    .map(([key, value]) => ({ [key]: value }));
-
+  let errorObj: object = {};
   try {
     errorJson = JSON.stringify(serializableFormValidationError(formError));
+
+    errorObj = serializableFormValidationError(formError);
   } catch (serializeError) {
     console.warn(
       `Error serializing error data for form validation error from ${origin}, sending event with no data`,
@@ -57,6 +54,10 @@ export function recordFormValidationError(origin: string, formError: FieldValues
     // eslint-disable-next-line camelcase
     errors_str: errorJson,
   });
+
+  const errorArr = Object.values(errorObj)
+    .flatMap(obj => Object.entries(obj))
+    .map(([key, value]) => ({ [key]: value }));
 
   errorArr.map(error => {
     return recordEvent('Custom Error', {

--- a/plugin-hrm-form/src/fullStory/index.ts
+++ b/plugin-hrm-form/src/fullStory/index.ts
@@ -30,11 +30,19 @@ export function recordEvent(eventType: string, payload: any) {
 /**
  * Sends form validation errors to fullstory.com, under the event name 'Form Error'
  * Specvific form error information is sent as a JSON blob in a single property for now because I'm not sure how much fullstory likes dynamic payloads
+ * In addition to 'Form Error', a custom 'Single Field Error' event is also sent which will separate the Form Error into specific field errors.
+ * To achieve 'Single Field Error', the original error is cleaned up with serializableFormValidationError method and flattened into the errorArr which holds all the error objects in an array.
  * @param origin - A string identifying the form the error originated from
  * @param formError - The error object produced by the form validation (i.e. the first parameter of the error handler)
  */
 export function recordFormValidationError(origin: string, formError: FieldValues): void {
   let errorJson: string = '{}';
+
+  const errorObj = serializableFormValidationError(formError);
+  const errorArr = Object.values(errorObj)
+    .flatMap(obj => Object.entries(obj))
+    .map(([key, value]) => ({ [key]: value }));
+
   try {
     errorJson = JSON.stringify(serializableFormValidationError(formError));
   } catch (serializeError) {
@@ -48,6 +56,17 @@ export function recordFormValidationError(origin: string, formError: FieldValues
     form_str: origin,
     // eslint-disable-next-line camelcase
     errors_str: errorJson,
+  });
+
+  errorArr.map(error => {
+    return recordEvent('Custom Error', {
+      // eslint-disable-next-line camelcase
+      form_str: origin,
+      // eslint-disable-next-line camelcase
+      field_str: `${Object.keys(error)}`,
+      // eslint-disable-next-line camelcase
+      error_str: JSON.stringify(error),
+    });
   });
 }
 


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
- Added FullStory event recording for documenting single field errors. 

### Verification steps
- To test this functionality in development environment, set devMode to false. 
- In FullStory 'Dashboards', check for the 'Disaggregated Errors' card to filter through errors. 
