### PR TITLE
[Bug fix] Search date range not filtering accurately for Cases

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/search/actions.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/search/actions.test.ts
@@ -131,6 +131,52 @@ describe('test action creators', () => {
     expect(dispatch).toBeCalledWith({ type: t.SEARCH_CASES_SUCCESS, taskId, searchResult });
   });
 
+  test('searchCases bundles dateFrom and dateTo under filters object if provided', async () => {
+    const caseObject = {
+      createdAt: '2020-11-23T17:38:42.227Z',
+      updatedAt: '2020-11-23T17:38:42.227Z',
+      helpline: '',
+      info: {
+        definitionVersion: 'v1',
+        households: [{ household: { name: { firstName: 'Maria', lastName: 'Silva' } } }],
+      },
+    };
+
+    const searchResult = {
+      count: 1,
+      cases: [caseObject],
+    };
+    // @ts-ignore
+
+    searchCases.mockClear();
+    searchCases.mockReturnValueOnce(Promise.resolve(searchResult));
+    const dispatch = jest.fn();
+
+    await actions.searchCases(dispatch)(taskId)(
+      { dateFrom: '2020-11-23', dateTo: '2020-11-23', anotherProperty: 'anotherProperty' },
+      null,
+      CASES_PER_PAGE,
+      0,
+    );
+
+    expect(dispatch).toBeCalledTimes(2);
+    expect(dispatch).toBeCalledWith({ type: t.SEARCH_CASES_REQUEST, taskId });
+    expect(dispatch).toBeCalledWith({ type: t.SEARCH_CASES_SUCCESS, taskId, searchResult });
+    expect(searchCases).toBeCalledWith(
+      {
+        anotherProperty: 'anotherProperty',
+        filters: {
+          createdAt: {
+            from: '2020-11-23T00:00:00.000Z',
+            to: '2020-11-23T00:00:00.000Z',
+          },
+        },
+      },
+      20,
+      0,
+    );
+  });
+
   test('searchCases (failure)', async () => {
     const error = new Error('Testing failure');
     // @ts-ignore

--- a/plugin-hrm-form/src/states/search/actions.ts
+++ b/plugin-hrm-form/src/states/search/actions.ts
@@ -58,7 +58,19 @@ export const searchCases = (dispatch: Dispatch<any>) => (taskId: string) => asyn
 ) => {
   try {
     dispatch({ type: t.SEARCH_CASES_REQUEST, taskId });
-    const searchResult = await searchCasesApiCall(searchParams, limit, offset);
+
+    // Adapt dateFrom and dateTo to what is expected in the search endpoint
+    const searchCasesPayload = {
+      ...searchParams,
+      filters: {
+        createdAt: {
+          from: searchParams.dateFrom ? new Date(searchParams.dateFrom).toISOString() : undefined,
+          to: searchParams.dateTo ? new Date(searchParams.dateTo).toISOString() : undefined,
+        },
+      },
+    };
+
+    const searchResult = await searchCasesApiCall(searchCasesPayload, limit, offset);
 
     const definitions = await getCasesMissingVersions(searchResult.cases);
     definitions.forEach(d => dispatch(updateDefinitionVersion(d.version, d.definition)));

--- a/plugin-hrm-form/src/states/search/actions.ts
+++ b/plugin-hrm-form/src/states/search/actions.ts
@@ -59,13 +59,15 @@ export const searchCases = (dispatch: Dispatch<any>) => (taskId: string) => asyn
   try {
     dispatch({ type: t.SEARCH_CASES_REQUEST, taskId });
 
+    const { dateFrom, dateTo, ...rest } = searchParams || {};
+
     // Adapt dateFrom and dateTo to what is expected in the search endpoint
     const searchCasesPayload = {
-      ...searchParams,
+      ...rest,
       filters: {
         createdAt: {
-          from: searchParams.dateFrom ? new Date(searchParams.dateFrom).toISOString() : undefined,
-          to: searchParams.dateTo ? new Date(searchParams.dateTo).toISOString() : undefined,
+          from: dateFrom ? new Date(dateFrom).toISOString() : undefined,
+          to: dateTo ? new Date(dateTo).toISOString() : undefined,
         },
       },
     };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand might be overwhelmed by PRs? @murilovmachado

## Description
This PR fixes the bug described in the ticket linked below, where "the Search date range filter is not pulling the correct cases in the search result based on the filter applied". This is fixed in the "search thunk" action, by capturing the date ranges specified and bundling them in the search payload as they are expected by the search endpoint. I choose to do so in the thunk because this function is used in `src/components/PreviousContactsBanner.tsx` and `src/components/search/index.tsx`, but happy to capture this behavior at a component level if that feels more correct.

This PR supersedes https://github.com/techmatters/hrm/pull/207.

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1203)
- [x] New tests added
- [n/a] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- Start development server.
- Perform searches using date ranges and confirm that the results are as expected.
- Optional: confirm that "previous contacts search" still works as expected (previous contacts banner).