### PR TITLE
CHI-1161: Multi-AWS region terraform prep

### DIFF
--- a/twilio-iac/terraform-modules/aws/default/main.tf
+++ b/twilio-iac/terraform-modules/aws/default/main.tf
@@ -11,6 +11,11 @@ terraform {
   }
 }
 
+provider "aws" {
+  alias = "bucket"
+  region = var.bucket_region
+}
+
 
 locals {
   docs_s3_location = "tl-aselo-docs-${lower(var.short_helpline)}-${lower(var.environment)}"
@@ -19,6 +24,7 @@ locals {
 
 resource "aws_s3_bucket" "docs" {
   bucket = local.docs_s3_location
+  provider = aws.bucket
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["GET", "POST", "PUT"]
@@ -53,6 +59,7 @@ resource "aws_s3_bucket_public_access_block" "chat" {
   restrict_public_buckets = false
 }
 
+// Still put SSM parameters in default region, they don't store any helpline data & it keeps the workflow logic simpler
 resource "aws_ssm_parameter" "main_group" {
   for_each = {
     WORKSPACE_SID = jsonencode(["TWILIO", var.flex_task_assignment_workspace_sid, "Twilio account - Workspace SID"])

--- a/twilio-iac/terraform-modules/aws/default/variables.tf
+++ b/twilio-iac/terraform-modules/aws/default/variables.tf
@@ -73,3 +73,8 @@ variable "post_survey_bot_sid" {
   type        = string
 }
 
+variable "bucket_region" {
+  description = "The region where the document & chat s3 buckets should be created"
+  type = string
+  default = "us-east-1"
+}

--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 locals {
-  hrm_url = var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-test.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")
+  hrm_url = var.hrm_url == "" ?  (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-test.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
   service_configuration_payload = jsonencode({"ui_attributes":  {
     "warmTransfers": {

--- a/twilio-iac/terraform-modules/flex/default/variables.tf
+++ b/twilio-iac/terraform-modules/flex/default/variables.tf
@@ -2,16 +2,22 @@ variable "account_sid" {
   description = "Twilio Account SID"
   type        = string
 }
-
 variable "serverless_url" {
   description = "URL used to access Aselo Twilio serverless functions"
   type        = string
+}
+
+variable "hrm_url" {
+  description = "Custom URL for the HRM backend (leave blank and it will infer a default) from the environments name"
+  type = string
+  default = ""
 }
 
 variable "short_environment" {
   description = "Short upper case environment identifier, typically 'PROD', 'STG' or 'DEV'"
   type        = string
 }
+
 
 variable "operating_info_key" {
   description = "Operating info key for this helpline"

--- a/twilio-iac/terraform-modules/flex/default/variables.tf
+++ b/twilio-iac/terraform-modules/flex/default/variables.tf
@@ -2,6 +2,7 @@ variable "account_sid" {
   description = "Twilio Account SID"
   type        = string
 }
+
 variable "serverless_url" {
   description = "URL used to access Aselo Twilio serverless functions"
   type        = string
@@ -17,7 +18,6 @@ variable "short_environment" {
   description = "Short upper case environment identifier, typically 'PROD', 'STG' or 'DEV'"
   type        = string
 }
-
 
 variable "operating_info_key" {
   description = "Operating info key for this helpline"

--- a/twilio-iac/terraform-poc-account/main.tf
+++ b/twilio-iac/terraform-poc-account/main.tf
@@ -45,7 +45,7 @@ module "services" {
 module "taskRouter" {
   source = "../terraform-modules/taskRouter/default"
   serverless_url = var.serverless_url
-  helpline = var.helpline
+  helpline = "ChildLine Zambia (ZM)"
 }
 
 module studioFlow {
@@ -61,8 +61,10 @@ module flex {
   account_sid = var.account_sid
   short_environment = var.short_environment
   operating_info_key = var.operating_info_key
+  permission_config = "zm"
   definition_version = var.definition_version
   serverless_url = var.serverless_url
+  hrm_url = "https://hrm-development-eu.tl.techmatters.org"
   multi_office_support = var.multi_office
   feature_flags = var.feature_flags
   flex_chat_service_sid = module.services.flex_chat_service_sid

--- a/twilio-iac/terraform-poc-account/variables.tf
+++ b/twilio-iac/terraform-poc-account/variables.tf
@@ -51,17 +51,19 @@ variable "feature_flags" {
   description = "A map of feature flags that need to be set for this helpline's flex plugin"
   type = map(bool)
   default = {
-    "enable_fullstory_monitoring" = false
-    "enable_upload_documents" = true
-    "enable_previous_contacts" = true
-    "enable_case_management" = true
-    "enable_offline_contact" = true
-    "enable_transfers" = true
-    "enable_manual_pulling" = true
-    "enable_csam_report" = false
-    "enable_canned_responses" = true
-    "enable_dual_write" = false
-    "enable_save_insights" = true
-    "enable_post_survey" = false
+    "enable_fullstory_monitoring": false,
+    "enable_upload_documents": true,
+    "enable_post_survey": false,
+    "enable_case_management": true,
+    "enable_offline_contact": true,
+    "enable_filter_cases": true,
+    "enable_sort_cases": true,
+    "enable_transfers": true,
+    "enable_manual_pulling": true,
+    "enable_csam_report": true,
+    "enable_canned_responses": true,
+    "enable_dual_write": false,
+    "enable_save_insights": true,
+    "enable_previous_contacts": true
   }
 }


### PR DESCRIPTION
Primary reviewer: @nickhurlburt @GPaoloni 

## Description

* Allow HRM URL to be specified explicitly in TF configs. 
* Allow the AWS region for S3 buckets set in TF. 
* TerraformPOC example as a european deploy

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Strings are localized
- [-] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-1161

### Verification steps

* Set up account with buckets & backend in a non standard region