### PR TITLE
CHI-1079: flex version bump -> 1.30.2

### DIFF
--- a/hrm-form-definitions/form-definitions/jm-v1/LayoutDefinitions.json
+++ b/hrm-form-definitions/form-definitions/jm-v1/LayoutDefinitions.json
@@ -36,6 +36,9 @@
       },
       "documents": {
         "splitFormAt": 1
+      },
+      "notes": {
+        "previewFields": ["assessment"]
       }
     }
   }

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -162,6 +162,7 @@ export type LayoutVersion = {
     incidents: LayoutDefinition;
     referrals: LayoutDefinition;
     documents: LayoutDefinition;
+    notes?: LayoutDefinition;
   };
 };
 

--- a/plugin-hrm-form/jest-standalone.config.js
+++ b/plugin-hrm-form/jest-standalone.config.js
@@ -6,7 +6,7 @@ module.exports = config => {
     ...defaults,
     rootDir: '.',
     setupFiles: ['./src/setupTests.js'],
-    testEnvironment: 'jsdom',
+    testEnvironment: 'jest-environment-jsdom-latest',
     testTimeout: 2 * 60 * 1000, // 2 minutes in ms
   };
 

--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -2991,61 +2991,13 @@
       }
     },
     "@material-ui/icons": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-2.0.3.tgz",
-      "integrity": "sha512-wgKUB4vgCzdKseV3MHdsR7lZMyNYKykrghKX4GHuMmlZrrWMh26jO1E6xyjuCpJ/E8DX+m+YGURbBYN9CxZ+rw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz",
+      "integrity": "sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.0.0-rc.1",
-        "recompose": "^0.28.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.0.0-rc.1",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-rc.1.tgz",
-          "integrity": "sha512-Nifv2kwP/nwR39cAOasNxzjYfpeuf/ZbZNtQz5eYxWTC9yHARU9wItFnAwz1GTZ62MU+AtSjzZPMbLK5Q9hmbg==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.12.0"
-          }
-        },
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-          "dev": true
-        },
-        "recompose": {
-          "version": "0.28.2",
-          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.28.2.tgz",
-          "integrity": "sha512-baVNKQBQAAAuLRnv6Cb/6/j59a1BVj6c6Pags1KXVyRB0yPfQVUZtuAUnqHDBXoR8iXPrLGWE4RNtCQ/AaRP3g==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "7.0.0-beta.56",
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "react-lifecycles-compat": "^3.0.2",
-            "symbol-observable": "^1.0.4"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.0.0-beta.56",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.56.tgz",
-              "integrity": "sha512-vP9XV2VP013UEyZdU9eWClCsm6rQPUYHVNCfmpcv5uKviW7mKmUZq71Y5cr5dYsFKfnGDxSo8h6plUGR60lwHg==",
-              "dev": true,
-              "requires": {
-                "regenerator-runtime": "^0.12.0"
-              }
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-          "dev": true
-        }
+        "@babel/runtime": "^7.2.0",
+        "recompose": "0.28.0 - 0.30.0"
       }
     },
     "@material-ui/lab": {
@@ -3427,10 +3379,69 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "@material-ui/core": {
+          "version": "3.9.4",
+          "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
+          "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.2.0",
+            "@material-ui/system": "^3.0.0-alpha.0",
+            "@material-ui/utils": "^3.0.0-alpha.2",
+            "@types/jss": "^9.5.6",
+            "@types/react-transition-group": "^2.0.8",
+            "brcast": "^3.0.1",
+            "classnames": "^2.2.5",
+            "csstype": "^2.5.2",
+            "debounce": "^1.1.0",
+            "deepmerge": "^3.0.0",
+            "dom-helpers": "^3.2.1",
+            "hoist-non-react-statics": "^3.2.1",
+            "is-plain-object": "^2.0.4",
+            "jss": "^9.8.7",
+            "jss-camel-case": "^6.0.0",
+            "jss-default-unit": "^8.0.2",
+            "jss-global": "^3.0.0",
+            "jss-nested": "^6.0.1",
+            "jss-props-sort": "^6.0.0",
+            "jss-vendor-prefixer": "^7.0.0",
+            "normalize-scroll-left": "^0.1.2",
+            "popper.js": "^1.14.1",
+            "prop-types": "^15.6.0",
+            "react-event-listener": "^0.6.2",
+            "react-transition-group": "^2.2.1",
+            "recompose": "0.28.0 - 0.30.0",
+            "warning": "^4.0.1"
+          }
+        },
+        "@material-ui/system": {
+          "version": "3.0.0-alpha.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-3.0.0-alpha.2.tgz",
+          "integrity": "sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.2.0",
+            "deepmerge": "^3.0.0",
+            "prop-types": "^15.6.0",
+            "warning": "^4.0.1"
+          }
+        },
         "core-js": {
           "version": "3.21.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
           "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+          "dev": true
+        },
+        "csstype": {
+          "version": "2.6.20",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+          "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
+          "dev": true
+        },
+        "deepmerge": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+          "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
           "dev": true
         },
         "eventemitter3": {
@@ -3443,6 +3454,12 @@
           "version": "1.6.7",
           "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
           "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
+          "dev": true
+        },
+        "popper.js": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+          "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
           "dev": true
         },
         "react-emotion": {
@@ -3501,10 +3518,122 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-rc.1.tgz",
+          "integrity": "sha512-Nifv2kwP/nwR39cAOasNxzjYfpeuf/ZbZNtQz5eYxWTC9yHARU9wItFnAwz1GTZ62MU+AtSjzZPMbLK5Q9hmbg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "@material-ui/core": {
+          "version": "3.9.4",
+          "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
+          "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.2.0",
+            "@material-ui/system": "^3.0.0-alpha.0",
+            "@material-ui/utils": "^3.0.0-alpha.2",
+            "@types/jss": "^9.5.6",
+            "@types/react-transition-group": "^2.0.8",
+            "brcast": "^3.0.1",
+            "classnames": "^2.2.5",
+            "csstype": "^2.5.2",
+            "debounce": "^1.1.0",
+            "deepmerge": "^3.0.0",
+            "dom-helpers": "^3.2.1",
+            "hoist-non-react-statics": "^3.2.1",
+            "is-plain-object": "^2.0.4",
+            "jss": "^9.8.7",
+            "jss-camel-case": "^6.0.0",
+            "jss-default-unit": "^8.0.2",
+            "jss-global": "^3.0.0",
+            "jss-nested": "^6.0.1",
+            "jss-props-sort": "^6.0.0",
+            "jss-vendor-prefixer": "^7.0.0",
+            "normalize-scroll-left": "^0.1.2",
+            "popper.js": "^1.14.1",
+            "prop-types": "^15.6.0",
+            "react-event-listener": "^0.6.2",
+            "react-transition-group": "^2.2.1",
+            "recompose": "0.28.0 - 0.30.0",
+            "warning": "^4.0.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.17.9",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+              "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.13.9",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+              "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+              "dev": true
+            }
+          }
+        },
+        "@material-ui/icons": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-2.0.3.tgz",
+          "integrity": "sha512-wgKUB4vgCzdKseV3MHdsR7lZMyNYKykrghKX4GHuMmlZrrWMh26jO1E6xyjuCpJ/E8DX+m+YGURbBYN9CxZ+rw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "7.0.0-rc.1",
+            "recompose": "^0.28.0"
+          }
+        },
+        "@material-ui/system": {
+          "version": "3.0.0-alpha.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-3.0.0-alpha.2.tgz",
+          "integrity": "sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.2.0",
+            "deepmerge": "^3.0.0",
+            "prop-types": "^15.6.0",
+            "warning": "^4.0.1"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.17.9",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+              "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.13.9",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+              "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+              "dev": true
+            }
+          }
+        },
         "core-js": {
           "version": "3.21.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
           "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+          "dev": true
+        },
+        "csstype": {
+          "version": "2.6.20",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+          "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
+          "dev": true
+        },
+        "deepmerge": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+          "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
           "dev": true
         },
         "hoist-non-react-statics": {
@@ -3522,6 +3651,12 @@
           "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
           "dev": true
         },
+        "popper.js": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+          "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+          "dev": true
+        },
         "react-emotion": {
           "version": "9.2.6",
           "resolved": "https://registry.npmjs.org/react-emotion/-/react-emotion-9.2.6.tgz",
@@ -3531,6 +3666,43 @@
             "babel-plugin-emotion": "^9.2.6",
             "create-emotion-styled": "^9.2.6"
           }
+        },
+        "recompose": {
+          "version": "0.28.2",
+          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.28.2.tgz",
+          "integrity": "sha512-baVNKQBQAAAuLRnv6Cb/6/j59a1BVj6c6Pags1KXVyRB0yPfQVUZtuAUnqHDBXoR8iXPrLGWE4RNtCQ/AaRP3g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "7.0.0-beta.56",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.0.0-beta.56",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.56.tgz",
+              "integrity": "sha512-vP9XV2VP013UEyZdU9eWClCsm6rQPUYHVNCfmpcv5uKviW7mKmUZq71Y5cr5dYsFKfnGDxSo8h6plUGR60lwHg==",
+              "dev": true,
+              "requires": {
+                "regenerator-runtime": "^0.12.0"
+              }
+            },
+            "hoist-non-react-statics": {
+              "version": "2.5.5",
+              "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+              "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+              "dev": true
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
         },
         "semver": {
           "version": "5.7.1",
@@ -15110,164 +15282,315 @@
         }
       }
     },
-    "jest-environment-jsdom-sixteen": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom-sixteen/-/jest-environment-jsdom-sixteen-1.0.3.tgz",
-      "integrity": "sha512-CwMqDUUfSl808uGPWXlNA1UFkWFgRmhHvyAjhCmCry6mYq4b/nn80MMN7tglqo5XgrANIs/w+mzINPzbZ4ZZrQ==",
+    "jest-environment-jsdom-latest": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom-latest/-/jest-environment-jsdom-latest-26.6.2.tgz",
+      "integrity": "sha512-SgFy1H+oDpv8giyVwdPtMoUy4ELaBR1JKmj2BqUXxJ5ul0MM7d8phqDw265U+mjmOsmJMwKJ1VJNevCtmCBWJw==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^25.1.0",
-        "jest-mock": "^25.1.0",
-        "jest-util": "^25.1.0",
-        "jsdom": "^16.2.1"
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jsdom": "^19.0.0"
       },
       "dependencies": {
+        "@jest/environment": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+          "integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.6.2",
+            "@jest/types": "^26.6.2",
+            "@types/node": "*",
+            "jest-mock": "^26.6.2"
+          }
+        },
         "@jest/fake-timers": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
-          "integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+          "integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^25.5.0",
-            "jest-message-util": "^25.5.0",
-            "jest-mock": "^25.5.0",
-            "jest-util": "^25.5.0",
-            "lolex": "^5.0.0"
+            "@jest/types": "^26.6.2",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "@types/node": "*",
+            "jest-message-util": "^26.6.2",
+            "jest-mock": "^26.6.2",
+            "jest-util": "^26.6.2"
           }
         },
-        "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
+            "@sinonjs/commons": "^1.7.0"
           }
         },
-        "@types/istanbul-reports": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "*",
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/stack-utils": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-          "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
-          "dev": true
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "escape-string-regexp": {
+        "@tootallnate/once": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
           "dev": true
         },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
           "dev": true
         },
-        "jest-message-util": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
-          "integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
+        "cssom": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+          "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+          "dev": true
+        },
+        "data-urls": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.1.tgz",
+          "integrity": "sha512-Ds554NeT5Gennfoo9KN50Vh6tpgtvYEwraYjejXnyTpu1C7oXKxdFk75REooENHE8ndTVOJuv+BEs4/J/xcozw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@jest/types": "^25.5.0",
-            "@types/stack-utils": "^1.0.1",
-            "chalk": "^3.0.0",
-            "graceful-fs": "^4.2.4",
-            "micromatch": "^4.0.2",
-            "slash": "^3.0.0",
-            "stack-utils": "^1.0.1"
+            "abab": "^2.0.3",
+            "whatwg-mimetype": "^3.0.0",
+            "whatwg-url": "^10.0.0"
           }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "decimal.js": {
+          "version": "10.3.1",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+          "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+          "dev": true
+        },
+        "domexception": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+          "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^7.0.0"
+          }
+        },
+        "escodegen": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+          "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+          "dev": true,
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^5.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+          "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+          "dev": true
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "html-encoding-sniffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+          "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+          "dev": true,
+          "requires": {
+            "whatwg-encoding": "^2.0.0"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "2",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "is-potential-custom-element-name": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+          "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+          "dev": true
         },
         "jest-mock": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
-          "integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+          "integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
           "dev": true,
           "requires": {
-            "@jest/types": "^25.5.0"
+            "@jest/types": "^26.6.2",
+            "@types/node": "*"
           }
         },
-        "jest-util": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
-          "integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
+        "jsdom": {
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-19.0.0.tgz",
+          "integrity": "sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==",
           "dev": true,
           "requires": {
-            "@jest/types": "^25.5.0",
-            "chalk": "^3.0.0",
-            "graceful-fs": "^4.2.4",
-            "is-ci": "^2.0.0",
-            "make-dir": "^3.0.0"
+            "abab": "^2.0.5",
+            "acorn": "^8.5.0",
+            "acorn-globals": "^6.0.0",
+            "cssom": "^0.5.0",
+            "cssstyle": "^2.3.0",
+            "data-urls": "^3.0.1",
+            "decimal.js": "^10.3.1",
+            "domexception": "^4.0.0",
+            "escodegen": "^2.0.0",
+            "form-data": "^4.0.0",
+            "html-encoding-sniffer": "^3.0.0",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "is-potential-custom-element-name": "^1.0.1",
+            "nwsapi": "^2.2.0",
+            "parse5": "6.0.1",
+            "saxes": "^5.0.1",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^4.0.0",
+            "w3c-hr-time": "^1.0.2",
+            "w3c-xmlserializer": "^3.0.0",
+            "webidl-conversions": "^7.0.0",
+            "whatwg-encoding": "^2.0.0",
+            "whatwg-mimetype": "^3.0.0",
+            "whatwg-url": "^10.0.0",
+            "ws": "^8.2.3",
+            "xml-name-validator": "^4.0.0"
           }
         },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        },
+        "tough-cookie": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
           "dev": true,
           "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
           }
         },
-        "stack-utils": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.4.tgz",
-          "integrity": "sha512-IPDJfugEGbfizBwBZRZ3xpccMdRyP5lqsBWXGQWimVjua/ccLCeMOAVjlc1R7LxFjo5sEDhyNIXd8mo/AiDS9w==",
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^2.0.0"
+            "punycode": "^2.1.1"
           }
         },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+        "w3c-xmlserializer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
+          "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
           "dev": true,
           "requires": {
-            "is-number": "^7.0.0"
+            "xml-name-validator": "^4.0.0"
           }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+          "dev": true
+        },
+        "whatwg-encoding": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+          "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.6.3"
+          }
+        },
+        "whatwg-mimetype": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+          "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
+          "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
+          "dev": true,
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "dev": true
+        },
+        "xml-name-validator": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+          "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+          "dev": true
         }
       }
     },
@@ -17990,15 +18313,6 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
       "dev": true
-    },
-    "lolex": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      }
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -2977,9 +2977,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.19",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-          "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+          "version": "2.6.20",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+          "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
           "dev": true
         },
         "deepmerge": {
@@ -3352,9 +3352,9 @@
       "dev": true
     },
     "@twilio/flex-sdk": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.8.1.tgz",
-      "integrity": "sha512-LftPU/ld05mKA1OMMMYT1/J/TV8tbwSqNiPCD05R0qAtbG0lBLhA1V4vBj8NFUXcMVIvBGfSatYRip7RN69cBQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.9.1.tgz",
+      "integrity": "sha512-is+Go9nqlsU4Qr6PeEbYBxKwa4THi2Z/jbx6g+2LJk10mhibfkJafJHGGdpTDf79pCN+3gnnsFPnG9I64yyAzw==",
       "dev": true,
       "requires": {
         "core-js": "^3.9.1",
@@ -3366,17 +3366,17 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.20.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
-          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
+          "version": "3.21.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+          "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
           "dev": true
         }
       }
     },
     "@twilio/flex-ui": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.28.1.tgz",
-      "integrity": "sha512-LgvDlIGi0roCCEPQW/bkF47Mr5NYLTUaIEPPEr70CHdwQzzFisjh1ritW5dRUWPOM+p1CaidirZUvllYOFZuvA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.30.2.tgz",
+      "integrity": "sha512-j8UIV+BDiPITs3GrLpo4BpFREviLuvB07M9ZPeD5e0M5HcSILR65edXcPTgFkv7kfO1UZiN6c0+i+1WaXV+new==",
       "dev": true,
       "requires": {
         "@gooddata/gooddata-js": "13.2.0",
@@ -3384,8 +3384,8 @@
         "@material-ui/lab": "3.0.0-alpha.30",
         "@twilio/flex-insights-identity-client-js": "2.0.6",
         "@twilio/flex-insights-player": "2.3.1",
-        "@twilio/flex-sdk": "^0.8.0",
-        "@twilio/flex-ui-core": "0.53.0",
+        "@twilio/flex-sdk": "^0.9.0",
+        "@twilio/flex-ui-core": "0.56.2",
         "@twilio/player": "1.0.1",
         "@types/deep-diff": "^1.0.0",
         "@types/react-select": "2.0.19",
@@ -3424,14 +3424,13 @@
         "twilio-chat": "~3.4.0",
         "twilio-client": "1.13.1",
         "twilio-sync": "^0.12.3",
-        "twilio-taskrouter": "^0.5.2",
         "uuid": "^3.3.2"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.20.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
-          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
+          "version": "3.21.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+          "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
           "dev": true
         },
         "eventemitter3": {
@@ -3471,9 +3470,9 @@
       }
     },
     "@twilio/flex-ui-core": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.53.0.tgz",
-      "integrity": "sha512-zoj4H+4ris8MowPmnFhhT0KD1L72lkb6Joh4TY9CFls/2N0DsMZriQJxpDC0RR07vKncg0j08bTIQ45JwiXbsA==",
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.56.2.tgz",
+      "integrity": "sha512-PY8d3gX+wjZsUzdml2DNXxXbpLEx9LRskMRzNjjcbMePTK1R6D1akCoiMW33qva8WR5B90aOV6zlWQ2nAobY2Q==",
       "dev": true,
       "requires": {
         "@material-ui/core": "3.9.4",
@@ -3503,9 +3502,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.20.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
-          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
+          "version": "3.21.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+          "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
           "dev": true
         },
         "hoist-non-react-statics": {
@@ -3785,9 +3784,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.19",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-          "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+          "version": "2.6.20",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+          "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
           "dev": true
         }
       }
@@ -6844,9 +6843,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.19",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-          "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+          "version": "2.6.20",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+          "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
           "dev": true
         }
       }
@@ -23532,18 +23531,6 @@
         }
       }
     },
-    "twilio-taskrouter": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.5.7.tgz",
-      "integrity": "sha512-YMz6Pi/UxGP5PuWCiqideXKiWdilH5LYrHvfRYKEzu6aaDguQWUPEpsVEOmDAnOCHwwRGmeaXvCR8goQEkFM0g==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.5",
-        "loglevel": "^1.4.1",
-        "ws": "^7.4.6",
-        "xmlhttprequest": "^1.8.0"
-      }
-    },
     "twilsock": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/twilsock/-/twilsock-0.8.3.tgz",
@@ -23640,9 +23627,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.0.tgz",
-      "integrity": "sha512-x+xdeDWq7FiORDvyIJ0q/waWd4PhjBNOm5dQUOq2AKC0IEjxOS66Ha9tctiVDGcRQuh69K7fgU5oRuTK4cysSg==",
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
       "dev": true,
       "optional": true
     },

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -41,7 +41,7 @@
     "@testing-library/dom": "^7.21.0",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^10.4.7",
-    "@twilio/flex-ui": "1.28.1",
+    "@twilio/flex-ui": "1.30.2",
     "@types/jest": "^26.0.20",
     "@types/react-redux": "^7.1.16",
     "@typescript-eslint/parser": "^3.8.0",

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -31,10 +31,12 @@
     "react-dom": "~16.13.1",
     "react-hook-form": "^6.11.0",
     "react-keyboard-event-handler": "^1.5.4",
+    "@material-ui/core": "^3.9.4",
+    "@material-ui/icons": "^3.0.2",
     "rollbar": "^2.19.3",
     "uuid": "^8.3.2",
-    "@babel/runtime": "^7.16.3",
-    "hrm-form-definitions": "file:../hrm-form-definitions"
+    "@babel/runtime": "^7.16.3",,
+    "hrm-form-definitions": "file:../hrm-form-definitions",
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.16.4",
@@ -59,7 +61,7 @@
     "jest": "^27.4.3",
     "jest-axe": "^3.4.0",
     "jest-each": "^27.5.1",
-    "jest-environment-jsdom-sixteen": "^1.0.3",
+    "jest-environment-jsdom-latest": "^26.6.2",
     "redux-mock-store": "^1.5.4",
     "rxjs-compat": "6.6.3",
     "ts-jest": "^26.5.0",

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -32,11 +32,10 @@ export const getConfig: any = () => {
   const logoUrl = manager.serviceConfiguration.attributes.logo_url;
   const chatServiceSid = manager.serviceConfiguration.chat_service_instance_sid;
   const workerSid = manager.workerClient.sid;
-  const { helpline, counselorLanguage } = manager.workerClient.attributes;
+  const { helpline, counselorLanguage, full_name: counselorName, roles } = manager.workerClient.attributes as any;
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
-  const counselorName = manager.workerClient.attributes.full_name;
-  const isSupervisor = manager.workerClient.attributes.roles.includes('supervisor');
+  const isSupervisor = roles.includes('supervisor');
   const {
     helplineLanguage,
     definitionVersion,

--- a/plugin-hrm-form/src/___tests__/components/menu/menu.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/menu/menu.test.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore
 import React from 'react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { mount } from 'enzyme';
@@ -5,14 +6,23 @@ import { StorelessThemeProvider } from '@twilio/flex-ui';
 import FolderIcon from '@material-ui/icons/FolderOpen';
 import CancelIcon from '@material-ui/icons/Cancel';
 
-import HrmTheme from '../../../styles/HrmTheme';
 import { Menu, MenuItem } from '../../../components/menu';
 
 expect.extend(toHaveNoViolations);
 
-const themeConf = {
-  colorTheme: HrmTheme,
-};
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toParseAsDate(date: Date): R;
+    }
+    // @ts-ignore
+    interface Expect<R> {
+      toParseAsDate(date: Date): R;
+    }
+  }
+}
+
+const themeConf = {};
 const anchorEl = React.createRef();
 
 test('do not show menu', () => {

--- a/plugin-hrm-form/src/___tests__/states/csam-report/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/csam-report/reducer.test.ts
@@ -1,14 +1,37 @@
 /* eslint-disable sonarjs/no-identical-functions */
+import { DefinitionVersion } from 'hrm-form-definitions';
+
 import { reduce, initialState, newTaskEntry } from '../../../states/csam-report/reducer';
 import * as actions from '../../../states/csam-report/actions';
 import * as GeneralActions from '../../../states/actions';
+import { GeneralActionType } from '../../../states/types';
 
 const task = { taskSid: 'task-sid' };
-const voidDefinitions = {
-  callerFormDefinition: [],
-  caseInfoFormDefinition: [],
-  categoriesFormDefinition: {},
-  childFormDefinition: [],
+const voidDefinitions: DefinitionVersion = {
+  tabbedForms: {
+    CallerInformationTab: [],
+    ChildInformationTab: [],
+    CaseInformationTab: [],
+    ContactlessTaskTab: {},
+    IssueCategorizationTab: () => ({}),
+  },
+  caseForms: {
+    HouseholdForm: [],
+    PerpetratorForm: [],
+    ReferralForm: [],
+    NoteForm: [],
+    DocumentForm: [],
+    IncidentForm: [],
+  },
+  callTypeButtons: [],
+  caseStatus: {},
+  layoutVersion: {
+    contact: { callerInformation: {}, caseInformation: {}, childInformation: {} },
+    case: { households: {}, referrals: {}, documents: {}, perpetrators: {}, incidents: {} },
+  },
+  helplineInformation: { label: '', helplines: [] },
+  prepopulateKeys: { ChildInformationTab: [], CallerInformationTab: [] },
+  insights: { oneToOneConfigSpec: {}, oneToManyConfigSpecs: [] },
 };
 
 describe('test reducer', () => {
@@ -17,7 +40,7 @@ describe('test reducer', () => {
 
     const expected = initialState;
 
-    const result = reduce(state, {});
+    const result = reduce(state, <GeneralActionType>{});
     expect(result).toStrictEqual(expected);
   });
 

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -108,7 +108,7 @@ const Case: React.FC<Props> = ({
       if (!props.connectedCaseId) return;
 
       setLoading(true);
-      const activities = getActivitiesFromCase(props.connectedCaseState.connectedCase);
+      const activities = await getActivitiesFromCase(props.connectedCaseState.connectedCase);
       setLoading(false);
       let timelineActivities = sortActivities(activities);
 
@@ -346,8 +346,8 @@ const Case: React.FC<Props> = ({
               temp => {
                 const { form: noteForm, ...entryInfo } = temp;
                 return {
+                  ...noteForm,
                   ...entryInfo,
-                  note: noteForm.note.toString(),
                 };
               },
             )}

--- a/plugin-hrm-form/src/components/case/Timeline.tsx
+++ b/plugin-hrm-form/src/components/case/Timeline.tsx
@@ -49,7 +49,7 @@ const Timeline: React.FC<Props> = props => {
     const { twilioWorkerId } = activity;
     const info: CaseItemEntry = {
       id: null,
-      form: { note: activity.text },
+      form: { ...activity.note },
       twilioWorkerId,
       createdAt: parseISO(activity.date).toISOString(),
       updatedAt: activity.updatedAt ? parseISO(activity.updatedAt).toISOString() : undefined,

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -18,7 +18,7 @@ import {
   SearchContactResult,
 } from '../types/types';
 import { saveContactToExternalBackend } from '../dualWrite';
-import { getNumberFromTask } from '../utils/task';
+import { getNumberFromTask } from '../utils';
 
 /**
  * Un-nests the information (caller/child) as it comes from DB, to match the form structure

--- a/plugin-hrm-form/src/setupTests.js
+++ b/plugin-hrm-form/src/setupTests.js
@@ -6,3 +6,7 @@ require('babel-polyfill');
 configure({
   adapter: new Adapter(),
 });
+
+// Workaround for jsdom not supporting media elements: https://github.com/jsdom/jsdom/issues/2155
+window.HTMLMediaElement.prototype.play = () => Promise.resolve();
+window.HTMLMediaElement.prototype.pause = () => undefined;

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -108,6 +108,7 @@ export type NoteActivity = {
   date: string;
   type: string;
   text: string;
+  note: t.Note;
   twilioWorkerId: string;
   updatedAt?: string;
   updatedBy?: string;
@@ -119,11 +120,7 @@ export type ReferralActivity = {
   createdAt: string;
   type: string;
   text: string;
-  referral: {
-    date: string;
-    comments: string;
-    referredTo: string;
-  };
+  referral: t.Referral;
   twilioWorkerId: string;
   updatedAt?: string;
   updatedBy?: string;

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -35,7 +35,7 @@ export type IncidentEntry = { incident: Incident } & EntryInfo;
 
 export type Note = { [key: string]: string | boolean };
 
-export type NoteEntry = { note: string } & EntryInfo;
+export type NoteEntry = Note & EntryInfo;
 
 export type Referral = { date: string; referredTo: string; [key: string]: string | boolean };
 


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description

* Updated flex UI to v1.30.2
* Added explicit material UI deps. Version 4.x had some issues so I pinned it back to the same version that used to be pulled in by flex for now
* Added some stubs for HTMLMediaElement objects that are not implemented by jsdom
* Mocked out a call to the flex API in ContactService tests that was causing issues

### Checklist
- [ X ] Corresponding issue has been opened
- [ X ] New tests added
- [ N/A ] Strings are localized
- [ X ] Tested for chat contacts
- [ NO ] Tested for call contacts

### Related Issues
CHI-1079

### Verification steps

* Ensure the correct version of flex is specified in the flex admin UI
* Regression test flex features