### PR TITLE
Sjh e2 e flake fix

### DIFF
--- a/e2e-tests/flexChat.ts
+++ b/e2e-tests/flexChat.ts
@@ -42,7 +42,7 @@ export function flexChat(page: Page) {
             break;
           case ChatStatementOrigin.CALLER:
             try {
-              await selectors.messageWithText(text).waitFor({ timeout: 2000 });
+              await selectors.messageWithText(text).waitFor({ timeout: 2000, state: 'attached' });
             } catch (err) {
               console.log(
                 `Caller statement '${text}' not found after 2 seconds. Assuming action is required to send it so the flex chat processor is yielding control.`,

--- a/e2e-tests/flexChat.ts
+++ b/e2e-tests/flexChat.ts
@@ -41,8 +41,12 @@ export function flexChat(page: Page) {
             console.log('Sent message in flex:', text);
             break;
           case ChatStatementOrigin.CALLER:
-            if (!(await selectors.messageWithText(text).count())) {
-              // Not already sent
+            try {
+              await selectors.messageWithText(text).waitFor({ timeout: 2000 });
+            } catch (err) {
+              console.log(
+                `Caller statement '${text}' not found after 2 seconds. Assuming action is required to send it so the flex chat processor is yielding control.`,
+              );
               yield statementItem;
             }
             await selectors.messageWithText(text).waitFor({ timeout: 60000 });


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @mmythily 

## Description

Added a 'waitfor' to ensure that when chatting, the flex client waits 2 seconds for a message to come through from the caller before assuming it wasn't sent

### Checklist
- [ ] Corresponding issue has been opened
- [X] New tests added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes #....

### Verification steps

Keep an eye on the E2E runs to ensure webchat tests pass consistently