### PR TITLE
Cache updated config when reducers run (for flex 2.0 upgrade).

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -68,7 +68,16 @@ const readConfig = () => {
   };
 };
 
-let cachedConfig = readConfig();
+let cachedConfig;
+
+try {
+  cachedConfig = readConfig();
+} catch (err) {
+  console.log(
+    'Failed to read config on page load, leaving undefined for now (it will be populated when the flex reducer runs)',
+    err,
+  );
+}
 
 export const getConfig = () => cachedConfig;
 
@@ -280,6 +289,16 @@ export default class HrmFormPlugin extends FlexPlugin {
     }
 
     manager.store.addReducer(namespace, reducers);
-    manager.store.subscribe(() => (cachedConfig = readConfig()));
+    /*
+     * Direct use of 'subscribe' is generally discouraged.
+     * This is a workaround until we deprecate 'getConfig' in it's current form after we migrate to Flex 2.0
+     */
+    manager.store.subscribe(() => {
+      try {
+        cachedConfig = readConfig();
+      } catch (err) {
+        console.warn('Failed to read configuration - leaving cached version the same', err);
+      }
+    });
   }
 }

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -32,11 +32,16 @@ const readConfig = () => {
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
   const isSupervisor = roles.includes('supervisor');
-  const { helplineLanguage, definitionVersion, pdfImagesSource, multipleOfficeSupport, permissionConfig } =
-    manager.serviceConfiguration.attributes;
+  const {
+    helplineLanguage,
+    definitionVersion,
+    pdfImagesSource,
+    multipleOfficeSupport,
+    permissionConfig,
+  } = manager.serviceConfiguration.attributes;
   const featureFlags = manager.serviceConfiguration.attributes.feature_flags || {};
   const contactsWaitingChannels = manager.serviceConfiguration.attributes.contacts_waiting_channels || null;
-  const { strings } = manager as unknown as { strings: { [key: string]: string } };
+  const { strings } = (manager as unknown) as { strings: { [key: string]: string } };
 
   return {
     hrmBaseUrl,

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -20,7 +20,7 @@ export const DEFAULT_TRANSFER_MODE = transferModes.cold;
 
 let sharedStateClient: SyncClient;
 
-export const getConfig = () => {
+const readConfig = () => {
   const manager = Flex.Manager.getInstance();
 
   const hrmBaseUrl = `${manager.serviceConfiguration.attributes.hrm_base_url}/${manager.serviceConfiguration.attributes.hrm_api_version}/accounts/${manager.workerClient.accountSid}`;
@@ -32,16 +32,11 @@ export const getConfig = () => {
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
   const isSupervisor = roles.includes('supervisor');
-  const {
-    helplineLanguage,
-    definitionVersion,
-    pdfImagesSource,
-    multipleOfficeSupport,
-    permissionConfig,
-  } = manager.serviceConfiguration.attributes;
+  const { helplineLanguage, definitionVersion, pdfImagesSource, multipleOfficeSupport, permissionConfig } =
+    manager.serviceConfiguration.attributes;
   const featureFlags = manager.serviceConfiguration.attributes.feature_flags || {};
   const contactsWaitingChannels = manager.serviceConfiguration.attributes.contacts_waiting_channels || null;
-  const { strings } = (manager as unknown) as { strings: { [key: string]: string } };
+  const { strings } = manager as unknown as { strings: { [key: string]: string } };
 
   return {
     hrmBaseUrl,
@@ -67,6 +62,10 @@ export const getConfig = () => {
     contactsWaitingChannels,
   };
 };
+
+let cachedConfig = readConfig();
+
+export const getConfig = () => cachedConfig;
 
 // eslint-disable-next-line import/no-unused-modules
 export type SetupObject = ReturnType<typeof getConfig> & {
@@ -276,5 +275,6 @@ export default class HrmFormPlugin extends FlexPlugin {
     }
 
     manager.store.addReducer(namespace, reducers);
+    manager.store.subscribe(() => (cachedConfig = readConfig()));
   }
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @GPaoloni 

## Description

This workaround subscribes to redux reducer cycles and updates a cached configuration object to a version generated using the same code `getConfig` currently uses to generate that object on demand. `getConfig()` now just returns that cached object.

I decided to do the workaround for the time being, because whilst this is technically 'pre-work', I'm concerned that the changes around flex redux between the 2 versions would mean there might be differences in the 'post getConfig()' API, and these differences would still need to be maintained for the lifetime of the fork, whereas this solution should work 'as is' for both versions

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Strings are localized
- N/A Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes CHI-1283

### Verification steps

General regression of Flex UI features