### PR TITLE
Add canEditNote permissions to helplines to fix build.

### DIFF
--- a/plugin-hrm-form/src/permissions/br.ts
+++ b/plugin-hrm-form/src/permissions/br.ts
@@ -3,6 +3,8 @@ export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, is
 
 export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canEditNote = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/et.ts
+++ b/plugin-hrm-form/src/permissions/et.ts
@@ -3,6 +3,8 @@ export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, is
 
 export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canEditNote = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/in.ts
+++ b/plugin-hrm-form/src/permissions/in.ts
@@ -3,6 +3,8 @@ export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, is
 
 export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canEditNote = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/jm.ts
+++ b/plugin-hrm-form/src/permissions/jm.ts
@@ -3,6 +3,8 @@ export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, is
 
 export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canEditNote = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => true;
+
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/mw.ts
+++ b/plugin-hrm-form/src/permissions/mw.ts
@@ -3,6 +3,9 @@ export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, is
 
 export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canEditNote = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);
+
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/za.ts
+++ b/plugin-hrm-form/src/permissions/za.ts
@@ -3,6 +3,9 @@ export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, is
 
 export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canEditNote = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);
+
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/zm.ts
+++ b/plugin-hrm-form/src/permissions/zm.ts
@@ -3,6 +3,9 @@ export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, is
 
 export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canEditNote = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);
+
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */


### PR DESCRIPTION
Primary reviewer: @Humairaa127 
## Description

Adds 'canEditNote' implementations to all permissioin files to fix build. Should be superseded by @GPaoloni JSONy permission defs shortly
