### PR TITLE
CHI-1322: Fix applied to release branch

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/case/actions.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/actions.test.ts
@@ -1,16 +1,21 @@
-import { Case } from '../../../types/types';
+import { Case, SearchContact } from '../../../types/types';
 import {
   AddTemporaryCaseInfo,
-  SET_CONNECTED_CASE,
-  REMOVE_CONNECTED_CASE,
-  UPDATE_CASE_INFO,
-  MARK_CASE_AS_UPDATED,
-  UPDATE_TEMP_INFO,
-  UPDATE_CASE_STATUS,
   CaseActionType,
+  MARK_CASE_AS_UPDATED,
+  REMOVE_CONNECTED_CASE,
+  SET_CONNECTED_CASE,
+  UPDATE_CASE_CONTACT,
+  UPDATE_CASE_INFO,
+  UPDATE_TEMP_INFO,
 } from '../../../states/case/types';
 import * as actions from '../../../states/case/actions';
 import { CaseItemAction, NewCaseSubroutes } from '../../../states/routing/types';
+import { searchContactToHrmServiceContact } from '../../../states/contacts/contactDetailsAdapter';
+
+jest.mock('../../../states/contacts/contactDetailsAdapter', () => ({
+  searchContactToHrmServiceContact: jest.fn(),
+}));
 
 const task = { taskSid: 'task1' };
 
@@ -83,5 +88,21 @@ describe('test action creators', () => {
     };
 
     expect(actions.markCaseAsUpdated(task.taskSid)).toStrictEqual(expectedAction);
+  });
+
+  test('searchContactToHrmServiceContact', async () => {
+    const expectedAction: CaseActionType = {
+      type: UPDATE_CASE_CONTACT,
+      taskId: task.taskSid,
+      contact: 'I AM A HRM CONTACT',
+    };
+    (<jest.Mock>searchContactToHrmServiceContact).mockReturnValue('I AM A HRM CONTACT');
+    const input: Partial<SearchContact> = {
+      contactId: 'something',
+    };
+    expect(actions.updateCaseContactsWithSearchContact(task.taskSid, <SearchContact>input)).toStrictEqual(
+      expectedAction,
+    );
+    expect(searchContactToHrmServiceContact).toHaveBeenCalledWith(input);
   });
 });

--- a/plugin-hrm-form/src/___tests__/states/contacts/contactDetailsAdapter.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/contactDetailsAdapter.test.ts
@@ -40,7 +40,6 @@ describe('retrieveCategories', () => {
 
 describe('hrmServiceContactToSearchContact', () => {
   const emptyOverview = {
-    taskId: undefined,
     helpline: undefined,
     dateTime: undefined,
     name: 'undefined undefined',
@@ -253,7 +252,6 @@ describe('searchContactToHrmServiceContact', () => {
     contactId: '1337',
     overview: {
       helpline: 'A helpline',
-      taskId: 'TASK_ID',
       conversationDuration: 14,
       createdBy: 'bob',
       channel: 'gopher',
@@ -286,7 +284,6 @@ describe('searchContactToHrmServiceContact', () => {
     const hrmContact = searchContactToHrmServiceContact(baseSearchContact);
     expect(hrmContact).toMatchObject({
       helpline: 'A helpline',
-      taskId: 'TASK_ID',
       conversationDuration: 14,
       createdBy: 'bob',
       channel: 'gopher',

--- a/plugin-hrm-form/src/___tests__/states/contacts/contactDetailsAdapter.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/contactDetailsAdapter.test.ts
@@ -1,4 +1,9 @@
-import { hrmServiceContactToSearchContact, retrieveCategories } from '../../../states/contacts/contactDetailsAdapter';
+import {
+  hrmServiceContactToSearchContact,
+  retrieveCategories,
+  searchContactToHrmServiceContact,
+} from '../../../states/contacts/contactDetailsAdapter';
+import { SearchContact } from '../../../types/types';
 
 describe('retrieveCategories', () => {
   test('falsy input, empty object output', () => expect(retrieveCategories(null)).toStrictEqual({}));
@@ -35,6 +40,7 @@ describe('retrieveCategories', () => {
 
 describe('hrmServiceContactToSearchContact', () => {
   const emptyOverview = {
+    taskId: undefined,
     helpline: undefined,
     dateTime: undefined,
     name: 'undefined undefined',
@@ -239,5 +245,63 @@ describe('hrmServiceContactToSearchContact', () => {
       hrmServiceContactToSearchContact({ rawJson: { caseInformation: {}, childInformation: {} } }),
     ).toThrow();
     expect(() => hrmServiceContactToSearchContact({ rawJson: { childInformation: { name: {} } } })).toThrow();
+  });
+});
+
+describe('searchContactToHrmServiceContact', () => {
+  const baseSearchContact: SearchContact = {
+    contactId: '1337',
+    overview: {
+      helpline: 'A helpline',
+      taskId: 'TASK_ID',
+      conversationDuration: 14,
+      createdBy: 'bob',
+      channel: 'gopher',
+      counselor: 'WK_roberta',
+      customerNumber: '1234 4321',
+      dateTime: 'Last Tuesday',
+      callType: 'child',
+      name: 'Lo Ballantyne',
+      categories: {},
+      notes: 'Hello',
+    },
+    csamReports: [
+      {
+        id: 1,
+        csamReportId: '1',
+        twilioWorkerId: 'WK_roberta',
+        createdAt: 'Last Thursday',
+      },
+    ],
+    details: {
+      callType: 'child',
+      childInformation: { name: { firstName: 'Lo', lastName: 'Ballantyne' } },
+      callerInformation: { name: { firstName: 'Lo', lastName: 'Ballantyne' } },
+      caseInformation: { categories: {} },
+      contactlessTask: {},
+    },
+  };
+
+  test('maps SearchContact overview to top level properties', () => {
+    const hrmContact = searchContactToHrmServiceContact(baseSearchContact);
+    expect(hrmContact).toMatchObject({
+      helpline: 'A helpline',
+      taskId: 'TASK_ID',
+      conversationDuration: 14,
+      createdBy: 'bob',
+      channel: 'gopher',
+      twilioWorkerId: 'WK_roberta',
+      number: '1234 4321',
+      timeOfContact: 'Last Tuesday',
+    });
+  });
+
+  test('copies details, csamReports and contactId to top level', () => {
+    const hrmContact = searchContactToHrmServiceContact(baseSearchContact);
+    expect(hrmContact).toMatchObject({
+      id: baseSearchContact.contactId,
+      rawJson: baseSearchContact.details,
+      csamReports: baseSearchContact.csamReports,
+    });
   });
 });

--- a/plugin-hrm-form/src/components/case/ViewContact.tsx
+++ b/plugin-hrm-form/src/components/case/ViewContact.tsx
@@ -8,12 +8,16 @@ import { CaseLayout } from '../../styles/case';
 import { configurationBase, connectedCaseBase, contactFormsBase, namespace, RootState } from '../../states';
 import * as CaseActions from '../../states/case/actions';
 import ContactDetails from '../contact/ContactDetails';
-import ActionHeader from './ActionHeader';
 import { CaseState } from '../../states/case/reducer';
 import type { CustomITask, StandaloneITask } from '../../types/types';
 import { loadContact, loadRawContact, releaseContact } from '../../states/contacts/existingContacts';
 import { DetailsContext } from '../../states/contacts/contactDetails';
 import { taskFormToSearchContact } from '../../states/contacts/contactDetailsAdapter';
+import { TemporaryCaseInfo, ViewContactInfo } from '../../states/case/types';
+
+function isViewContactCaseInfo(temporaryCaseInfo: TemporaryCaseInfo): temporaryCaseInfo is ViewContactInfo {
+  return temporaryCaseInfo && temporaryCaseInfo.screen === 'view-contact';
+}
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const form = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];
@@ -21,11 +25,27 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const caseState: CaseState = state[namespace][connectedCaseBase];
   const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
   const { temporaryCaseInfo, connectedCase } = caseState.tasks[ownProps.task.taskSid];
-  return { form, counselorsHash, tempInfo: temporaryCaseInfo, connectedCase, editContactFormOpen };
+  if (isViewContactCaseInfo(temporaryCaseInfo)) {
+    const { contact: contactFromInfo } = temporaryCaseInfo.info;
+    const isSavedContact = Boolean(contactFromInfo);
+    const contactId = contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`;
+    const contact = state[namespace][contactFormsBase].existingContacts[contactId]?.savedContact;
+    return {
+      form,
+      counselorsHash,
+      tempInfo: temporaryCaseInfo,
+      connectedCase,
+      editContactFormOpen,
+      contactId,
+      contact,
+      isSavedContact,
+    };
+  }
+  return { form, connectedCase, counselorsHash, editContactFormOpen };
 };
 
 const mapDispatchToProps = {
-  setConnectedCase: CaseActions.setConnectedCase,
+  updateCaseContactsWithSearchContact: CaseActions.updateCaseContactsWithSearchContact,
   loadRawContactIntoState: loadRawContact,
   loadContactIntoState: loadContact,
   releaseContactFromState: releaseContact,
@@ -49,45 +69,60 @@ const ViewContact: React.FC<Props> = ({
   releaseContactFromState,
   connectedCase,
   editContactFormOpen,
+  contactId,
+  contact,
+  isSavedContact,
+  updateCaseContactsWithSearchContact,
 }) => {
+  const handleClose = () => {
+    releaseContactFromState(contactId, task.taskSid);
+    onClickClose();
+  };
+
   useEffect(() => {
-    if (tempInfo && tempInfo.screen === 'view-contact') {
+    if (isViewContactCaseInfo(tempInfo)) {
       const { contact: contactFromInfo, timeOfContact, counselor } = tempInfo.info;
-      if (contactFromInfo) {
-        loadRawContactIntoState(contactFromInfo);
-        return () => releaseContactFromState(contactFromInfo.id);
+      if (isSavedContact) {
+        loadRawContactIntoState(contactFromInfo, task.taskSid);
+      } else {
+        const temporaryId = `__unsavedFromCase:${connectedCase.id}`;
+        loadContactIntoState(taskFormToSearchContact(task, form, timeOfContact, counselor, temporaryId), task.taskSid);
       }
-      const temporaryId = `__unsavedFromCase:${connectedCase.id}`;
-      loadContactIntoState(taskFormToSearchContact(task, form, timeOfContact, counselor, temporaryId));
-      return () => releaseContactFromState(temporaryId);
     }
-    return () => {
-      /* no cleanup to do. */
-    };
   }, [
     counselorsHash,
     loadContactIntoState,
     releaseContactFromState,
-    connectedCase.id,
+    connectedCase?.id,
     task,
     form,
     loadRawContactIntoState,
     tempInfo,
+    isSavedContact,
   ]);
 
-  if (!tempInfo || tempInfo.screen !== 'view-contact') return null;
+  useEffect(() => {
+    if (contact) {
+      updateCaseContactsWithSearchContact(task.taskSid, contact);
+    }
+  }, [updateCaseContactsWithSearchContact, task, contact]);
+
+  if (!isViewContactCaseInfo(tempInfo)) {
+    return null;
+  }
+
   const { contact: contactFromInfo } = tempInfo.info;
 
   return (
     <CaseLayout className={editContactFormOpen ? 'editingContact' : ''}>
       <Container removePadding={editContactFormOpen}>
         <ContactDetails
-          contactId={contactFromInfo?.id ?? `__unsavedFromCase:${connectedCase.id}`}
+          contactId={contactId}
           enableEditing={Boolean(contactFromInfo)}
           context={DetailsContext.CASE_DETAILS}
         />
         <BottomButtonBar className="hiddenWhenEditingContact" style={{ marginBlockStart: 'auto' }}>
-          <StyledNextStepButton roundCorners onClick={onClickClose} data-testid="Case-ViewContactScreen-CloseButton">
+          <StyledNextStepButton roundCorners onClick={handleClose} data-testid="Case-ViewContactScreen-CloseButton">
             <Template code="CloseButton" />
           </StyledNextStepButton>
         </BottomButtonBar>

--- a/plugin-hrm-form/src/states/case/actions.ts
+++ b/plugin-hrm-form/src/states/case/actions.ts
@@ -1,21 +1,29 @@
-import { Case, CaseInfo } from '../../types/types';
+import { Case, CaseInfo, SearchContact } from '../../types/types';
 import {
   CaseActionType,
-  TemporaryCaseInfo,
-  SET_CONNECTED_CASE,
-  REMOVE_CONNECTED_CASE,
-  UPDATE_CASE_INFO,
-  UPDATE_TEMP_INFO,
-  UPDATE_CASE_STATUS,
   MARK_CASE_AS_UPDATED,
+  REMOVE_CONNECTED_CASE,
+  SET_CONNECTED_CASE,
+  TemporaryCaseInfo,
+  UPDATE_CASE_CONTACT,
+  UPDATE_CASE_INFO,
+  UPDATE_CASE_STATUS,
+  UPDATE_TEMP_INFO,
 } from './types';
+import { searchContactToHrmServiceContact } from '../contacts/contactDetailsAdapter';
 
 // Action creators
-export const setConnectedCase = (connectedCase: Case, taskId: string, caseHasBeenEdited: Boolean): CaseActionType => ({
+export const setConnectedCase = (
+  connectedCase: Case,
+  taskId: string,
+  caseHasBeenEdited: Boolean,
+  clearTemporaryInfo = true,
+): CaseActionType => ({
   type: SET_CONNECTED_CASE,
   connectedCase,
   taskId,
   caseHasBeenEdited,
+  clearTemporaryInfo,
 });
 
 export const removeConnectedCase = (taskId: string): CaseActionType => ({
@@ -49,4 +57,10 @@ export const updateCaseStatus = (status: string, taskId: string): CaseActionType
 export const markCaseAsUpdated = (taskId: string): CaseActionType => ({
   type: MARK_CASE_AS_UPDATED,
   taskId,
+});
+
+export const updateCaseContactsWithSearchContact = (taskId: string, contact: SearchContact): CaseActionType => ({
+  type: UPDATE_CASE_CONTACT,
+  taskId,
+  contact: searchContactToHrmServiceContact(contact),
 });

--- a/plugin-hrm-form/src/states/case/actions.ts
+++ b/plugin-hrm-form/src/states/case/actions.ts
@@ -13,17 +13,11 @@ import {
 import { searchContactToHrmServiceContact } from '../contacts/contactDetailsAdapter';
 
 // Action creators
-export const setConnectedCase = (
-  connectedCase: Case,
-  taskId: string,
-  caseHasBeenEdited: Boolean,
-  clearTemporaryInfo = true,
-): CaseActionType => ({
+export const setConnectedCase = (connectedCase: Case, taskId: string, caseHasBeenEdited: Boolean): CaseActionType => ({
   type: SET_CONNECTED_CASE,
   connectedCase,
   taskId,
   caseHasBeenEdited,
-  clearTemporaryInfo,
 });
 
 export const removeConnectedCase = (taskId: string): CaseActionType => ({

--- a/plugin-hrm-form/src/states/case/reducer.ts
+++ b/plugin-hrm-form/src/states/case/reducer.ts
@@ -3,13 +3,14 @@ import { omit } from 'lodash';
 import { Case } from '../../types/types';
 import {
   CaseActionType,
-  TemporaryCaseInfo,
-  SET_CONNECTED_CASE,
-  REMOVE_CONNECTED_CASE,
-  UPDATE_CASE_INFO,
-  UPDATE_TEMP_INFO,
-  UPDATE_CASE_STATUS,
   MARK_CASE_AS_UPDATED,
+  REMOVE_CONNECTED_CASE,
+  SET_CONNECTED_CASE,
+  TemporaryCaseInfo,
+  UPDATE_CASE_CONTACT,
+  UPDATE_CASE_INFO,
+  UPDATE_CASE_STATUS,
+  UPDATE_TEMP_INFO,
 } from './types';
 import { GeneralActionType, REMOVE_CONTACT_STATE } from '../types';
 
@@ -104,6 +105,22 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
           [action.taskId]: {
             ...state.tasks[action.taskId],
             caseHasBeenEdited: false,
+          },
+        },
+      };
+    case UPDATE_CASE_CONTACT:
+      return {
+        ...state,
+        tasks: {
+          ...state.tasks,
+          [action.taskId]: {
+            ...state.tasks[action.taskId],
+            connectedCase: {
+              ...state.tasks[action.taskId].connectedCase,
+              connectedContacts: state.tasks[action.taskId].connectedCase.connectedContacts.map(cc =>
+                cc.id === action.contact.id ? action.contact : cc,
+              ),
+            },
           },
         },
       };

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -10,6 +10,7 @@ export const UPDATE_CASE_INFO = 'UPDATE_CASE_INFO';
 export const UPDATE_TEMP_INFO = 'UPDATE_TEMP_INFO';
 export const UPDATE_CASE_STATUS = 'UPDATE_CASE_STATUS';
 export const MARK_CASE_AS_UPDATED = 'MARK_CASE_AS_UPDATED';
+export const UPDATE_CASE_CONTACT = 'UPDATE_CASE_CONTACT';
 
 type ViewContact = {
   contact?: any; // TODO: create Contact type
@@ -53,17 +54,16 @@ export function isAddTemporaryCaseInfo(tci: TemporaryCaseInfo): tci is AddTempor
   return tci && (<AddTemporaryCaseInfo>tci).action === CaseItemAction.Add;
 }
 
-export type TemporaryCaseInfo =
-  | { screen: typeof NewCaseSubroutes.ViewContact; info: ViewContact }
-  | ViewTemporaryCaseInfo
-  | AddTemporaryCaseInfo
-  | EditTemporaryCaseInfo;
+export type ViewContactInfo = { screen: typeof NewCaseSubroutes.ViewContact; info: ViewContact };
+
+export type TemporaryCaseInfo = ViewContactInfo | ViewTemporaryCaseInfo | AddTemporaryCaseInfo | EditTemporaryCaseInfo;
 
 type SetConnectedCaseAction = {
   type: typeof SET_CONNECTED_CASE;
   connectedCase: t.Case;
   taskId: string;
   caseHasBeenEdited: Boolean;
+  clearTemporaryInfo: boolean;
 };
 
 type RemoveConnectedCaseAction = {
@@ -94,13 +94,20 @@ type MarkCaseAsUpdated = {
   taskId: string;
 };
 
+type UpdateCaseContactAction = {
+  type: typeof UPDATE_CASE_CONTACT;
+  taskId: string;
+  contact: any;
+};
+
 export type CaseActionType =
   | SetConnectedCaseAction
   | RemoveConnectedCaseAction
   | UpdateCaseInfoAction
   | TemporaryCaseInfoAction
   | UpdateCasesStatusAction
-  | MarkCaseAsUpdated;
+  | MarkCaseAsUpdated
+  | UpdateCaseContactAction;
 
 export type Activity = NoteActivity | ReferralActivity | ConnectedCaseActivity;
 

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -63,7 +63,6 @@ type SetConnectedCaseAction = {
   connectedCase: t.Case;
   taskId: string;
   caseHasBeenEdited: Boolean;
-  clearTemporaryInfo: boolean;
 };
 
 type RemoveConnectedCaseAction = {

--- a/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
@@ -45,7 +45,7 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
   const { callType, caseInformation } = contact.rawJson;
   const categories = retrieveCategories(caseInformation.categories);
   const notes = caseInformation.callSummary;
-  const { conversationDuration, csamReports, createdBy, helpline, channel } = contact;
+  const { conversationDuration, csamReports, createdBy, helpline, channel, taskId } = contact;
 
   return {
     contactId: contact.id,
@@ -61,6 +61,7 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
       channel,
       conversationDuration,
       createdBy,
+      taskId,
     },
     details: contact.rawJson,
     csamReports,
@@ -68,20 +69,30 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
 };
 
 export const searchContactToHrmServiceContact = (contact: SearchContact) => {
-  const { conversationDuration, createdBy, helpline, channel, counselor, customerNumber, dateTime } = contact.overview;
+  const {
+    conversationDuration,
+    createdBy,
+    helpline,
+    channel,
+    counselor,
+    customerNumber,
+    dateTime,
+    taskId,
+  } = contact.overview;
   return {
     id: contact.contactId,
     number: customerNumber,
     rawJson: contact.details,
     csamReports: contact.csamReports,
     timeOfContact: dateTime,
-    twilioWorkerId:counselor,
+    twilioWorkerId: counselor,
     conversationDuration,
     createdBy,
     helpline,
     channel,
+    taskId,
   };
-}
+};
 
 export const taskFormToSearchContact = (task, form, date, counselor, temporaryId): SearchContact => {
   const details = transformForm(form);
@@ -109,6 +120,7 @@ export const taskFormToSearchContact = (task, form, date, counselor, temporaryId
       notes,
       channel: channelType,
       conversationDuration,
+      taskId: task.taskSid,
     },
     details,
     csamReports,

--- a/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
@@ -68,15 +68,7 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
 };
 
 export const searchContactToHrmServiceContact = (contact: SearchContact) => {
-  const {
-    conversationDuration,
-    createdBy,
-    helpline,
-    channel,
-    counselor,
-    customerNumber,
-    dateTime,
-  } = contact.overview;
+  const { conversationDuration, createdBy, helpline, channel, counselor, customerNumber, dateTime } = contact.overview;
   return {
     id: contact.contactId,
     number: customerNumber,

--- a/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
@@ -67,6 +67,22 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
   };
 };
 
+export const searchContactToHrmServiceContact = (contact: SearchContact) => {
+  const { conversationDuration, createdBy, helpline, channel, counselor, customerNumber, dateTime } = contact.overview;
+  return {
+    id: contact.contactId,
+    number: customerNumber,
+    rawJson: contact.details,
+    csamReports: contact.csamReports,
+    timeOfContact: dateTime,
+    twilioWorkerId:counselor,
+    conversationDuration,
+    createdBy,
+    helpline,
+    channel,
+  };
+}
+
 export const taskFormToSearchContact = (task, form, date, counselor, temporaryId): SearchContact => {
   const details = transformForm(form);
   const dateTime = date;

--- a/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
@@ -45,7 +45,7 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
   const { callType, caseInformation } = contact.rawJson;
   const categories = retrieveCategories(caseInformation.categories);
   const notes = caseInformation.callSummary;
-  const { conversationDuration, csamReports, createdBy, helpline, channel, taskId } = contact;
+  const { conversationDuration, csamReports, createdBy, helpline, channel } = contact;
 
   return {
     contactId: contact.id,
@@ -61,7 +61,6 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
       channel,
       conversationDuration,
       createdBy,
-      taskId,
     },
     details: contact.rawJson,
     csamReports,
@@ -77,7 +76,6 @@ export const searchContactToHrmServiceContact = (contact: SearchContact) => {
     counselor,
     customerNumber,
     dateTime,
-    taskId,
   } = contact.overview;
   return {
     id: contact.contactId,
@@ -90,7 +88,6 @@ export const searchContactToHrmServiceContact = (contact: SearchContact) => {
     createdBy,
     helpline,
     channel,
-    taskId,
   };
 };
 
@@ -120,7 +117,6 @@ export const taskFormToSearchContact = (task, form, date, counselor, temporaryId
       notes,
       channel: channelType,
       conversationDuration,
-      taskId: task.taskSid,
     },
     details,
     csamReports,


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @GPaoloni

A better for would be for the Case to save it's connected contacts to the existingContacts as soon as it loads and use that everywhere in the case, but that would be a bigger change with much higher potential for knock on bugs, so didn't seem appropriate when we were trying to get a new prod version out.

## Description

* The ViewContact.tsx page now sends an 'Update Case Contact' action when the viewed action changes
* This action replaces the contact in the parent case's `connectedContacts` collection with the updated version
* This required yet another 'Contact' -> 'Same Contact in a Slightly Different Format' conversion function. :sadpanda

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1322

### Verification steps

See CHI-1322 description