### PR TITLE
Hide Add buttons in Case Details when user permission does not allow adding. 

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseAddButton.jsx
+++ b/plugin-hrm-form/src/components/case/CaseAddButton.jsx
@@ -8,13 +8,17 @@ import HrmTheme from '../../styles/HrmTheme';
 
 const CaseAddButton = ({ disabled, templateCode, onClick, withDivider }) => {
   const color = disabled ? HrmTheme.colors.disabledColor : 'initial';
-
+  console.log('CaseAddButton', disabled)
   return (
     <CaseAddButtonStyled disabled={disabled} onClick={onClick}>
-      <Add style={{ marginRight: 10, fontSize: 16, height: 17, color }} />
-      <CaseAddButtonFont style={{ marginRight: 20 }} disabled={disabled}>
-        <Template code={templateCode} />
-      </CaseAddButtonFont>
+      {!disabled &&
+        <>
+          <Add style={{ marginRight: 10, fontSize: 16, height: 17, color }} />
+          <CaseAddButtonFont style={{ marginRight: 20 }} disabled={disabled}>
+            <Template code={templateCode} />
+          </CaseAddButtonFont>
+        </>
+      }
     </CaseAddButtonStyled>
   );
 };

--- a/plugin-hrm-form/src/components/case/CaseAddButton.jsx
+++ b/plugin-hrm-form/src/components/case/CaseAddButton.jsx
@@ -8,17 +8,16 @@ import HrmTheme from '../../styles/HrmTheme';
 
 const CaseAddButton = ({ disabled, templateCode, onClick, withDivider }) => {
   const color = disabled ? HrmTheme.colors.disabledColor : 'initial';
-  console.log('CaseAddButton', disabled)
   return (
     <CaseAddButtonStyled disabled={disabled} onClick={onClick}>
-      {!disabled &&
+      {!disabled && (
         <>
           <Add style={{ marginRight: 10, fontSize: 16, height: 17, color }} />
           <CaseAddButtonFont style={{ marginRight: 20 }} disabled={disabled}>
             <Template code={templateCode} />
           </CaseAddButtonFont>
         </>
-      }
+      )}
     </CaseAddButtonStyled>
   );
 };

--- a/plugin-hrm-form/src/components/case/CaseAddButton.jsx
+++ b/plugin-hrm-form/src/components/case/CaseAddButton.jsx
@@ -13,7 +13,7 @@ const CaseAddButton = ({ disabled, templateCode, onClick, withDivider }) => {
       {!disabled && (
         <>
           <Add style={{ marginRight: 10, fontSize: 16, height: 17, color }} />
-          <CaseAddButtonFont style={{ marginRight: 20 }} disabled={disabled}>
+          <CaseAddButtonFont style={{ marginRight: 20 }}>
             <Template code={templateCode} />
           </CaseAddButtonFont>
         </>


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
In the case details of certain cases where user does not have permission to add certain details - such as note, referral, perpetrator, incident, document - the user will not see these options greyed out. 

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
A case detail page where user does not have permissions to add details
![A case detail page where user does not have permissions to add details](https://user-images.githubusercontent.com/42842977/156264231-24f2e6df-4614-4de0-ac96-00067386ee2e.png)

