### PR TITLE
Pagination refactor to use nav and button & focus on tab key

### DIFF
--- a/plugin-hrm-form/src/components/Pagination.tsx
+++ b/plugin-hrm-form/src/components/Pagination.tsx
@@ -21,16 +21,19 @@ const renderPaginationButton = (page, handleChangePage) => n => {
   if (n === -1)
     return (
       <PaginationButton key={`ellipsis-${Math.random()}`}>
-        <ButtonText style={{ paddingTop: 10 }}>...</ButtonText>
+        <ButtonText>...</ButtonText>
       </PaginationButton>
     );
 
   return (
-    <ButtonBase key={`CaseList-pagination-${n}`} onClick={() => handleChangePage(n)}>
-      <PaginationButton highlight={page === n}>
-        <ButtonText highlight={page === n}>{n + 1}</ButtonText>
-      </PaginationButton>
-    </ButtonBase>
+    <PaginationButton
+      aria-label={`Page${n + 1}`}
+      highlight={page === n}
+      key={`CaseList-pagination-${n}`}
+      onClick={() => handleChangePage(n)}
+    >
+      <ButtonText highlight={page === n}>{n + 1}</ButtonText>
+    </PaginationButton>
   );
 };
 
@@ -43,16 +46,12 @@ type ChevronButtonProps = {
 const ChevronButton: React.FC<ChevronButtonProps> = ({ chevronDirection, onClick, templateCode }) => {
   const ChevronIcon = chevronDirection === 'left' ? ChevronLeft : ChevronRight;
   return (
-    <ButtonBase onClick={onClick}>
-      <PaginationChevron>
-        <HiddenText>
-          <Template code={templateCode} />
-        </HiddenText>
-        <ButtonText>
-          <ChevronIcon />
-        </ButtonText>
-      </PaginationChevron>
-    </ButtonBase>
+    <PaginationChevron onClick={onClick}>
+      <HiddenText>
+        <Template code={templateCode} />
+      </HiddenText>
+      <ChevronIcon style={{ margin: '-7px 0' }} />
+    </PaginationChevron>
   );
 };
 ChevronButton.displayName = 'ChevronButton';
@@ -76,17 +75,11 @@ const Pagination: React.FC<PaginationProps> = ({ page, pagesCount, handleChangeP
   };
 
   return (
-    <TableFooter data-testid="CaseList-TableFooter">
-      <PaginationRow transparent={transparent}>
-        <TableCell colSpan={8}>
-          <div style={{ display: 'flex', width: '100%', justifyContent: 'center' }}>
-            <ChevronButton chevronDirection="left" onClick={decreasePage} templateCode="CaseList-PrevPage" />
-            {getPaginationNumbers(page, pagesCount).map(renderButtons)}
-            <ChevronButton chevronDirection="right" onClick={increasePage} templateCode="CaseList-NextPage" />
-          </div>
-        </TableCell>
-      </PaginationRow>
-    </TableFooter>
+    <PaginationRow transparent={transparent} data-testid="CaseList-TableFooter">
+      <ChevronButton chevronDirection="left" onClick={decreasePage} templateCode="CaseList-PrevPage" />
+      {getPaginationNumbers(page, pagesCount).map(renderButtons)}
+      <ChevronButton chevronDirection="right" onClick={increasePage} templateCode="CaseList-NextPage" />
+    </PaginationRow>
   );
 };
 

--- a/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
@@ -74,9 +74,9 @@ const CaseListTable: React.FC<Props> = ({
               ))}
             </TableBody>
           )}
-          <Pagination page={currentPage} pagesCount={pagesCount} handleChangePage={updateCaseListPage} />
         </CLTable>
       </TableContainer>
+      <Pagination page={currentPage} pagesCount={pagesCount} handleChangePage={updateCaseListPage} />
     </>
   );
 };

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -525,11 +525,12 @@ type PaginationRowProps = {
   transparent?: boolean;
 };
 
-export const PaginationRow = styled(TableRow)<PaginationRowProps>`
+export const PaginationRow = styled('nav')<PaginationRowProps>`
   height: auto;
   vertical-align: top;
   background-color: ${props => (props.transparent ? 'transparent' : props.theme.colors.base2)};
-  margin-top: -5;
+  margin: 3rem auto;
+  text-align: center;
 `;
 PaginationRow.displayName = 'PaginationRow';
 

--- a/plugin-hrm-form/src/styles/caseList/index.ts
+++ b/plugin-hrm-form/src/styles/caseList/index.ts
@@ -137,14 +137,19 @@ export const PaginationButton = styled('div')<PaginationButtonProps>`
   background-color: ${props => (props.highlight ? '#1976D2' : 'transparent')};
   box-shadow: ${props => (props.highlight ? '0 1px 1px 0 rgba(0, 0, 0, 0.06)' : '0')};
   border-radius: 4px;
-  padding: 5px 10px;
-  margin: 5px 5px 0 5px;
+  padding: 6px 10px;
+  margin: 0 2px;
+  border: none;
+  &:focus-visible {
+    outline: auto;
+    outline-color: #1976d2;
+  }
 `;
 PaginationButton.displayName = 'PaginationButton';
 
 export const PaginationChevron = styled(PaginationButton)`
   margin: 0;
-  padding-bottom: 10px;
+  padding: 7px 3px;
 `;
 PaginationChevron.displayName = 'PaginationChevron';
 


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
- Visual cue with a focus box has been added to ensure user can tab keyboard. Pagination component is updated to use semantic nav element to wrap the pagination UI and buttons instead of MUI components. 

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes [#1121](https://bugs.benetech.org/browse/CHI-1121)

### Verification steps
- Use keyboard to tab and to navigate through pagination UI within the Case List page and Search Contacts/Cases page
- Use Screen Reader to navigate through pagination UI within the Case List page and Search Contacts/Cases page