### PR TITLE
add warning dialog on close in Case details /tempInfo sections

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/case/AddEditCaseItem.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/AddEditCaseItem.test.tsx
@@ -178,7 +178,7 @@ describe('Test AddHousehold', () => {
     expect(screen.getByTestId('Case-CloseButton')).toBeInTheDocument();
     screen.getByTestId('Case-CloseButton').click();
 
-    expect(onClickClose).toHaveBeenCalled();
+    expect(screen.getByTestId('CloseCaseDialog')).toBeInTheDocument();
   });
 
   test('a11y', async () => {

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -38,6 +38,7 @@ import { AppRoutesWithCase } from '../../states/routing/types';
 import useFocus from '../../utils/useFocus';
 import { recordingErrorHandler } from '../../fullStory';
 import { AddTemporaryCaseInfo, CaseUpdater, isAddTemporaryCaseInfo, TemporaryCaseInfo } from '../../states/case/types';
+import CloseCaseDialog from './CloseCaseDialog';
 
 type CaseItemPayload = { [key: string]: string | boolean };
 
@@ -87,6 +88,13 @@ const AddEditCaseItem: React.FC<Props> = ({
   const firstElementRef = useFocus();
 
   const { temporaryCaseInfo } = connectedCaseState;
+  const [tempInfoHasBeenEdited, setTempInfoHasBeenEdited] = React.useState(false);
+  const [openDialog, setOpenDialog] = React.useState(false);
+  React.useEffect(() => {
+    if (temporaryCaseInfo.info !== null) {
+      setTempInfoHasBeenEdited(true);
+    }
+  }, [temporaryCaseInfo.info]);
 
   const [initialForm] = React.useState(getTemporaryFormContent(temporaryCaseInfo) ?? {}); // grab initial values in first render only. This value should never change or will ruin the memoization below
   const methods = useForm(reactHookFormOptions);
@@ -162,7 +170,11 @@ const AddEditCaseItem: React.FC<Props> = ({
     <FormProvider {...methods}>
       <CaseActionLayout>
         <CaseActionFormContainer>
-          <ActionHeader titleTemplate={`Case-Add${itemType}`} onClickClose={onClickClose} counselor={counselor} />
+          <ActionHeader
+            titleTemplate={`Case-Add${itemType}`}
+            onClickClose={tempInfoHasBeenEdited ? () => setOpenDialog(true) : onClickClose}
+            counselor={counselor}
+          />
           <Container>
             <Box paddingBottom={`${BottomButtonBarHeight}px`}>
               <TwoColumnLayout>
@@ -175,9 +187,20 @@ const AddEditCaseItem: React.FC<Props> = ({
         <div style={{ width: '100%', height: 5, backgroundColor: '#ffffff' }} />
         <BottomButtonBar>
           <Box marginRight="15px">
-            <StyledNextStepButton data-testid="Case-CloseButton" secondary roundCorners onClick={onClickClose}>
+            <StyledNextStepButton
+              data-testid="Case-CloseButton"
+              secondary
+              roundCorners
+              onClick={tempInfoHasBeenEdited ? () => setOpenDialog(true) : onClickClose}
+            >
               <Template code="BottomBar-Cancel" />
             </StyledNextStepButton>
+            <CloseCaseDialog
+              setDialog={() => setOpenDialog(false)}
+              handleDontSaveClose={onClickClose}
+              handleSaveUpdate={saveAndLeave}
+              openDialog={openDialog}
+            />
           </Box>
           <Box marginRight="15px">
             <StyledNextStepButton

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -170,11 +170,7 @@ const AddEditCaseItem: React.FC<Props> = ({
     <FormProvider {...methods}>
       <CaseActionLayout>
         <CaseActionFormContainer>
-          <ActionHeader
-            titleTemplate={`Case-Add${itemType}`}
-            onClickClose={tempInfoHasBeenEdited ? () => setOpenDialog(true) : onClickClose}
-            counselor={counselor}
-          />
+          <ActionHeader titleTemplate={`Case-Add${itemType}`} onClickClose={onClickClose} counselor={counselor} />
           <Container>
             <Box paddingBottom={`${BottomButtonBarHeight}px`}>
               <TwoColumnLayout>

--- a/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
+++ b/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
@@ -25,9 +25,7 @@ export default function CloseCaseDialog({ setDialog, handleDontSaveClose, handle
             <CloseButton aria-label="CloseButton" />
           </Box>
           <CloseDialogText>
-            <p>
-              <WarningIcon style={{ color: '#f6ca4a' }} />
-            </p>
+            <WarningIcon style={{ color: '#f6ca4a' }} /> <br />
             <Template code="BottomBar-SaveOnClose" />
           </CloseDialogText>
           <Row>

--- a/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
+++ b/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
@@ -16,7 +16,7 @@ type Props = {
 export default function CloseCaseDialog({ setDialog, handleDontSaveClose, handleSaveUpdate, openDialog }: Props) {
   return (
     <>
-      <CloseTaskDialog open={openDialog} onClose={setDialog}>
+      <CloseTaskDialog data-testid="CloseCaseDialog" open={openDialog} onClose={setDialog}>
         <TabPressWrapper>
           <Box textAlign="end" onClick={setDialog} tabIndex={3}>
             <HiddenText id="CloseButton">


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
This PR adds a warning dialog modal for content in the nested case details sections (+Note, +Perpetrators, etc.) triggered by changes by user

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added - older test changed
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes #CHI1054

### Verification steps
There will be a dialog warning modal at changes for content in the nested case details