### PR TITLE
Allow patch security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
     allow:
       - dependency-name: "*"
         dependency-type: "production"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
         
   - package-ecosystem: "npm"
     directory: "/plugin-hrm-form/"
@@ -20,9 +17,6 @@ updates:
     allow:
       - dependency-name: "*"
         dependency-type: "production"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
         
   - package-ecosystem: "npm"
     directory: "/hrm-form-definitions/"
@@ -32,6 +26,3 @@ updates:
     allow:
       - dependency-name: "*"
         dependency-type: "production"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @murilovmachado 

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
We have been iterating on our use of dependabot to catch security updates but not create a lot of spam PRs for the team. Just now when looking at a dependabot alert, I saw:
![image](https://user-images.githubusercontent.com/10714292/176323403-34a8583a-9387-446c-b086-554670e051f7.png)

I think the `ignore` clause is preventing us from opening a PR to fix a vulnerability if a patch update is all that is required. I could be wrong, but I'd like to make this change to find out.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->