### PR TITLE
CHI-1302: Edit contact state in Redux

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/case/ViewContact.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/ViewContact.test.tsx
@@ -154,8 +154,9 @@ describe('View Contact', () => {
           tasks: {},
           existingContacts: {
             'TEST ID': {
-              contact,
-              refCount: 1,
+              savedContact: contact,
+              references: new Set(['task-id']),
+              categories: { gridView: false, expanded: {} },
             },
           },
           contactDetails: {

--- a/plugin-hrm-form/src/___tests__/search/ContactDetails.test.tsx
+++ b/plugin-hrm-form/src/___tests__/search/ContactDetails.test.tsx
@@ -15,9 +15,7 @@ import { DetailsContext } from '../../states/contacts/contactDetails';
 
 const mockStore = configureMockStore([]);
 
-const themeConf = {
-  colorTheme: HrmTheme,
-};
+const themeConf = {};
 
 const contactOfType = type => ({
   contactId: 'TEST CONTACT ID',
@@ -121,7 +119,7 @@ beforeAll(async () => {
         existingContacts: {
           'TEST CONTACT ID': {
             refCount: 1,
-            contact: contactOfType(type),
+            savedContact: contactOfType(type),
           },
         },
         contactDetails: {
@@ -148,6 +146,7 @@ test(`<ContactDetails> with contact of type ${callTypes.child}`, () => {
           handleMockedMessage={handleMockedMessage}
           handleSelectSearchResult={handleSelectSearchResult}
           detailsExpanded={detailsExpanded}
+          task={{ taskSid: 'TEST_TASK_ID' }}
         />
       </Provider>
     </StorelessThemeProvider>,
@@ -172,6 +171,7 @@ test(`<ContactDetails> with contact of type ${callTypes.caller}`, () => {
           handleMockedMessage={handleMockedMessage}
           handleSelectSearchResult={handleSelectSearchResult}
           detailsExpanded={detailsExpanded}
+          task={{ taskSid: 'TEST_TASK_ID' }}
         />
       </Provider>
     </StorelessThemeProvider>,
@@ -196,6 +196,7 @@ test(`<ContactDetails> with a non data (standalone) contact`, () => {
           handleMockedMessage={handleMockedMessage}
           handleSelectSearchResult={handleSelectSearchResult}
           detailsExpanded={detailsExpanded}
+          task={{ taskSid: 'TEST_TASK_ID' }}
         />
       </Provider>
     </StorelessThemeProvider>,

--- a/plugin-hrm-form/src/___tests__/states/contacts/contactDetails.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/contactDetails.test.ts
@@ -1,16 +1,13 @@
 import {
-  ContactDetailsRoute,
   ContactDetailsState,
   DetailsContext,
-  navigateContactDetails,
-  navigateContactDetailsReducer,
   sectionExpandedStateReducer,
   toggleDetailSectionExpanded,
 } from '../../../states/contacts/contactDetails';
 
 const emptyState: ContactDetailsState = {
-  [DetailsContext.CASE_DETAILS]: { detailsExpanded: {}, route: ContactDetailsRoute.HOME },
-  [DetailsContext.CONTACT_SEARCH]: { detailsExpanded: {}, route: ContactDetailsRoute.HOME },
+  [DetailsContext.CASE_DETAILS]: { detailsExpanded: {} },
+  [DetailsContext.CONTACT_SEARCH]: { detailsExpanded: {} },
 };
 
 describe('sectionExpandedStateReducer', () => {
@@ -20,7 +17,6 @@ describe('sectionExpandedStateReducer', () => {
         ...emptyState,
         [DetailsContext.CASE_DETAILS]: {
           detailsExpanded: { 'Caller information': true },
-          route: ContactDetailsRoute.HOME,
         },
       },
       toggleDetailSectionExpanded(DetailsContext.CASE_DETAILS, 'Caller information'),
@@ -39,21 +35,5 @@ describe('sectionExpandedStateReducer', () => {
       toggleDetailSectionExpanded(DetailsContext.CASE_DETAILS, 'Child information'),
     );
     expect(newState[DetailsContext.CASE_DETAILS].detailsExpanded['Child information']).toBe(true);
-  });
-});
-
-describe('navigateContactDetailsReducer', () => {
-  test('Sets the route in the specified context, changing nothing else in the state', () => {
-    const newState = navigateContactDetailsReducer(
-      emptyState,
-      navigateContactDetails(DetailsContext.CONTACT_SEARCH, ContactDetailsRoute.EDIT_CATEGORIES),
-    );
-    expect(newState).toStrictEqual({
-      ...emptyState,
-      [DetailsContext.CONTACT_SEARCH]: {
-        ...emptyState[DetailsContext.CONTACT_SEARCH],
-        route: ContactDetailsRoute.EDIT_CATEGORIES,
-      },
-    });
   });
 });

--- a/plugin-hrm-form/src/___tests__/states/contacts/issueCategorizationStateApi.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/issueCategorizationStateApi.test.ts
@@ -4,6 +4,11 @@ import { contactFormsBase, namespace } from '../../../states';
 import * as taskActions from '../../../states/contacts/actions';
 import * as existingContactActions from '../../../states/contacts/existingContacts';
 
+const mockCats = [
+  'categories.category1.subcategory1',
+  'categories.category1.subcategory2',
+  'categories.category2.subcategory1',
+];
 describe('forTask', () => {
   const api = forTask(<CustomITask>{ taskSid: 'mock task' });
   test('retrieveState - Returns contact from the tasks area of the state', () => {
@@ -25,7 +30,7 @@ describe('forTask', () => {
   });
   test('updateFormActionDispatcher - dispatches an update form action with the task ID', () => {
     const mockDispatcher = jest.fn();
-    const mockCats = { any: 'thing' };
+
     api.updateFormActionDispatcher(mockDispatcher)(mockCats);
     expect(mockDispatcher).toHaveBeenCalledWith(taskActions.updateForm('mock task', 'categories', mockCats));
   });
@@ -53,9 +58,22 @@ describe('forExistingCategory', () => {
     api.setGridViewActionDispatcher(mockDispatcher)(true);
     expect(mockDispatcher).toHaveBeenCalledWith(existingContactActions.setCategoriesGridView(MOCK_CONTACT_ID, true));
   });
-  test('updateFormActionDispatcher - dispatches nothing', () => {
+  test('updateFormActionDispatcher - dispatches an updated categories draft', () => {
     const mockDispatcher = jest.fn();
-    api.updateFormActionDispatcher(mockDispatcher)({ going: 'nowhere' });
-    expect(mockDispatcher).not.toHaveBeenCalled();
+    api.updateFormActionDispatcher(mockDispatcher)([
+      'categories.category1.subcategory1',
+      'categories.category1.subcategory2',
+      'categories.category2.subcategory1',
+    ]);
+    expect(mockDispatcher).toHaveBeenCalledWith(
+      existingContactActions.updateDraft(MOCK_CONTACT_ID, {
+        overview: {
+          categories: {
+            category1: ['subcategory1', 'subcategory2'],
+            category2: ['subcategory1'],
+          },
+        },
+      }),
+    );
   });
 });

--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -50,20 +50,21 @@ const ViewContact: React.FC<Props> = ({
   connectedCase,
   editContactFormOpen,
 }) => {
+  const handleClose = () => {
+    releaseContactFromState(contactFromInfo.id, task.taskSid);
+    onClickClose();
+  };
+
   useEffect(() => {
     if (tempInfo && tempInfo.screen === 'view-contact') {
       const { contact: contactFromInfo, timeOfContact, counselor } = tempInfo.info;
       if (contactFromInfo) {
-        loadRawContactIntoState(contactFromInfo);
-        return () => releaseContactFromState(contactFromInfo.id);
+        loadRawContactIntoState(contactFromInfo, task.taskSid);
+      } else {
+        const temporaryId = `__unsavedFromCase:${connectedCase.id}`;
+        loadContactIntoState(taskFormToSearchContact(task, form, timeOfContact, counselor, temporaryId), task.taskSid);
       }
-      const temporaryId = `__unsavedFromCase:${connectedCase.id}`;
-      loadContactIntoState(taskFormToSearchContact(task, form, timeOfContact, counselor, temporaryId));
-      return () => releaseContactFromState(temporaryId);
     }
-    return () => {
-      /* no cleanup to do. */
-    };
   }, [
     counselorsHash,
     loadContactIntoState,
@@ -87,7 +88,7 @@ const ViewContact: React.FC<Props> = ({
           context={DetailsContext.CASE_DETAILS}
         />
         <BottomButtonBar className="hiddenWhenEditingContact" style={{ marginBlockStart: 'auto' }}>
-          <StyledNextStepButton roundCorners onClick={onClickClose} data-testid="Case-ViewContactScreen-CloseButton">
+          <StyledNextStepButton roundCorners onClick={handleClose} data-testid="Case-ViewContactScreen-CloseButton">
             <Template code="CloseButton" />
           </StyledNextStepButton>
         </BottomButtonBar>

--- a/plugin-hrm-form/src/components/contact/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetails.tsx
@@ -4,7 +4,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { CircularProgress } from '@material-ui/core';
 
 import ContactDetailsHome from './ContactDetailsHome';
-import { ContactDetailsRoute, DetailsContext, navigateContactDetails } from '../../states/contacts/contactDetails';
+import { DetailsContext } from '../../states/contacts/contactDetails';
 import { configurationBase, contactFormsBase, namespace, RootState } from '../../states';
 import EditContactSection from './EditContactSection';
 import { getDefinitionVersion } from '../../services/ServerlessService';
@@ -37,7 +37,6 @@ const ContactDetails: React.FC<Props> = ({
   updateDefinitionVersion,
   savedContact,
   draftContact,
-  navigateForContext,
   enableEditing = true,
   updateContactDraft,
 }) => {
@@ -58,14 +57,6 @@ const ContactDetails: React.FC<Props> = ({
     }
   }, [definitionVersions, updateDefinitionVersion, version, savedContact]);
 
-  /**
-   * Reset to home after we leave
-   */
-  React.useEffect(() => {
-    return () => {
-      navigateForContext(context, ContactDetailsRoute.HOME);
-    };
-  }, [navigateForContext, context]);
   const definitionVersion = definitionVersions[version];
 
   if (!definitionVersion)
@@ -140,13 +131,11 @@ const ContactDetails: React.FC<Props> = ({
 
 const mapDispatchToProps = {
   updateDefinitionVersion: ConfigActions.updateDefinitionVersion,
-  navigateForContext: navigateContactDetails,
   updateContactDraft: updateDraft,
 };
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   definitionVersions: state[namespace][configurationBase].definitionVersions,
-  route: state[namespace][contactFormsBase].contactDetails[ownProps.context].route,
   savedContact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.savedContact,
   draftContact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.draftContact,
 });

--- a/plugin-hrm-form/src/components/contact/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetails.tsx
@@ -15,6 +15,8 @@ import ContactDetailsSectionForm from './ContactDetailsSectionForm';
 import IssueCategorizationSectionForm from './IssueCategorizationSectionForm';
 import { forExistingContact } from '../../states/contacts/issueCategorizationStateApi';
 import { getConfig } from '../../HrmFormPlugin';
+import { updateDraft } from '../../states/contacts/existingContacts';
+import { transformContactFormValues } from '../../services/ContactService';
 
 type OwnProps = {
   contactId: string;
@@ -31,14 +33,15 @@ const ContactDetails: React.FC<Props> = ({
   contactId,
   handleOpenConnectDialog,
   showActionIcons,
-  route,
   definitionVersions,
   updateDefinitionVersion,
-  contact,
+  savedContact,
+  draftContact,
   navigateForContext,
   enableEditing = true,
+  updateContactDraft,
 }) => {
-  const version = contact?.details.definitionVersion;
+  const version = savedContact?.details.definitionVersion;
 
   const { featureFlags } = getConfig();
   /**
@@ -53,7 +56,7 @@ const ContactDetails: React.FC<Props> = ({
     if (version && !definitionVersions[version]) {
       fetchDefinitionVersions(version);
     }
-  }, [definitionVersions, updateDefinitionVersion, version, contact]);
+  }, [definitionVersions, updateDefinitionVersion, version, savedContact]);
 
   /**
    * Reset to home after we leave
@@ -81,22 +84,23 @@ const ContactDetails: React.FC<Props> = ({
         tabPath={formPath}
         definition={section.getFormDefinition(definitionVersion)}
         layoutDefinition={section.getLayoutDefinition(definitionVersion)}
-        initialValues={section.getFormValues(definitionVersion, contact)[formPath]}
+        initialValues={section.getFormValues(definitionVersion, draftContact)[formPath]}
         display={true}
         autoFocus={true}
-        updateFormActionDispatcher={() => () => {
-          /* */
-        }}
+        updateFormActionDispatcher={dispatch => values =>
+          dispatch(
+            updateContactDraft(contactId, {
+              details: {
+                [formPath]: transformContactFormValues(values[formPath], section.getFormDefinition(definitionVersion)),
+              },
+            }),
+          )}
       />
     </EditContactSection>
   );
 
-  switch (route) {
-    case ContactDetailsRoute.EDIT_CHILD_INFORMATION:
-      return editContactSectionElement(contactDetailsSectionFormApi.CHILD_INFORMATION, 'childInformation');
-    case ContactDetailsRoute.EDIT_CALLER_INFORMATION:
-      return editContactSectionElement(contactDetailsSectionFormApi.CALLER_INFORMATION, 'callerInformation');
-    case ContactDetailsRoute.EDIT_CATEGORIES:
+  if (draftContact) {
+    if (draftContact.overview?.categories) {
       const issueSection = contactDetailsSectionFormApi.ISSUE_CATEGORIZATION;
       return (
         <EditContactSection
@@ -106,40 +110,45 @@ const ContactDetails: React.FC<Props> = ({
           tabPath="categories"
         >
           <IssueCategorizationSectionForm
-            definition={definitionVersion.tabbedForms.IssueCategorizationTab(contact.overview.helpline)}
-            initialValue={issueSection.getFormValues(definitionVersion, contact).categories}
+            definition={definitionVersion.tabbedForms.IssueCategorizationTab(draftContact.overview.helpline)}
+            initialValue={issueSection.getFormValues(definitionVersion, draftContact).categories}
             stateApi={forExistingContact(contactId)}
             display={true}
             autoFocus={true}
           />
         </EditContactSection>
       );
-    case ContactDetailsRoute.EDIT_CASE_INFORMATION: {
-      return editContactSectionElement(contactDetailsSectionFormApi.CASE_INFORMATION, 'caseInformation');
     }
-    case ContactDetailsRoute.HOME:
-    default:
-      return (
-        <ContactDetailsHome
-          context={context}
-          showActionIcons={showActionIcons}
-          contactId={contactId}
-          handleOpenConnectDialog={handleOpenConnectDialog}
-          enableEditing={enableEditing && featureFlags.enable_contact_editing}
-        />
-      );
+    const { callerInformation, caseInformation, childInformation } = draftContact.details;
+    if (childInformation)
+      return editContactSectionElement(contactDetailsSectionFormApi.CHILD_INFORMATION, 'childInformation');
+    if (callerInformation)
+      return editContactSectionElement(contactDetailsSectionFormApi.CALLER_INFORMATION, 'callerInformation');
+    if (caseInformation)
+      return editContactSectionElement(contactDetailsSectionFormApi.CASE_INFORMATION, 'caseInformation');
   }
+  return (
+    <ContactDetailsHome
+      context={context}
+      showActionIcons={showActionIcons}
+      contactId={contactId}
+      handleOpenConnectDialog={handleOpenConnectDialog}
+      enableEditing={enableEditing && featureFlags.enable_contact_editing}
+    />
+  );
 };
 
 const mapDispatchToProps = {
   updateDefinitionVersion: ConfigActions.updateDefinitionVersion,
   navigateForContext: navigateContactDetails,
+  updateContactDraft: updateDraft,
 };
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   definitionVersions: state[namespace][configurationBase].definitionVersions,
   route: state[namespace][contactFormsBase].contactDetails[ownProps.context].route,
-  contact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.contact,
+  savedContact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.savedContact,
+  draftContact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.draftContact,
 });
 
 ContactDetails.displayName = 'ContactDetails';

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -14,14 +14,9 @@ import { formatCategories, formatDuration, formatName, mapChannelForInsights } f
 import { ContactDetailsSections, ContactDetailsSectionsType } from '../common/ContactDetails';
 import { unNestInformation } from '../../services/ContactService';
 import { configurationBase, contactFormsBase, namespace, RootState } from '../../states';
-import {
-  ContactDetailsRoute,
-  DetailsContext,
-  navigateContactDetails,
-  toggleDetailSectionExpanded,
-} from '../../states/contacts/contactDetails';
+import { DetailsContext, toggleDetailSectionExpanded } from '../../states/contacts/contactDetails';
 import { getPermissionsForContact, PermissionActions } from '../../permissions';
-import { createDraft, updateDraft } from '../../states/contacts/existingContacts';
+import { createDraft, ContactDetailsRoute } from '../../states/contacts/existingContacts';
 
 // TODO: complete this type
 type OwnProps = {
@@ -260,7 +255,6 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
 
 const mapDispatchToProps = {
   toggleSectionExpandedForContext: toggleDetailSectionExpanded,
-  navigateForContext: navigateContactDetails,
   createContactDraft: createDraft,
 };
 

--- a/plugin-hrm-form/src/components/contact/contactDetailsSectionFormApi.ts
+++ b/plugin-hrm-form/src/components/contact/contactDetailsSectionFormApi.ts
@@ -1,12 +1,13 @@
 import { DefinitionVersion, FormDefinition, LayoutDefinition } from 'hrm-form-definitions';
 
-import { ContactRawJson, SearchContact } from '../../types/types';
+import { ContactRawJson, InformationObject, SearchContact } from '../../types/types';
 import {
   transformCategories,
   transformContactFormValues,
   transformValues,
   unNestInformationObject,
 } from '../../services/ContactService';
+import { SearchContactDraftChanges } from '../../states/contacts/existingContacts';
 
 export type ContactFormValues = {
   [key in 'childInformation' | 'callerInformation' | 'caseInformation']?: Record<string, string | boolean>;
@@ -15,7 +16,7 @@ export type ContactFormValues = {
 export type ContactDetailsSectionFormApi = {
   getFormDefinition: (def: DefinitionVersion) => FormDefinition;
   getLayoutDefinition: (def: DefinitionVersion) => LayoutDefinition;
-  getFormValues: (def: DefinitionVersion, contact: SearchContact) => ContactFormValues;
+  getFormValues: (def: DefinitionVersion, contact: SearchContactDraftChanges) => ContactFormValues;
   formToPayload: (
     def: DefinitionVersion,
     form: ContactFormValues,
@@ -30,7 +31,7 @@ export type ContactDetailsSectionFormApi = {
 export type IssueCategorizationSectionFormApi = {
   getFormDefinition: (def: DefinitionVersion) => FormDefinition;
   getLayoutDefinition: (def: DefinitionVersion) => LayoutDefinition;
-  getFormValues: (def: DefinitionVersion, contact: SearchContact) => { categories: string[] };
+  getFormValues: (def: DefinitionVersion, contact: SearchContactDraftChanges) => { categories: string[] };
   type: 'IssueCategorizationSectionForm';
   formToPayload: (
     def: DefinitionVersion,
@@ -47,7 +48,10 @@ export const contactDetailsSectionFormApi: {
 } = {
   CHILD_INFORMATION: {
     getFormValues: (def, contact) => ({
-      childInformation: unNestInformationObject(def.tabbedForms.ChildInformationTab, contact.details.childInformation),
+      childInformation: unNestInformationObject(
+        def.tabbedForms.ChildInformationTab,
+        <InformationObject>contact.details.childInformation,
+      ),
     }),
     getFormDefinition: def => def.tabbedForms.ChildInformationTab,
     getLayoutDefinition: def => def.layoutVersion.contact.childInformation,
@@ -61,7 +65,7 @@ export const contactDetailsSectionFormApi: {
     getFormValues: (def, contact) => ({
       callerInformation: unNestInformationObject(
         def.tabbedForms.CallerInformationTab,
-        contact.details.callerInformation,
+        <InformationObject>contact.details.callerInformation,
       ),
     }),
     getFormDefinition: def => def.tabbedForms.CallerInformationTab,

--- a/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
@@ -47,12 +47,14 @@ const ContactDetails: React.FC<Props> = ({
   const [anchorEl, setAnchorEl] = useState(null);
 
   useEffect(() => {
-    loadContactIntoState(contact);
-    return () => {
-      releaseContactFromState(contact.contactId);
-    };
+    loadContactIntoState(contact, task.taskSid);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contact]);
+
+  const handleBackToResults = () => {
+    releaseContactFromState(contact.contactId, task.taskSid);
+    handleBack();
+  };
 
   const handleCloseDialog = () => {
     setAnchorEl(null);
@@ -83,7 +85,7 @@ const ContactDetails: React.FC<Props> = ({
       <div className={`${editContactFormOpen ? 'editingContact' : ''} hiddenWhenEditingContact`}>
         <BackToSearchResultsButton
           text={<Template code="SearchResultsIndex-BackToResults" />}
-          handleBack={handleBack}
+          handleBack={handleBackToResults}
         />
       </div>
 

--- a/plugin-hrm-form/src/states/contacts/contactDetails.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetails.ts
@@ -5,18 +5,9 @@ export enum DetailsContext {
   CASE_DETAILS = 'caseDetails',
 }
 
-export enum ContactDetailsRoute {
-  HOME = 'home',
-  EDIT_CALLER_INFORMATION = 'editCallerInformation',
-  EDIT_CHILD_INFORMATION = 'editChildInformation',
-  EDIT_CATEGORIES = 'editIssueCategories',
-  EDIT_CASE_INFORMATION = 'editCaseInformation',
-}
-
 export type ContactDetailsState = {
   [context in DetailsContext]: {
     detailsExpanded: { [Section in ContactDetailsSectionsType]?: boolean };
-    route: ContactDetailsRoute;
   };
 };
 
@@ -51,32 +42,4 @@ export const sectionExpandedStateReducer = (
   },
 });
 
-export const NAVIGATE_CONTACT_DETAILS_ACTION = 'NAVIGATE_CONTACT_DETAILS_ACTION';
-
-type NavigateContactDetailsAction = {
-  type: typeof NAVIGATE_CONTACT_DETAILS_ACTION;
-  context: DetailsContext;
-  route: ContactDetailsRoute;
-};
-
-export const navigateContactDetails = (
-  context: DetailsContext,
-  route: ContactDetailsRoute,
-): NavigateContactDetailsAction => ({
-  type: NAVIGATE_CONTACT_DETAILS_ACTION,
-  context,
-  route,
-});
-
-export const navigateContactDetailsReducer = (
-  state: ContactDetailsState,
-  action: NavigateContactDetailsAction,
-): ContactDetailsState => ({
-  ...state,
-  [action.context]: {
-    ...state[action.context],
-    route: action.route,
-  },
-});
-
-export type ContactDetailsAction = ToggleDetailExpandedAction | NavigateContactDetailsAction;
+export type ContactDetailsAction = ToggleDetailExpandedAction;

--- a/plugin-hrm-form/src/states/contacts/existingContacts.ts
+++ b/plugin-hrm-form/src/states/contacts/existingContacts.ts
@@ -2,7 +2,13 @@ import { omit } from 'lodash';
 
 import { SearchContact } from '../../types/types';
 import { hrmServiceContactToSearchContact } from './contactDetailsAdapter';
-import { ContactDetailsRoute } from './contactDetails';
+
+export enum ContactDetailsRoute {
+  EDIT_CALLER_INFORMATION = 'editCallerInformation',
+  EDIT_CHILD_INFORMATION = 'editChildInformation',
+  EDIT_CATEGORIES = 'editIssueCategories',
+  EDIT_CASE_INFORMATION = 'editCaseInformation',
+}
 
 // From https://stackoverflow.com/questions/47914536/use-partial-in-nested-property-with-typescript
 type RecursivePartial<T> = {

--- a/plugin-hrm-form/src/states/contacts/issueCategorizationStateApi.ts
+++ b/plugin-hrm-form/src/states/contacts/issueCategorizationStateApi.ts
@@ -3,7 +3,7 @@ import { Dispatch } from 'react';
 import { CustomITask } from '../../types/types';
 import { contactFormsBase, namespace, RootState } from '..';
 import * as actions from './actions';
-import { setCategoriesGridView, toggleCategoryExpanded } from './existingContacts';
+import { setCategoriesGridView, toggleCategoryExpanded, updateDraft } from './existingContacts';
 
 export type IssueCategorizationStateApi = {
   retrieveState: (
@@ -14,7 +14,7 @@ export type IssueCategorizationStateApi = {
   };
   toggleCategoryExpandedActionDispatcher: (dispatch: Dispatch<any>) => (category: string) => void;
   setGridViewActionDispatcher: (dispatch: Dispatch<any>) => (useGridView: boolean) => void;
-  updateFormActionDispatcher: (dispatch: Dispatch<any>) => (categories: any) => void;
+  updateFormActionDispatcher: (dispatch: Dispatch<any>) => (categories: string[]) => void;
 };
 
 export const forTask = (task: CustomITask): IssueCategorizationStateApi => ({
@@ -31,7 +31,12 @@ export const forExistingContact = (contactId: string): IssueCategorizationStateA
   retrieveState: state => state[namespace][contactFormsBase].existingContacts[contactId].categories,
   toggleCategoryExpandedActionDispatcher: dispatch => category => dispatch(toggleCategoryExpanded(contactId, category)),
   setGridViewActionDispatcher: dispatch => useGridView => dispatch(setCategoriesGridView(contactId, useGridView)),
-  updateFormActionDispatcher: () => () => {
-    /*  */
+  updateFormActionDispatcher: dispatch => categories => {
+    const draftCategories: Record<string, string[]> = {};
+    categories.forEach(c => {
+      const [, category, subCategory] = c.split('.');
+      draftCategories[category] = [...(draftCategories[category] ?? []), subCategory];
+    });
+    dispatch(updateDraft(contactId, { overview: { categories: draftCategories } }));
   },
 });

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -30,11 +30,8 @@ import {
 import { CSAMReportEntry } from '../../types/types';
 import {
   ContactDetailsAction,
-  ContactDetailsRoute,
   ContactDetailsState,
   DetailsContext,
-  NAVIGATE_CONTACT_DETAILS_ACTION,
-  navigateContactDetailsReducer,
   sectionExpandedStateReducer,
   TOGGLE_DETAIL_EXPANDED_ACTION,
 } from './contactDetails';
@@ -120,8 +117,8 @@ const initialState: ContactsState = {
   tasks: {},
   existingContacts: {},
   contactDetails: {
-    [DetailsContext.CASE_DETAILS]: { detailsExpanded: {}, route: ContactDetailsRoute.HOME },
-    [DetailsContext.CONTACT_SEARCH]: { detailsExpanded: {}, route: ContactDetailsRoute.HOME },
+    [DetailsContext.CASE_DETAILS]: { detailsExpanded: {} },
+    [DetailsContext.CONTACT_SEARCH]: { detailsExpanded: {} },
   },
   editingContact: false,
 };
@@ -300,9 +297,6 @@ export function reduce(
     }
     case TOGGLE_DETAIL_EXPANDED_ACTION: {
       return { ...state, contactDetails: sectionExpandedStateReducer(state.contactDetails, action) };
-    }
-    case NAVIGATE_CONTACT_DETAILS_ACTION: {
-      return { ...state, contactDetails: navigateContactDetailsReducer(state.contactDetails, action) };
     }
     case EXISTING_CONTACT_UPDATE_DRAFT_ACTION: {
       return { ...state, existingContacts: updateDraftReducer(state.existingContacts, action) };

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -12,8 +12,11 @@ import {
 import { createStateItem } from '../../components/common/forms/formGenerators';
 import { createContactlessTaskTabDefinition } from '../../components/tabbedForms/ContactlessTaskTabDefinition';
 import {
+  createDraftReducer,
+  EXISTING_CONTACT_CREATE_DRAFT_ACTION,
   EXISTING_CONTACT_SET_CATEGORIES_GRID_VIEW_ACTION,
   EXISTING_CONTACT_TOGGLE_CATEGORY_EXPANDED_ACTION,
+  EXISTING_CONTACT_UPDATE_DRAFT_ACTION,
   ExistingContactAction,
   ExistingContactsState,
   LOAD_CONTACT_ACTION,
@@ -22,6 +25,7 @@ import {
   releaseContactReducer,
   setCategoriesGridViewReducer,
   toggleCategoryExpandedReducer,
+  updateDraftReducer,
 } from './existingContacts';
 import { CSAMReportEntry } from '../../types/types';
 import {
@@ -299,6 +303,12 @@ export function reduce(
     }
     case NAVIGATE_CONTACT_DETAILS_ACTION: {
       return { ...state, contactDetails: navigateContactDetailsReducer(state.contactDetails, action) };
+    }
+    case EXISTING_CONTACT_UPDATE_DRAFT_ACTION: {
+      return { ...state, existingContacts: updateDraftReducer(state.existingContacts, action) };
+    }
+    case EXISTING_CONTACT_CREATE_DRAFT_ACTION: {
+      return { ...state, existingContacts: createDraftReducer(state.existingContacts, action) };
     }
     default:
       return state;


### PR DESCRIPTION
Primary reviewer: @mmythily 

Fixes the issue where the state of a contact halfway through being edited is lost when switching tasks

## Description

* Adds a 'draftContact' to the existing contacts redux state, which is a partial SearchContact holding the content being edited
* The existence of this draft and and which part of the contact is in the draft now determine which route should be shown, rather than a route.
* Reference counts for existing contacts are replaced with named references, this way edited states are held in redux rather than being released when the user switches tasks

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes CHI-1302

### Verification steps

* Open a contact from the search within a contactless task, edit each section, saving normally (regression)
* Repeat the above but switch to another task partway through making the edits on the form and switch back - the form should be in exactly the state you left it
* Repeat the above but for a contact you are viewing from a case you searched for from a contactless task
* Repeat the above but for a contact you are viewing from a top level search
* Repeat the above but for a contact you are viewing from within a case you opened in a top level search
* Repeat the above but for a contact you are viewing from within a case opened from the case list