### PR TITLE
[Don't merge] Attempt to add modal for Editing Contact

### DIFF
--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -12,16 +12,17 @@ import ActionHeader from './ActionHeader';
 import { CaseState } from '../../states/case/reducer';
 import type { CustomITask, StandaloneITask } from '../../types/types';
 import { loadContact, loadRawContact, releaseContact } from '../../states/contacts/existingContacts';
-import { DetailsContext } from '../../states/contacts/contactDetails';
+import { ContactDetailsRoute, DetailsContext } from '../../states/contacts/contactDetails';
 import { taskFormToSearchContact } from '../../states/contacts/contactDetailsAdapter';
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const form = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];
+  const contactDetailsRoute = state[namespace][contactFormsBase].contactDetails[DetailsContext.CASE_DETAILS].route;
   const counselorsHash = state[namespace][configurationBase].counselors.hash;
   const caseState: CaseState = state[namespace][connectedCaseBase];
   const { temporaryCaseInfo, connectedCase } = caseState.tasks[ownProps.task.taskSid];
 
-  return { form, counselorsHash, tempInfo: temporaryCaseInfo, connectedCase };
+  return { form, counselorsHash, tempInfo: temporaryCaseInfo, connectedCase, contactDetailsRoute };
 };
 
 const mapDispatchToProps = {
@@ -48,6 +49,7 @@ const ViewContact: React.FC<Props> = ({
   loadRawContactIntoState,
   releaseContactFromState,
   connectedCase,
+  contactDetailsRoute,
 }) => {
   useEffect(() => {
     if (tempInfo && tempInfo.screen === 'view-contact') {
@@ -83,12 +85,14 @@ const ViewContact: React.FC<Props> = ({
   return (
     <CaseLayout>
       <Container>
-        <ActionHeader
-          titleTemplate="Case-Contact"
-          onClickClose={onClickClose}
-          addingCounsellor={createdByName}
-          added={added}
-        />
+        {contactDetailsRoute === ContactDetailsRoute.HOME && (
+          <ActionHeader
+            titleTemplate="Case-Contact"
+            onClickClose={onClickClose}
+            addingCounsellor={createdByName}
+            added={added}
+          />
+        )}
         <ContactDetails
           contactId={contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`}
           enableEditing={Boolean(contactFromInfo)}

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -77,7 +77,7 @@ const ContactDetailsHome: React.FC<Props> = ({
     channel === 'default'
       ? mapChannelForInsights(details.contactlessTask.channel.toString())
       : mapChannelForInsights(channel);
-  console.log('>>>', { overview });
+
   const formattedDateStandard = `${format(new Date(dateTime), 'M/dd/yyyy')}`;
   const formattedTimeStandard = `${format(new Date(dateTime), 'h:mm a')}`;
 

--- a/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
@@ -7,7 +7,7 @@ import { Container } from '../../../styles/HrmStyles';
 import GeneralContactDetails from '../../contact/ContactDetails';
 import ConnectDialog from '../ConnectDialog';
 import BackToSearchResultsButton from '../SearchResults/SearchResultsBackButton';
-import { SearchContact } from '../../../types/types';
+import { SearchContact, standaloneTaskSid } from '../../../types/types';
 import { loadContact, releaseContact } from '../../../states/contacts/existingContacts';
 import { DetailsContext } from '../../../states/contacts/contactDetails';
 
@@ -15,7 +15,6 @@ type OwnProps = {
   task: any;
   currentIsCaller: boolean;
   contact: SearchContact;
-  showActionIcons: boolean;
   handleBack: () => void;
   handleSelectSearchResult: (contact: SearchContact) => void;
 };
@@ -31,7 +30,6 @@ const ContactDetails: React.FC<Props> = ({
   contact,
   currentIsCaller,
   handleBack,
-  showActionIcons,
   task,
   handleSelectSearchResult,
   loadContactIntoState,
@@ -61,6 +59,8 @@ const ContactDetails: React.FC<Props> = ({
     e.stopPropagation();
     setAnchorEl(e.currentTarget);
   };
+
+  const showActionIcons = task.taskSid !== standaloneTaskSid;
 
   return (
     <Container>

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -12,7 +12,7 @@ import SearchResults, { CONTACTS_PER_PAGE, CASES_PER_PAGE } from './SearchResult
 import ContactDetails from './ContactDetails';
 import Case from '../case';
 import { SearchPages } from '../../states/search/types';
-import { CustomITask, SearchContact, standaloneTaskSid } from '../../types/types';
+import { CustomITask, SearchContact } from '../../types/types';
 import SearchResultsBackButton from './SearchResults/SearchResultsBackButton';
 import {
   handleSearchFormChange,
@@ -149,7 +149,6 @@ const Search: React.FC<Props> = props => {
         return (
           <ContactDetails
             task={props.task}
-            showActionIcons={props.showActionIcons}
             currentIsCaller={props.currentIsCaller}
             contact={currentContact}
             handleBack={goToResultsOnContacts}
@@ -202,7 +201,6 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const taskSearchState = searchContactsState.tasks[taskId];
   const { counselors } = state[namespace][configurationBase];
   const routing = state[namespace][routingBase].tasks[taskId];
-  const isStandaloneSearch = taskId === standaloneTaskSid;
 
   return {
     isRequesting: taskSearchState.isRequesting,
@@ -213,7 +211,6 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
     searchContactsResults: taskSearchState.searchContactsResult,
     searchCasesResults: taskSearchState.searchCasesResult,
     counselorsHash: counselors.hash,
-    showActionIcons: !isStandaloneSearch,
     routing,
   };
 };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
This PR is an attempt to comply with the mocks provided in https://marvelapp.com/prototype/ah7f313/screen/85946828, where when entering in "edit contact" mode, even from within the tabbed forms -> sarch -> view contact -> edit, the entire right pane is occupied with the `EditContactSection` view. This is done in the same way we do that for case edits: trimming the tabbed forms tree.

Some thoughts on this approach:
- It does not feel right to mimic the bad behavior we currently have when editing a case, just to make the contacts looks the same. I'd prefer to step back and rethink the usages of case and contact views, and think how can we be consistent across all the different places where we can open this screens.
- We need some way to "go back to search results" when previewing a contact. The consistent way would be to "add a close cross top right", or a "close button in the bottom bar" like we do for cases. Till then we are relying on this button.
  ![Screenshot from 2022-06-23 19-37-39](https://user-images.githubusercontent.com/15805319/175426429-ec0b5324-0750-4a36-af32-998fa592b681.png)
- There's some redundancy when viewing a contact from within a case (and somehow they are computed differently :laughing:).
  ![Screenshot from 2022-06-23 19-29-53](https://user-images.githubusercontent.com/15805319/175425760-c8a3bd70-7d2a-4470-a3bb-04782df58333.png)