### PR TITLE
Edit Contact permissions

### DIFF
--- a/plugin-hrm-form/src/___tests__/permissions/index.test.js
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.js
@@ -137,14 +137,10 @@ describe('Test different scenarios (random action) for Cases', () => {
 });
 
 describe('Test different scenarios (random action) for Contacts', () => {
-  const PermissionActionsValues = Object.values(PermissionActions);
-  const getRandomAction = () =>
-    PermissionActionsValues[Math.floor(Math.random() * 100) % PermissionActionsValues.length];
-
   each(
     [
       {
-        action: getRandomAction(),
+        action: 'editContact',
         conditionsSets: [['everyone']],
         workerSid: 'not owner',
         isSupervisor: false,
@@ -152,7 +148,7 @@ describe('Test different scenarios (random action) for Contacts', () => {
         expectedDescription: 'is not owner nor supervisor',
       },
       {
-        action: getRandomAction(),
+        action: 'editContact',
         conditionsSets: [],
         workerSid: 'owner',
         isSupervisor: true,
@@ -160,7 +156,7 @@ describe('Test different scenarios (random action) for Contacts', () => {
         expectedDescription: 'user is owner and supervisor',
       },
       {
-        action: getRandomAction(),
+        action: 'editContact',
         conditionsSets: [['isOwner']],
         workerSid: 'owner',
         isSupervisor: false,
@@ -168,7 +164,7 @@ describe('Test different scenarios (random action) for Contacts', () => {
         expectedDescription: 'is a owner but not a supervisor',
       },
       {
-        action: getRandomAction(),
+        action: 'editContact',
         conditionsSets: [['isSupervisor']],
         workerSid: 'not owner',
         isSupervisor: true,
@@ -176,7 +172,7 @@ describe('Test different scenarios (random action) for Contacts', () => {
         expectedDescription: 'is a supervisor but not a owner',
       },
       {
-        action: getRandomAction(),
+        action: 'editContact',
         conditionsSets: [['isOwner']],
         workerSid: 'not owner',
         isSupervisor: true,
@@ -184,7 +180,7 @@ describe('Test different scenarios (random action) for Contacts', () => {
         expectedDescription: 'is not a owner but a supervisorr',
       },
       {
-        action: getRandomAction(),
+        action: 'editContact',
         conditionsSets: [['isSupervisor']],
         workerSid: 'owner',
         isSupervisor: false,
@@ -192,7 +188,7 @@ describe('Test different scenarios (random action) for Contacts', () => {
         expectedDescription: 'is a supervisor but not a owner',
       },
       {
-        action: getRandomAction(),
+        action: 'editContact',
         conditionsSets: [['isSupervisor'], ['isOwner']],
         workerSid: 'not owner',
         isSupervisor: true,
@@ -200,7 +196,7 @@ describe('Test different scenarios (random action) for Contacts', () => {
         expectedDescription: 'user is supervisor but not owner',
       },
       {
-        action: getRandomAction(),
+        action: 'editContact',
         conditionsSets: [['isSupervisor'], ['isOwner']],
         workerSid: 'not owner',
         isSupervisor: false,

--- a/plugin-hrm-form/src/___tests__/permissions/index.test.js
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.js
@@ -136,7 +136,7 @@ describe('Test different scenarios (random action) for Cases', () => {
   );
 });
 
-describe('Test different scenarios (random action) for Contacts', () => {
+describe('Test different scenarios for Contacts', () => {
   each(
     [
       {

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -23,6 +23,7 @@ import {
   navigateContactDetails,
   toggleDetailSectionExpanded,
 } from '../../states/contacts/contactDetails';
+import { getPermissionsForContact, PermissionActions } from '../../permissions';
 
 // TODO: complete this type
 type OwnProps = {
@@ -35,6 +36,7 @@ type OwnProps = {
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
+/* eslint-disable complexity */
 const Details: React.FC<Props> = ({
   context,
   detailsExpanded,
@@ -46,6 +48,7 @@ const Details: React.FC<Props> = ({
   toggleSectionExpandedForContext,
   navigateForContext,
   enableEditing,
+  // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const version = contact?.details.definitionVersion;
 
@@ -66,6 +69,10 @@ const Details: React.FC<Props> = ({
     categories,
     createdBy,
   } = overview;
+
+  // Permission to edit is based the counselor who created the contact - identified by Twilio worker ID
+  const createdByTwilioWorkerId = contact?.overview.createdBy;
+  const { can } = getPermissionsForContact(createdByTwilioWorkerId);
 
   // Format the obtained information
   const isDataCall = !isNonDataCallType(callType);
@@ -145,7 +152,7 @@ const Details: React.FC<Props> = ({
           sectionTitle={<Template code="TabbedForms-AddCallerInfoTab" />}
           expanded={detailsExpanded[CALLER_INFORMATION]}
           handleExpandClick={() => toggleSection(CALLER_INFORMATION)}
-          showEditButton={enableEditing}
+          showEditButton={enableEditing && can(PermissionActions.EDIT_CONTACT)}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CALLER_INFORMATION)}
           buttonDataTestid="ContactDetails-Section-CallerInformation"
         >
@@ -164,7 +171,7 @@ const Details: React.FC<Props> = ({
           sectionTitle={<Template code="TabbedForms-AddChildInfoTab" />}
           expanded={detailsExpanded[CHILD_INFORMATION]}
           handleExpandClick={() => toggleSection(CHILD_INFORMATION)}
-          showEditButton={enableEditing}
+          showEditButton={enableEditing && can(PermissionActions.EDIT_CONTACT)}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CHILD_INFORMATION)}
           buttonDataTestid="ContactDetails-Section-ChildInformation"
         >
@@ -184,7 +191,7 @@ const Details: React.FC<Props> = ({
           expanded={detailsExpanded[ISSUE_CATEGORIZATION]}
           handleExpandClick={() => toggleSection(ISSUE_CATEGORIZATION)}
           buttonDataTestid="ContactDetails-Section-IssueCategorization"
-          showEditButton={enableEditing}
+          showEditButton={enableEditing && can(PermissionActions.EDIT_CONTACT)}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CATEGORIES)}
         >
           {formattedCategories.length ? (
@@ -210,7 +217,7 @@ const Details: React.FC<Props> = ({
           expanded={detailsExpanded[CONTACT_SUMMARY]}
           handleExpandClick={() => toggleSection(CONTACT_SUMMARY)}
           buttonDataTestid={`ContactDetails-Section-${CONTACT_SUMMARY}`}
-          showEditButton={enableEditing}
+          showEditButton={enableEditing && can(PermissionActions.EDIT_CONTACT)}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CASE_INFORMATION)}
         >
           {definitionVersion.tabbedForms.CaseInformationTab.map(e => (

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -71,7 +71,7 @@ const Details: React.FC<Props> = ({
   } = overview;
 
   // Permission to edit is based the counselor who created the contact - identified by Twilio worker ID
-  const createdByTwilioWorkerId = contact?.overview.createdBy;
+  const createdByTwilioWorkerId = contact?.overview.counselor;
   const { can } = getPermissionsForContact(createdByTwilioWorkerId);
 
   // Format the obtained information

--- a/plugin-hrm-form/src/permissions/br.json
+++ b/plugin-hrm-form/src/permissions/br.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/ca.json
+++ b/plugin-hrm-form/src/permissions/ca.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/demo.json
+++ b/plugin-hrm-form/src/permissions/demo.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/et.json
+++ b/plugin-hrm-form/src/permissions/et.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/in.json
+++ b/plugin-hrm-form/src/permissions/in.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"],["isOwner"]]
 }

--- a/plugin-hrm-form/src/permissions/in.json
+++ b/plugin-hrm-form/src/permissions/in.json
@@ -17,5 +17,5 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"],["isOwner"]]
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -68,7 +68,7 @@ export const getPermissionsForCase = (twilioWorkerId: t.Case['twilioWorkerId'], 
   };
 };
 
-export const getPermissionsForContact = (twilioWorkerId: t.SearchContact['overview']['createdBy']) => {
+export const getPermissionsForContact = (twilioWorkerId: t.SearchContact['overview']['counselor']) => {
   const { workerSid, isSupervisor, permissionConfig } = getConfig();
 
   if (!permissionConfig || !twilioWorkerId) return { can: undefined };

--- a/plugin-hrm-form/src/permissions/jm.json
+++ b/plugin-hrm-form/src/permissions/jm.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/mw.json
+++ b/plugin-hrm-form/src/permissions/mw.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/uk.json
+++ b/plugin-hrm-form/src/permissions/uk.json
@@ -18,5 +18,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/za.json
+++ b/plugin-hrm-form/src/permissions/za.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/zm.json
+++ b/plugin-hrm-form/src/permissions/zm.json
@@ -16,5 +16,6 @@
   "editDocument": [["isSupervisor"]],
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "editContact": [["isSupervisor"], ["isOwner"]]
 }

--- a/plugin-hrm-form/src/permissions/zm.json
+++ b/plugin-hrm-form/src/permissions/zm.json
@@ -17,5 +17,5 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"], ["isOwner"]]
+  "editContact": [["isSupervisor"]]
 }


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
- Added a new edit contact permission action
- Added permission logic that will allow the user to edit contact based on two roles (isSupervisor and isOwner)
- Added the action for all helplines where only Supervisors can edit, except for IN and ZM, where owners can edit contact as well(as per @dee-luo's request)
- Added tests for testing permission logic for contacts

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes [#1094](https://bugs.benetech.org/browse/CHI-1094)

### Verification steps
- In all helplines, only supervisor should be able to see the Edit button and edit. 