### PR TITLE
Make Offline Contact Channel options customizable

### DIFF
--- a/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -65,6 +65,16 @@ export async function loadDefinition(version: DefinitionVersionId): Promise<Defi
   const issueCategorizationTabModule = await import(
     /* webpackMode: "eager" */ `../../form-definitions/${version}/tabbedForms/IssueCategorizationTab.json`
   );
+
+  let contactlessTaskTabModule;
+  try {
+    contactlessTaskTabModule = await import(
+      /* webpackMode: "eager" */ `../../form-definitions/${version}/tabbedForms/ContactlessTaskTab.json`
+    );
+  } catch (err) {
+    contactlessTaskTabModule = {};
+  }
+
   const callTypeButtonsModule = await import(
     /* webpackMode: "eager" */ `../../form-definitions/${version}/CallTypeButtons.json`
   );
@@ -113,6 +123,7 @@ export async function loadDefinition(version: DefinitionVersionId): Promise<Defi
       IssueCategorizationTab: (helpline: string) =>
         issueCategorizationTabModule.default[helpline] ||
         issueCategorizationTabModule.default[defaultHelpline],
+      ContactlessTaskTab: contactlessTaskTabModule,
     },
     callTypeButtons: callTypeButtonsModule.default as CallTypeButtonsDefinitions,
     layoutVersion: layoutDefinitionsModule.default as LayoutVersion,

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -190,7 +190,7 @@ export type DefinitionVersion = {
     CaseInformationTab: FormDefinition;
     ChildInformationTab: FormDefinition;
     IssueCategorizationTab: (helpline: string) => CategoriesDefinition;
-    ContactlessTaskTab: { customChannels?: string[] };
+    ContactlessTaskTab: { offlineChannels?: string[] };
   };
   callTypeButtons: CallTypeButtonsDefinitions;
   layoutVersion: LayoutVersion;

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -190,6 +190,7 @@ export type DefinitionVersion = {
     CaseInformationTab: FormDefinition;
     ChildInformationTab: FormDefinition;
     IssueCategorizationTab: (helpline: string) => CategoriesDefinition;
+    ContactlessTaskTab: { customChannels?: string[] };
   };
   callTypeButtons: CallTypeButtonsDefinitions;
   layoutVersion: LayoutVersion;

--- a/plugin-hrm-form/src/___tests__/utils/mappers.test.js
+++ b/plugin-hrm-form/src/___tests__/utils/mappers.test.js
@@ -1,5 +1,5 @@
 import { mapAge, mapCallType, mapChannel } from '../../utils';
-import { channelTypes, otherContactChannels } from '../../states/DomainConstants';
+import { channelTypes } from '../../states/DomainConstants';
 
 test('Test contact call type mapper', () => {
   const mapSelf = 'Child calling about self';
@@ -51,8 +51,6 @@ test('Test contact channel mapper', () => {
   expect(fmtCh5).toEqual(expectCh5);
   expect(fmtCh6).toEqual(expectCh6);
   expect(fmtCh7).toEqual(expectCh7);
-  // otherContactChannels are mapped with it's identity
-  Object.values(otherContactChannels).forEach(value => expect(mapChannel(value)).toBe(value));
   expect(fmtUndef).toEqual(expectUndef);
 });
 

--- a/plugin-hrm-form/src/___tests__/utils/mappers.test.js
+++ b/plugin-hrm-form/src/___tests__/utils/mappers.test.js
@@ -32,8 +32,16 @@ test('Test contact channel mapper', () => {
   const expectCh5 = 'WhatsApp';
   const fmtCh5 = mapChannel(ch5);
 
-  const undef = 'anything else';
-  const expectUndef = 'Undefined';
+  const ch6 = channelTypes.twitter;
+  const expectCh6 = 'Twitter';
+  const fmtCh6 = mapChannel(ch6);
+
+  const ch7 = channelTypes.instagram;
+  const expectCh7 = 'Instagram';
+  const fmtCh7 = mapChannel(ch7);
+
+  const undef = 'Anything else';
+  const expectUndef = 'Anything else';
   const fmtUndef = mapChannel(undef);
 
   expect(fmtCh1).toEqual(expectCh1);
@@ -41,6 +49,8 @@ test('Test contact channel mapper', () => {
   expect(fmtCh3).toEqual(expectCh3);
   expect(fmtCh4).toEqual(expectCh4);
   expect(fmtCh5).toEqual(expectCh5);
+  expect(fmtCh6).toEqual(expectCh6);
+  expect(fmtCh7).toEqual(expectCh7);
   // otherContactChannels are mapped with it's identity
   Object.values(otherContactChannels).forEach(value => expect(mapChannel(value)).toBe(value));
   expect(fmtUndef).toEqual(expectUndef);

--- a/plugin-hrm-form/src/components/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/ContactDetails.tsx
@@ -76,7 +76,7 @@ const Details: React.FC<Props> = ({
   const childOrUnknown = formatName(childName);
   const childUpperCased = childOrUnknown.toUpperCase();
   const formattedChannel =
-    channel === 'default' ? mapChannelForInsights(details.contactlessTask.channel) : mapChannel(channel);
+    channel === 'default' ? mapChannelForInsights(details.contactlessTask.channel) : mapChannelForInsights(channel);
   const formattedDate = `${format(new Date(dateTime), 'MMM d, yyyy / h:mm aaaaa')}m`;
   const formattedDuration = formatDuration(conversationDuration);
 

--- a/plugin-hrm-form/src/components/case/TimelineIcon.jsx
+++ b/plugin-hrm-form/src/components/case/TimelineIcon.jsx
@@ -7,7 +7,7 @@ import AssignmentInd from '@material-ui/icons/AssignmentInd';
 import ReplyIcon from '@material-ui/icons/Reply';
 
 import { TimelineIconContainer } from '../../styles/case';
-import { channelTypes, otherContactChannels } from '../../states/DomainConstants';
+import { channelTypes } from '../../states/DomainConstants';
 import TwitterIcon from '../common/icons/TwitterIcon';
 import InstagramIcon from '../common/icons/InstagramIcon';
 
@@ -32,7 +32,7 @@ const getIcon = type => {
       return <NoteIcon style={{ opacity: 0.62, fontSize: '20px' }} />;
     case 'referral':
       return <ReplyIcon style={{ transform: 'scaleX(-1)', fontSize: '20px' }} />;
-    // defaulting to otherContactChannels.includes(type). Maybe at some point we need to address this in a different way.
+    // defaulting to isOtherContactChannel(channel). Maybe at some point we need to address this in a different way.
     default:
       return <AssignmentInd style={{ opacity: 0.62, fontSize: '20px' }} />;
   }
@@ -42,8 +42,7 @@ const TimelineIcon = ({ type }) => <TimelineIconContainer>{getIcon(type)}</Timel
 
 TimelineIcon.displayName = 'TimelineIcon';
 TimelineIcon.propTypes = {
-  type: PropTypes.oneOf([...Object.values(channelTypes), ...Object.values(otherContactChannels), 'note', 'referral'])
-    .isRequired,
+  type: PropTypes.string.isRequired,
 };
 
 const DefaultIcon = ({ defaultTaskChannel }) => (

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
@@ -4,7 +4,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { FieldError, useFormContext } from 'react-hook-form';
 import { isFuture } from 'date-fns';
 import { get } from 'lodash';
-import type { HelplineDefinitions } from 'hrm-form-definitions';
+import type { DefinitionVersion } from 'hrm-form-definitions';
 
 import { createFormFromDefinition, disperseInputs } from '../common/forms/formGenerators';
 import { updateForm } from '../../states/contacts/actions';
@@ -19,7 +19,8 @@ import useFocus from '../../utils/useFocus';
 type OwnProps = {
   task: OfflineContactTask;
   display: boolean;
-  definition: HelplineDefinitions;
+  helplineInformation: DefinitionVersion['helplineInformation'];
+  definition: DefinitionVersion['tabbedForms']['ContactlessTaskTab'];
   initialValues: TaskEntry[keyof TaskEntry];
   autoFocus: boolean;
 };
@@ -31,6 +32,7 @@ const ContactlessTaskTab: React.FC<Props> = ({
   dispatch,
   display,
   task,
+  helplineInformation,
   definition,
   initialValues,
   counselorsList,
@@ -49,14 +51,23 @@ const ContactlessTaskTab: React.FC<Props> = ({
       dispatch(updateForm(task.taskSid, 'contactlessTask', rest));
     };
 
-    const formDefinition = createContactlessTaskTabDefinition(counselorsList, definition);
+    const formDefinition = createContactlessTaskTabDefinition({ counselorsList, helplineInformation, definition });
 
     const tab = createFormFromDefinition(formDefinition)(['contactlessTask'])(initialForm, firstElementRef)(
       updateCallBack,
     );
 
     return disperseInputs(5)(tab);
-  }, [counselorsList, dispatch, getValues, definition, initialForm, firstElementRef, task.taskSid]);
+  }, [
+    counselorsList,
+    helplineInformation,
+    definition,
+    initialForm,
+    firstElementRef,
+    getValues,
+    dispatch,
+    task.taskSid,
+  ]);
 
   // Add invisible field that errors if date + time are future (triggered by validaiton)
   React.useEffect(() => {

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -1,5 +1,5 @@
 import { isFuture } from 'date-fns';
-import type { FormDefinition, HelplineDefinitions } from 'hrm-form-definitions';
+import type { FormDefinition, DefinitionVersion } from 'hrm-form-definitions';
 
 import { channelTypes, otherContactChannels } from '../../states/DomainConstants';
 import { mapChannelForInsights } from '../../utils/mappers';
@@ -7,29 +7,38 @@ import { splitDate } from '../../utils/helpers';
 import type { CounselorsList } from '../../states/configuration/types';
 import { getConfig } from '../../HrmFormPlugin';
 
-const channelOptions = [{ value: '', label: '' }].concat(
+const defaultChannelOptions = [{ value: '', label: '' }].concat(
   [...Object.values(channelTypes), ...Object.values(otherContactChannels)].map(s => ({
     label: mapChannelForInsights(s),
     value: s,
   })),
 );
 
-export const createContactlessTaskTabDefinition = (
-  counselorsList: CounselorsList,
-  helplineDefinitions: HelplineDefinitions,
-): FormDefinition => {
+export const createContactlessTaskTabDefinition = ({
+  counselorsList,
+  helplineInformation,
+  definition,
+}: {
+  counselorsList: CounselorsList;
+  helplineInformation: DefinitionVersion['helplineInformation'];
+  definition: DefinitionVersion['tabbedForms']['ContactlessTaskTab'];
+}): FormDefinition => {
   const { workerSid } = getConfig();
   const counsellorOptions = [
     { label: '', value: '' },
     ...counselorsList.map(c => ({ label: c.fullName, value: c.sid })),
   ];
 
-  const helplineLabel = helplineDefinitions.label;
+  const helplineLabel = helplineInformation.label;
   const mapHelplineEntriesToOptions = ({ value, label }) => ({ value, label });
-  const helplineOptions = helplineDefinitions.helplines.map(mapHelplineEntriesToOptions);
+  const helplineOptions = helplineInformation.helplines.map(mapHelplineEntriesToOptions);
   const defaultHelplineOption = (
-    helplineDefinitions.helplines.find(helpline => helpline.default) || helplineDefinitions.helplines[0]
+    helplineInformation.helplines.find(helpline => helpline.default) || helplineInformation.helplines[0]
   ).value;
+
+  const channelOptions = definition.customChannels
+    ? defaultChannelOptions.concat(definition.customChannels.map(c => ({ value: c, label: c })))
+    : defaultChannelOptions;
 
   return [
     {

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -1,14 +1,14 @@
 import { isFuture } from 'date-fns';
 import type { FormDefinition, DefinitionVersion } from 'hrm-form-definitions';
 
-import { channelTypes, otherContactChannels } from '../../states/DomainConstants';
+import { channelTypes } from '../../states/DomainConstants';
 import { mapChannelForInsights } from '../../utils/mappers';
 import { splitDate } from '../../utils/helpers';
 import type { CounselorsList } from '../../states/configuration/types';
 import { getConfig } from '../../HrmFormPlugin';
 
 const defaultChannelOptions = [{ value: '', label: '' }].concat(
-  [...Object.values(channelTypes), ...Object.values(otherContactChannels)].map(s => ({
+  Object.values(channelTypes).map(s => ({
     label: mapChannelForInsights(s),
     value: s,
   })),

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -36,8 +36,8 @@ export const createContactlessTaskTabDefinition = ({
     helplineInformation.helplines.find(helpline => helpline.default) || helplineInformation.helplines[0]
   ).value;
 
-  const channelOptions = definition.customChannels
-    ? defaultChannelOptions.concat(definition.customChannels.map(c => ({ value: c, label: c })))
+  const channelOptions = definition.offlineChannels
+    ? defaultChannelOptions.concat(definition.offlineChannels.map(c => ({ value: c, label: c })))
     : defaultChannelOptions;
 
   return [

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -216,7 +216,8 @@ const TabbedForms: React.FC<Props> = ({
                 <ContactlessTaskTab
                   task={task}
                   display={subroute === 'contactlessTask'}
-                  definition={currentDefinitionVersion.helplineInformation}
+                  helplineInformation={currentDefinitionVersion.helplineInformation}
+                  definition={currentDefinitionVersion.tabbedForms.ContactlessTaskTab}
                   initialValues={contactForm.contactlessTask}
                   autoFocus={autoFocus}
                 />

--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -15,17 +15,6 @@ export const channelsAndDefault = {
 
 export type ChannelTypes = typeof channelTypes[keyof typeof channelTypes];
 
-export const otherContactChannels = {
-  'Bulletin board': 'Bulletin board',
-  'E-mail': 'E-mail',
-  'Mobile app': 'Mobile app',
-  Outreach: 'Outreach',
-  Post: 'Post',
-  'Walk-in / In person': 'Walk-in / In person',
-  'Website forum': 'Website forum',
-  Other: 'Other',
-} as const;
-
 export const transferModes = {
   cold: 'COLD',
   warm: 'WARM',

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -67,7 +67,11 @@ export const createNewTaskEntry = (definitions: DefinitionVersion) => (recreated
     categories: categoriesMeta,
   };
 
-  const initialContactlessTaskTabDefinition = createContactlessTaskTabDefinition([], definitions.helplineInformation);
+  const initialContactlessTaskTabDefinition = createContactlessTaskTabDefinition({
+    counselorsList: [],
+    definition: definitions.tabbedForms.ContactlessTaskTab,
+    helplineInformation: definitions.helplineInformation,
+  });
   const contactlessTask = initialContactlessTaskTabDefinition.reduce(createStateItem, {});
 
   return {

--- a/plugin-hrm-form/src/utils/mappers.ts
+++ b/plugin-hrm-form/src/utils/mappers.ts
@@ -1,6 +1,6 @@
 import { callTypes } from 'hrm-form-definitions';
 
-import { channelTypes, otherContactChannels } from '../states/DomainConstants';
+import { channelTypes } from '../states/DomainConstants';
 
 export const mapCallType = (str: string) => {
   switch (str) {
@@ -13,7 +13,7 @@ export const mapCallType = (str: string) => {
   }
 };
 
-const isOtherContactChannel = (channel: string) => (Object.values(otherContactChannels) as string[]).includes(channel); // Needed typecast here. For details see https://github.com/microsoft/TypeScript/issues/26255
+const isOtherContactChannel = (channel: string) => !(Object.values(channelTypes) as string[]).includes(channel); // Needed typecast here. For details see https://github.com/microsoft/TypeScript/issues/26255
 
 export const mapChannel = (channel: string) => {
   if (isOtherContactChannel(channel)) {


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

## Description
This PR adds support for custom channels in the channels dropdown of Contact Info tab (Offline contacts only).
- Removes the `otherContactChannels` object and all references to it. If the helpline wants more channels other than the contact ones (Facebook, web, voice, SMS, Whatsapp, Twitter, Instagram), then those should defined in the new format introduced here.
- The custom channels can be defined via an optional json file under `flex-plugins/hrm-form-definitions/form-definitions/<definition version>/tabbedForms/ContactlessTaskTab.json` (that is, a new file `ContactlessTaskTab.json` under the `/tabbedForms` folder of the definition version). 
- If the file is not present, nothing happens, the UI will look like
  ![Screenshot from 2022-03-18 15-12-30](https://user-images.githubusercontent.com/15805319/159060204-0e168970-b764-45a4-87b1-a5abfed4ece9.png)

- To add custom channels the new file should have a shape like this
  ```
  {
    "offlineChannels": ["Custom Channel 1", "Custom Channel 2"]
  }
  ```
  That is, an array (list) of strings where each one is a custom channel. The result of the above is an expanded list of the channels like
  ![Screenshot from 2022-03-18 15-03-11](https://user-images.githubusercontent.com/15805319/159059522-5fad683e-03fe-414c-9e18-a377e9aa7db4.png)

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-967)
- [ ] New tests added
- [N/A] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Verification steps
- `UNBUNDLED_REACT=true npm ci` to remove the old `node_modules` and install the updated version of `hrm-form-definitions`.
- `npm run dev` and confirm everything works fine (the list of channels of an offline contact should be only the ones that support an actual contact).
- Create a `/tabbedForms/ContactlessTaskTab.json` file as described above for the custom forms being used.
- `UNBUNDLED_REACT=true npm ci` to install the updated definitions.
- `npm run dev` again and confirm the custom channels are now being added to the dropdown.
- Case timeline icon should default to the `AssignmentInd` icon
  ![Screenshot from 2022-03-18 15-12-39](https://user-images.githubusercontent.com/15805319/159059950-9f15dd0d-4c02-4ea8-964e-b97945826979.png)
