### PR TITLE
Make strings localizable

### DIFF
--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -86,7 +86,9 @@ const PreviousContactsBanner: React.FC<Props> = ({
               {contactsCount} <Template code="PreviousContacts-PreviousContacts" />
             </Bold>
           )}
-          &nbsp;and&nbsp;
+          &nbsp;
+          <Template code="PreviousContacts-And" />
+          &nbsp;
           {casesCount === 1 ? (
             <Bold>
               {casesCount} <Template code="PreviousContacts-Case" />

--- a/plugin-hrm-form/src/components/search/ContactPreview/CallSummary.jsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/CallSummary.jsx
@@ -27,20 +27,19 @@ class CallSummary extends React.Component {
 
   render() {
     const { callSummary } = this.props;
-    const isLong = callSummary.length > CHAR_LIMIT;
 
-    if (!callSummary) return null;
+    const isLong = callSummary && callSummary.length > CHAR_LIMIT;
 
     return this.state.expanded ? (
       <div>
-        <SummaryText>{this.props.callSummary}</SummaryText>
+        <SummaryText>{callSummary}</SummaryText>
         <StyledLink onClick={this.props.onClickFull}>
           <Template code="CallSummary-ViewFull" />
         </StyledLink>
       </div>
     ) : (
       <Row style={{ height: '23px' }}>
-        <ShortSummaryText>{getShortSummary(this.props.callSummary, CHAR_LIMIT)}</ShortSummaryText>
+        <ShortSummaryText>{getShortSummary(callSummary, CHAR_LIMIT)}</ShortSummaryText>
         {isLong && (
           <StyledLink onClick={this.handleClick(true)}>
             <Template code="CallSummary-MoreNotes" />

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -327,6 +327,7 @@
   "PreviousContacts-Contacts": "contacts",
   "PreviousContacts-Case": "case",
   "PreviousContacts-Cases": "cases",
+  "PreviousContacts-And": "and",
   "PreviousContacts-From": "from",
   "PreviousContacts-IPAddress": "IP address",
   "PreviousContacts-PhoneNumber": "phone number",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -358,5 +358,7 @@
 
   "BottomBar-SaveOnClose": "Save Changes?",
   "BottomBar-DontSave": "No, Don't Save",
-  "BottomBar-Save": "Yes, Save"
+  "BottomBar-Save": "Yes, Save",
+
+  "CaseSummary-None": "- No case summary -"
 }

--- a/plugin-hrm-form/src/utils/formatters.tsx
+++ b/plugin-hrm-form/src/utils/formatters.tsx
@@ -1,5 +1,6 @@
 import { truncate } from 'lodash';
 import { format } from 'date-fns';
+import { Template } from '@twilio/flex-ui';
 import type { FormItemDefinition } from 'hrm-form-definitions';
 
 /**
@@ -42,9 +43,9 @@ export const formatDuration = inSeconds => {
  */
 export const getShortSummary = (summary, charLimit, chooseMessage = 'call') => {
   if (!summary) {
-    if (chooseMessage === 'case') return '- No case summary -';
+    if (chooseMessage === 'case') return <Template code="CaseSummary-None"/>;
 
-    return '- No call summary -';
+    return <Template code="CallSummary-None"/>;
   }
 
   return truncate(summary, {

--- a/plugin-hrm-form/src/utils/formatters.tsx
+++ b/plugin-hrm-form/src/utils/formatters.tsx
@@ -44,9 +44,9 @@ export const formatDuration = inSeconds => {
  */
 export const getShortSummary = (summary, charLimit, chooseMessage = 'call') => {
   if (!summary) {
-    if (chooseMessage === 'case') return <Template code="CaseSummary-None"/>;
+    if (chooseMessage === 'case') return <Template code="CaseSummary-None" />;
 
-    return <Template code="CallSummary-None"/>;
+    return <Template code="CallSummary-None" />;
   }
 
   return truncate(summary, {

--- a/plugin-hrm-form/src/utils/formatters.tsx
+++ b/plugin-hrm-form/src/utils/formatters.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { truncate } from 'lodash';
 import { format } from 'date-fns';
 import { Template } from '@twilio/flex-ui';


### PR DESCRIPTION
## Description
This PR 
- Addresses an observation that @janorivera made on one of our strings being hardcoded. The helper function changed to return templated strings so we can localize them from now on.
- Also I've noticed an early return statement on the contact preview that caused it being empty when actually the intention was to show a "no summary" string, so addressed that here too.
- Converts `and` string from "previous contacts banner" to a template string.

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1308)
- [ ] New tests added
- [x] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Start local server (`npm run dev`).
- Look (or add) for a case with no summary and confirm the string is properly rendered in the case list.
- Look (or add) for a contact with no summary and confirm the string is properly rendered in the contact preview (search). For this you might need to edit the form definition in use to not have summary as required.
- Start a new contact and confirm that the `and` word in the previous contacts banner is render as it should.