### PR TITLE
CHI-1157 Update CaseInformationTab.json and remove case printing

### DIFF
--- a/hrm-form-definitions/form-definitions/br-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/br-v1/tabbedForms/CaseInformationTab.json
@@ -44,7 +44,8 @@
     {
       "name": "okForCaseWorkerToCall",
       "label": "Ok para alguém da equipe contatar?",
-      "type": "mixed-checkbox"
+      "type": "mixed-checkbox",
+      "highlightedAtCasePrint": false
     },
     {
       "name": "didYouDiscussRightsWithTheChild",

--- a/hrm-form-definitions/form-definitions/ca-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/ca-v1/tabbedForms/CaseInformationTab.json
@@ -44,12 +44,14 @@
     "name": "keepConfidential",
     "label": "Keep confidential?",
     "type": "checkbox",
-    "initialChecked": true
+    "initialChecked": true,
+    "highlightedAtCasePrint": false
   },
   {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didYouDiscussRightsWithTheChild",

--- a/hrm-form-definitions/form-definitions/demo-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/demo-v1/tabbedForms/CaseInformationTab.json
@@ -44,7 +44,8 @@
     "name": "keepConfidential",
     "label": "Keep confidential?",
     "type": "mixed-checkbox",
-    "initialChecked": true
+    "initialChecked": true,
+    "highlightedAtCasePrint": false
   },
   {
     "name": "mustCallBack",
@@ -54,7 +55,8 @@
   {
     "name": "okForCaseWorkerToCall",
     "label": "Is it okay for case worker to call?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didYouDiscussRightsWithTheChild",

--- a/hrm-form-definitions/form-definitions/et-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/et-v1/tabbedForms/CaseInformationTab.json
@@ -50,12 +50,14 @@
     "name": "keepConfidential",
     "label": "Keep confidential?",
     "type": "checkbox",
-    "initialChecked": true
+    "initialChecked": true,
+    "highlightedAtCasePrint": false
   },
   {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didYouDiscussRightsWithTheChild",

--- a/hrm-form-definitions/form-definitions/in-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/in-v1/tabbedForms/CaseInformationTab.json
@@ -84,7 +84,8 @@
   {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didTheChildFeelWeSolvedTheirProblem",

--- a/hrm-form-definitions/form-definitions/jm-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/jm-v1/tabbedForms/CaseInformationTab.json
@@ -55,12 +55,14 @@
     "name": "keepConfidential",
     "label": "Keep confidential?",
     "type": "checkbox",
-    "initialChecked": true
+    "initialChecked": true,
+    "highlightedAtCasePrint": false
   },
   {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didTheChildFeelWeSolvedTheirProblem",

--- a/hrm-form-definitions/form-definitions/mw-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/mw-v1/tabbedForms/CaseInformationTab.json
@@ -48,12 +48,14 @@
     "name": "keepConfidential",
     "label": "Keep confidential?",
     "type": "checkbox",
-    "initialChecked": true
+    "initialChecked": true,
+    "highlightedAtCasePrint": false
   },
   {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didYouDiscussRightsWithTheChild",

--- a/hrm-form-definitions/form-definitions/ph-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/ph-v1/tabbedForms/CaseInformationTab.json
@@ -67,7 +67,8 @@
   {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didWeSolveTheirProblem",

--- a/hrm-form-definitions/form-definitions/v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/v1/tabbedForms/CaseInformationTab.json
@@ -48,12 +48,14 @@
     "name": "keepConfidential",
     "label": "Keep confidential?",
     "type": "checkbox",
-    "initialChecked": true
+    "initialChecked": true,
+    "highlightedAtCasePrint": false
   },
   {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didYouDiscussRightsWithTheChild",

--- a/hrm-form-definitions/form-definitions/za-v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/za-v1/tabbedForms/CaseInformationTab.json
@@ -46,12 +46,14 @@
     "name": "keepConfidential",
     "label": "Keep confidential?",
     "type": "checkbox",
-    "initialChecked": true
+    "initialChecked": true,
+    "highlightedAtCasePrint": false
   },
   {
     "name": "okForCaseWorkerToCall",
     "label": "May social worker call/SMS?",
-    "type": "mixed-checkbox"
+    "type": "mixed-checkbox",
+    "highlightedAtCasePrint": false
   },
   {
     "name": "didYouDiscussRightsWithTheChild",

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -49,7 +49,6 @@ export const getConfig: any = () => {
    *  @type {{ strings: { [key: string]: string } }}
    */
   const { strings } = manager;
-
   return {
     hrmBaseUrl,
     serverlessBaseUrl,

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
@@ -30,29 +30,59 @@ type OwnProps = {
 };
 type Props = OwnProps;
 
-const extraFieldDefinitions = (strings: ReturnType<typeof getConfig>['strings']): FormDefinition => {
-  return [
-    {
-      name: 'keepConfidential',
-      label: strings['ContactDetails-GeneralDetails-KeepConfidential'],
-      type: 'checkbox',
-    },
-    {
-      name: 'okForCaseWorkerToCall',
-      label: strings['ContactDetails-GeneralDetails-OKToCall'],
-      type: 'mixed-checkbox',
-    },
-  ];
-};
-
-const addExtraValues = (caseInformation: ContactRawJson['caseInformation']) => {
-  return {
-    keepConfidential: Boolean(caseInformation?.keepConfidential),
-    okForCaseWorkerToCall: caseInformation?.okForCaseWorkerToCall,
-  };
-};
-
 const CasePrintView: React.FC<Props> = ({ onClickClose, caseDetails, definitionVersion, counselorsHash }) => {
+  const caseInfotab = (name: string): any =>
+    definitionVersion.tabbedForms.CaseInformationTab.filter(def => {
+      return def.name === name;
+    });
+
+  const printKeepConfidential = caseInfotab('keepConfidential')[0].highlightedAtCasePrint;
+  const printOkForCaseWorkerToCall = caseInfotab('okForCaseWorkerToCall')[0].highlightedAtCasePrint;
+
+  const extraFieldDefinitions = (strings: ReturnType<typeof getConfig>['strings']): FormDefinition => {
+    let extraDefinitions;
+    if (printKeepConfidential && printOkForCaseWorkerToCall) {
+      extraDefinitions = [
+        {
+          name: 'keepConfidential',
+          label: strings['ContactDetails-GeneralDetails-KeepConfidential'],
+          type: 'checkbox',
+        },
+        {
+          name: 'okForCaseWorkerToCall',
+          label: strings['ContactDetails-GeneralDetails-OKToCall'],
+          type: 'mixed-checkbox',
+        },
+      ];
+    } else if (printKeepConfidential) {
+      extraDefinitions = [
+        {
+          name: 'keepConfidential',
+          label: strings['ContactDetails-GeneralDetails-KeepConfidential'],
+          type: 'checkbox',
+        },
+      ];
+    } else if (printOkForCaseWorkerToCall) {
+      extraDefinitions = [
+        {
+          name: 'okForCaseWorkerToCall',
+          label: strings['ContactDetails-GeneralDetails-OKToCall'],
+          type: 'mixed-checkbox',
+        },
+      ];
+    } else {
+      extraDefinitions = [];
+    }
+    return extraDefinitions;
+  };
+
+  const addExtraValues = (caseInformation: ContactRawJson['caseInformation']) => {
+    return {
+      keepConfidential: Boolean(caseInformation?.keepConfidential),
+      okForCaseWorkerToCall: caseInformation?.okForCaseWorkerToCall,
+    };
+  };
+
   const { pdfImagesSource, strings } = getConfig();
 
   const logoSource = `${pdfImagesSource}/helpline-logo.png`;
@@ -63,7 +93,6 @@ const CasePrintView: React.FC<Props> = ({ onClickClose, caseDetails, definitionV
   const [logoBlob, setLogoBlob] = useState<string>(null);
   const [chkOnBlob, setChkOnBlob] = useState<string>(null);
   const [chkOffBlob, setChkOffBlob] = useState<string>(null);
-
   /*
    * The purpose of this effect is to load all the images at once, to avoid re-renders in PDFViewer that leads to issues
    * https://stackoverflow.com/questions/60614940/unhandled-rejection-typeerror-nbind-externallistnum-dereference-is-not-a-f


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
- Updated CaseInformationTab.json with `highlightedAtCasePrinting` flag to show 'Keep Confidential' and 'May social worker call' based on the form per helpline

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
- [Case Printing:Remove hardcoded fields](https://bugs.benetech.org/browse/CHI-1157)

### Verification steps
- Check that 'Keep Confidential' and 'May social worker call' are not while at case printing
- Modifying highlightedAtCasePrinting flag to true in hrm-form-definitions/.../caseInformationTab will show the respective fields.