### PR TITLE
Make Non Data Call Types customizable

### DIFF
--- a/hrm-form-definitions/src/formDefinition/callTypes.ts
+++ b/hrm-form-definitions/src/formDefinition/callTypes.ts
@@ -4,6 +4,7 @@ export const callTypes = {
   caller: 'Someone calling about a child',
 } as const;
 
-export type DataCallTypes = typeof callTypes['child' | 'caller'];
-export type CallTypeKeys = DataCallTypes | string; // This results in "strings" as it's a broader type. Leaving the DataCallTypes in intentionally to emphasize them.
-export type CallTypes = string;
+export type DataCallTypesKeys = keyof typeof callTypes;
+export type CallTypeKeys = DataCallTypesKeys | string; // This results in "strings" as it's a broader type. Leaving the DataCallTypesKeys in intentionally to emphasize them.
+export type DataCallTypes = typeof callTypes[keyof typeof callTypes];
+export type CallTypes = DataCallTypes | string; // This results in "strings" as it's a broader type. Leaving the DataCallTypes in intentionally to emphasize them.

--- a/hrm-form-definitions/src/formDefinition/callTypes.ts
+++ b/hrm-form-definitions/src/formDefinition/callTypes.ts
@@ -1,16 +1,9 @@
+// Data callTypes. Preserving name to avoid big refactor
 export const callTypes = {
   child: 'Child calling about self',
   caller: 'Someone calling about a child',
-  silent: 'Silent',
-  blank: 'Blank',
-  joke: 'Joke',
-  hangup: 'Hang up',
-  wrongnumber: 'Wrong Number',
-  abusive: 'Abusive',
-  adult: 'Adult Contact',
-  test: 'test',
 } as const;
 
-export type CallTypeKeys = keyof typeof callTypes;
-export type CallTypes = typeof callTypes[keyof typeof callTypes];
 export type DataCallTypes = typeof callTypes['child' | 'caller'];
+export type CallTypeKeys = DataCallTypes | string; // This results in "strings" as it's a broader type. Leaving the DataCallTypes in intentionally to emphasize them.
+export type CallTypes = string;

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -110,7 +110,7 @@ export type FormDefinition = FormItemDefinition[];
 export type CategoryEntry = { color: string; subcategories: string[] };
 export type CategoriesDefinition = { [category: string]: CategoryEntry };
 
-type CallTypeButtonsEntry = {
+export type CallTypeButtonsEntry = {
   type: 'button';
   name: CallTypeKeys;
   label: string;

--- a/plugin-hrm-form/src/___tests__/callTypeButtons/CallTypeButtons.test.js
+++ b/plugin-hrm-form/src/___tests__/callTypeButtons/CallTypeButtons.test.js
@@ -50,6 +50,59 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
+const currentDefinitionVersion = {
+  callTypeButtons: [
+    {
+      name: 'child',
+      label: 'Child calling about self',
+      type: 'button',
+      category: 'data',
+    },
+    {
+      name: 'caller',
+      label: 'Someone calling about a child',
+      type: 'button',
+      category: 'data',
+    },
+    {
+      name: 'silent',
+      label: 'Silent',
+      type: 'button',
+      category: 'non-data',
+    },
+    {
+      name: 'blank',
+      label: 'Blank',
+      type: 'button',
+      category: 'non-data',
+    },
+    {
+      name: 'joke',
+      label: 'Joke',
+      type: 'button',
+      category: 'non-data',
+    },
+    {
+      name: 'hangup',
+      label: 'Hang up',
+      type: 'button',
+      category: 'non-data',
+    },
+    {
+      name: 'wrongnumber',
+      label: 'Wrong Number',
+      type: 'button',
+      category: 'non-data',
+    },
+    {
+      name: 'abusive',
+      label: 'Abusive',
+      type: 'button',
+      category: 'non-data',
+    },
+  ],
+};
+
 test('<CallTypeButtons> inital render (no dialog)', () => {
   const initialState = {
     [namespace]: {
@@ -61,58 +114,7 @@ test('<CallTypeButtons> inital render (no dialog)', () => {
         },
       },
       [configurationBase]: {
-        currentDefinitionVersion: {
-          callTypeButtons: [
-            {
-              name: 'child',
-              label: 'Child calling about self',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'caller',
-              label: 'Someone calling about a child',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'silent',
-              label: 'Silent',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'blank',
-              label: 'Blank',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'joke',
-              label: 'Joke',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'hangup',
-              label: 'Hang up',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'wrongnumber',
-              label: 'Wrong Number',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'abusive',
-              label: 'Abusive',
-              type: 'button',
-              category: 'non-data',
-            },
-          ],
-        },
+        currentDefinitionVersion,
       },
       [connectedCaseBase]: { tasks: {} },
     },
@@ -147,58 +149,7 @@ test('<CallTypeButtons> renders dialog with all buttons', () => {
         },
       },
       [configurationBase]: {
-        currentDefinitionVersion: {
-          callTypeButtons: [
-            {
-              name: 'child',
-              label: 'Child calling about self',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'caller',
-              label: 'Someone calling about a child',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'silent',
-              label: 'Silent',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'blank',
-              label: 'Blank',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'joke',
-              label: 'Joke',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'hangup',
-              label: 'Hang up',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'wrongnumber',
-              label: 'Wrong Number',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'abusive',
-              label: 'Abusive',
-              type: 'button',
-              category: 'non-data',
-            },
-          ],
-        },
+        currentDefinitionVersion,
       },
       [connectedCaseBase]: { tasks: {} },
     },
@@ -238,58 +189,7 @@ test('<CallTypeButtons> renders dialog with END CHAT button', () => {
         },
       },
       [configurationBase]: {
-        currentDefinitionVersion: {
-          callTypeButtons: [
-            {
-              name: 'child',
-              label: 'Child calling about self',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'caller',
-              label: 'Someone calling about a child',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'silent',
-              label: 'Silent',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'blank',
-              label: 'Blank',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'joke',
-              label: 'Joke',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'hangup',
-              label: 'Hang up',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'wrongnumber',
-              label: 'Wrong Number',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'abusive',
-              label: 'Abusive',
-              type: 'button',
-              category: 'non-data',
-            },
-          ],
-        },
+        currentDefinitionVersion,
       },
       [connectedCaseBase]: { tasks: {} },
     },
@@ -323,58 +223,7 @@ test('<CallTypeButtons> renders dialog with HANG UP button', () => {
         },
       },
       [configurationBase]: {
-        currentDefinitionVersion: {
-          callTypeButtons: [
-            {
-              name: 'child',
-              label: 'Child calling about self',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'caller',
-              label: 'Someone calling about a child',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'silent',
-              label: 'Silent',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'blank',
-              label: 'Blank',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'joke',
-              label: 'Joke',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'hangup',
-              label: 'Hang up',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'wrongnumber',
-              label: 'Wrong Number',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'abusive',
-              label: 'Abusive',
-              type: 'button',
-              category: 'non-data',
-            },
-          ],
-        },
+        currentDefinitionVersion,
       },
       [connectedCaseBase]: { tasks: {} },
     },
@@ -408,58 +257,7 @@ test('<CallTypeButtons> click on Data (Child) button', () => {
         },
       },
       [configurationBase]: {
-        currentDefinitionVersion: {
-          callTypeButtons: [
-            {
-              name: 'child',
-              label: 'Child calling about self',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'caller',
-              label: 'Someone calling about a child',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'silent',
-              label: 'Silent',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'blank',
-              label: 'Blank',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'joke',
-              label: 'Joke',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'hangup',
-              label: 'Hang up',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'wrongnumber',
-              label: 'Wrong Number',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'abusive',
-              label: 'Abusive',
-              type: 'button',
-              category: 'non-data',
-            },
-          ],
-        },
+        currentDefinitionVersion,
       },
       [connectedCaseBase]: { tasks: {} },
     },
@@ -497,58 +295,7 @@ test('<CallTypeButtons> click on NonData (Joke) button', () => {
         },
       },
       [configurationBase]: {
-        currentDefinitionVersion: {
-          callTypeButtons: [
-            {
-              name: 'child',
-              label: 'Child calling about self',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'caller',
-              label: 'Someone calling about a child',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'silent',
-              label: 'Silent',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'blank',
-              label: 'Blank',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'joke',
-              label: 'Joke',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'hangup',
-              label: 'Hang up',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'wrongnumber',
-              label: 'Wrong Number',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'abusive',
-              label: 'Abusive',
-              type: 'button',
-              category: 'non-data',
-            },
-          ],
-        },
+        currentDefinitionVersion,
       },
       [connectedCaseBase]: { tasks: {} },
     },
@@ -569,7 +316,7 @@ test('<CallTypeButtons> click on NonData (Joke) button', () => {
   expect(screen.getByText('Joke')).toBeInTheDocument();
   screen.getByText('Joke').click();
 
-  expect(store.dispatch).toHaveBeenCalledWith(updateCallType(task.taskSid, callTypes.joke));
+  expect(store.dispatch).toHaveBeenCalledWith(updateCallType(task.taskSid, 'Joke'));
 });
 
 test('<CallTypeButtons> click on END CHAT button', async () => {
@@ -583,58 +330,7 @@ test('<CallTypeButtons> click on END CHAT button', async () => {
         },
       },
       [configurationBase]: {
-        currentDefinitionVersion: {
-          callTypeButtons: [
-            {
-              name: 'child',
-              label: 'Child calling about self',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'caller',
-              label: 'Someone calling about a child',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'silent',
-              label: 'Silent',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'blank',
-              label: 'Blank',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'joke',
-              label: 'Joke',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'hangup',
-              label: 'Hang up',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'wrongnumber',
-              label: 'Wrong Number',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'abusive',
-              label: 'Abusive',
-              type: 'button',
-              category: 'non-data',
-            },
-          ],
-        },
+        currentDefinitionVersion,
       },
       [connectedCaseBase]: { tasks: {} },
     },
@@ -670,58 +366,7 @@ test('<CallTypeButtons> click on CANCEL button', () => {
         },
       },
       [configurationBase]: {
-        currentDefinitionVersion: {
-          callTypeButtons: [
-            {
-              name: 'child',
-              label: 'Child calling about self',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'caller',
-              label: 'Someone calling about a child',
-              type: 'button',
-              category: 'data',
-            },
-            {
-              name: 'silent',
-              label: 'Silent',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'blank',
-              label: 'Blank',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'joke',
-              label: 'Joke',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'hangup',
-              label: 'Hang up',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'wrongnumber',
-              label: 'Wrong Number',
-              type: 'button',
-              category: 'non-data',
-            },
-            {
-              name: 'abusive',
-              label: 'Abusive',
-              type: 'button',
-              category: 'non-data',
-            },
-          ],
-        },
+        currentDefinitionVersion,
       },
       [connectedCaseBase]: { tasks: {} },
     },

--- a/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.tsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { ITask, TaskHelper, Template } from '@twilio/flex-ui';
 import { connect, ConnectedProps } from 'react-redux';
-import { callTypes, CallTypeKeys } from 'hrm-form-definitions';
+import { callTypes, CallTypeButtonsEntry } from 'hrm-form-definitions';
 
 import { namespace, contactFormsBase, configurationBase, connectedCaseBase, RootState } from '../../states';
 import { updateCallType } from '../../states/contacts/actions';
@@ -40,31 +40,37 @@ const CallTypeButtons: React.FC<Props> = props => {
   if (!currentDefinitionVersion) return null;
   const { callTypeButtons } = currentDefinitionVersion;
 
-  const handleClick = (taskSid: string, callTypekey: CallTypeKeys) => {
+  const handleClick = (taskSid: string, callTypeEntry: CallTypeButtonsEntry) => {
     if (!hasTaskControl(task)) return;
-    // TODO: We currently need the call type name in English. I think we should actually save callType.name (instead of label) on the DB, and use it in here.
-    props.dispatch(updateCallType(taskSid, callTypes[callTypekey]));
+
+    /*
+     *  TODO: We currently save the call type name in English if data or the label string if non-data.
+     * I think we should actually save callType.name (instead of label) on the DB, and use it in here.
+     */
+    const callType = callTypes[callTypeEntry.name] ? callTypes[callTypeEntry.name] : callTypeEntry.label;
+
+    props.dispatch(updateCallType(taskSid, callType));
   };
 
-  const handleClickAndRedirect = (taskSid: string, callTypekey: CallTypeKeys) => {
+  const handleClickAndRedirect = (taskSid: string, callTypeEntry: CallTypeButtonsEntry) => {
     if (!hasTaskControl(task)) return;
 
     // eslint-disable-next-line no-nested-ternary
     const subroute = isOfflineContactTask(task)
       ? 'contactlessTask'
-      : callTypekey === 'caller'
+      : callTypeEntry.name === 'caller'
       ? 'callerInformation'
       : 'childInformation';
 
-    handleClick(taskSid, callTypekey);
+    handleClick(taskSid, callTypeEntry);
     props.dispatch(changeRoute({ route: 'tabbed-forms', subroute, autoFocus: true }, taskSid));
   };
 
-  const handleNonDataClick = (taskSid: string, callTypekey: CallTypeKeys) => {
+  const handleNonDataClick = (taskSid: string, callTypeEntry: CallTypeButtonsEntry) => {
     if (isOfflineContactTask(task)) {
-      handleClickAndRedirect(taskSid, callTypekey);
+      handleClickAndRedirect(taskSid, callTypeEntry);
     } else {
-      handleClick(taskSid, callTypekey);
+      handleClick(taskSid, callTypeEntry);
     }
   };
 
@@ -94,7 +100,7 @@ const CallTypeButtons: React.FC<Props> = props => {
             .map((callType, index) => {
               return (
                 <DataCallTypeButton
-                  onClick={() => handleClickAndRedirect(task.taskSid, callType.name)}
+                  onClick={() => handleClickAndRedirect(task.taskSid, callType)}
                   key={callType.name}
                   autoFocus={index === 0}
                 >
@@ -117,7 +123,7 @@ const CallTypeButtons: React.FC<Props> = props => {
             .map((callType, i) => (
               <NonDataCallTypeButton
                 key={callType.name}
-                onClick={() => handleNonDataClick(task.taskSid, callType.name)}
+                onClick={() => handleNonDataClick(task.taskSid, callType)}
                 marginRight={i % 2 === 0}
               >
                 {callType.label}

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -15,7 +15,7 @@ import type { CSAMReportEntry } from '../../types/types';
 
 export type TaskEntry = {
   helpline: string;
-  callType: CallTypes | '';
+  callType: CallTypes;
   childInformation: { [key: string]: string | boolean };
   callerInformation: { [key: string]: string | boolean };
   caseInformation: { [key: string]: string | boolean };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @murilovmachado 

## Description
This PR adds support for any `non-data` call type. After this PR is merged, all `non-data` call types PR must be defined in the `CallTypeButtons.json` file of the form definition.

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1033)
- [ ] New tests added
- [ ] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- Edit the form definition that you'll be using on the local server, adding/removing `non-data` call types.
- `➜ UNBUNDLED_REACT=true npm ci` to install the updated form definition.
- ➜ `npm run dev` to start a local server.
- Test saving and retrieving the contacts. `data` contacts should keep working as usual (pre-populate. copy functionality, etc). 