### PR TITLE
Import Flex chat service + Childline Thailand Staging

### DIFF
--- a/twilio-iac/README.md
+++ b/twilio-iac/README.md
@@ -2,6 +2,8 @@
 
 These are scripts for provisioning some of the Aselo Twilio infrastructure.
 
+This file looks better in your IDE than in the web :)
+
 ## Prerequisites
 
 You will require the following installed locally:
@@ -38,6 +40,7 @@ Important notes:
     - If you are copying over from `terraform-poc-account`, beware that in `main.tf`, under the `services` module, the flag `uses_conversation_service` is set to `false`. Remove this if you are working with a new Twilio account, as that is intended for compatibility with older setups of Flex.
     - Check under `flex` module, the poc account uses `hrm_url` to specify the target url for the Aselo backend. Remove this and rely on the naming convention to decide if it's staging or production (or specify the target one if the regular notation does not applies to this case).
     - Check under `flex` module, `permission_config` should be set to `var.permission_config` if you are describing it in the `variables.tf` file, or specify the correct one if not.
+    - Review the `main.tf` to make sure there are no stuff being harcoded unless you are sure that's what you want. A few minutes on this step might save you much more time debugging a missconfigured account.
 
 3. In the 'backend "s3""' section modify the 'bucket' and 'dynamodb_table' to replace 'terraform-poc' with the account identifier convention we use for s3, i.e. <short_lowercase_helpline_code>.<full+_lowercase_environment_name> . For example, Aarambh Production would look like this:
 ```hcl

--- a/twilio-iac/README.md
+++ b/twilio-iac/README.md
@@ -68,36 +68,36 @@ serverless_url = "https://serverless-XXX-production.twil.io"
 local_os = "Windows" (optional flag for Windows users)
 ```
 
-<div style="border: 1px solid #FFFDD0; border-radius: 4px; margin: 10px; padding: 5px;">
-For the following steps (9-13), make sure to have the following env vars loaded in your terminal session:
-<pre>
-AWS_ACCESS_KEY_ID=xxx
-AWS_SECRET_ACCESS_KEY=xxx
-AWS_REGION=us-east-1
-TWILIO_ACCOUNT_SID=xxx
-TWILIO_AUTH_TOKEN=xxx
-GITHUB_TOKEN=xxx
-</pre>
-On MacOS/Unix you can export them or prepend those vars when running a command.
-Another possible way to so (Unix) is composing a .env file like
-<pre>
-AWS_ACCESS_KEY_ID=xxx
-AWS_SECRET_ACCESS_KEY=xxx
-AWS_REGION=us-east-1
-TWILIO_ACCOUNT_SID=xxx
-TWILIO_AUTH_TOKEN=xxx
-GITHUB_TOKEN=xxx
-</pre>
-and load the content of the file in the terminal session like <pre>➜ export $(grep -v '^#' .env | xargs)</pre>
-Be aware that if you are not using a .private.tfvars, you need to bundle all it's equivalents in TF_VAR_* format here.
-
-<p style="color: red;">NOTE</p> 
-From now on, the above env vars are exported to this console session ~only~ (bash/powershel/whatever). Be sure you continue to use this session, or in case of opening a different one, you repeat the step to export the required variables.
-</div>
+> For the following steps (9-13), make sure to have the following env vars loaded in your terminal session:
+> ```
+> AWS_ACCESS_KEY_ID=xxx
+> AWS_SECRET_ACCESS_KEY=xxx
+> AWS_REGION=us-east-1
+> TWILIO_ACCOUNT_SID=xxx
+> TWILIO_AUTH_TOKEN=xxx
+> GITHUB_TOKEN=xxx
+> ```
+> On MacOS/Unix you can export them or prepend those vars when running a command.
+>
+> Another possible way to do so (Unix) is composing a .env file like
+> ```
+> AWS_ACCESS_KEY_ID=xxx
+> AWS_SECRET_ACCESS_KEY=xxx
+> AWS_REGION=us-east-1
+> TWILIO_ACCOUNT_SID=xxx
+> TWILIO_AUTH_TOKEN=xxx
+> GITHUB_TOKEN=xxx
+> ```
+> and load the content of the file in the terminal session like `➜ export $(grep -v '^#' .env | xargs)`.
+> Be aware that if you are not using a `.private.tfvars`, you need to bundle all it's equivalents in `TF_VAR_*` format here.
+>
+> NOTE (!!)
+>
+> From now on, the above env vars are exported to this console session ~only~ (bash/powershel/whatever). Be sure you continue to use this session, or in case of opening a different one, you repeat the step to export the required variables. 
 
 9. Run the script below from `flex-plugins/scripts/` folder. Twilio creates a bunch of default resources on a new account and Aselo uses some of them. We need to import them into terraform first, otherwise terraform assumes they don't exist and will try to create them, resulting in errors.
 ```shell
-npm run twilioResources -- import-account-defaults <helpline>-<environment> [-v my-private.tfvars]]
+npm run twilioResources -- import-account-defaults <helpline>-<environment> [-v my-private.tfvars]
 ```
 10. From the folder you created for the account (`twilio-iac/<helpline>-<environment>/`), run and review the output of:
 ```shell

--- a/twilio-iac/README.md
+++ b/twilio-iac/README.md
@@ -9,18 +9,21 @@ You will require the following installed locally:
 * Terraform - https://www.terraform.io/downloads
 * _You previously had to build & install the twilio-terraform-provider yourself, but they are being pushed up to the Terraform registry now: https://registry.terraform.io/providers/twilio/twilio_
 * You need the following environment variables: 
-  - AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY set for the script user
-  - TWILIO_ACCOUNT_SID & TWILIO_AUTH_TOKEN set to the account you want to manage, and TF_VAR_account_sid & TF_VAR_auth_token to the same as TWILIO_ACCOUNT_SID & TWILIO_AUTH_TOKEN respectively (we need the account sid & token as a variable as well as a cred.)
-  - TF_VAR_datadog_app_id & TF_VAR_datadog_access_token set for the RUM app that should already be created for the account
-  - TF_VAR_serverless_url - once set, the production serverless environment's domain, once set, use a placeholder until then.
-  - TF_VAR_aws_account_id - The account ID of the AWS account you are using to create resources
-  - GITHUB_TOKEN - a personal access token with write access to the tech matters serverless & flex plugins repo
+  - `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` set for the script user (currently script user is missconfigured, used your personal ones).
+  - `TWILIO_ACCOUNT_SID` & `TWILIO_AUTH_TOKEN` set to the account you want to manage.
+  - `GITHUB_TOKEN` - a personal access token with write access to the tech matters serverless & flex plugins repo.
+  - `TF_VAR_account_sid` & `TF_VAR_auth_token` to the same as `TWILIO_ACCOUNT_SID` & `TWILIO_AUTH_TOKEN` respectively (we need the account sid & token as a variable as well as a cred.).
+  - `TF_VAR_datadog_app_id` & `TF_VAR_datadog_access_token` set for the RUM app that should already be created for the account.
+  - `TF_VAR_serverless_url` - once set, the production serverless environment's domain, once set, use a placeholder until then.
+  - `TF_VAR_aws_account_id` - The account ID of the AWS account you are using to create resources.
+
+  All the variables that start with `TF_VAR_` can, instead than be placed in the env vars, be placed in a `.private.tfvars` file (better described below).
 
 ## Preparation
 
 In order to set up the Aselo Terraform project:
 
-* In the directory named for the account you are working on, run `terrafom init`
+* In the directory named for the account you are working on, run `terraform init`
 * Run `terraform validate` - this should give the all clear.
 
 ## Running on a new environment
@@ -29,8 +32,13 @@ There are currently some gotchas which mean that, unfortunately, it's not a simp
 
 The process for a first run is as follows:
 
-1. Create a new directory in /twilio-iac named using the <helpline>-<environment> convention
-2. Copy any .tf extension files from the 'terraform-poc-account' folder into the new folder (or if it is a production account, copy from the helpline's staging account, this will save a lot of time aligning them later)
+1. Create a new directory in `/twilio-iac` named using the <helpline>-<environment> convention
+2. Copy any `.tf` extension files from the `terraform-poc-account` folder into the new folder (or if it is a production account, copy from the helpline's staging account, this will save a lot of time aligning them later).
+Important notes: 
+    - If you are copying over from `terraform-poc-account`, beware that in `main.tf`, under the `services` module, the flag `uses_conversation_service` is set to `false`. Remove this if you are working with a new Twilio account, as that is intended for compatibility with older setups of Flex.
+    - Check under `flex` module, the poc account uses `hrm_url` to specify the target url for the Aselo backend. Remove this and rely on the naming convention to decide if it's staging or production (or specify the target one if the regular notation does not applies to this case).
+    - Check under `flex` module, `permission_config` should be set to `var.permission_config` if you are describing it in the `variables.tf` file, or specify the correct one if not.
+
 3. In the 'backend "s3""' section modify the 'bucket' and 'dynamodb_table' to replace 'terraform-poc' with the account identifier convention we use for s3, i.e. <short_lowercase_helpline_code>.<full+_lowercase_environment_name> . For example, Aarambh Production would look like this:
 ```hcl
   backend "s3" {
@@ -44,33 +52,51 @@ The process for a first run is as follows:
 5. Create a dynamo db table named after the 'dynamodb_table' attribute you just set. It needs a String partition key called `LockID` but otherwise the default settings are fine
 6. Open the `variables.tf` file and update the defaults to ones appropriate to this helpline & environment
 7. Run `terraform init` from your new folder (you might need to run `terraform init -reconfigure` if it complains.)
-8. _Optional:_ You can create a private `.tfvars` for the sensitive variables you can't check in values for - if you name it something ending in `private.tfvars` it will be ignored by git - or you can use TF_VAR_* environment variables for these as instructed above.
+8. _Optional:_ You can create a private `.tfvars` for the sensitive variables you can't check in values for - if you name it something ending in `.private.tfvars` it will be ignored by git - or you can use `TF_VAR_*` environment variables for these as instructed above.
+If you go with the `.private.tfvars`, this is how it should look like:
+```
+account_sid = "ACxxx"
+auth_token  = "xxx"
+aws_account_id = "xxx"
+datadog_app_id = "xxx"
+datadog_access_token = "pubXXX"
+serverless_url = "https://serverless-XXX-production.twil.io"
 
+local_os = "Windows" (optional flag for Windows users)
+```
+
+<div style="border: 1px solid #FFFDD0; border-radius: 4px; margin: 10px; padding: 5px;">
 For the following steps (9-13), make sure to have the following env vars loaded in your terminal session:
-```shell
+<pre>
 AWS_ACCESS_KEY_ID=xxx
 AWS_SECRET_ACCESS_KEY=xxx
 AWS_REGION=us-east-1
 TWILIO_ACCOUNT_SID=xxx
 TWILIO_AUTH_TOKEN=xxx
-```
+GITHUB_TOKEN=xxx
+</pre>
 On MacOS/Unix you can export them or prepend those vars when running a command.
 Another possible way to so (Unix) is composing a .env file like
-```shell
+<pre>
 AWS_ACCESS_KEY_ID=xxx
 AWS_SECRET_ACCESS_KEY=xxx
 AWS_REGION=us-east-1
 TWILIO_ACCOUNT_SID=xxx
 TWILIO_AUTH_TOKEN=xxx
-```
-and load the content of the file in the terminal session like `➜ export $(grep -v '^#' .env | xargs)`
+GITHUB_TOKEN=xxx
+</pre>
+and load the content of the file in the terminal session like <pre>➜ export $(grep -v '^#' .env | xargs)</pre>
+Be aware that if you are not using a .private.tfvars, you need to bundle all it's equivalents in TF_VAR_* format here.
 
+<p style="color: red;">NOTE</p> 
+From now on, the above env vars are exported to this console session ~only~ (bash/powershel/whatever). Be sure you continue to use this session, or in case of opening a different one, you repeat the step to export the required variables.
+</div>
 
-9. Run the script below from flex-plugins/scripts/ folder. Twilio creates a bunch of default resources on a new account and Aselo uses some of them. We need to import them into terraform first, otherwise terraform assumes they don't exist and will try to create them, resulting in errors.
+9. Run the script below from `flex-plugins/scripts/` folder. Twilio creates a bunch of default resources on a new account and Aselo uses some of them. We need to import them into terraform first, otherwise terraform assumes they don't exist and will try to create them, resulting in errors.
 ```shell
 npm run twilioResources -- import-account-defaults <helpline>-<environment> [-v my-private.tfvars]]
 ```
-10. Run and review the output of:
+10. From the folder you created for the account (`twilio-iac/<helpline>-<environment>/`), run and review the output of:
 ```shell
 terraform plan [-var-file my-private.tfvars]
 ```
@@ -78,14 +104,14 @@ terraform plan [-var-file my-private.tfvars]
 ```shell
 terraform apply [-var-file my-private.tfvars]
 ```
-12. Go to the console for your environment, go into Functions > Services > serverless > environments and copy the domain for production (e.g. http://serverless-1234-production.twil.io) and set it as your `TF_VAR_serverless_url` environment variable.
+12. Go to the console for your environment, go into Functions > Services > serverless > environments and copy the domain for production (e.g. http://serverless-1234-production.twil.io) and set it as your `serverless_url` (or `TF_VAR_serverless_url` environment variable).
 13. Rerun
 ```shell
 terraform apply [-var-file my-private.tfvars]
 ```
 Unfortunately, a feature gap in the twilio terraform provider means the domain URL cannot be extracted from the resource. The easiest workaround is to put it in a variable after it has been generated initially
 
-14. Go into Twilio Console and check if the 'redirect_function' task has the correct serverless url set. If it is not correct, update it manually in Twilio Console.
+14. Go into Twilio Console -> Autopilot -> demo_chatbot and check if the 'redirect_function' task has the correct serverless url set. If it is not correct, update it manually in Twilio Console.
     Unfortunately due to this issue with the provider, it may not be updated as part of the second `terraform apply`: https://github.com/twilio/terraform-provider-twilio/issues/92
 15. Don't forget to raise a PR to merge the new configuration you created
 

--- a/twilio-iac/README.md
+++ b/twilio-iac/README.md
@@ -2,8 +2,6 @@
 
 These are scripts for provisioning some of the Aselo Twilio infrastructure.
 
-This file looks better in your IDE than in the web :)
-
 ## Prerequisites
 
 You will require the following installed locally:

--- a/twilio-iac/thailand-staging/main.tf
+++ b/twilio-iac/thailand-staging/main.tf
@@ -1,0 +1,112 @@
+terraform {
+  required_providers {
+    twilio = {
+      source  = "twilio/twilio"
+      version = "0.17.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "tl-terraform-state-twilio-th-staging"
+    key            = "twilio/terraform.tfstate"
+    dynamodb_table = "twilio-terraform-th-staging-locks"
+    encrypt        = true
+  }
+}
+
+module "chatbots" {
+  source = "../terraform-modules/chatbots/default"
+  serverless_url = var.serverless_url
+}
+
+module "hrmServiceIntegration" {
+  source = "../terraform-modules/hrmServiceIntegration/default"
+  local_os = var.local_os
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
+}
+
+module "serverless" {
+  source = "../terraform-modules/serverless/default"
+}
+
+module "services" {
+  source = "../terraform-modules/services/default"
+  local_os = var.local_os
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
+}
+
+module "taskRouter" {
+  source = "../terraform-modules/taskRouter/default"
+  serverless_url = var.serverless_url
+  helpline = "ChildLine Zambia (ZM)"
+}
+
+module studioFlow {
+  source = "../terraform-modules/studioFlow/default"
+  master_workflow_sid = module.taskRouter.master_workflow_sid
+  chat_task_channel_sid = module.taskRouter.chat_task_channel_sid
+  default_task_channel_sid = module.taskRouter.default_task_channel_sid
+  pre_survey_bot_sid = module.chatbots.pre_survey_bot_sid
+}
+
+module flex {
+  source = "../terraform-modules/flex/default"
+  account_sid = var.account_sid
+  short_environment = var.short_environment
+  operating_info_key = var.operating_info_key
+  permission_config = var.permission_config
+  definition_version = var.definition_version
+  serverless_url = var.serverless_url
+  multi_office_support = var.multi_office
+  feature_flags = var.feature_flags
+  flex_chat_service_sid = module.services.flex_chat_service_sid
+  messaging_studio_flow_sid = module.studioFlow.messaging_studio_flow_sid
+  messaging_flow_contact_identity = var.messaging_flow_contact_identity
+}
+
+module survey {
+  source = "../terraform-modules/survey/default"
+  helpline = var.helpline
+  flex_task_assignment_workspace_sid = module.taskRouter.flex_task_assignment_workspace_sid
+}
+
+module aws {
+  source = "../terraform-modules/aws/default"
+  account_sid = var.account_sid
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  short_environment = var.short_environment
+  operating_info_key = var.operating_info_key
+  datadog_app_id = var.datadog_app_id
+  datadog_access_token = var.datadog_access_token
+  flex_task_assignment_workspace_sid = module.taskRouter.flex_task_assignment_workspace_sid
+  master_workflow_sid = module.taskRouter.master_workflow_sid
+  shared_state_sync_service_sid = module.services.shared_state_sync_service_sid
+  flex_chat_service_sid = module.services.flex_chat_service_sid
+  flex_proxy_service_sid = module.services.flex_proxy_service_sid
+  post_survey_bot_sid = module.chatbots.post_survey_bot_sid
+  survey_workflow_sid = module.survey.survey_workflow_sid
+}
+
+module aws_monitoring {
+  source = "../terraform-modules/aws-monitoring/default"
+  helpline = var.helpline
+  short_helpline = var.short_helpline
+  environment = var.environment
+  aws_account_id = var.aws_account_id
+}
+
+module github {
+  source = "../terraform-modules/github/default"
+  twilio_account_sid = var.account_sid
+  twilio_auth_token = var.auth_token
+  short_environment = var.short_environment
+  short_helpline = var.short_helpline
+}

--- a/twilio-iac/thailand-staging/main.tf
+++ b/twilio-iac/thailand-staging/main.tf
@@ -44,7 +44,7 @@ module "services" {
 module "taskRouter" {
   source = "../terraform-modules/taskRouter/default"
   serverless_url = var.serverless_url
-  helpline = "ChildLine Zambia (ZM)"
+  helpline = var.helpline
 }
 
 module studioFlow {

--- a/twilio-iac/thailand-staging/variables.tf
+++ b/twilio-iac/thailand-staging/variables.tf
@@ -1,0 +1,81 @@
+variable "account_sid" {}
+variable "auth_token" {}
+variable "serverless_url" {}
+variable "datadog_app_id" {}
+variable "datadog_access_token" {}
+
+variable "aws_account_id" {
+  description = "Numeric AWS account ID used in ARNs"
+  type        = string
+  default     = null
+}
+
+variable "local_os" {
+  description = "The OS running the terraform script. The only value that currently changes behaviour from default is 'Windows'"
+  type        = string
+  default = "Linux"
+}
+
+variable "helpline" {
+  default = "Childline Thailand"
+}
+
+variable "short_helpline" {
+  default = "TH"
+}
+
+variable "operating_info_key" {
+  default = "th"
+}
+
+variable "environment" {
+  default = "Staging"
+}
+
+variable "short_environment" {
+  default = "STG"
+}
+
+variable "definition_version" {
+  description = "Key that determines which set of form definitions this helpline will use"
+  type        = string
+  default = "th-v1"
+}
+
+variable "permission_config" {
+  description = "Key that determines which set of permission rules this helpline will use"
+  type        = string
+  default = "th"
+}
+
+variable multi_office {
+  default = false
+  type = bool
+  description = "Sets the multipleOfficeSupport flag in Flex Service Configuration"
+}
+
+variable "feature_flags" {
+  description = "A map of feature flags that need to be set for this helpline's flex plugin"
+  type = map(bool)
+  default = {
+    "enable_fullstory_monitoring": false,
+    "enable_upload_documents": true,
+    "enable_post_survey": false,
+    "enable_case_management": true,
+    "enable_offline_contact": true,
+    "enable_filter_cases": true,
+    "enable_sort_cases": true,
+    "enable_transfers": true,
+    "enable_manual_pulling": true,
+    "enable_csam_report": true,
+    "enable_canned_responses": true,
+    "enable_dual_write": false,
+    "enable_save_insights": true,
+    "enable_previous_contacts": true,
+    "enable_contact_editing": true
+  }
+}
+
+variable "messaging_flow_contact_identity" {
+  default = "+17152201076"
+}	

--- a/twilio-iac/thailand-staging/variables.tf
+++ b/twilio-iac/thailand-staging/variables.tf
@@ -45,7 +45,7 @@ variable "definition_version" {
 variable "permission_config" {
   description = "Key that determines which set of permission rules this helpline will use"
   type        = string
-  default = "th"
+  default = "demo"
 }
 
 variable multi_office {


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
This PR:
- Changes the import defaults script: instead than trying to import the Flex chat service by name, we import the one configured in the Flex Service Configuration (if any).
- Updates README.
- Adds `.tf` files for Childline Thailand Staging

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1277)
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts
