### PR TITLE
CHI-1165: Enabled custom form definitions for notes & referrals to be supported

### DIFF
--- a/hrm-form-definitions/form-definitions/jm-v1/LayoutDefinitions.json
+++ b/hrm-form-definitions/form-definitions/jm-v1/LayoutDefinitions.json
@@ -36,6 +36,9 @@
       },
       "documents": {
         "splitFormAt": 1
+      },
+      "notes": {
+        "previewFields": ["assessment"]
       }
     }
   }

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -162,6 +162,7 @@ export type LayoutVersion = {
     incidents: LayoutDefinition;
     referrals: LayoutDefinition;
     documents: LayoutDefinition;
+    notes?: LayoutDefinition;
   };
 };
 

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -108,7 +108,7 @@ const Case: React.FC<Props> = ({
       if (!props.connectedCaseId) return;
 
       setLoading(true);
-      const activities = getActivitiesFromCase(props.connectedCaseState.connectedCase);
+      const activities = await getActivitiesFromCase(props.connectedCaseState.connectedCase);
       setLoading(false);
       let timelineActivities = sortActivities(activities);
 
@@ -346,8 +346,8 @@ const Case: React.FC<Props> = ({
               temp => {
                 const { form: noteForm, ...entryInfo } = temp;
                 return {
+                  ...noteForm,
                   ...entryInfo,
-                  note: noteForm.note.toString(),
                 };
               },
             )}

--- a/plugin-hrm-form/src/components/case/Timeline.tsx
+++ b/plugin-hrm-form/src/components/case/Timeline.tsx
@@ -49,7 +49,7 @@ const Timeline: React.FC<Props> = props => {
     const { twilioWorkerId } = activity;
     const info: CaseItemEntry = {
       id: null,
-      form: { note: activity.text },
+      form: { ...activity.note },
       twilioWorkerId,
       createdAt: parseISO(activity.date).toISOString(),
       updatedAt: activity.updatedAt ? parseISO(activity.updatedAt).toISOString() : undefined,

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -108,6 +108,7 @@ export type NoteActivity = {
   date: string;
   type: string;
   text: string;
+  note: t.Note;
   twilioWorkerId: string;
   updatedAt?: string;
   updatedBy?: string;
@@ -119,11 +120,7 @@ export type ReferralActivity = {
   createdAt: string;
   type: string;
   text: string;
-  referral: {
-    date: string;
-    comments: string;
-    referredTo: string;
-  };
+  referral: t.Referral;
   twilioWorkerId: string;
   updatedAt?: string;
   updatedBy?: string;

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -35,7 +35,7 @@ export type IncidentEntry = { incident: Incident } & EntryInfo;
 
 export type Note = { [key: string]: string | boolean };
 
-export type NoteEntry = { note: string } & EntryInfo;
+export type NoteEntry = Note & EntryInfo;
 
 export type Referral = { date: string; referredTo: string; [key: string]: string | boolean };
 


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description

* All data is now fed through from timeline activities to note & referral forms, not just a predefined set.
* Added an optional 'notes' section of the layout definition json, with a `previewFields` item where the notes fields that should be used in the timeline summary for notes can be specified, in line with what's in place for incidents. Referrals still uses hardcoded fields for this, things are a bit trickier there with the 2 dates etc. so decided to leave the summary for referrals alone for now.
* Updated relevant types to reflect that they are now generic forms.
* Added the `assessment` field as a preview field in the JM layout definition

Needs to be tested alongside https://github.com/techmatters/hrm/pull/173 to get the fix, but shouldn't be any worse than current versions against other versions of HRM

### Checklist
- [ X ] Corresponding issue has been opened
- [ X ] New tests added
- [ N/A ] Strings are localized
- [ N/A ] Tested for chat contacts
- [ N/A ] Tested for call contacts

### Related Issues
CHI-1165

### Verification steps

* In a local version customise your NoteForm.json and add previewFields to a notes section of the `LayoutDefinitions.json`
* Check that the timeline, viewing, adding and editing notes works as expected - be aware that this will only work for new notes created after you changed the definition
* Repeat the above steps for referrals (changing `ReferralForm` this time).