### PR TITLE
Autopopulate Contact Info Date/Time

### DIFF
--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -68,13 +68,17 @@ type TextareaDefinition = {
   width?: number;
 } & ItemBase;
 
+type TimeRelatedInput = {
+  initializeWithCurrent?: boolean;
+} & ItemBase;
+
 type DateInputDefinition = {
   type: 'date-input';
-} & ItemBase;
+} & TimeRelatedInput;
 
 type TimeInputDefinition = {
   type: 'time-input';
-} & ItemBase;
+} & TimeRelatedInput;
 
 type FileUploadDefinition = {
   type: 'file-upload';

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -44,10 +44,26 @@ export const getInitialValue = (def: FormItemDefinition) => {
     case 'numeric-input':
     case 'email':
     case 'textarea':
-    case 'date-input':
-    case 'time-input':
     case 'file-upload':
       return '';
+    case 'date-input': {
+      if (def.initializeWithCurrent) {
+        const date = new Date();
+        // Return the YYYY-MM-DD part of the ISO string (from new Date to fix timezone differences)
+        return new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`).toISOString().slice(0, 10);
+      }
+
+      return '';
+    }
+    case 'time-input': {
+      if (def.initializeWithCurrent) {
+        const date = new Date();
+        // Return the locale hh:mm
+        return `${date.getHours()}:${date.getMinutes()}`;
+      }
+
+      return '';
+    }
     case 'radio-input':
       return def.defaultOption ?? '';
     case 'select':

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -51,6 +51,7 @@ export const createContactlessTaskTabDefinition = (
       name: 'date',
       type: 'date-input',
       label: 'Date of Contact',
+      initializeWithCurrent: true,
       required: { value: true, message: 'RequiredFieldError' },
       validate: date => {
         const [y, m, d] = splitDate(date);
@@ -69,6 +70,7 @@ export const createContactlessTaskTabDefinition = (
       name: 'time',
       type: 'time-input',
       label: 'Time of Contact',
+      initializeWithCurrent: true,
       required: { value: true, message: 'RequiredFieldError' },
     },
     {


### PR DESCRIPTION
## Description
This PR
- Adds a new option to `date-input` and `time-input` type definitions: `initializeWithCurrent`, an optional boolean that if present will use the current date or time.
- Sets `initializeWithCurrent` to `true` in the date and time pickers of the offline contact tab.

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1024)
- [ ] New tests added
- [N/A] Strings are localized

### Verification steps
- `➜ UNBUNDLED_REACT=true npm ci`
- `➜ npm run dev`
- Start adding an offline contact and confirm that in the first form tab the date and time pickers are using the latest available option.