### PR TITLE
CHI1180 Edit contact modal

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/case/ViewContact.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/ViewContact.test.tsx
@@ -178,29 +178,9 @@ describe('View Contact', () => {
       </Provider>,
     );
 
-    await waitFor(() => expect(screen.getByTestId('Case-ActionHeaderAdded')).toBeInTheDocument());
     // TODO: Verify interpolated translations contain the expected data
     await waitFor(() => expect(screen.getByTestId('ContactDetails-Container')).toBeInTheDocument());
     expect(screen.getByText('Jill Smith')).toBeInTheDocument();
-  });
-
-  test('click on x button', async () => {
-    const onClickClose = jest.fn();
-    const store = mockStore(initialState);
-
-    render(
-      <Provider store={store}>
-        <StorelessThemeProvider themeConf={themeConf}>
-          <ViewContact task={task as any} onClickClose={onClickClose} />
-        </StorelessThemeProvider>
-      </Provider>,
-    );
-
-    await waitFor(() => expect(screen.getByTestId('Case-CloseCross')).toBeInTheDocument());
-
-    screen.getByTestId('Case-CloseCross').click();
-
-    expect(onClickClose).toHaveBeenCalled();
   });
 
   test('click on close button', async () => {

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -9,7 +9,7 @@ import {
   searchContacts as searchContactsAction,
   searchCases as searchCasesAction,
 } from '../states/search/actions';
-import { namespace, searchContactsBase, configurationBase, RootState } from '../states';
+import { namespace, searchContactsBase, configurationBase, RootState, contactFormsBase } from '../states';
 import { CONTACTS_PER_PAGE, CASES_PER_PAGE } from './search/SearchResults';
 import { YellowBanner } from '../styles/previousContactsBanner';
 import { Bold } from '../styles/HrmStyles';
@@ -43,6 +43,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
   searchContacts,
   searchCases,
   changeRoute,
+  editContactFormOpen,
 }) => {
   useEffect(() => {
     if (isTwilioTask(task) && previousContacts === undefined) {
@@ -70,42 +71,43 @@ const PreviousContactsBanner: React.FC<Props> = ({
 
   const contactIdentifier = getFormattedNumberFromTask(task);
   return (
-    <YellowBanner data-testid="PreviousContacts-Container">
-      {/* eslint-disable-next-line prettier/prettier */}
+    <div className={editContactFormOpen ? 'editingContact' : ''}>
+      <YellowBanner data-testid="PreviousContacts-Container" className="hiddenWhenEditingContact">
+        {/* eslint-disable-next-line prettier/prettier */}
       <pre>
-        <Template code="PreviousContacts-ThereAre" />
-        &nbsp;
-        {contactsCount === 1 ? (
-          <Bold>
-            {contactsCount} <Template code="PreviousContacts-PreviousContact" />
-          </Bold>
-        ) : (
-          <Bold>
-            {contactsCount} <Template code="PreviousContacts-PreviousContacts" />
-          </Bold>
-        )}
-        &nbsp;and&nbsp;
-        {casesCount === 1 ? (
-          <Bold>
-            {casesCount} <Template code="PreviousContacts-Case" />
-          </Bold>
-        ) : (
-          <Bold>
-            {casesCount} <Template code="PreviousContacts-Cases" />
-          </Bold>
-        )}
-        &nbsp;
-        <Template code="PreviousContacts-From" />
-        &nbsp;
-        <Template code={localizedSource[task.channelType]} />
-        &nbsp;
-        <Bold>{contactIdentifier}</Bold>.
-      </pre>
-
-      <StyledLink underline data-testid="PreviousContacts-ViewRecords" onClick={handleClickViewRecords}>
-        <Template code="PreviousContacts-ViewRecords" />
-      </StyledLink>
-    </YellowBanner>
+          <Template code="PreviousContacts-ThereAre" />
+          &nbsp;
+          {contactsCount === 1 ? (
+            <Bold>
+              {contactsCount} <Template code="PreviousContacts-PreviousContact" />
+            </Bold>
+          ) : (
+            <Bold>
+              {contactsCount} <Template code="PreviousContacts-PreviousContacts" />
+            </Bold>
+          )}
+          &nbsp;and&nbsp;
+          {casesCount === 1 ? (
+            <Bold>
+              {casesCount} <Template code="PreviousContacts-Case" />
+            </Bold>
+          ) : (
+            <Bold>
+              {casesCount} <Template code="PreviousContacts-Cases" />
+            </Bold>
+          )}
+          &nbsp;
+          <Template code="PreviousContacts-From" />
+          &nbsp;
+          <Template code={localizedSource[task.channelType]} />
+          &nbsp;
+          <Bold>{contactIdentifier}</Bold>.
+        </pre>
+        <StyledLink underline data-testid="PreviousContacts-ViewRecords" onClick={handleClickViewRecords}>
+          <Template code="PreviousContacts-ViewRecords" />
+        </StyledLink>
+      </YellowBanner>
+    </div>
   );
 };
 
@@ -116,10 +118,12 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const taskId = ownProps.task.taskSid;
   const taskSearchState = searchContactsState.tasks[taskId];
   const { counselors } = state[namespace][configurationBase];
+  const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
 
   return {
     previousContacts: taskSearchState.previousContacts,
     counselorsHash: counselors.hash,
+    editContactFormOpen,
   };
 };
 

--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -82,8 +82,6 @@ const ViewContact: React.FC<Props> = ({
   return (
     <CaseLayout
       className={editContactFormOpen ? 'editingContact' : ''}
-
-      // style={{ height: '-webkit-fill-available', border: '15px red solid' }}
     >
       <Container>
         <ContactDetails

--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Template } from '@twilio/flex-ui';
 
-import { BottomButtonBar, Container, StyledNextStepButton } from '../../styles/HrmStyles';
+import { BottomButtonBar, Container, StyledNextStepButton, Flex } from '../../styles/HrmStyles';
 import { CaseLayout } from '../../styles/case';
 import { configurationBase, connectedCaseBase, contactFormsBase, namespace, RootState } from '../../states';
 import * as CaseActions from '../../states/case/actions';
@@ -19,9 +19,9 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const form = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];
   const counselorsHash = state[namespace][configurationBase].counselors.hash;
   const caseState: CaseState = state[namespace][connectedCaseBase];
+  const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
   const { temporaryCaseInfo, connectedCase } = caseState.tasks[ownProps.task.taskSid];
-
-  return { form, counselorsHash, tempInfo: temporaryCaseInfo, connectedCase };
+  return { form, counselorsHash, tempInfo: temporaryCaseInfo, connectedCase, editContactFormOpen };
 };
 
 const mapDispatchToProps = {
@@ -48,6 +48,7 @@ const ViewContact: React.FC<Props> = ({
   loadRawContactIntoState,
   releaseContactFromState,
   connectedCase,
+  editContactFormOpen,
 }) => {
   useEffect(() => {
     if (tempInfo && tempInfo.screen === 'view-contact') {
@@ -73,33 +74,29 @@ const ViewContact: React.FC<Props> = ({
     loadRawContactIntoState,
     tempInfo,
   ]);
+  console.log('>>> ViewContact', { editContactFormOpen });
 
   if (!tempInfo || tempInfo.screen !== 'view-contact') return null;
-  const { contact: contactFromInfo, createdAt, counselor } = tempInfo.info;
-  const createdByName = counselorsHash[contactFromInfo?.createdBy ?? counselor] || 'Unknown';
-
-  const added = new Date(createdAt);
+  const { contact: contactFromInfo } = tempInfo.info;
 
   return (
-    <CaseLayout>
+    <CaseLayout
+      className={editContactFormOpen ? 'editingContact' : ''}
+
+      // style={{ height: '-webkit-fill-available', border: '15px red solid' }}
+    >
       <Container>
-        <ActionHeader
-          titleTemplate="Case-Contact"
-          onClickClose={onClickClose}
-          addingCounsellor={createdByName}
-          added={added}
-        />
         <ContactDetails
           contactId={contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`}
           enableEditing={Boolean(contactFromInfo)}
           context={DetailsContext.CASE_DETAILS}
         />
+        <BottomButtonBar className="hiddenWhenEditingContact" style={{ marginBlockStart: 'auto' }}>
+          <StyledNextStepButton roundCorners onClick={onClickClose} data-testid="Case-ViewContactScreen-CloseButton">
+            <Template code="CloseButton" />
+          </StyledNextStepButton>
+        </BottomButtonBar>
       </Container>
-      <BottomButtonBar>
-        <StyledNextStepButton roundCorners onClick={onClickClose} data-testid="Case-ViewContactScreen-CloseButton">
-          <Template code="CloseButton" />
-        </StyledNextStepButton>
-      </BottomButtonBar>
     </CaseLayout>
   );
 };

--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -74,7 +74,6 @@ const ViewContact: React.FC<Props> = ({
     loadRawContactIntoState,
     tempInfo,
   ]);
-  console.log('>>> ViewContact', { editContactFormOpen });
 
   if (!tempInfo || tempInfo.screen !== 'view-contact') return null;
   const { contact: contactFromInfo } = tempInfo.info;

--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -80,10 +80,8 @@ const ViewContact: React.FC<Props> = ({
   const { contact: contactFromInfo } = tempInfo.info;
 
   return (
-    <CaseLayout
-      className={editContactFormOpen ? 'editingContact' : ''}
-    >
-      <Container>
+    <CaseLayout className={editContactFormOpen ? 'editingContact' : ''}>
+      <Container removePadding={editContactFormOpen}>
         <ContactDetails
           contactId={contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`}
           enableEditing={Boolean(contactFromInfo)}

--- a/plugin-hrm-form/src/components/contact/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetails.tsx
@@ -76,7 +76,7 @@ const ContactDetails: React.FC<Props> = ({
     section: ContactDetailsSectionFormApi,
     formPath: 'callerInformation' | 'childInformation' | 'caseInformation',
   ) => (
-    <EditContactSection context={context} contactId={contactId} contactDetailsSectionForm={section}>
+    <EditContactSection context={context} contactId={contactId} contactDetailsSectionForm={section} tabPath={formPath}>
       <ContactDetailsSectionForm
         tabPath={formPath}
         definition={section.getFormDefinition(definitionVersion)}
@@ -103,6 +103,7 @@ const ContactDetails: React.FC<Props> = ({
           context={context}
           contactId={contactId}
           contactDetailsSectionForm={contactDetailsSectionFormApi.ISSUE_CATEGORIZATION}
+          tabPath="categories"
         >
           <IssueCategorizationSectionForm
             definition={definitionVersion.tabbedForms.IssueCategorizationTab(contact.overview.helpline)}

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -77,7 +77,6 @@ const ContactDetailsHome: React.FC<Props> = ({
     channel === 'default'
       ? mapChannelForInsights(details.contactlessTask.channel.toString())
       : mapChannelForInsights(channel);
-  console.log('>>>', { overview });
   const formattedDateStandard = `${format(new Date(dateTime), 'M/dd/yyyy')}`;
   const formattedTimeStandard = `${format(new Date(dateTime), 'h:mm a')}`;
 

--- a/plugin-hrm-form/src/components/contact/EditContactSection.tsx
+++ b/plugin-hrm-form/src/components/contact/EditContactSection.tsx
@@ -14,6 +14,7 @@ import { ContactDetailsRoute, DetailsContext, navigateContactDetails } from '../
 import { ContactDetailsSectionFormApi, IssueCategorizationSectionFormApi } from './contactDetailsSectionFormApi';
 import { refreshRawContact } from '../../states/contacts/existingContacts';
 import CloseCaseDialog from '../case/CloseCaseDialog';
+import * as t from '../../states/contacts/actions';
 
 type OwnProps = {
   context: DetailsContext;
@@ -33,6 +34,8 @@ const EditContactSection: React.FC<Props> = ({
   navigateForContext,
   refreshContact,
   contactDetailsSectionForm,
+  setEditContactPageOpen,
+  setEditContactPageClosed,
   children,
 }) => {
   const methods = useForm({
@@ -55,6 +58,10 @@ const EditContactSection: React.FC<Props> = ({
      * of adding any dependency inside the array
      */
     setInitialFormValues(methods.getValues());
+    setEditContactPageOpen();
+    return () => {
+      setEditContactPageClosed();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -134,6 +141,8 @@ const EditContactSection: React.FC<Props> = ({
 const mapDispatchToProps = {
   navigateForContext: navigateContactDetails,
   refreshContact: refreshRawContact,
+  setEditContactPageOpen: t.setEditContactPageOpen,
+  setEditContactPageClosed: t.setEditContactPageClosed,
 };
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({

--- a/plugin-hrm-form/src/components/contact/EditContactSection.tsx
+++ b/plugin-hrm-form/src/components/contact/EditContactSection.tsx
@@ -4,10 +4,12 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { Template } from '@twilio/flex-ui';
 import { CircularProgress } from '@material-ui/core';
 import _ from 'lodash';
+import { Close } from '@material-ui/icons';
 
 import { configurationBase, contactFormsBase, namespace, RootState } from '../../states';
 import { updateContactInHrm } from '../../services/ContactService';
-import { Flex, Box, StyledNextStepButton, BottomButtonBar } from '../../styles/HrmStyles';
+import { Box, StyledNextStepButton, BottomButtonBar, Row, HiddenText, HeaderCloseButton } from '../../styles/HrmStyles';
+import { CaseActionTitle } from '../../styles/case';
 import { recordBackendError, recordingErrorHandler } from '../../fullStory';
 import { getConfig } from '../../HrmFormPlugin';
 import { ContactDetailsRoute, DetailsContext, navigateContactDetails } from '../../states/contacts/contactDetails';
@@ -15,12 +17,14 @@ import { ContactDetailsSectionFormApi, IssueCategorizationSectionFormApi } from 
 import { refreshRawContact } from '../../states/contacts/existingContacts';
 import CloseCaseDialog from '../case/CloseCaseDialog';
 import * as t from '../../states/contacts/actions';
+import type { TaskEntry } from '../../states/contacts/reducer';
 
 type OwnProps = {
   context: DetailsContext;
   contactId: string;
   contactDetailsSectionForm: ContactDetailsSectionFormApi | IssueCategorizationSectionFormApi;
   children?: React.ReactNode;
+  tabPath?: keyof TaskEntry;
 };
 
 // eslint-disable-next-line no-use-before-define
@@ -36,6 +40,7 @@ const EditContactSection: React.FC<Props> = ({
   contactDetailsSectionForm,
   setEditContactPageOpen,
   setEditContactPageClosed,
+  tabPath,
   children,
 }) => {
   const methods = useForm({
@@ -51,7 +56,7 @@ const EditContactSection: React.FC<Props> = ({
   const [isSubmitting, setSubmitting] = useState(false);
   const [openDialog, setOpenDialog] = useState(false);
   const [initialFormValues, setInitialFormValues] = useState({});
-
+  console.log('>>>', { tabPath });
   useEffect(() => {
     /*
      * we need this to run only once, hence no need
@@ -100,41 +105,81 @@ const EditContactSection: React.FC<Props> = ({
     }
   };
 
+  // With tabPath as an input, this function returns the localized string for section's title
+  const editContactSectionTitle = (tabPath: keyof TaskEntry): string => {
+    if (tabPath === 'callerInformation') {
+      return strings['Contact-EditCaller'];
+    } else if (tabPath === 'childInformation') {
+      return strings['Contact-EditChild'];
+    } else if (tabPath === 'categories') {
+      return strings['Contact-EditCategories'];
+    } else if (tabPath === 'caseInformation') {
+      return strings['Contact-EditSummary'];
+    }
+    return '';
+  };
+
   return (
-    <FormProvider {...methods}>
-      {children}
-      <BottomButtonBar>
-        <Box marginRight="15px">
-          <StyledNextStepButton
-            roundCorners={true}
+    <div
+      className="CHANGEME"
+      style={{
+        display: 'grid',
+        height: '100%',
+        alignContent: 'space-between',
+        border: '10px grey solid',
+        overflow: 'overlay',
+      }}
+    >
+      <FormProvider {...methods}>
+        <Row style={{ width: '100%', margin: '15px auto' }}>
+          <CaseActionTitle style={{ margin: 'auto 15px' }}>
+            <Template code={editContactSectionTitle(tabPath)} />
+          </CaseActionTitle>
+          <HeaderCloseButton
             onClick={checkForEdits}
-            disabled={isSubmitting}
-            secondary
-            data-fs-id="BottomBar-Cancel"
+            data-testid="Case-CloseCross"
+            style={{ marginRight: '15px', opacity: '.75' }}
           >
-            <Template code="BottomBar-Cancel" />
-          </StyledNextStepButton>
-          <CloseCaseDialog
-            data-testid="CloseCaseDialog"
-            openDialog={openDialog}
-            setDialog={() => setOpenDialog(false)}
-            handleDontSaveClose={() => navigate(ContactDetailsRoute.HOME)}
-            handleSaveUpdate={methods.handleSubmit(onSubmitValidForm, onError)}
-          />
-        </Box>
-        <Box marginRight="15px">
-          <StyledNextStepButton
-            roundCorners={true}
-            onClick={methods.handleSubmit(onSubmitValidForm, onError)}
-            disabled={isSubmitting}
-            data-fs-id="Contact-SaveContact-Button"
-            data-testid="EditContact-SaveContact-Button"
-          >
-            {isSubmitting ? <CircularProgress size={12} /> : <Template code="BottomBar-SaveContact" />}
-          </StyledNextStepButton>
-        </Box>
-      </BottomButtonBar>
-    </FormProvider>
+            <HiddenText>
+              <Template code="Case-CloseButton" />
+            </HiddenText>
+            <Close />
+          </HeaderCloseButton>
+        </Row>
+        {children}
+        <BottomButtonBar>
+          <Box marginRight="15px">
+            <StyledNextStepButton
+              roundCorners={true}
+              onClick={checkForEdits}
+              disabled={isSubmitting}
+              secondary
+              data-fs-id="BottomBar-Cancel"
+            >
+              <Template code="BottomBar-Cancel" />
+            </StyledNextStepButton>
+            <CloseCaseDialog
+              data-testid="CloseCaseDialog"
+              openDialog={openDialog}
+              setDialog={() => setOpenDialog(false)}
+              handleDontSaveClose={() => navigate(ContactDetailsRoute.HOME)}
+              handleSaveUpdate={methods.handleSubmit(onSubmitValidForm, onError)}
+            />
+          </Box>
+          <Box marginRight="15px">
+            <StyledNextStepButton
+              roundCorners={true}
+              onClick={methods.handleSubmit(onSubmitValidForm, onError)}
+              disabled={isSubmitting}
+              data-fs-id="Contact-SaveContact-Button"
+              data-testid="EditContact-SaveContact-Button"
+            >
+              {isSubmitting ? <CircularProgress size={12} /> : <Template code="BottomBar-SaveContact" />}
+            </StyledNextStepButton>
+          </Box>
+        </BottomButtonBar>
+      </FormProvider>
+    </div>
   );
 };
 

--- a/plugin-hrm-form/src/components/contact/EditContactSection.tsx
+++ b/plugin-hrm-form/src/components/contact/EditContactSection.tsx
@@ -9,7 +9,7 @@ import { Close } from '@material-ui/icons';
 import { configurationBase, contactFormsBase, namespace, RootState } from '../../states';
 import { updateContactInHrm } from '../../services/ContactService';
 import { Box, StyledNextStepButton, BottomButtonBar, Row, HiddenText, HeaderCloseButton } from '../../styles/HrmStyles';
-import { CaseActionTitle } from '../../styles/case';
+import { CaseActionTitle, EditContactContainer } from '../../styles/case';
 import { recordBackendError, recordingErrorHandler } from '../../fullStory';
 import { getConfig } from '../../HrmFormPlugin';
 import { ContactDetailsRoute, DetailsContext, navigateContactDetails } from '../../states/contacts/contactDetails';
@@ -56,7 +56,7 @@ const EditContactSection: React.FC<Props> = ({
   const [isSubmitting, setSubmitting] = useState(false);
   const [openDialog, setOpenDialog] = useState(false);
   const [initialFormValues, setInitialFormValues] = useState({});
-  console.log('>>>', { tabPath });
+
   useEffect(() => {
     /*
      * we need this to run only once, hence no need
@@ -120,19 +120,10 @@ const EditContactSection: React.FC<Props> = ({
   };
 
   return (
-    <div
-      className="CHANGEME"
-      style={{
-        display: 'grid',
-        height: '100%',
-        alignContent: 'space-between',
-        border: '10px grey solid',
-        overflow: 'overlay',
-      }}
-    >
+    <EditContactContainer>
       <FormProvider {...methods}>
-        <Row style={{ width: '100%', margin: '15px auto' }}>
-          <CaseActionTitle style={{ margin: 'auto 15px' }}>
+        <Row style={{ margin: '30px' }}>
+          <CaseActionTitle>
             <Template code={editContactSectionTitle(tabPath)} />
           </CaseActionTitle>
           <HeaderCloseButton
@@ -179,7 +170,7 @@ const EditContactSection: React.FC<Props> = ({
           </Box>
         </BottomButtonBar>
       </FormProvider>
-    </div>
+    </EditContactContainer>
   );
 };
 

--- a/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
@@ -1,8 +1,11 @@
 /* eslint-disable no-empty-function */
+/* eslint-disable react/require-default-props */
+
 import React, { useEffect, useState } from 'react';
 import { Template } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 
+import { namespace, contactFormsBase, RootState } from '../../../states';
 import { Container } from '../../../styles/HrmStyles';
 import GeneralContactDetails from '../../contact/ContactDetails';
 import ConnectDialog from '../ConnectDialog';
@@ -19,13 +22,16 @@ type OwnProps = {
   handleBack: () => void;
   handleSelectSearchResult: (contact: SearchContact) => void;
 };
-
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
+  const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
+  return { editContactFormOpen };
+};
 const mapDispatchToProps = {
   loadContactIntoState: loadContact,
   releaseContactFromState: releaseContact,
 };
 
-type Props = OwnProps & typeof mapDispatchToProps;
+type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
 const ContactDetails: React.FC<Props> = ({
   contact,
@@ -36,6 +42,7 @@ const ContactDetails: React.FC<Props> = ({
   handleSelectSearchResult,
   loadContactIntoState,
   releaseContactFromState,
+  editContactFormOpen,
 }: Props) => {
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -72,7 +79,14 @@ const ContactDetails: React.FC<Props> = ({
         handleConfirm={handleConfirmDialog}
         handleClose={handleCloseDialog}
       />
-      <BackToSearchResultsButton text={<Template code="SearchResultsIndex-BackToResults" />} handleBack={handleBack} />
+
+      <div className={`${editContactFormOpen ? 'editingContact' : ''} hiddenWhenEditingContact`}>
+        <BackToSearchResultsButton
+          text={<Template code="SearchResultsIndex-BackToResults" />}
+          handleBack={handleBack}
+        />
+      </div>
+
       <GeneralContactDetails
         context={DetailsContext.CONTACT_SEARCH}
         showActionIcons={showActionIcons}
@@ -85,4 +99,4 @@ const ContactDetails: React.FC<Props> = ({
 
 ContactDetails.displayName = 'ContactDetails';
 
-export default connect(null, mapDispatchToProps)(ContactDetails);
+export default connect(mapStateToProps, mapDispatchToProps)(ContactDetails);

--- a/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
@@ -70,7 +70,7 @@ const ContactDetails: React.FC<Props> = ({
   };
 
   return (
-    <Container>
+    <Container removePadding={editContactFormOpen}>
       <ConnectDialog
         task={task}
         anchorEl={anchorEl}

--- a/plugin-hrm-form/src/components/search/ContactPreview/ChildNameAndDate.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ChildNameAndDate.tsx
@@ -6,6 +6,7 @@ import { CallTypes } from 'hrm-form-definitions';
 
 import { Flex, Row } from '../../../styles/HrmStyles';
 import { PrevNameText, ContactButtonsWrapper, DateText, ViewContactButton } from '../../../styles/search';
+import { ViewButton } from '../../../styles/case';
 import { isNonDataCallType } from '../../../states/ValidationRules';
 import CallTypeIcon from '../../common/icons/CallTypeIcon';
 import { channelTypes, ChannelTypes } from '../../../states/DomainConstants';
@@ -46,9 +47,9 @@ const ChildNameAndDate: React.FC<Props> = ({ channel, callType, name, number, da
         <Flex marginRight="20px">
           <DateText>{dateString}</DateText>
         </Flex>
-        <ViewContactButton type="button" onClick={onClickFull}>
+        <ViewButton onClick={onClickFull}>
           <Template code="Contact-ViewButton" />
-        </ViewContactButton>
+        </ViewButton>
       </ContactButtonsWrapper>
     </Row>
   );

--- a/plugin-hrm-form/src/components/search/SearchResults/SearchResultsBackButton.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/SearchResultsBackButton.tsx
@@ -13,7 +13,7 @@ type Props = OwnProps;
 
 const SearchResultsBackButton: React.FC<Props> = ({ text, handleBack }) => {
   return (
-    <Row>
+    <Row className="hiddenWhenEditingContact">
       <StyledBackButton onClick={handleBack}>
         <Row>
           <BackIcon />

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -189,6 +189,7 @@ const Search: React.FC<Props> = props => {
   const { currentPage, currentContact, searchContactsResults, searchCasesResults, form, routing } = props;
 
   return (
+    // TODO: Needs converting to a div and the className={editContactFormOpen ? 'editingContact' : ''} adding, but that messes up the CSS
     <>
       {renderMockDialog()}
       {renderSearchPages(currentPage, currentContact, searchContactsResults, searchCasesResults, form, routing)}

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -21,7 +21,14 @@ import {
   searchContacts,
   searchCases,
 } from '../../states/search/actions';
-import { namespace, searchContactsBase, configurationBase, routingBase, RootState } from '../../states';
+import {
+  namespace,
+  searchContactsBase,
+  configurationBase,
+  routingBase,
+  RootState,
+  contactFormsBase,
+} from '../../states';
 import { Flex } from '../../styles/HrmStyles';
 
 type OwnProps = {
@@ -203,6 +210,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const { counselors } = state[namespace][configurationBase];
   const routing = state[namespace][routingBase].tasks[taskId];
   const isStandaloneSearch = taskId === standaloneTaskSid;
+  const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
 
   return {
     isRequesting: taskSearchState.isRequesting,
@@ -214,6 +222,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
     searchCasesResults: taskSearchState.searchCasesResult,
     counselorsHash: counselors.hash,
     showActionIcons: !isStandaloneSearch,
+    editContactFormOpen,
     routing,
   };
 };

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -202,11 +202,7 @@ const TabbedForms: React.FC<Props> = ({
 
   return (
     <FormProvider {...methods}>
-      <div
-        role="form"
-        style={{ height: '100%', overflow: 'scroll' }}
-        className={editContactFormOpen ? 'editingContact' : ''}
-      >
+      <div role="form" style={{ height: '100%' }} className={editContactFormOpen ? 'editingContact' : ''}>
         <TabbedFormsContainer>
           {/* Buttons at the top of the form */}
           <HeaderControlButtons />

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -87,6 +87,7 @@ const TabbedForms: React.FC<Props> = ({
   contactForm,
   currentDefinitionVersion,
   csamReportEnabled,
+  editContactFormOpen,
 }) => {
   const methods = useForm({
     shouldFocusError: false,
@@ -183,7 +184,7 @@ const TabbedForms: React.FC<Props> = ({
 
   // eslint-disable-next-line react/display-name
   const HeaderControlButtons = () => (
-    <Box marginTop="10px" marginBottom="10px" paddingLeft="20px">
+    <Box className="hiddenWhenEditingContact" marginTop="10px" marginBottom="10px" paddingLeft="20px">
       <Row>
         <SearchResultsBackButton handleBack={handleBackButton} text={<Template code="TabbedForms-BackButton" />} />
         {csamReportEnabled && (
@@ -201,12 +202,23 @@ const TabbedForms: React.FC<Props> = ({
 
   return (
     <FormProvider {...methods}>
-      <div role="form" style={{ height: '100%', overflow: 'scroll' }}>
+      <div
+        role="form"
+        style={{ height: '100%', overflow: 'scroll' }}
+        className={editContactFormOpen ? 'editingContact' : ''}
+      >
         <TabbedFormsContainer>
           {/* Buttons at the top of the form */}
           <HeaderControlButtons />
 
-          <StyledTabs name="tab" variant="scrollable" scrollButtons="auto" value={tabIndex} onChange={handleTabsChange}>
+          <StyledTabs
+            className="hiddenWhenEditingContact"
+            name="tab"
+            variant="scrollable"
+            scrollButtons="auto"
+            value={tabIndex}
+            onChange={handleTabsChange}
+          >
             {tabs}
           </StyledTabs>
           {subroute === 'search' ? (
@@ -279,19 +291,21 @@ const TabbedForms: React.FC<Props> = ({
               )}
             </div>
           )}
-          <BottomBar
-            task={task}
-            nextTab={() =>
-              dispatch(
-                changeRoute({ route: 'tabbed-forms', subroute: tabsToIndex[tabIndex + 1], autoFocus: true }, taskId),
-              )
-            }
-            // TODO: move this two functions to a separate file to centralize "handle task completions"
-            showNextButton={tabIndex !== 0 && tabIndex < tabs.length - 1}
-            showSubmitButton={showSubmitButton}
-            handleSubmitIfValid={methods.handleSubmit} // TODO: this should be used within BottomBar, but that requires a small refactor to make it a functional component
-            optionalButtons={optionalButtons}
-          />
+          <div className="hiddenWhenEditingContact">
+            <BottomBar
+              task={task}
+              nextTab={() =>
+                dispatch(
+                  changeRoute({ route: 'tabbed-forms', subroute: tabsToIndex[tabIndex + 1], autoFocus: true }, taskId),
+                )
+              }
+              // TODO: move this two functions to a separate file to centralize "handle task completions"
+              showNextButton={tabIndex !== 0 && tabIndex < tabs.length - 1}
+              showSubmitButton={showSubmitButton}
+              handleSubmitIfValid={methods.handleSubmit} // TODO: this should be used within BottomBar, but that requires a small refactor to make it a functional component
+              optionalButtons={optionalButtons}
+            />
+          </div>
         </TabbedFormsContainer>
       </div>
     </FormProvider>
@@ -303,8 +317,9 @@ TabbedForms.displayName = 'TabbedForms';
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const routing = state[namespace][routingBase].tasks[ownProps.task.taskSid];
   const contactForm = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];
+  const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
   const { currentDefinitionVersion } = state[namespace][configurationBase];
-  return { routing, contactForm, currentDefinitionVersion };
+  return { routing, contactForm, currentDefinitionVersion, editContactFormOpen };
 };
 
 const connector = connect(mapStateToProps);

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -210,7 +210,6 @@ const TabbedForms: React.FC<Props> = ({
         <TabbedFormsContainer>
           {/* Buttons at the top of the form */}
           <HeaderControlButtons />
-
           <StyledTabs
             className="hiddenWhenEditingContact"
             name="tab"

--- a/plugin-hrm-form/src/permissions/demo.json
+++ b/plugin-hrm-form/src/permissions/demo.json
@@ -17,5 +17,5 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"],["isOwner"]]
 }

--- a/plugin-hrm-form/src/states/contacts/actions.ts
+++ b/plugin-hrm-form/src/states/contacts/actions.ts
@@ -66,3 +66,13 @@ export const addCSAMReportEntry = (csamReportEntry: CSAMReportEntry, taskId: str
   csamReportEntry,
   taskId,
 });
+
+export const setEditContactPageOpen = (): t.ContactsActionType => ({
+  type: t.SET_EDITING_CONTACT,
+  editing: true,
+});
+
+export const setEditContactPageClosed = (): t.ContactsActionType => ({
+  type: t.SET_EDITING_CONTACT,
+  editing: false,
+});

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -12,15 +12,15 @@ import {
 import { createStateItem } from '../../components/common/forms/formGenerators';
 import { createContactlessTaskTabDefinition } from '../../components/tabbedForms/ContactlessTaskTabDefinition';
 import {
+  EXISTING_CONTACT_SET_CATEGORIES_GRID_VIEW_ACTION,
+  EXISTING_CONTACT_TOGGLE_CATEGORY_EXPANDED_ACTION,
   ExistingContactAction,
   ExistingContactsState,
   LOAD_CONTACT_ACTION,
   loadContactReducer,
   RELEASE_CONTACT_ACTION,
   releaseContactReducer,
-  EXISTING_CONTACT_SET_CATEGORIES_GRID_VIEW_ACTION,
   setCategoriesGridViewReducer,
-  EXISTING_CONTACT_TOGGLE_CATEGORY_EXPANDED_ACTION,
   toggleCategoryExpandedReducer,
 } from './existingContacts';
 import { CSAMReportEntry } from '../../types/types';
@@ -61,6 +61,7 @@ type ContactsState = {
   };
   existingContacts: ExistingContactsState;
   contactDetails: ContactDetailsState;
+  editingContact: boolean;
 };
 
 export const emptyCategories = [];
@@ -118,9 +119,10 @@ const initialState: ContactsState = {
     [DetailsContext.CASE_DETAILS]: { detailsExpanded: {}, route: ContactDetailsRoute.HOME },
     [DetailsContext.CONTACT_SEARCH]: { detailsExpanded: {}, route: ContactDetailsRoute.HOME },
   },
+  editingContact: false,
 };
 
-// eslint-disable-next-line import/no-unused-modules
+// eslint-disable-next-line import/no-unused-modules,complexity
 export function reduce(
   state = initialState,
   action: t.ContactsActionType | ExistingContactAction | ContactDetailsAction | GeneralActionType,
@@ -276,6 +278,9 @@ export function reduce(
           },
         },
       };
+    }
+    case t.SET_EDITING_CONTACT: {
+      return { ...state, editingContact: action.editing };
     }
     case LOAD_CONTACT_ACTION: {
       return { ...state, existingContacts: loadContactReducer(state.existingContacts, action) };

--- a/plugin-hrm-form/src/states/contacts/types.ts
+++ b/plugin-hrm-form/src/states/contacts/types.ts
@@ -13,6 +13,7 @@ export const PREPOPULATE_FORM = 'PREPOPULATE_FORM';
 export const RESTORE_ENTIRE_FORM = 'RESTORE_ENTIRE_FORM';
 export const UPDATE_HELPLINE = 'UPDATE_HELPLINE';
 export const ADD_CSAM_REPORT_ENTRY = 'contacts/ADD_CSAM_REPORT_ENTRY';
+export const SET_EDITING_CONTACT = 'SET_EDITING_CONTACT';
 
 type UpdateFormAction = {
   type: typeof UPDATE_FORM;
@@ -63,6 +64,11 @@ type AddCSAMReportEntry = {
   taskId: string;
 };
 
+type SetEditingContact = {
+  type: typeof SET_EDITING_CONTACT;
+  editing: boolean;
+};
+
 export type ContactsActionType =
   | UpdateFormAction
   | SaveEndMillisAction
@@ -71,4 +77,5 @@ export type ContactsActionType =
   | PrePopulateFormAction
   | RestoreEntireFormAction
   | UpdateHelpline
-  | AddCSAMReportEntry;
+  | AddCSAMReportEntry
+  | SetEditingContact;

--- a/plugin-hrm-form/src/styles/GlobalOverrides.js
+++ b/plugin-hrm-form/src/styles/GlobalOverrides.js
@@ -44,4 +44,8 @@ injectGlobal`
     height: 16px;
     font-size: 16px;
   }
+  
+  .editingContact .hiddenWhenEditingContact {
+    display: none;
+  }
 `;

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -94,9 +94,13 @@ export const TabbedFormTabContainer = styled(({ display, ...rest }: TabbedFormTa
 TabbedFormTabContainer.displayName = 'TabbedFormTabContainer';
 
 const containerLeftRightMargin = '5px';
-export const Container = styled('div')`
+
+type ContainerProps = {
+  removePadding?: boolean;
+};
+export const Container = styled('div')<ContainerProps>`
   display: flex;
-  padding: 32px 20px 12px 20px;
+  padding: ${({ removePadding }) => (removePadding ? '0' : '32px 20px 12px 20px')};
   flex-direction: column;
   flex-wrap: nowrap;
   background-color: #ffffff;

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -316,7 +316,7 @@ export const ChildIsAtRiskWrapper = styled(Row)`
   box-sizing: border-box;
   border-radius: 4px;
   border: 'none';
-  boxshadow: 'none';
+  box-shadow: 'none';
 `;
 ChildIsAtRiskWrapper.displayName = 'ChildIsAtRiskWrapper';
 
@@ -376,3 +376,13 @@ export const CloseDialogText = styled('p')`
 `;
 
 CloseDialogText.displayName = 'CloseDialogText';
+
+export const EditContactContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: 8px rgba(25, 43, 51, 0.3) solid;
+  border-radius: 4px;
+  overflow-y: clip;
+`;
+EditContactContainer.displayName = 'EditContactContainer';

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -322,7 +322,7 @@ export const DetailsContainer = styled('div')`
 export const SectionTitleContainer = styled(Row)<ColorProps>`
   background-color: #ecedf1;
   padding: 8px 25px 8px;
-  margin:2px 0;
+  margin: 2px 0;
   border-left: ${({ color }) => (color ? `6px solid ${color}` : 'none')};
 `;
 SectionTitleContainer.displayName = 'SectionTitleContainer';

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -313,7 +313,7 @@ export const ContactDetailsIcon = icon => styled(icon)`
   font-size: 16px;
 `;
 
-const containerPadding = 40;
+const containerPadding = 20;
 export const DetailsContainer = styled('div')`
   padding-left: ${containerPadding}px;
   padding-right: ${containerPadding}px;

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -321,9 +321,8 @@ export const DetailsContainer = styled('div')`
 
 export const SectionTitleContainer = styled(Row)<ColorProps>`
   background-color: #ecedf1;
-  padding: 8px;
-  padding-left: 18px;
-  margin: 2px 0;
+  padding: 8px 25px 8px;
+  margin:2px 0;
   border-left: ${({ color }) => (color ? `6px solid ${color}` : 'none')};
 `;
 SectionTitleContainer.displayName = 'SectionTitleContainer';

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -293,6 +293,12 @@
   "SectionName-Referral": "Referral",
   "SectionName-Notes": "Notes",
   "SectionName-CaseSummary": "Case Summary",
+  
+  "Contact-EditCaller":"Edit Caller Information",
+  "Contact-EditChild":"Edit Child Information",
+  "Contact-EditCategories":"Edit Categories",
+  "Contact-EditSummary":"Edit Summary",
+
   "ContactCopyButton": "Copy",
   "ManualPullButtonText": "Another Task",
   "NoTaskAssignableNotification": "No task assignable to you at the moment.",

--- a/plugin-hrm-form/src/translations/es-ES/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-ES/flexUI.json
@@ -411,10 +411,10 @@
     "SectionEntry-No": "No",
     "SectionEntry-Yes": "Sí",
 
-  "Contact-EditCaller":"Editar información del Llamante",
-  "Contact-EditChild":"Editar información del niño",
-  "Contact-EditCategories":"Editar categorías",
-  "Contact-EditSummary":"Editar resumen",
+    "Contact-EditCaller":"Editar información del Llamante",
+    "Contact-EditChild":"Editar información del niño",
+    "Contact-EditCategories":"Editar categorías",
+    "Contact-EditSummary":"Editar resumen",
   
     "Case-CaseStatus": "Estado de la caja",
     "Case-CaseManager": "Administrador de casos",

--- a/plugin-hrm-form/src/translations/es-ES/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-ES/flexUI.json
@@ -410,6 +410,12 @@
     "SectionName-Perpetrator": "Perpetrador",
     "SectionEntry-No": "No",
     "SectionEntry-Yes": "Sí",
+
+  "Contact-EditCaller":"Editar información del Llamante",
+  "Contact-EditChild":"Editar información del niño",
+  "Contact-EditCategories":"Editar categorías",
+  "Contact-EditSummary":"Editar resumen",
+  
     "Case-CaseStatus": "Estado de la caja",
     "Case-CaseManager": "Administrador de casos",
     "First Name": "Nombre",

--- a/plugin-hrm-form/src/translations/es-ES/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-ES/flexUI.json
@@ -411,7 +411,7 @@
     "SectionEntry-No": "No",
     "SectionEntry-Yes": "Sí",
 
-    "Contact-EditCaller":"Editar información del Llamante",
+    "Contact-EditCaller":"Editar información del llamante",
     "Contact-EditChild":"Editar información del niño",
     "Contact-EditCategories":"Editar categorías",
     "Contact-EditSummary":"Editar resumen",

--- a/plugin-hrm-form/src/translations/pt-BR/flexUI.json
+++ b/plugin-hrm-form/src/translations/pt-BR/flexUI.json
@@ -419,6 +419,11 @@
   "SectionName-Contact": "Contato",
   "SectionName-CaseSummary": "Resumo do Caso",
 
+  "Contact-EditCaller":"Editar Informação do Chamador",
+  "Contact-EditChild":"Editar Informação do Criança",
+  "Contact-EditCategories":"Editar Categorias",
+  "Contact-EditSummary":"Editar Resumo",
+
   "CannedResponses": "Respostas predefinidas",
 
   "OfflineContactFirstLine": "Contato off-line",


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
- Changed the Edit Contact Sections to imitate a modal-like container. With a editingContact state, components are hidden based on when user edits a contact. 
- Added Edit <Section Name> and close button. As such, added these localized strings -  "Contact-EditCaller",
  "Contact-EditChild", "Contact-EditCategories",  "Contact-EditSummary"
- Removed duplicate headers in Contact view with in Case List page

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [x] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes # [1180](https://bugs.benetech.org/browse/CHI-1180)

### Verification steps
- Check these four ways to get to a Edit Contact Section
1. From Contacts Queue view, search for a contact and attempt to edit a contact section
2. From Contacts Queue view, search for a case and attempt to edit a contact section
3. From Case List view, open a case, and the contact, and attempt to edit a contact section
4. From Search Contacts/Case, attempt to edit a contact section
![](https://user-images.githubusercontent.com/102122005/176332911-30222c8e-1706-490d-a1ba-ace54589c978.png)
![](https://user-images.githubusercontent.com/102122005/176332917-71264668-b56e-4f43-88d3-7d9b0295d393.png)
