### PR TITLE
Dependabot config to disable automatic PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/scripts/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     open-pull-requests-limit: 0
     allow:
       - dependency-name: "*"
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/plugin-hrm-form/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     open-pull-requests-limit: 0
     allow:
       - dependency-name: "*"
@@ -27,7 +27,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/hrm-form-definitions/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     open-pull-requests-limit: 0
     allow:
       - dependency-name: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/scripts/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-name: "*"
+        dependency-type: "production"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+        
+  - package-ecosystem: "npm"
+    directory: "/plugin-hrm-form/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-name: "*"
+        dependency-type: "production"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+        
+  - package-ecosystem: "npm"
+    directory: "/hrm-form-definitions/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-name: "*"
+        dependency-type: "production"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Primary reviewer: @nickhurlburt 

## Description
Example dependabot config that:
* limits to checking only 3 package directories
* reduces frequency to monthly checks
* ignores patch upgrades
* sets open PR limit to 0 essentially preventing PRs from getting opened until this is manually changed 