### PR TITLE
Fixed wrong initial value for time input when missing leading zero

### DIFF
--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -59,7 +59,7 @@ export const getInitialValue = (def: FormItemDefinition) => {
       if (def.initializeWithCurrent) {
         const date = new Date();
         // Return the locale hh:mm
-        return `${`0${date.getHours()}`.slice(-2)}:${`0${date.getMinutes()}`.slice(-2)}`;
+        return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
       }
 
       return '';

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -59,7 +59,7 @@ export const getInitialValue = (def: FormItemDefinition) => {
       if (def.initializeWithCurrent) {
         const date = new Date();
         // Return the locale hh:mm
-        return `${date.getHours()}:${date.getMinutes()}`;
+        return `${`0${date.getHours()}`.slice(-2)}:${`0${date.getMinutes()}`.slice(-2)}`;
       }
 
       return '';


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

## Description
Fixes a silly bug introduced in https://github.com/techmatters/flex-plugins/pull/652:
When the hours or the minutes have a leading zero, `Date.getHours` and `Date.getMinutes` methods does not includes the zero (as they return a `number`).
![Screenshot from 2022-02-24 17-04-19](https://user-images.githubusercontent.com/15805319/155600283-c0bbfecd-0b22-4b2e-872d-ea614c047c22.png)

This resulted in the following "initial value" for a time like `17:03`:
![Screenshot from 2022-02-24 17-04-36](https://user-images.githubusercontent.com/15805319/155600369-a1681fd0-86b1-459f-98fe-22a11b61c41a.png)

which is not a valid value for a time input (hh:mm format).
The fix is actually simple: always prefix a zero to the hours and the minutes, and only use the last two characters:
![Screenshot from 2022-02-24 17-01-19](https://user-images.githubusercontent.com/15805319/155600504-75b0f5a8-ec5c-42dd-96c0-6829566cc92b.png)

Giving as a result the correct initial value for a time input with times like `17:03`:
![Screenshot from 2022-02-24 17-05-30](https://user-images.githubusercontent.com/15805319/155600617-73d59536-815a-47ec-b8a6-bab8a373c6bc.png)


### Verification steps
- Run locally with `npm run dev`.
- Add an offline contact at a time that has leading zeros in the hour or minutes components (like 08:xx, 12:0x).