### PR TITLE
Refactor Case Details Close Dialog

### DIFF
--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -718,7 +718,7 @@ const Case: React.FC<Props> = props => {
                     setDialog={() => setCloseDialog(false)}
                     handleDontSaveClose={props.handleClose}
                     handleSaveUpdate={handleUpdate}
-                    closeDialog={closeDialog}
+                    openDialog={closeDialog}
                   />
                 </Box>
                 <StyledNextStepButton disabled={!caseHasBeenEdited} roundCorners onClick={handleUpdate}>

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -25,9 +25,8 @@ import { cancelCase, getActivities, updateCase } from '../../services/CaseServic
 import { completeTask, submitContactForm } from '../../services/formSubmissionHelpers';
 import { getDefinitionVersion } from '../../services/ServerlessService';
 import { getDateFromNotSavedContact, getHelplineData, isConnectedCaseActivity, sortActivities } from './caseHelpers';
-import { BottomButtonBar, Box, Row, StyledNextStepButton, HiddenText } from '../../styles/HrmStyles';
-import { CaseContainer, CenteredContainer, CloseDialogText } from '../../styles/case';
-import { CloseTaskDialog, CloseButton } from '../../styles/callTypeButtons';
+import { BottomButtonBar, Box, StyledNextStepButton } from '../../styles/HrmStyles';
+import { CaseContainer, CenteredContainer } from '../../styles/case';
 import CaseDetails from './CaseDetails';
 import { Menu, MenuItem } from '../menu';
 import { getLocaleDateTime } from '../../utils/helpers';
@@ -57,6 +56,7 @@ import DocumentInformationRow from './DocumentInformationRow';
 import AddEditCaseItem from './AddEditCaseItem';
 import ViewCaseItem from './ViewCaseItem';
 import documentUploadHandler from './documentUploadHandler';
+import CloseCaseDialog from './CloseCaseDialog';
 
 export const isStandaloneITask = (task): task is StandaloneITask => {
   return task && task.taskSid === 'standalone-task-sid';
@@ -714,26 +714,12 @@ const Case: React.FC<Props> = props => {
                   >
                     <Template code="BottomBar-Close" />
                   </StyledNextStepButton>
-                  <CloseTaskDialog open={closeDialog} onClose={() => setCloseDialog(false)}>
-                    <Box marginLeft="auto" onClick={() => setCloseDialog(false)}>
-                      <HiddenText id="CloseButton">
-                        <Template code="CloseButton" />
-                      </HiddenText>
-                      <CloseButton aria-label="CloseButton" />
-                    </Box>
-                    <CloseDialogText>
-                      <Template code="BottomBar-SaveOnClose" />
-                    </CloseDialogText>
-                    <Row>
-                      <StyledNextStepButton secondary onClick={props.handleClose} margin="15px auto">
-                        <Template code="BottomBar-DontSave" />
-                      </StyledNextStepButton>
-                      <StyledNextStepButton disabled={null} onClick={handleUpdate} margin="15px auto">
-                        <Template code="BottomBar-Save" />
-                      </StyledNextStepButton>
-                    </Row>
-                    <Box marginBottom="25px" />
-                  </CloseTaskDialog>
+                  <CloseCaseDialog
+                    setDialog={() => setCloseDialog(false)}
+                    handleDontSaveClose={props.handleClose}
+                    handleSaveUpdate={handleUpdate}
+                    closeDialog={closeDialog}
+                  />
                 </Box>
                 <StyledNextStepButton disabled={!caseHasBeenEdited} roundCorners onClick={handleUpdate}>
                   <Template code="BottomBar-Update" />

--- a/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
+++ b/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
@@ -11,14 +11,12 @@ type Props = {
   setDialog: () => void;
   handleDontSaveClose: () => void;
   handleSaveUpdate: () => void;
-  closeDialog: boolean;
+  openDialog: boolean;
 };
-
-// eslint-disable-next-line react/display-name
-export default function CloseCaseDialog({ setDialog, handleDontSaveClose, handleSaveUpdate, closeDialog }: Props) {
+export default function CloseCaseDialog({ setDialog, handleDontSaveClose, handleSaveUpdate, openDialog }: Props) {
   return (
     <>
-      <CloseTaskDialog open={closeDialog} onClose={setDialog}>
+      <CloseTaskDialog open={openDialog} onClose={setDialog}>
         <TabPressWrapper>
           <Box textAlign="end" onClick={setDialog} tabIndex={3}>
             <HiddenText id="CloseButton">
@@ -52,3 +50,5 @@ export default function CloseCaseDialog({ setDialog, handleDontSaveClose, handle
     </>
   );
 }
+
+CloseCaseDialog.displayName = 'CloseCaseDialog';

--- a/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
+++ b/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Template } from '@twilio/flex-ui';
+import WarningIcon from '@material-ui/icons/Warning';
+
+import TabPressWrapper from '../TabPressWrapper';
+import { Box, Row, StyledNextStepButton, HiddenText } from '../../styles/HrmStyles';
+import { CloseButton, CloseTaskDialog } from '../../styles/callTypeButtons';
+import { CloseDialogText } from '../../styles/case';
+
+type Props = {
+  setDialog: () => void;
+  handleDontSaveClose: () => void;
+  handleSaveUpdate: () => void;
+  closeDialog: boolean;
+};
+
+// eslint-disable-next-line react/display-name
+export default function CloseCaseDialog({ setDialog, handleDontSaveClose, handleSaveUpdate, closeDialog }: Props) {
+  return (
+    <>
+      <CloseTaskDialog open={closeDialog} onClose={setDialog}>
+        <TabPressWrapper>
+          <Box textAlign="end" onClick={setDialog} tabIndex={3}>
+            <HiddenText id="CloseButton">
+              <Template code="CloseButton" />
+            </HiddenText>
+            <CloseButton aria-label="CloseButton" />
+          </Box>
+          <CloseDialogText>
+            <p>
+              <WarningIcon style={{ color: '#f6ca4a' }} />
+            </p>
+            <Template code="BottomBar-SaveOnClose" />
+          </CloseDialogText>
+          <Row>
+            <StyledNextStepButton
+              tabIndex={1}
+              secondary
+              onClick={handleDontSaveClose}
+              margin="15px auto"
+              style={{ background: '#fff' }}
+            >
+              <Template code="BottomBar-DontSave" />
+            </StyledNextStepButton>
+            <StyledNextStepButton tabIndex={2} onClick={handleSaveUpdate} margin="15px auto">
+              <Template code="BottomBar-Save" />
+            </StyledNextStepButton>
+          </Row>
+          <Box marginBottom="25px" />
+        </TabPressWrapper>
+      </CloseTaskDialog>
+    </>
+  );
+}

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -22,6 +22,7 @@ type BoxProps = {
   paddingLeft?: string;
   paddingRight?: string;
   alignSelf?: string;
+  textAlign?: string;
 };
 
 export const Box = styled('div')<BoxProps>`
@@ -38,6 +39,7 @@ export const Box = styled('div')<BoxProps>`
   ${({ paddingLeft }) => paddingLeft && `padding-left: ${paddingLeft};`}
   ${({ paddingRight }) => paddingRight && `padding-right: ${paddingRight};`}
   ${({ alignSelf }) => alignSelf && `align-self: ${alignSelf};`}
+  ${({ textAlign }) => textAlign && `text-align: ${textAlign};`}
 `;
 Box.displayName = 'Box';
 

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -371,6 +371,7 @@ export const CloseDialogText = styled('p')`
   font-weight: 700;
   margin-bottom: 20px;
   align-self: center;
+  text-align: center;
 `;
 
 CloseDialogText.displayName = 'CloseDialogText';


### PR DESCRIPTION
Primary reviewer: @murilovmachado

## Description
- Implemented changes suggested in related [PR](https://github.com/techmatters/flex-plugins/pull/675)
- Added TabWrapper for tabbing between onclick events in dialog - for accessibility 
- Added Warning Icon
- Made Don't Save button's background transparent

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes # CHI-1043.

### Verification steps
- After changes made to summary, checkbox, follow-up date, and/or case status, press Close button at the bottom, and check the behaviours of the click events in the dialog and check styling according to https://marvelapp.com/prototype/2d8dab36/screen/84808888