### PR TITLE
CHI-1115: Demo downloadable voice recordings

### DIFF
--- a/plugin-hrm-form/src/components/common/forms/DownloadFile.tsx
+++ b/plugin-hrm-form/src/components/common/forms/DownloadFile.tsx
@@ -9,9 +9,10 @@ import { getFileDownloadUrl } from '../../../services/ServerlessService';
 
 type Props = {
   fileNameAtAws: string;
+  convertFileName?: (original: string) => string;
 };
 
-const DownloadFile: React.FC<Props> = ({ fileNameAtAws }) => {
+const DownloadFile: React.FC<Props> = ({ fileNameAtAws, convertFileName = formatFileNameAtAws }) => {
   const [preSignedUrl, setPreSignedUrl] = useState('');
   const downloadLink = useRef<HTMLAnchorElement>();
 
@@ -21,7 +22,7 @@ const DownloadFile: React.FC<Props> = ({ fileNameAtAws }) => {
     }
   }, [preSignedUrl, downloadLink]);
 
-  const fileName = formatFileNameAtAws(fileNameAtAws);
+  const fileName = convertFileName(fileNameAtAws);
 
   const handleClick = async () => {
     const response = await getFileDownloadUrl(fileNameAtAws, fileName);

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -21,6 +21,7 @@ import {
   toggleDetailSectionExpanded,
 } from '../../states/contacts/contactDetails';
 import { getPermissionsForContact, PermissionActions } from '../../permissions';
+import DownloadFile from '../common/forms/DownloadFile';
 
 // TODO: complete this type
 type OwnProps = {
@@ -90,13 +91,8 @@ const ContactDetailsHome: React.FC<Props> = ({
     channel === channelTypes.voice || channel === channelTypes.sms || channel === channelTypes.whatsapp;
   const formattedCategories = formatCategories(categories);
 
-  const {
-    GENERAL_DETAILS,
-    CALLER_INFORMATION,
-    CHILD_INFORMATION,
-    ISSUE_CATEGORIZATION,
-    CONTACT_SUMMARY,
-  } = ContactDetailsSections;
+  const { GENERAL_DETAILS, CALLER_INFORMATION, CHILD_INFORMATION, ISSUE_CATEGORIZATION, CONTACT_SUMMARY } =
+    ContactDetailsSections;
   const addedBy = counselorsHash[createdBy];
   const counselorName = counselorsHash[counselor];
 
@@ -238,6 +234,25 @@ const ContactDetailsHome: React.FC<Props> = ({
             />
           )}
         </ContactDetailsSection>
+      )}
+      {contact.details.mediaUrls && (
+        <>
+          <p>Media:</p>
+          {contact.details.mediaUrls.map(mediaUrl => {
+            let mediaPath = null;
+            try {
+              mediaPath = new URL(mediaUrl.url).pathname.slice(1);
+            } catch (err) {
+              console.warn(`Invalid media URL`, mediaUrl?.url);
+            }
+            return (
+              <p key={mediaUrl.url}>
+                [{mediaUrl.type}]: {mediaUrl.url}
+                {mediaPath && <DownloadFile fileNameAtAws={mediaPath} convertFileName={s => s} />}
+              </p>
+            );
+          })}
+        </>
       )}
     </DetailsContainer>
   );

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -76,6 +76,15 @@ export type Case = {
   connectedContacts: any[]; // TODO: create contact type
 };
 
+export const contactMediaType = {
+  RECORDING: 'recording',
+  TRANSCRIPT: 'transcript',
+} as const;
+
+export type ContactMediaType = typeof contactMediaType[keyof typeof contactMediaType];
+
+export type ContactMediaUrl = { url: string; type: ContactMediaType };
+
 type NestedInformation = { name: { firstName: string; lastName: string } };
 export type InformationObject = NestedInformation & {
   [key: string]: string | boolean | NestedInformation[keyof NestedInformation]; // having NestedInformation[keyof NestedInformation] makes type looser here because of this https://github.com/microsoft/TypeScript/issues/17867. Possible/future solution https://github.com/microsoft/TypeScript/pull/29317
@@ -89,6 +98,7 @@ export type ContactRawJson = {
   callerInformation: InformationObject;
   caseInformation: { categories: {} } & { [key: string]: string | boolean | {} }; // having {} makes type looser here because of this https://github.com/microsoft/TypeScript/issues/17867. Possible/future solution https://github.com/microsoft/TypeScript/pull/29317
   contactlessTask: { [key: string]: string | boolean };
+  mediaUrls?: ContactMediaUrl[];
 };
 
 // Information about a single contact, as expected from search contacts endpoint (we might want to reuse this type in backend) - (is this a correct placement for this?)


### PR DESCRIPTION
## Description

Flex changes to demonstrate storing & retrieving external voice recordings.

* Records the 'worker' Call Sid (which is different from the 'caller Sid' put on the top level of the task, because this is required to look up the call recording
* Uses the same presigned URL serverless function to download voice recordings from S3, with media URLs added to the contact information by an async process in S3

### Related Issues
CHI-1115

### Verification steps

* Point at an instance of HRM build from https://github.com/techmatters/hrm/pull/209
* Log a voice call contact
* Reopen the contact from search or from the case you attached it to
* The media URLs should be shown on the Contact Details view, download one and play it