### PR TITLE
Case Statuses shown based on form definition values, styling edits

### DIFF
--- a/plugin-hrm-form/src/components/caseList/CaseList.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseList.tsx
@@ -19,7 +19,7 @@ import { undoCaseListSettingsUpdate } from '../../states/caseList/reducer';
 import { dateFilterPayloadFromFilters } from './filters/dateFilters';
 import * as ListContent from '../../states/caseList/listContent';
 
-export const CASES_PER_PAGE = 5;
+export const CASES_PER_PAGE = 10;
 
 const standaloneTask: StandaloneITask = {
   taskSid: 'standalone-task-sid',

--- a/plugin-hrm-form/src/components/caseList/CaseListTableRow.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTableRow.tsx
@@ -67,7 +67,7 @@ const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleCli
   const definitionVersion = definitionVersions[version];
 
   // Get the status for a case from the value of CaseStatus.json of the current form definitions
-  const getStatusValue = (caseStatus: string) => {
+  const getCaseStatusLabel = (caseStatus: string) => {
     return Object.values(definitionVersion.caseStatus).filter(status => status.value === caseStatus)[0].label;
   };
 
@@ -83,7 +83,7 @@ const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleCli
             {caseItem.id}
           </CLCaseIDButton>
           <CLTableBodyFont style={{ color: '#606B85', paddingTop: '2px', textAlign: 'center' }}>
-            {getStatusValue(caseItem.status)}
+            {getCaseStatusLabel(caseItem.status)}
           </CLTableBodyFont>
         </CLCaseNumberContainer>
       </CLNumberCell>

--- a/plugin-hrm-form/src/components/caseList/CaseListTableRow.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTableRow.tsx
@@ -1,9 +1,12 @@
 /* eslint-disable react/prop-types */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { format, parseISO } from 'date-fns';
-import { Fullscreen } from '@material-ui/icons';
 import { Template } from '@twilio/flex-ui';
+import { connect, ConnectedProps } from 'react-redux';
 
+import { getDefinitionVersion } from '../../services/ServerlessService';
+import { configurationBase, namespace, RootState } from '../../states';
+import * as ConfigActions from '../../states/configuration/actions';
 import { Case, CounselorHash } from '../../types/types';
 import {
   CLTableRow,
@@ -15,22 +18,24 @@ import {
   CLCaseNumberContainer,
   CLCaseIDButton,
 } from '../../styles/caseList';
-import { Box, Row, HiddenText } from '../../styles/HrmStyles';
+import { Box, HiddenText } from '../../styles/HrmStyles';
 import { formatName, getShortSummary } from '../../utils';
 import { getContactTags, renderTag } from '../../utils/categories';
-import { caseStatuses } from '../../states/DomainConstants';
 import CategoryWithTooltip from '../common/CategoryWithTooltip';
+import { caseStatuses } from '../../states/DomainConstants';
 
 const CHAR_LIMIT = 200;
 
 // eslint-disable-next-line react/no-multi-comp
-type Props = {
+type OwnProps = {
   caseItem: Case;
   counselorsHash: CounselorHash;
   handleClickViewCase: (currentCase: Case) => () => void;
 };
 
-const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleClickViewCase }) => {
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleClickViewCase, ...props }) => {
   const { status } = caseItem;
   const statusString = status.charAt(0).toUpperCase() + status.slice(1);
   const name = formatName(caseItem.childName);
@@ -45,10 +50,29 @@ const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleCli
       ? `${format(parseISO(caseItem.info.followUpDate), 'MMM d, yyyy')}`
       : '—';
   const categories = getContactTags(caseItem.info.definitionVersion, caseItem.categories);
-  const isOpenCase = caseItem.status !== caseStatuses.closed;
+
+  const { updateDefinitionVersion, definitionVersions } = props;
+  const version = caseItem.info.definitionVersion;
+
+  useEffect(() => {
+    const fetchDefinitionVersions = async (v: string) => {
+      const definitionVersion = await getDefinitionVersion(version);
+      updateDefinitionVersion(version, definitionVersion);
+    };
+    if (version && !definitionVersions[version]) {
+      fetchDefinitionVersions(version);
+    }
+  }, [definitionVersions, updateDefinitionVersion, version]);
+
+  const definitionVersion = definitionVersions[version];
+
+  // Get the status for a case from the value of CaseStatus.json of the current form definitions
+  const getStatusValue = (caseStatus: string) => {
+    return Object.values(definitionVersion.caseStatus).filter(status => status.value === caseStatus)[0].label;
+  };
 
   return (
-    <CLTableRow data-testid="CaseList-TableRow">
+    <CLTableRow data-testid="CaseList-TableRow" onClick={handleClickViewCase(caseItem)}>
       <CLNumberCell>
         <CLCaseNumberContainer>
           <CLCaseIDButton tabIndex={0} onClick={handleClickViewCase(caseItem)}>
@@ -59,7 +83,7 @@ const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleCli
             {caseItem.id}
           </CLCaseIDButton>
           <CLTableBodyFont style={{ color: '#606B85', paddingTop: '2px', textAlign: 'center' }}>
-            <Template code={`CaseList-Status${statusString}`} />
+            {getStatusValue(caseItem.status)}
           </CLTableBodyFont>
         </CLCaseNumberContainer>
       </CLNumberCell>
@@ -97,4 +121,15 @@ const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleCli
 
 CaseListTableRow.displayName = 'CaseListTableRow';
 
-export default CaseListTableRow;
+const mapStateToProps = (state: RootState) => ({
+  definitionVersions: state[namespace][configurationBase].definitionVersions,
+});
+
+const mapDispatchToProps = {
+  updateDefinitionVersion: ConfigActions.updateDefinitionVersion,
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+const connected = connector(CaseListTableRow);
+
+export default connected;

--- a/plugin-hrm-form/src/components/caseList/filters/Filters.tsx
+++ b/plugin-hrm-form/src/components/caseList/filters/Filters.tsx
@@ -148,6 +148,7 @@ const Filters: React.FC<Props> = ({
 
   const [openedFilter, setOpenedFilter] = useState<string>();
   const [statusValues, setStatusValues] = useState<Item[]>(statusInitialValues);
+  console.log('>>>statusValues ', statusValues)
   const [counselorValues, setCounselorValues] = useState<Item[]>(getCounselorsInitialValue(counselorsHash));
   const [dateFilterValues, setDateFilterValues] = useState<{
     createdAt?: DateFilterValue;
@@ -164,6 +165,7 @@ const Filters: React.FC<Props> = ({
       checked: counsellors.includes(cv.value),
     }));
     const newStatusValues = statusValues.map(sv => ({ ...sv, checked: statuses.includes(sv.value) }));
+    console.log('>>> newStatusValues', newStatusValues)
     const newCategoriesValues = getUpdatedCategoriesValues(categories, categoriesValues);
     setCounselorValues(newCounselorValues);
     setStatusValues(newStatusValues);
@@ -253,7 +255,7 @@ const Filters: React.FC<Props> = ({
             setOpenedFilter={setOpenedFilter}
             searchable
           />
-          <FiltersContainer style={{ marginLeft: '100px', boxShadow: 'none' }}>
+          <FiltersContainer style={{ marginLeft: 'auto', boxShadow: 'none', }}>
             <DateRange fontSize="inherit" style={{ marginRight: 5 }} />
             <Template code="CaseList-Filters-DateFiltersLabel" />
             {getInitialDateFilters().map(df => {

--- a/plugin-hrm-form/src/components/caseList/filters/Filters.tsx
+++ b/plugin-hrm-form/src/components/caseList/filters/Filters.tsx
@@ -148,7 +148,6 @@ const Filters: React.FC<Props> = ({
 
   const [openedFilter, setOpenedFilter] = useState<string>();
   const [statusValues, setStatusValues] = useState<Item[]>(statusInitialValues);
-  console.log('>>>statusValues ', statusValues)
   const [counselorValues, setCounselorValues] = useState<Item[]>(getCounselorsInitialValue(counselorsHash));
   const [dateFilterValues, setDateFilterValues] = useState<{
     createdAt?: DateFilterValue;
@@ -165,7 +164,6 @@ const Filters: React.FC<Props> = ({
       checked: counsellors.includes(cv.value),
     }));
     const newStatusValues = statusValues.map(sv => ({ ...sv, checked: statuses.includes(sv.value) }));
-    console.log('>>> newStatusValues', newStatusValues)
     const newCategoriesValues = getUpdatedCategoriesValues(categories, categoriesValues);
     setCounselorValues(newCounselorValues);
     setStatusValues(newStatusValues);
@@ -255,7 +253,7 @@ const Filters: React.FC<Props> = ({
             setOpenedFilter={setOpenedFilter}
             searchable
           />
-          <FiltersContainer style={{ marginLeft: 'auto', boxShadow: 'none', }}>
+          <FiltersContainer style={{ marginLeft: 'auto', boxShadow: 'none' }}>
             <DateRange fontSize="inherit" style={{ marginRight: 5 }} />
             <Template code="CaseList-Filters-DateFiltersLabel" />
             {getInitialDateFilters().map(df => {

--- a/plugin-hrm-form/src/styles/caseList/index.ts
+++ b/plugin-hrm-form/src/styles/caseList/index.ts
@@ -19,7 +19,6 @@ CenteredContainer.displayName = 'CenteredContainer';
 export const TableContainer = styled(Flex)`
   border-left: 15px solid ${props => props.theme.colors.base2};
   border-right: 10px solid ${props => props.theme.colors.base2};
-  
 `;
 TableContainer.displayName = 'TableContainer';
 
@@ -31,7 +30,6 @@ export const CLTable = withStyles({
       outline: 'none',
     },
   },
-  
 })(Table);
 CLTable.displayName = 'CLTable';
 

--- a/plugin-hrm-form/src/styles/caseList/index.ts
+++ b/plugin-hrm-form/src/styles/caseList/index.ts
@@ -5,7 +5,6 @@ import { Absolute, FontOpenSans, Flex } from '../HrmStyles';
 
 export const CaseListContainer = styled(Absolute)`
   height: 100%;
-  width: 100%;
   background-color: ${props => props.theme.colors.base2};
 `;
 CaseListContainer.displayName = 'CaseListContainer';
@@ -17,9 +16,10 @@ export const CenteredContainer = styled(CaseListContainer)`
 `;
 CenteredContainer.displayName = 'CenteredContainer';
 
-export const TableContainer = styled('div')`
+export const TableContainer = styled(Flex)`
   border-left: 15px solid ${props => props.theme.colors.base2};
   border-right: 10px solid ${props => props.theme.colors.base2};
+  
 `;
 TableContainer.displayName = 'TableContainer';
 
@@ -31,6 +31,7 @@ export const CLTable = withStyles({
       outline: 'none',
     },
   },
+  
 })(Table);
 CLTable.displayName = 'CLTable';
 

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -209,8 +209,6 @@
   "CaseList-THFollowUp": "Follow Up",
   "CaseList-THCategory": "Category",
   "CaseList-ExpandButton": "Open case details",
-  "CaseList-StatusOpen": "Open",
-  "CaseList-StatusClosed": "Closed",
   "CaseList-PrevPage": "Previous page",
   "CaseList-NextPage": "Next page",
   "CaseList-FilterBy": "Filter by",

--- a/plugin-hrm-form/src/translations/pt-BR/flexUI.json
+++ b/plugin-hrm-form/src/translations/pt-BR/flexUI.json
@@ -274,8 +274,6 @@
   "CaseList-THCategory": "Categoria",
   "NoCaseSummary": "Sem resumo do caso",
   "CaseList-ExpandButton": "Abrir detalhes do caso",
-  "CaseList-StatusOpen": "Aberto",
-  "CaseList-StatusClosed": "Fechado",
   "CaseList-PrevPage": "Página anterior",
   "CaseList-NextPage": "Próxima página",
   "CaseList-FilterBy": "Filtrar por",


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
- In Case List table, each Case Item's status is displayed with the value in the form definitions(CaseStatus.json). 
- Number of Cases shown is 10 (instead of 5)
- Right align the date filters

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes # CHI1178

### Verification steps
- Check that additional case statuses other than open and closes are displayed leveraged other definition versions (br-v1 and in-v1)