### PR TITLE
Adding back slashes to ${var.helpline}

### DIFF
--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
@@ -5,7 +5,7 @@ locals {
 resource "null_resource" "hrm_static_api_key" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- new-key-with-ssm-secret hrm-static-key ${var.short_environment}_TWILIO_${var.short_helpline}_HRM_STATIC_KEY ${var.helpline} ${var.environment}"
+    command = "npm run twilioResources -- new-key-with-ssm-secret hrm-static-key ${var.short_environment}_TWILIO_${var.short_helpline}_HRM_STATIC_KEY \"${var.helpline}\" ${var.environment}"
     interpreter = local.sync_key_provisioner_interpreter
   }
 }

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -26,7 +26,7 @@ resource "twilio_sync_services_v1" "shared_state_service" {
 resource "null_resource" "sync_api_key" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- new-key-with-ssm-secret \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET ${var.helpline} ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
+    command = "npm run twilioResources -- new-key-with-ssm-secret \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET \"${var.helpline}\" ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
     interpreter = local.sync_key_provisioner_interpreter
   }
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:
@stephenhand 
## Description
Adding quotes to ${var.helpline} in provisioner CLI commands. This should fix an error when provisioning with Terraform whan a helpline name contains spaces.
