### PR TITLE
UI modification when No cases are available in Case List page

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/caseList/CaseList.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/caseList/CaseList.test.tsx
@@ -112,8 +112,8 @@ test('Should dispatch fetchStarted and fetchSuccess actions if case lists return
   expect(screen.getByTestId('CaseList-Table')).toBeInTheDocument();
 
   expect(screen.getAllByTestId('CaseList-TableHead')).toHaveLength(1);
+  expect(screen.queryByTestId('CaseList-TableFooter')).not.toBeInTheDocument();
 
-  expect(screen.getAllByTestId('CaseList-TableFooter')).toHaveLength(1);
   expect(store.getActions().length).toBe(2);
 
   expect(store.getActions()[0]).toStrictEqual(fetchCaseListStarted());
@@ -168,6 +168,51 @@ test('Should render list if it is populated', async () => {
   expect(row1.textContent).toContain('Michael Smith');
   expect(row2.textContent).toContain('Sonya Michels');
 });
+
+test('Should render no cases and show No Cases Found row', async () => {
+  // @ts-ignore
+  listCases.mockReturnValueOnce(Promise.resolve({ cases: [], count: 0}));
+
+  const initialState = createState({
+    [configurationBase]: {
+      counselors: {
+        list: [],
+        hash: { worker1: 'worker1 name' },
+      },
+      definitionVersions: { v1: mockV1 },
+      currentDefinitionVersion: mockV1,
+    },
+    [caseListBase]: {
+      ...blankCaseListState,
+      content: {
+        ...blankCaseListState.content,
+        caseList: [],
+        caseCount: 0,
+        listLoading: false,
+      },
+    },
+  });
+  const store = mockStore(initialState);
+
+  render(
+    <StorelessThemeProvider themeConf={themeConf}>
+      <Provider store={store}>
+        <CaseList />
+      </Provider>
+    </StorelessThemeProvider>,
+  );
+
+  await waitFor(() => screen.getByTestId('CaseList-Table'));
+
+  expect(screen.getByTestId('CaseList-Table')).toBeInTheDocument();
+
+  expect(screen.getAllByTestId('CaseList-TableHead')).toHaveLength(1);
+
+  expect(screen.queryByTestId('CaseList-TableFooter')).not.toBeInTheDocument();
+
+  expect(screen.queryByTestId('CaseList-TableRow')).not.toBeInTheDocument();
+});
+
 
 test('Should dispatch fetchStarted and fetchError actions if case lists error', async () => {
   // @ts-ignore

--- a/plugin-hrm-form/src/___tests__/components/caseList/CaseList.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/caseList/CaseList.test.tsx
@@ -171,7 +171,7 @@ test('Should render list if it is populated', async () => {
 
 test('Should render no cases and show No Cases Found row', async () => {
   // @ts-ignore
-  listCases.mockReturnValueOnce(Promise.resolve({ cases: [], count: 0}));
+  listCases.mockReturnValueOnce(Promise.resolve({ cases: [], count: 0 }));
 
   const initialState = createState({
     [configurationBase]: {
@@ -212,7 +212,6 @@ test('Should render no cases and show No Cases Found row', async () => {
 
   expect(screen.queryByTestId('CaseList-TableRow')).not.toBeInTheDocument();
 });
-
 
 test('Should dispatch fetchStarted and fetchError actions if case lists error', async () => {
   // @ts-ignore

--- a/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
@@ -1,23 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { TableBody, TableRow, CircularProgress } from '@material-ui/core';
+import { TableBody, CircularProgress } from '@material-ui/core';
 import { connect, ConnectedProps } from 'react-redux';
-import { Absolute, FontOpenSans, Flex } from '../../styles/HrmStyles';
+import { Template } from '@twilio/flex-ui';
 
-import {
-  namespace,
-  configurationBase,
-  RootState,
-  caseListBase,
-} from '../../states';
-import {
-  TableContainer,
-  CLTable,
-  CLTableRow,
-  CLNamesCell,
-  CLTableCell,
-  CLTableBodyFont,
-} from '../../styles/caseList';
+import { namespace, configurationBase, RootState, caseListBase } from '../../states';
+import { TableContainer, CLTable, CLTableRow, CLNamesCell, CLTableCell, CLTableBodyFont } from '../../styles/caseList';
 import Filters from './filters/Filters';
 import CaseListTableHead from './CaseListTableHead';
 import CaseListTableRow from './CaseListTableRow';
@@ -25,7 +13,6 @@ import Pagination from '../Pagination';
 import { CASES_PER_PAGE } from './CaseList';
 import type { Case } from '../../types/types';
 import * as CaseListSettingsActions from '../../states/caseList/settings';
-import { Template } from '@twilio/flex-ui';
 
 const ROW_HEIGHT = 89;
 
@@ -56,16 +43,9 @@ const CaseListTable: React.FC<Props> = ({
 
   return (
     <>
-      <Filters
-        caseCount={caseCount}
-        currentDefinitionVersion={currentDefinitionVersion}
-      />
+      <Filters caseCount={caseCount} currentDefinitionVersion={currentDefinitionVersion} />
       <TableContainer>
-        <CLTable
-          tabIndex={0}
-          aria-labelledby="CaseList-Cases-label"
-          data-testid="CaseList-Table"
-        >
+        <CLTable tabIndex={0} aria-labelledby="CaseList-Cases-label" data-testid="CaseList-Table">
           <CaseListTableHead />
           {loading && (
             <TableBody>
@@ -74,19 +54,10 @@ const CaseListTable: React.FC<Props> = ({
                 style={{
                   position: 'relative',
                   background: 'transparent',
-                  height: `${
-                    (caseList.length || CASES_PER_PAGE) * ROW_HEIGHT
-                  }px`,
+                  height: `${(caseList.length || CASES_PER_PAGE) * ROW_HEIGHT}px`,
                 }}
               >
-                <CLNamesCell
-                  style={{
-                    position: 'absolute',
-                    textAlign: 'center',
-                    width: '100%',
-                    top: '40%',
-                  }}
-                >
+                <CLNamesCell style={{ position: 'absolute', textAlign: 'center', width: '100%', top: '40%' }}>
                   <CircularProgress size={50} />
                 </CLNamesCell>
               </CLTableRow>
@@ -106,9 +77,7 @@ const CaseListTable: React.FC<Props> = ({
               ) : (
                 <CLTableRow>
                   <CLTableCell colSpan={8}>
-                    <CLTableBodyFont
-                      style={{ paddingLeft: '6px', fontWeight: 'initial' }}
-                    >
+                    <CLTableBodyFont style={{ paddingLeft: '6px', fontWeight: 'initial' }}>
                       <Template code="CaseList-NoCases" />
                     </CLTableBodyFont>
                   </CLTableCell>
@@ -119,11 +88,7 @@ const CaseListTable: React.FC<Props> = ({
         </CLTable>
       </TableContainer>
       {caseList.length > 0 ? (
-        <Pagination
-          page={currentPage}
-          pagesCount={pagesCount}
-          handleChangePage={updateCaseListPage}
-        />
+        <Pagination page={currentPage} pagesCount={pagesCount} handleChangePage={updateCaseListPage} />
       ) : null}
     </>
   );
@@ -133,8 +98,7 @@ CaseListTable.displayName = 'CaseListTable';
 
 const mapStateToProps = state => ({
   counselorsHash: state[namespace][configurationBase].counselors.hash,
-  currentDefinitionVersion:
-    state[namespace][configurationBase].currentDefinitionVersion,
+  currentDefinitionVersion: state[namespace][configurationBase].currentDefinitionVersion,
   currentPage: state[namespace][caseListBase].currentSettings.page,
 });
 

--- a/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
@@ -1,10 +1,23 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { TableBody, CircularProgress } from '@material-ui/core';
+import { TableBody, TableRow, CircularProgress } from '@material-ui/core';
 import { connect, ConnectedProps } from 'react-redux';
+import { Absolute, FontOpenSans, Flex } from '../../styles/HrmStyles';
 
-import { namespace, configurationBase, RootState, caseListBase } from '../../states';
-import { TableContainer, CLTable, CLTableRow, CLNamesCell } from '../../styles/caseList';
+import {
+  namespace,
+  configurationBase,
+  RootState,
+  caseListBase,
+} from '../../states';
+import {
+  TableContainer,
+  CLTable,
+  CLTableRow,
+  CLNamesCell,
+  CLTableCell,
+  CLTableBodyFont,
+} from '../../styles/caseList';
 import Filters from './filters/Filters';
 import CaseListTableHead from './CaseListTableHead';
 import CaseListTableRow from './CaseListTableRow';
@@ -12,6 +25,7 @@ import Pagination from '../Pagination';
 import { CASES_PER_PAGE } from './CaseList';
 import type { Case } from '../../types/types';
 import * as CaseListSettingsActions from '../../states/caseList/settings';
+import { Template } from '@twilio/flex-ui';
 
 const ROW_HEIGHT = 89;
 
@@ -42,9 +56,16 @@ const CaseListTable: React.FC<Props> = ({
 
   return (
     <>
-      <Filters caseCount={caseCount} currentDefinitionVersion={currentDefinitionVersion} />
+      <Filters
+        caseCount={caseCount}
+        currentDefinitionVersion={currentDefinitionVersion}
+      />
       <TableContainer>
-        <CLTable tabIndex={0} aria-labelledby="CaseList-Cases-label" data-testid="CaseList-Table">
+        <CLTable
+          tabIndex={0}
+          aria-labelledby="CaseList-Cases-label"
+          data-testid="CaseList-Table"
+        >
           <CaseListTableHead />
           {loading && (
             <TableBody>
@@ -53,10 +74,19 @@ const CaseListTable: React.FC<Props> = ({
                 style={{
                   position: 'relative',
                   background: 'transparent',
-                  height: `${(caseList.length || CASES_PER_PAGE) * ROW_HEIGHT}px`,
+                  height: `${
+                    (caseList.length || CASES_PER_PAGE) * ROW_HEIGHT
+                  }px`,
                 }}
               >
-                <CLNamesCell style={{ position: 'absolute', textAlign: 'center', width: '100%', top: '40%' }}>
+                <CLNamesCell
+                  style={{
+                    position: 'absolute',
+                    textAlign: 'center',
+                    width: '100%',
+                    top: '40%',
+                  }}
+                >
                   <CircularProgress size={50} />
                 </CLNamesCell>
               </CLTableRow>
@@ -64,19 +94,37 @@ const CaseListTable: React.FC<Props> = ({
           )}
           {!loading && (
             <TableBody>
-              {caseList.map(caseItem => (
-                <CaseListTableRow
-                  caseItem={caseItem}
-                  key={`CaseListItem-${caseItem.id}`}
-                  handleClickViewCase={handleClickViewCase}
-                  counselorsHash={counselorsHash}
-                />
-              ))}
+              {caseList.length > 0 ? (
+                caseList.map(caseItem => (
+                  <CaseListTableRow
+                    caseItem={caseItem}
+                    key={`CaseListItem-${caseItem.id}`}
+                    handleClickViewCase={handleClickViewCase}
+                    counselorsHash={counselorsHash}
+                  />
+                ))
+              ) : (
+                <CLTableRow>
+                  <CLTableCell colSpan={8}>
+                    <CLTableBodyFont
+                      style={{ paddingLeft: '6px', fontWeight: 'initial' }}
+                    >
+                      <Template code="CaseList-NoCases" />
+                    </CLTableBodyFont>
+                  </CLTableCell>
+                </CLTableRow>
+              )}
             </TableBody>
           )}
         </CLTable>
       </TableContainer>
-      <Pagination page={currentPage} pagesCount={pagesCount} handleChangePage={updateCaseListPage} />
+      {caseList.length > 0 ? (
+        <Pagination
+          page={currentPage}
+          pagesCount={pagesCount}
+          handleChangePage={updateCaseListPage}
+        />
+      ) : null}
     </>
   );
 };
@@ -85,7 +133,8 @@ CaseListTable.displayName = 'CaseListTable';
 
 const mapStateToProps = state => ({
   counselorsHash: state[namespace][configurationBase].counselors.hash,
-  currentDefinitionVersion: state[namespace][configurationBase].currentDefinitionVersion,
+  currentDefinitionVersion:
+    state[namespace][configurationBase].currentDefinitionVersion,
   currentPage: state[namespace][caseListBase].currentSettings.page,
 });
 

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -198,6 +198,7 @@
   "Case-Notes": "Notes",
   "SideNavCaseList": "Case List",
   "CaseList-Cases": "Cases",
+  "CaseList-NoCases": "No cases found.",
   "CaseList-Filters-CaseCount-Singular": "{{count}} case",
   "CaseList-Filters-CaseCount-Plural": "{{count}} cases",
   "CaseList-THCase": "Case",

--- a/plugin-hrm-form/src/translations/pt-BR/flexUI.json
+++ b/plugin-hrm-form/src/translations/pt-BR/flexUI.json
@@ -262,6 +262,7 @@
   "QueuesStatsHeaderSLA": "SLA",
 
   "CaseList-Cases": "Casos",
+  "CaseList-NoCases": "Nenhum caso encontrado.",
   "CaseList-Filters-CaseCount-Singular": "{{count}} caso",
   "CaseList-Filters-CaseCount-Plural": "{{count}} casos",
   "CaseList-THCase": "Caso #",


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
- In case of no cases / filtered down to zero cases to be shown in Case List, a table row with 'No Cases found.' is shown. As requested in https://marvelapp.com/prototype/df7eed1/screen/86858678 and https://marvelapp.com/prototype/df7eed1/screen/86858679
- Added a new string for No cases found as `CaseList-NoCases`
- Pagination component is hidden completely when no cases are shown

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [x] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes # [1202](https://bugs.benetech.org/browse/CHI-1202) partially

### Verification steps
- Check the Case List page when filtered to zero cases in development
- Cross check string localization when using a different helpline