### PR TITLE
Chi 1167 redact counselor name on case pdf

### DIFF
--- a/hrm-form-definitions/form-definitions/jm-v1/LayoutDefinitions.json
+++ b/hrm-form-definitions/form-definitions/jm-v1/LayoutDefinitions.json
@@ -39,6 +39,7 @@
       },
       "notes": {
         "previewFields": ["assessment"]
-      }
+      },
+      "hideCounselorDetails": true
     }
   }

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintDetails.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintDetails.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Text, View, Image } from '@react-pdf/renderer';
-import { DefinitionVersionId } from 'hrm-form-definitions';
+import { DefinitionVersionId, DefinitionVersion } from 'hrm-form-definitions';
 
 import { getConfig } from '../../../HrmFormPlugin';
 import styles from './styles';
@@ -28,6 +28,7 @@ type OwnProps = {
   version: DefinitionVersionId;
   chkOnBlob?: string;
   chkOffBlob?: string;
+  definitionVersion: DefinitionVersion
 };
 
 type Props = OwnProps;
@@ -44,8 +45,11 @@ const CasePrintDetails: React.FC<Props> = ({
   version,
   chkOnBlob,
   chkOffBlob,
+  definitionVersion,
 }) => {
   const { strings } = getConfig();
+
+  const { hideCounselorDetails } = definitionVersion.layoutVersion.case;
 
   return (
     <View style={styles.caseDetailsContainer}>
@@ -75,6 +79,7 @@ const CasePrintDetails: React.FC<Props> = ({
           </View>
         </View>
       </View>
+      {hideCounselorDetails ? null : 
       <View style={styles.caseDetailsSubSection}>
         <View style={styles.caseCounsellorSection}>
           <View style={styles.flexColumn}>
@@ -91,7 +96,7 @@ const CasePrintDetails: React.FC<Props> = ({
         <View>
           <CasePrintCategories categories={categories} version={version} />
         </View>
-      </View>
+      </View>}
     </View>
   );
 };

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintDetails.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintDetails.tsx
@@ -28,7 +28,7 @@ type OwnProps = {
   version: DefinitionVersionId;
   chkOnBlob?: string;
   chkOffBlob?: string;
-  definitionVersion: DefinitionVersion
+  definitionVersion: DefinitionVersion;
 };
 
 type Props = OwnProps;
@@ -79,24 +79,25 @@ const CasePrintDetails: React.FC<Props> = ({
           </View>
         </View>
       </View>
-      {hideCounselorDetails ? null : 
-      <View style={styles.caseDetailsSubSection}>
-        <View style={styles.caseCounsellorSection}>
-          <View style={styles.flexColumn}>
-            <Text>{strings['Case-Counsellor']}</Text>
-            <Text style={styles.caseDetailsBoldText}>{counselor}</Text>
+      {hideCounselorDetails ? null : (
+        <View style={styles.caseDetailsSubSection}>
+          <View style={styles.caseCounsellorSection}>
+            <View style={styles.flexColumn}>
+              <Text>{strings['Case-Counsellor']}</Text>
+              <Text style={styles.caseDetailsBoldText}>{counselor}</Text>
+            </View>
+            <View style={{ marginTop: 15, ...styles.flexColumn }}>
+              <Text>{strings['Case-CaseManager']}</Text>
+              <Text style={styles.caseDetailsBoldText}>{caseManager?.name}</Text>
+              <Text style={styles.caseDetailsBoldText}>{caseManager?.phone}</Text>
+              <Text style={styles.caseDetailsBoldText}>{caseManager?.email}</Text>
+            </View>
           </View>
-          <View style={{ marginTop: 15, ...styles.flexColumn }}>
-            <Text>{strings['Case-CaseManager']}</Text>
-            <Text style={styles.caseDetailsBoldText}>{caseManager?.name}</Text>
-            <Text style={styles.caseDetailsBoldText}>{caseManager?.phone}</Text>
-            <Text style={styles.caseDetailsBoldText}>{caseManager?.email}</Text>
+          <View>
+            <CasePrintCategories categories={categories} version={version} />
           </View>
         </View>
-        <View>
-          <CasePrintCategories categories={categories} version={version} />
-        </View>
-      </View>}
+      )}
     </View>
   );
 };

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
@@ -116,6 +116,7 @@ const CasePrintView: React.FC<Props> = ({ onClickClose, caseDetails, definitionV
                   caseManager={caseDetails.office?.manager}
                   chkOnBlob={chkOnBlob}
                   chkOffBlob={chkOffBlob}
+                  definitionVersion={definitionVersion}
                 />
                 {caseDetails.contact?.rawJson?.callType === callTypes.caller ? (
                   <View>


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand @nickhurlburt

## Description
<!--
- What this pull request does.
- New feature
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes # N/A

### Verification steps
<!--
Describe how to validate your changes.
-In the layoutDefinitions.json file in the v1 folder of hrm-form-definitions, add the name of the helpline inside the `hideCounselorDetails` array
-Print case PDF
-Verify that the counsellor's details were redacted
-Replace the `hideCounselorDetails` array with `false` to completely deactivate..
-->