### PR TITLE
CHI-1206: Fix loading up contacts into contact view

### DIFF
--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -11,22 +11,23 @@ import ContactDetails from '../contact/ContactDetails';
 import ActionHeader from './ActionHeader';
 import { CaseState } from '../../states/case/reducer';
 import type { CustomITask, StandaloneITask } from '../../types/types';
-import { loadRawContact, releaseContact } from '../../states/contacts/existingContacts';
+import { loadContact, loadRawContact, releaseContact } from '../../states/contacts/existingContacts';
 import { DetailsContext } from '../../states/contacts/contactDetails';
+import { taskFormToSearchContact } from '../../states/contacts/contactDetailsAdapter';
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const form = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];
   const counselorsHash = state[namespace][configurationBase].counselors.hash;
   const caseState: CaseState = state[namespace][connectedCaseBase];
-  const { temporaryCaseInfo } = caseState.tasks[ownProps.task.taskSid];
+  const { temporaryCaseInfo, connectedCase } = caseState.tasks[ownProps.task.taskSid];
 
-  return { form, counselorsHash, tempInfo: temporaryCaseInfo };
+  return { form, counselorsHash, tempInfo: temporaryCaseInfo, connectedCase };
 };
 
 const mapDispatchToProps = {
-  updateTempInfo: CaseActions.updateTempInfo,
   setConnectedCase: CaseActions.setConnectedCase,
-  loadContactIntoState: loadRawContact,
+  loadRawContactIntoState: loadRawContact,
+  loadContactIntoState: loadContact,
   releaseContactFromState: releaseContact,
 };
 
@@ -38,30 +39,43 @@ type OwnProps = {
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
 const ViewContact: React.FC<Props> = ({
+  form,
   task,
   counselorsHash,
   tempInfo,
   onClickClose,
-  updateTempInfo,
   loadContactIntoState,
+  loadRawContactIntoState,
   releaseContactFromState,
+  connectedCase,
 }) => {
   useEffect(() => {
     if (tempInfo && tempInfo.screen === 'view-contact') {
-      const { contact: contactFromInfo } = tempInfo.info;
+      const { contact: contactFromInfo, timeOfContact, counselor } = tempInfo.info;
       if (contactFromInfo) {
-        loadContactIntoState(contactFromInfo);
+        loadRawContactIntoState(contactFromInfo);
         return () => releaseContactFromState(contactFromInfo.id);
       }
+      const temporaryId = `__unsavedFromCase:${connectedCase.id}`;
+      loadContactIntoState(taskFormToSearchContact(task, form, timeOfContact, counselor, temporaryId));
+      return () => releaseContactFromState(temporaryId);
     }
     return () => {
       /* no cleanup to do. */
     };
-  }, [tempInfo, counselorsHash, loadContactIntoState, releaseContactFromState]);
+  }, [
+    counselorsHash,
+    loadContactIntoState,
+    releaseContactFromState,
+    connectedCase.id,
+    task,
+    form,
+    loadRawContactIntoState,
+  ]);
 
   if (!tempInfo || tempInfo.screen !== 'view-contact') return null;
-  const { contact: contactFromInfo, createdAt } = tempInfo.info;
-  const createdByName = counselorsHash[contactFromInfo.createdBy] || 'Unknown';
+  const { contact: contactFromInfo, createdAt, counselor } = tempInfo.info;
+  const createdByName = counselorsHash[contactFromInfo?.createdBy ?? counselor] || 'Unknown';
 
   const added = new Date(createdAt);
 
@@ -74,7 +88,10 @@ const ViewContact: React.FC<Props> = ({
           addingCounsellor={createdByName}
           added={added}
         />
-        <ContactDetails contactId={contactFromInfo.id} context={DetailsContext.CASE_DETAILS} />
+        <ContactDetails
+          contactId={contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`}
+          context={DetailsContext.CASE_DETAILS}
+        />
       </Container>
       <BottomButtonBar>
         <StyledNextStepButton roundCorners onClick={onClickClose} data-testid="Case-ViewContactScreen-CloseButton">

--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -71,6 +71,7 @@ const ViewContact: React.FC<Props> = ({
     task,
     form,
     loadRawContactIntoState,
+    tempInfo,
   ]);
 
   if (!tempInfo || tempInfo.screen !== 'view-contact') return null;

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -204,9 +204,9 @@ const Details: React.FC<Props> = ({
               <SectionEntry
                 key={`Category ${index + 1}`}
                 description={
-                  <div style={{ display: 'inline-block' }}>
+                  <span style={{ display: 'inline-block' }}>
                     <Template code="Category" /> {index + 1}
-                  </div>
+                  </span>
                 }
                 value={c}
               />

--- a/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
@@ -4,6 +4,9 @@
  */
 
 import { SearchContact } from '../../types/types';
+import { getNumberFromTask } from '../../utils';
+import { transformForm } from '../../services/ContactService';
+import { getConversationDuration } from '../../utils/conversationDuration';
 
 /**
  * @param {string[]} accumulator
@@ -59,6 +62,37 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
       createdBy,
     },
     details: contact.rawJson,
+    csamReports,
+  };
+};
+
+export const taskFormToSearchContact = (task, form, date, counselor, temporaryId): SearchContact => {
+  const details = transformForm(form);
+  const dateTime = date;
+  const name = `${details.childInformation.name.firstName} ${details.childInformation.name.lastName}`;
+  const customerNumber = getNumberFromTask(task);
+  const { callType, caseInformation } = details;
+  const categories = retrieveCategories(caseInformation.categories);
+  const notes = caseInformation.callSummary as string;
+  const { channelType } = task;
+  const conversationDuration = getConversationDuration(task, form.metadata);
+  const { csamReports } = form;
+
+  return {
+    contactId: temporaryId,
+    overview: {
+      createdBy: counselor,
+      dateTime,
+      name,
+      customerNumber,
+      callType,
+      categories,
+      counselor,
+      notes,
+      channel: channelType,
+      conversationDuration,
+    },
+    details,
     csamReports,
   };
 };


### PR DESCRIPTION
 Fix loading up contacts into contact view from a task form when the contact hasn't been saved.

Primary reviewer: @GPaoloni 

## Description

* Now loads contact from a task / form into the existing contacts store under a temporary ID before viewing it in the contact details view

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes CHI-1206:

### Verification steps

1. Create an offline contact
2. Add it to a case
3. View the contact in the case timeline BEFORE saving

Also regression test all other scenarios where the contact details can be viewed