### PR TITLE
CHI-1189: Category pill buttons have color everywhere they appear

### DIFF
--- a/plugin-hrm-form/src/utils/categories.tsx
+++ b/plugin-hrm-form/src/utils/categories.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 
 import HrmTheme from '../styles/HrmTheme';
 import { ContactTag, TagText, TagMiddleDot } from '../styles/search';
-import { getDefinitionVersions } from '../HrmFormPlugin';
+import { getConfig, getDefinitionVersions } from '../HrmFormPlugin';
 import { ContactRawJson } from '../types/types';
 
 const getCategoryColor = (definitionVersion: ContactRawJson['definitionVersion'], category: string) => {
-  const categories = getDefinitionVersions().definitionVersions[definitionVersion].tabbedForms.IssueCategorizationTab;
+  const { helpline } = getConfig();
+
+  const categories = getDefinitionVersions().definitionVersions[definitionVersion].tabbedForms.IssueCategorizationTab(
+    helpline,
+  );
 
   return categories[category] ? categories[category].color : HrmTheme.colors.defaultCategoryColor;
 };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Bug fix: Make category pill buttons to be in colour everywhere

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [x] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes # CHI-1189

### Verification steps
<!--
Describe how to validate your changes.
- Include screenshots if applicable.
- Note if migrations are required.
-->
- Navigate to wherever category pill buttons appear (All Cases view, Case view, Search, etc) and verify that they all appear in their respective category colour.