### PR TITLE
CHI1181 Fixes warning modal that allows saving blank case form

### DIFF
--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -286,7 +286,6 @@ const AddEditCaseItem: React.FC<Props> = ({
                 secondary
                 roundCorners
                 onClick={methods.handleSubmit(saveAndStay, onError)}
-                disabled={!isDirty}
               >
                 <Template code={`BottomBar-SaveAndAddAnother${itemType}`} />
               </StyledNextStepButton>
@@ -296,7 +295,6 @@ const AddEditCaseItem: React.FC<Props> = ({
             data-testid="Case-AddEditItemScreen-SaveItem"
             roundCorners
             onClick={methods.handleSubmit(saveAndLeave, onError)}
-            disabled={!isDirty}
           >
             <Template code={`BottomBar-Save${itemType}`} />
           </StyledNextStepButton>

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -101,12 +101,12 @@ const AddEditCaseItem: React.FC<Props> = ({
   const { temporaryCaseInfo } = connectedCaseState;
 
   const [initialForm] = React.useState(getTemporaryFormContent(temporaryCaseInfo) ?? {}); // grab initial values in first render only. This value should never change or will ruin the memoization below
-  const methods = useForm({ mode:'onChange' });
+  const methods = useForm({ mode: 'onChange' });
   const [openDialog, setOpenDialog] = React.useState(false);
 
   const [isDirty, setDirty] = React.useState(false);
   React.useEffect(() => {
-    if (methods.formState.isDirty && methods.formState.isValid){
+    if (methods.formState.isDirty && methods.formState.isValid) {
       setDirty(true);
     }
   }, [methods.formState.isDirty, methods.formState.isValid]);
@@ -231,7 +231,8 @@ const AddEditCaseItem: React.FC<Props> = ({
   const checkForEdits = () => {
     if (
       (isEditTemporaryCaseInfo(temporaryCaseInfo) || isAddTemporaryCaseInfo(temporaryCaseInfo)) &&
-      temporaryCaseInfo.isEdited && isDirty
+      temporaryCaseInfo.isEdited &&
+      isDirty
     ) {
       setOpenDialog(true);
     } else close();

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -217,7 +217,7 @@ const AddEditCaseItem: React.FC<Props> = ({
     if (isAddTemporaryCaseInfo(temporaryCaseInfo)) {
       const blankForm = formDefinition.reduce(createStateItem, {});
       methods.reset(blankForm); // Resets the form.
-      updateTempInfo({ screen: temporaryCaseInfo.screen, info: {}, action: CaseItemAction.Add }, task.taskSid);
+      updateTempInfo({ screen: temporaryCaseInfo.screen, info: null, action: CaseItemAction.Add }, task.taskSid);
       changeRoute({ ...routing, action: CaseItemAction.Add }, task.taskSid);
     }
   }

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -47,7 +47,6 @@ import {
   temporaryCaseInfoHistory,
 } from '../../states/case/types';
 import CloseCaseDialog from './CloseCaseDialog';
-import { isEqual } from 'lodash';
 
 type CaseItemPayload = { [key: string]: string | boolean };
 
@@ -102,7 +101,7 @@ const AddEditCaseItem: React.FC<Props> = ({
   const { temporaryCaseInfo } = connectedCaseState;
 
   const [initialForm] = React.useState(getTemporaryFormContent(temporaryCaseInfo) ?? {}); // grab initial values in first render only. This value should never change or will ruin the memoization below
-  const methods = useForm({...reactHookFormOptions, mode: 'onChange' });
+  const methods = useForm({ ...reactHookFormOptions, mode: 'onChange' });
   const [openDialog, setOpenDialog] = React.useState(false);
   const [isDirty, setDirty] = React.useState(false);
 

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -47,6 +47,7 @@ import {
   temporaryCaseInfoHistory,
 } from '../../states/case/types';
 import CloseCaseDialog from './CloseCaseDialog';
+import { isEqual } from 'lodash';
 
 type CaseItemPayload = { [key: string]: string | boolean };
 
@@ -101,15 +102,15 @@ const AddEditCaseItem: React.FC<Props> = ({
   const { temporaryCaseInfo } = connectedCaseState;
 
   const [initialForm] = React.useState(getTemporaryFormContent(temporaryCaseInfo) ?? {}); // grab initial values in first render only. This value should never change or will ruin the memoization below
-  const methods = useForm({ mode: 'onChange' });
+  const methods = useForm({...reactHookFormOptions, mode: 'onChange' });
   const [openDialog, setOpenDialog] = React.useState(false);
-
   const [isDirty, setDirty] = React.useState(false);
+
   React.useEffect(() => {
-    if (methods.formState.isDirty && methods.formState.isValid) {
+    if (methods.formState.isDirty) {
       setDirty(true);
     }
-  }, [methods.formState.isDirty, methods.formState.isValid]);
+  }, [methods.formState.isDirty]);
 
   const [l, r] = React.useMemo(() => {
     const createUpdatedTemporaryFormContent = (
@@ -231,8 +232,7 @@ const AddEditCaseItem: React.FC<Props> = ({
   const checkForEdits = () => {
     if (
       (isEditTemporaryCaseInfo(temporaryCaseInfo) || isAddTemporaryCaseInfo(temporaryCaseInfo)) &&
-      temporaryCaseInfo.isEdited &&
-      isDirty
+      temporaryCaseInfo.isEdited
     ) {
       setOpenDialog(true);
     } else close();
@@ -254,7 +254,7 @@ const AddEditCaseItem: React.FC<Props> = ({
             openDialog={openDialog}
             setDialog={() => setOpenDialog(false)}
             handleDontSaveClose={close}
-            handleSaveUpdate={saveAndLeave}
+            handleSaveUpdate={methods.handleSubmit(saveAndLeave, onError)}
           />
           <Container>
             <Box paddingBottom={`${BottomButtonBarHeight}px`}>
@@ -276,7 +276,7 @@ const AddEditCaseItem: React.FC<Props> = ({
               openDialog={openDialog}
               setDialog={() => setOpenDialog(false)}
               handleDontSaveClose={close}
-              handleSaveUpdate={saveAndLeave}
+              handleSaveUpdate={methods.handleSubmit(saveAndLeave, onError)}
             />
           </Box>
           {routing.action === CaseItemAction.Add && (

--- a/plugin-hrm-form/src/components/case/Timeline.tsx
+++ b/plugin-hrm-form/src/components/case/Timeline.tsx
@@ -22,7 +22,7 @@ import CaseAddButton from './CaseAddButton';
 import * as CaseActions from '../../states/case/actions';
 import * as RoutingActions from '../../states/routing/actions';
 import { ContactDetailsSections } from '../common/ContactDetails';
-import { blankReferral, CaseItemEntry, CustomITask } from '../../types/types';
+import { CaseItemEntry, CustomITask } from '../../types/types';
 import { isConnectedCaseActivity } from './caseActivities';
 import { TaskEntry } from '../../states/contacts/reducer';
 import { Activity, NoteActivity, ReferralActivity } from '../../states/case/types';
@@ -111,7 +111,7 @@ const Timeline: React.FC<Props> = props => {
   };
 
   const handleAddReferralClick = () => {
-    updateTempInfo({ screen: NewCaseSubroutes.Referral, action: CaseItemAction.Add, info: blankReferral }, taskSid);
+    updateTempInfo({ screen: NewCaseSubroutes.Referral, action: CaseItemAction.Add, info: null }, taskSid);
     changeRoute({ route, subroute: NewCaseSubroutes.Referral, action: CaseItemAction.Add }, taskSid);
   };
 

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -49,12 +49,6 @@ export type DocumentEntry = { document: Document; id: string | undefined } & Ent
 
 export type CSAMReportEntry = { csamReportId: string; id: number } & EntryInfo;
 
-export const blankReferral = {
-  date: null,
-  referredTo: null,
-  comments: null,
-};
-
 export type CaseInfo = {
   definitionVersion?: DefinitionVersionId;
   offlineContactCreator?: string;


### PR DESCRIPTION
Primary reviewer:

## Description
- Bug Fix - Checking required fields isValid flag in Case Section form changes. Dialog only shows up when all required fields are filled out. 
- Disabled  the `Save and Add CaseSection` button and `Save CaseSection` button when changes are not valid 

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes [#1181](https://bugs.benetech.org/browse/CHI-1181)

### Verification steps
- When adding a new case section(referral, note, perpetrator), try leaving some of the required fields and Close. The previous errors described in [#1181](https://bugs.benetech.org/browse/CHI-1181) should no longer occur. Except Note section, it would still save in some cases note field is left blank. 
