### PR TITLE
Fixed case updated time not showing when in same day as created at

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/case/Case.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/Case.test.tsx
@@ -15,6 +15,7 @@ import CaseHome from '../../../components/case/CaseHome';
 import { namespace, configurationBase, contactFormsBase, connectedCaseBase, routingBase } from '../../../states';
 import { getDefinitionVersions } from '../../../HrmFormPlugin';
 import { StandaloneITask } from '../../../types/types';
+import { getLocaleDateTime } from '../../../utils/helpers';
 
 jest.mock('../../../services/CaseService', () => ({ getActivities: jest.fn(() => []), cancelCase: jest.fn() }));
 jest.mock('../../../permissions', () => ({
@@ -155,7 +156,7 @@ describe('useState mocked', () => {
 
     expect(component.findAllByType(CaseHome).length).toBe(1);
     const details = component.findByType(CaseHome);
-    const { id, name, caseCounselor, status, openedDate, lastUpdatedDate, followUpDate } = details.props.caseDetails;
+    const { id, name, caseCounselor, status, createdAt, updatedAt, followUpDate } = details.props.caseDetails;
 
     expect(id).toBe(123);
     expect(name).toStrictEqual({
@@ -164,8 +165,8 @@ describe('useState mocked', () => {
     });
     expect(caseCounselor).toBe('worker1 name');
     expect(status).toBe('open');
-    expect(openedDate).toBe('6/29/2020'); // the day the createdAt number represents
-    expect(lastUpdatedDate).toBe('Invalid Date');
+    expect(getLocaleDateTime(createdAt)).toBe('6/29/2020'); // the day the createdAt number represents
+    expect(getLocaleDateTime(updatedAt)).toBe('Invalid Date');
     expect(followUpDate).toBe('');
   });
 

--- a/plugin-hrm-form/src/___tests__/components/case/Case.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/Case.test.tsx
@@ -2,20 +2,18 @@
 // @ts-ignore
 import React from 'react';
 import { Provider } from 'react-redux';
-import renderer from 'react-test-renderer';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import configureMockStore from 'redux-mock-store';
 import { configureAxe, toHaveNoViolations } from 'jest-axe';
-import { mount } from 'enzyme';
 import { StorelessThemeProvider } from '@twilio/flex-ui';
 import { DefinitionVersionId, loadDefinition } from 'hrm-form-definitions';
 
 import { mockGetDefinitionsResponse } from '../../mockGetConfig';
 import Case from '../../../components/case';
-import CaseHome from '../../../components/case/CaseHome';
 import { namespace, configurationBase, contactFormsBase, connectedCaseBase, routingBase } from '../../../states';
 import { getDefinitionVersions } from '../../../HrmFormPlugin';
 import { StandaloneITask } from '../../../types/types';
-import { getLocaleDateTime } from '../../../utils/helpers';
 
 jest.mock('../../../services/CaseService', () => ({ getActivities: jest.fn(() => []), cancelCase: jest.fn() }));
 jest.mock('../../../permissions', () => ({
@@ -77,6 +75,7 @@ describe('useState mocked', () => {
             connectedCase: {
               id: 123,
               createdAt: '2020-06-29T22:26:00.208Z',
+              updatedAt: '2020-06-29T22:26:00.208Z',
               twilioWorkerId: 'worker1',
               status: 'open',
               info: { definitionVersion: 'v1' },
@@ -94,11 +93,6 @@ describe('useState mocked', () => {
       task: initialState[namespace][connectedCaseBase].tasks.task1 as StandaloneITask,
     };
   });
-
-  const setState = jest.fn();
-  const useStateMock = initState => [initState, setState];
-
-  jest.spyOn(React, 'useState').mockImplementation(useStateMock);
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -131,49 +125,69 @@ describe('useState mocked', () => {
     });
     const store = mockStore(initialState);
 
-    const component = renderer.create(
+    render(
       <StorelessThemeProvider themeConf={{}}>
         <Provider store={store}>
           <Case {...ownProps} />
         </Provider>
       </StorelessThemeProvider>,
-    ).root;
+    );
 
-    const details = component.findAllByType(CaseHome);
-    expect(details.length).toBe(0);
+    expect(screen.queryByTestId('CaseHome-CaseDetailsComponent')).not.toBeInTheDocument();
   });
 
-  test('Case (should render)', async () => {
+  test('Case (should render, no updated)', async () => {
     const store = mockStore(initialState);
 
-    const component = renderer.create(
+    render(
       <StorelessThemeProvider themeConf={{}}>
         <Provider store={store}>
           <Case {...ownProps} />
         </Provider>
       </StorelessThemeProvider>,
-    ).root;
+    );
 
-    expect(component.findAllByType(CaseHome).length).toBe(1);
-    const details = component.findByType(CaseHome);
-    const { id, name, caseCounselor, status, createdAt, updatedAt, followUpDate } = details.props.caseDetails;
+    expect(screen.getByTestId('CaseHome-CaseDetailsComponent')).toBeInTheDocument();
 
-    expect(id).toBe(123);
-    expect(name).toStrictEqual({
-      firstName: 'first',
-      lastName: 'last',
-    });
-    expect(caseCounselor).toBe('worker1 name');
-    expect(status).toBe('open');
-    expect(getLocaleDateTime(createdAt)).toBe('6/29/2020'); // the day the createdAt number represents
-    expect(getLocaleDateTime(updatedAt)).toBe('Invalid Date');
-    expect(followUpDate).toBe('');
+    expect(screen.getByTestId('Case-DetailsHeaderCaseId').innerHTML).toContain('123');
+    expect(screen.getByTestId('Case-DetailsHeaderChildName').innerHTML).toContain('first last');
+    expect(screen.getByTestId('Case-DetailsHeaderCounselor').innerHTML).toContain('worker1 name');
+    expect(
+      within(screen.getByTestId('Case-Details_CaseStatus')).getByRole('option', { name: 'Open' }).selected,
+    ).toBeTruthy();
+    expect(screen.getByTestId('Case-Details_DateOpened').value).toBe('6/29/2020');
+    expect(screen.getByTestId('Case-Details_DateLastUpdated').value).toBe('—');
+  });
+
+  test('Case (should render, after update)', async () => {
+    const initial = initialState;
+    initial[namespace][connectedCaseBase].tasks.task1.connectedCase.updatedAt = '2020-06-29T22:29:00.208Z';
+    const store = mockStore(initial);
+
+    render(
+      <StorelessThemeProvider themeConf={{}}>
+        <Provider store={store}>
+          <Case {...ownProps} />
+        </Provider>
+      </StorelessThemeProvider>,
+    );
+
+    expect(screen.getByTestId('CaseHome-CaseDetailsComponent')).toBeInTheDocument();
+
+    expect(screen.getByTestId('Case-DetailsHeaderCaseId').innerHTML).toContain('123');
+    expect(screen.getByTestId('Case-DetailsHeaderChildName').innerHTML).toContain('first last');
+    expect(screen.getByTestId('Case-DetailsHeaderCounselor').innerHTML).toContain('worker1 name');
+    expect(
+      within(screen.getByTestId('Case-Details_CaseStatus')).getByRole('option', { name: 'Open' }).selected,
+    ).toBeTruthy();
+    expect(screen.getByTestId('Case-Details_DateOpened').value).toBe('6/29/2020');
+    expect(screen.getByTestId('Case-Details_DateLastUpdated').value).toBe('6/29/2020');
   });
 
   test('a11y', async () => {
     const store = mockStore(initialState);
 
-    const wrapper = mount(
+    const { container } = render(
       <StorelessThemeProvider themeConf={{}}>
         <Provider store={store}>
           <Case {...ownProps} />
@@ -186,7 +200,7 @@ describe('useState mocked', () => {
     };
 
     const axe = configureAxe({ rules });
-    const results = await axe(wrapper.getDOMNode());
+    const results = await axe(container);
 
     (expect(results) as any).toHaveNoViolations();
   });

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -189,8 +189,6 @@ const Case: React.FC<Props> = ({
   const { workerSid } = getConfig();
   const caseCounselor = counselorsHash[twilioWorkerId];
   const currentCounselor = counselorsHash[workerSid];
-  const openedDate = getLocaleDateTime(createdAt);
-  const lastUpdatedDate = getLocaleDateTime(updatedAt);
   // -- Date cannot be converted here since the date dropdown uses the yyyy-MM-dd format.
   const followUpDate = info && info.followUpDate ? info.followUpDate : '';
   // -- Converting followUpDate to match the same format as the rest of the dates
@@ -272,8 +270,8 @@ const Case: React.FC<Props> = ({
     prevStatus,
     caseCounselor,
     currentCounselor,
-    openedDate,
-    lastUpdatedDate,
+    createdAt,
+    updatedAt,
     followUpDate,
     followUpPrintedDate,
     households,

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -102,7 +102,6 @@ const Case: React.FC<Props> = ({
      */
     const getTimeline = () => {
       if (!props.connectedCaseId) return;
-
       setLoading(true);
       const activities = getActivitiesFromCase(props.connectedCaseState.connectedCase);
       setLoading(false);
@@ -466,6 +465,7 @@ const Case: React.FC<Props> = ({
       // Fall through to next switch for other routes without actions
     }
   }
+
   switch (routing.subroute) {
     case NewCaseSubroutes.ViewContact:
       return <ViewContact onClickClose={handleCloseSubSection} task={task} />;

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -19,14 +19,15 @@ import {
 } from '../../styles/case';
 import { FormOption } from '../../styles/HrmStyles';
 import { PermissionActions } from '../../permissions';
+import { getLocaleDateTime } from '../../utils/helpers';
 
 const CaseDetails = ({
   caseId,
   name,
   categories,
   counselor,
-  openedDate,
-  lastUpdatedDate,
+  createdAt,
+  updatedAt,
   followUpDate,
   status,
   prevStatus,
@@ -78,7 +79,8 @@ const CaseDetails = ({
   const canTransition = statusOptions.length !== 1;
 
   const color = definitionVersion.caseStatus[status].color || '#000000';
-  const lastUpdatedClosedDate = openedDate === lastUpdatedDate ? '—' : lastUpdatedDate;
+  const formattedCreatedAt = getLocaleDateTime(createdAt);
+  const formattedUpdatedAt = createdAt === updatedAt ? '—' : getLocaleDateTime(updatedAt);
 
   return (
     <>
@@ -104,7 +106,7 @@ const CaseDetails = ({
             <StyledInputField
               disabled
               id="Details_DateOpened"
-              value={openedDate}
+              value={formattedCreatedAt}
               aria-labelledby="CaseDetailsDateOpened"
             />
           </div>
@@ -117,7 +119,7 @@ const CaseDetails = ({
             <StyledInputField
               disabled
               id="Details_DateLastUpdated"
-              value={lastUpdatedClosedDate}
+              value={formattedUpdatedAt}
               aria-labelledby="CaseDetailsLastUpdated"
             />
           </div>
@@ -172,13 +174,13 @@ CaseDetails.propTypes = {
   name: PropTypes.string.isRequired,
   categories: PropTypes.object.isRequired,
   counselor: PropTypes.string.isRequired,
-  openedDate: PropTypes.string.isRequired,
+  createdAt: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
   prevStatus: PropTypes.string.isRequired,
   can: PropTypes.func.isRequired,
   office: PropTypes.string,
   followUpDate: PropTypes.string,
-  lastUpdatedDate: PropTypes.string,
+  updatedAt: PropTypes.string,
   childIsAtRisk: PropTypes.bool.isRequired,
   handlePrintCase: PropTypes.func.isRequired,
   handleInfoChange: PropTypes.func.isRequired,
@@ -192,7 +194,7 @@ CaseDetails.propTypes = {
 CaseDetails.defaultProps = {
   office: '',
   followUpDate: '',
-  lastUpdatedDate: '',
+  updatedAt: '',
   isOrphanedCase: false,
 };
 

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -104,6 +104,7 @@ const CaseDetails = ({
               </label>
             </DetailDescription>
             <StyledInputField
+              data-testid="Case-Details_DateOpened"
               disabled
               id="Details_DateOpened"
               value={formattedCreatedAt}
@@ -117,6 +118,7 @@ const CaseDetails = ({
               </label>
             </DetailDescription>
             <StyledInputField
+              data-testid="Case-Details_DateLastUpdated"
               disabled
               id="Details_DateLastUpdated"
               value={formattedUpdatedAt}
@@ -147,6 +149,7 @@ const CaseDetails = ({
             </DetailDescription>
             <StyledSelectWrapper disabled={!canTransition}>
               <StyledSelectField
+                data-testid="Case-Details_CaseStatus"
                 id="Details_CaseStatus"
                 name="Details_CaseStatus"
                 aria-labelledby="CaseDetailsStatusLabel"

--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -252,7 +252,7 @@ const CaseHome: React.FC<Props> = ({
 
   return (
     <>
-      <CaseContainer>
+      <CaseContainer data-testid="CaseHome-CaseDetailsComponent">
         <Box marginLeft="25px" marginTop="13px">
           <CaseDetailsComponent
             caseId={id}

--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -153,8 +153,8 @@ const CaseHome: React.FC<Props> = ({
     name,
     categories,
     contact,
-    openedDate,
-    lastUpdatedDate,
+    createdAt,
+    updatedAt,
     childIsAtRisk,
     caseCounselor,
     status,
@@ -262,8 +262,8 @@ const CaseHome: React.FC<Props> = ({
             can={can}
             counselor={caseCounselor}
             categories={categories}
-            openedDate={openedDate}
-            lastUpdatedDate={lastUpdatedDate}
+            createdAt={createdAt}
+            updatedAt={updatedAt}
             followUpDate={followUpDate}
             childIsAtRisk={childIsAtRisk}
             office={office?.label}

--- a/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
+++ b/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
@@ -50,15 +50,17 @@ const CaseDetailsHeader: React.FC<OwnProps> = ({
   return (
     <DetailsHeaderContainer>
       <DetailsHeaderTextContainer>
-        <DetailsHeaderChildName variant="h6">{childName}</DetailsHeaderChildName>
+        <DetailsHeaderChildName variant="h6" data-testid="Case-DetailsHeaderChildName">
+          {childName}
+        </DetailsHeaderChildName>
         <DetailsHeaderCaseContainer>
-          <DetailsHeaderCaseId id="Case-CaseId-label">
+          <DetailsHeaderCaseId id="Case-CaseId-label" data-testid="Case-DetailsHeaderCaseId">
             <Template code="Case-CaseNumber" />
             {caseId}
           </DetailsHeaderCaseId>
           {multipleOfficeSupport && office && <DetailsHeaderOfficeName>({office})</DetailsHeaderOfficeName>}
         </DetailsHeaderCaseContainer>
-        <DetailsHeaderCounselor>
+        <DetailsHeaderCounselor data-testid="Case-DetailsHeaderCounselor">
           <Template code="Case-Counsellor" />: {counselor}
         </DetailsHeaderCounselor>
       </DetailsHeaderTextContainer>

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
@@ -20,7 +20,7 @@ import CasePrintHeader from './CasePrintHeader';
 import CasePrintFooter from './CasePrintFooter';
 // import CasePrintContact from './CasePrintContact'; // Removed by ZA request, could be useful for other helplines.
 import { getImageAsString, ImageSource } from './helpers';
-import { ContactRawJson } from '../../../types/types';
+import { getLocaleDateTime } from '../../../utils/helpers';
 
 type OwnProps = {
   onClickClose: () => void;
@@ -106,8 +106,8 @@ const CasePrintView: React.FC<Props> = ({ onClickClose, caseDetails, definitionV
               <View>
                 <CasePrintDetails
                   status={caseDetails.status}
-                  openedDate={caseDetails.openedDate}
-                  lastUpdatedDate={caseDetails.lastUpdatedDate}
+                  openedDate={getLocaleDateTime(caseDetails.createdAt)}
+                  lastUpdatedDate={getLocaleDateTime(caseDetails.updatedAt)}
                   followUpDate={caseDetails.followUpPrintedDate}
                   childIsAtRisk={caseDetails.childIsAtRisk}
                   counselor={caseDetails.caseCounselor}

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -155,8 +155,8 @@ export type CaseDetails = {
   prevStatus: string;
   caseCounselor: string;
   currentCounselor: string;
-  openedDate: string;
-  lastUpdatedDate: string;
+  createdAt: string;
+  updatedAt: string;
   followUpDate: string;
   followUpPrintedDate: string;
   households: t.HouseholdEntry[];


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
This PR fixes a UI bug on Case screen, where "updated" date won't show if it was the same day as "opened".
![Screenshot from 2022-05-20 14-42-38](https://user-images.githubusercontent.com/15805319/169583340-65cbf861-3fb7-4bc1-b138-011d0f933adc.png)

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1201)
- [x] New tests added
- [N/A] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Verification steps
- Create a new case.
- Update the case.
- Check that "Last Updated / Closed" is shown the current date (even if it's the same as "Opened").