### PR TITLE
Chi 1206 hotfix cherry pick

### DIFF
--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -90,6 +90,7 @@ const ViewContact: React.FC<Props> = ({
         />
         <ContactDetails
           contactId={contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`}
+          enableEditing={Boolean(contactFromInfo)}
           context={DetailsContext.CASE_DETAILS}
         />
       </Container>

--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -11,22 +11,23 @@ import ContactDetails from '../contact/ContactDetails';
 import ActionHeader from './ActionHeader';
 import { CaseState } from '../../states/case/reducer';
 import type { CustomITask, StandaloneITask } from '../../types/types';
-import { loadRawContact, releaseContact } from '../../states/contacts/existingContacts';
+import { loadContact, loadRawContact, releaseContact } from '../../states/contacts/existingContacts';
 import { DetailsContext } from '../../states/contacts/contactDetails';
+import { taskFormToSearchContact } from '../../states/contacts/contactDetailsAdapter';
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const form = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];
   const counselorsHash = state[namespace][configurationBase].counselors.hash;
   const caseState: CaseState = state[namespace][connectedCaseBase];
-  const { temporaryCaseInfo } = caseState.tasks[ownProps.task.taskSid];
+  const { temporaryCaseInfo, connectedCase } = caseState.tasks[ownProps.task.taskSid];
 
-  return { form, counselorsHash, tempInfo: temporaryCaseInfo };
+  return { form, counselorsHash, tempInfo: temporaryCaseInfo, connectedCase };
 };
 
 const mapDispatchToProps = {
-  updateTempInfo: CaseActions.updateTempInfo,
   setConnectedCase: CaseActions.setConnectedCase,
-  loadContactIntoState: loadRawContact,
+  loadRawContactIntoState: loadRawContact,
+  loadContactIntoState: loadContact,
   releaseContactFromState: releaseContact,
 };
 
@@ -38,30 +39,43 @@ type OwnProps = {
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
 const ViewContact: React.FC<Props> = ({
+  form,
   task,
   counselorsHash,
   tempInfo,
   onClickClose,
-  updateTempInfo,
   loadContactIntoState,
+  loadRawContactIntoState,
   releaseContactFromState,
+  connectedCase,
 }) => {
   useEffect(() => {
     if (tempInfo && tempInfo.screen === 'view-contact') {
-      const { contact: contactFromInfo } = tempInfo.info;
+      const { contact: contactFromInfo, timeOfContact, counselor } = tempInfo.info;
       if (contactFromInfo) {
-        loadContactIntoState(contactFromInfo);
+        loadRawContactIntoState(contactFromInfo);
         return () => releaseContactFromState(contactFromInfo.id);
       }
+      const temporaryId = `__unsavedFromCase:${connectedCase.id}`;
+      loadContactIntoState(taskFormToSearchContact(task, form, timeOfContact, counselor, temporaryId));
+      return () => releaseContactFromState(temporaryId);
     }
     return () => {
       /* no cleanup to do. */
     };
-  }, [tempInfo, counselorsHash, loadContactIntoState, releaseContactFromState]);
+  }, [
+    counselorsHash,
+    loadContactIntoState,
+    releaseContactFromState,
+    connectedCase.id,
+    task,
+    form,
+    loadRawContactIntoState,
+  ]);
 
   if (!tempInfo || tempInfo.screen !== 'view-contact') return null;
-  const { contact: contactFromInfo, createdAt } = tempInfo.info;
-  const createdByName = counselorsHash[contactFromInfo.createdBy] || 'Unknown';
+  const { contact: contactFromInfo, createdAt, counselor } = tempInfo.info;
+  const createdByName = counselorsHash[contactFromInfo?.createdBy ?? counselor] || 'Unknown';
 
   const added = new Date(createdAt);
 
@@ -74,7 +88,10 @@ const ViewContact: React.FC<Props> = ({
           addingCounsellor={createdByName}
           added={added}
         />
-        <ContactDetails contactId={contactFromInfo.id} context={DetailsContext.CASE_DETAILS} />
+        <ContactDetails
+          contactId={contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`}
+          context={DetailsContext.CASE_DETAILS}
+        />
       </Container>
       <BottomButtonBar>
         <StyledNextStepButton roundCorners onClick={onClickClose} data-testid="Case-ViewContactScreen-CloseButton">

--- a/plugin-hrm-form/src/components/contact/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetails.tsx
@@ -14,11 +14,13 @@ import { ContactDetailsSectionFormApi, contactDetailsSectionFormApi } from './co
 import ContactDetailsSectionForm from './ContactDetailsSectionForm';
 import IssueCategorizationSectionForm from './IssueCategorizationSectionForm';
 import { forExistingContact } from '../../states/contacts/issueCategorizationStateApi';
+import { getConfig } from '../../HrmFormPlugin';
 
 type OwnProps = {
   contactId: string;
   context: DetailsContext;
   handleOpenConnectDialog?: (event: any) => void;
+  enableEditing?: boolean;
   showActionIcons?: boolean;
 };
 
@@ -34,9 +36,11 @@ const ContactDetails: React.FC<Props> = ({
   updateDefinitionVersion,
   contact,
   navigateForContext,
+  enableEditing = true,
 }) => {
   const version = contact?.details.definitionVersion;
 
+  const { featureFlags } = getConfig();
   /**
    * Check if the definitionVersion for this case exists in redux, and look for it if not.
    */
@@ -120,6 +124,7 @@ const ContactDetails: React.FC<Props> = ({
           showActionIcons={showActionIcons}
           contactId={contactId}
           handleOpenConnectDialog={handleOpenConnectDialog}
+          enableEditing={enableEditing && featureFlags.enable_contact_editing}
         />
       );
   }

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -30,6 +30,7 @@ type OwnProps = {
   context: DetailsContext;
   showActionIcons?: boolean;
   handleOpenConnectDialog?: (event: any) => void;
+  enableEditing: boolean;
 };
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
@@ -44,8 +45,8 @@ const Details: React.FC<Props> = ({
   contact,
   toggleSectionExpandedForContext,
   navigateForContext,
+  enableEditing,
 }) => {
-  const { featureFlags } = getConfig();
   const version = contact?.details.definitionVersion;
 
   const definitionVersion = definitionVersions[version];
@@ -144,7 +145,7 @@ const Details: React.FC<Props> = ({
           sectionTitle={<Template code="TabbedForms-AddCallerInfoTab" />}
           expanded={detailsExpanded[CALLER_INFORMATION]}
           handleExpandClick={() => toggleSection(CALLER_INFORMATION)}
-          showEditButton={featureFlags.enable_contact_editing}
+          showEditButton={enableEditing}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CALLER_INFORMATION)}
           buttonDataTestid="ContactDetails-Section-CallerInformation"
         >
@@ -163,7 +164,7 @@ const Details: React.FC<Props> = ({
           sectionTitle={<Template code="TabbedForms-AddChildInfoTab" />}
           expanded={detailsExpanded[CHILD_INFORMATION]}
           handleExpandClick={() => toggleSection(CHILD_INFORMATION)}
-          showEditButton={featureFlags.enable_contact_editing}
+          showEditButton={enableEditing}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CHILD_INFORMATION)}
           buttonDataTestid="ContactDetails-Section-ChildInformation"
         >
@@ -183,7 +184,7 @@ const Details: React.FC<Props> = ({
           expanded={detailsExpanded[ISSUE_CATEGORIZATION]}
           handleExpandClick={() => toggleSection(ISSUE_CATEGORIZATION)}
           buttonDataTestid="ContactDetails-Section-IssueCategorization"
-          showEditButton={featureFlags.enable_contact_editing}
+          showEditButton={enableEditing}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CATEGORIES)}
         >
           {formattedCategories.length ? (
@@ -209,7 +210,7 @@ const Details: React.FC<Props> = ({
           expanded={detailsExpanded[CONTACT_SUMMARY]}
           handleExpandClick={() => toggleSection(CONTACT_SUMMARY)}
           buttonDataTestid={`ContactDetails-Section-${CONTACT_SUMMARY}`}
-          showEditButton={featureFlags.enable_contact_editing}
+          showEditButton={enableEditing}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CASE_INFORMATION)}
         >
           {definitionVersion.tabbedForms.CaseInformationTab.map(e => (

--- a/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
@@ -4,6 +4,9 @@
  */
 
 import { SearchContact } from '../../types/types';
+import { getNumberFromTask } from '../../utils';
+import { transformForm } from '../../services/ContactService';
+import { getConversationDuration } from '../../utils/conversationDuration';
 
 /**
  * @param {string[]} accumulator
@@ -60,6 +63,37 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
       createdBy,
     },
     details: contact.rawJson,
+    csamReports,
+  };
+};
+
+export const taskFormToSearchContact = (task, form, date, counselor, temporaryId): SearchContact => {
+  const details = transformForm(form);
+  const dateTime = date;
+  const name = `${details.childInformation.name.firstName} ${details.childInformation.name.lastName}`;
+  const customerNumber = getNumberFromTask(task);
+  const { callType, caseInformation } = details;
+  const categories = retrieveCategories(caseInformation.categories);
+  const notes = caseInformation.callSummary as string;
+  const { channelType } = task;
+  const conversationDuration = getConversationDuration(task, form.metadata);
+  const { csamReports } = form;
+
+  return {
+    contactId: temporaryId,
+    overview: {
+      createdBy: counselor,
+      dateTime,
+      name,
+      customerNumber,
+      callType,
+      categories,
+      counselor,
+      notes,
+      channel: channelType,
+      conversationDuration,
+    },
+    details,
     csamReports,
   };
 };

--- a/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
@@ -77,11 +77,12 @@ export const taskFormToSearchContact = (task, form, date, counselor, temporaryId
   const notes = caseInformation.callSummary as string;
   const { channelType } = task;
   const conversationDuration = getConversationDuration(task, form.metadata);
-  const { csamReports } = form;
+  const { csamReports, helpline } = form;
 
   return {
     contactId: temporaryId,
     overview: {
+      helpline,
       createdBy: counselor,
       dateTime,
       name,


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description

* Cherry picks #755 over to master
* Disables contact editing when viewing an unsaved contact from a case

### Checklist
- [X] Corresponding issue has been opened
- [X] Tested for chat contacts

### Related Issues
Fixes CHI-1206

### Verification steps

See #755.
Also check that editing is not permitted viewing an unsaved contact from a new case, but is still enabled everywhere else
