### PR TITLE
Attempt to add modal for Editing Contact

### DIFF
--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { Template } from '@twilio/flex-ui';
 
@@ -49,6 +49,7 @@ const ViewContact: React.FC<Props> = ({
   releaseContactFromState,
   connectedCase,
 }) => {
+  const [hideControls, setHideControls] = useState<boolean>(false);
   useEffect(() => {
     if (tempInfo && tempInfo.screen === 'view-contact') {
       const { contact: contactFromInfo, timeOfContact, counselor } = tempInfo.info;
@@ -83,23 +84,28 @@ const ViewContact: React.FC<Props> = ({
   return (
     <CaseLayout>
       <Container>
-        <ActionHeader
-          titleTemplate="Case-Contact"
-          onClickClose={onClickClose}
-          addingCounsellor={createdByName}
-          added={added}
-        />
+        {hideControls && (
+          <ActionHeader
+            titleTemplate="Case-Contact"
+            onClickClose={onClickClose}
+            addingCounsellor={createdByName}
+            added={added}
+          />
+        )}
         <ContactDetails
           contactId={contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`}
           enableEditing={Boolean(contactFromInfo)}
           context={DetailsContext.CASE_DETAILS}
+          setHideControls={setHideControls}
         />
       </Container>
-      <BottomButtonBar>
-        <StyledNextStepButton roundCorners onClick={onClickClose} data-testid="Case-ViewContactScreen-CloseButton">
-          <Template code="CloseButton" />
-        </StyledNextStepButton>
-      </BottomButtonBar>
+      {hideControls && (
+        <BottomButtonBar>
+          <StyledNextStepButton roundCorners onClick={onClickClose} data-testid="Case-ViewContactScreen-CloseButton">
+            <Template code="CloseButton" />
+          </StyledNextStepButton>
+        </BottomButtonBar>
+      )}
     </CaseLayout>
   );
 };

--- a/plugin-hrm-form/src/components/contact/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetails.tsx
@@ -22,6 +22,7 @@ type OwnProps = {
   handleOpenConnectDialog?: (event: any) => void;
   enableEditing?: boolean;
   showActionIcons?: boolean;
+  setHideControls?: (hideControls: boolean) => void;
 };
 
 type Props = OwnProps & ConnectedProps<typeof connector>;
@@ -37,6 +38,7 @@ const ContactDetails: React.FC<Props> = ({
   contact,
   navigateForContext,
   enableEditing = true,
+  setHideControls,
 }) => {
   const version = contact?.details.definitionVersion;
 
@@ -76,7 +78,12 @@ const ContactDetails: React.FC<Props> = ({
     section: ContactDetailsSectionFormApi,
     formPath: 'callerInformation' | 'childInformation' | 'caseInformation',
   ) => (
-    <EditContactSection context={context} contactId={contactId} contactDetailsSectionForm={section}>
+    <EditContactSection
+      context={context}
+      contactId={contactId}
+      contactDetailsSectionForm={section}
+      setHideControls={setHideControls}
+    >
       <ContactDetailsSectionForm
         tabPath={formPath}
         definition={section.getFormDefinition(definitionVersion)}
@@ -103,6 +110,7 @@ const ContactDetails: React.FC<Props> = ({
           context={context}
           contactId={contactId}
           contactDetailsSectionForm={contactDetailsSectionFormApi.ISSUE_CATEGORIZATION}
+          setHideControls={setHideControls}
         >
           <IssueCategorizationSectionForm
             definition={definitionVersion.tabbedForms.IssueCategorizationTab(contact.overview.helpline)}

--- a/plugin-hrm-form/src/components/contact/EditContactSection.tsx
+++ b/plugin-hrm-form/src/components/contact/EditContactSection.tsx
@@ -20,6 +20,7 @@ type OwnProps = {
   contactId: string;
   contactDetailsSectionForm: ContactDetailsSectionFormApi | IssueCategorizationSectionFormApi;
   children?: React.ReactNode;
+  setHideControls: (hideControls: boolean) => void;
 };
 
 // eslint-disable-next-line no-use-before-define
@@ -33,6 +34,7 @@ const EditContactSection: React.FC<Props> = ({
   navigateForContext,
   refreshContact,
   contactDetailsSectionForm,
+  setHideControls,
   children,
 }) => {
   const methods = useForm({
@@ -48,7 +50,7 @@ const EditContactSection: React.FC<Props> = ({
   const [isSubmitting, setSubmitting] = useState(false);
   const [openDialog, setOpenDialog] = useState(false);
   const [initialFormValues, setInitialFormValues] = useState({});
-
+  console.log('>>>', { children });
   useEffect(() => {
     /*
      * we need this to run only once, hence no need
@@ -57,6 +59,11 @@ const EditContactSection: React.FC<Props> = ({
     setInitialFormValues(methods.getValues());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    setHideControls(false);
+    return () => setHideControls(true);
+  }, [setHideControls]);
 
   const navigate = (route: ContactDetailsRoute) => navigateForContext(context, route);
 

--- a/plugin-hrm-form/src/permissions/demo.json
+++ b/plugin-hrm-form/src/permissions/demo.json
@@ -17,5 +17,5 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"], ["isOwner"]]
 }


### PR DESCRIPTION
- From case list view/ tab, when you attempt to edit a contact, the usual action buttons are hidden with the following changes. The other two views (main conversation and search contact) where edit contact is rendered will break. 
1. I have tried to use React Portals wrapping the Form Provider in EditContactSection component with createPortal, but not sure where (which component) to call this portal. I understand that this eventually will help with edit contact to render in the other views.