### PR TITLE
Bumped node version to 14.x for ci runs

### DIFF
--- a/.github/workflows/plugin-hrm-form-ci.yml
+++ b/.github/workflows/plugin-hrm-form-ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - name: Checkout Branch

--- a/.github/workflows/plugin-hrm-form-ci.yml
+++ b/.github/workflows/plugin-hrm-form-ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install the Twilio CLI and plugins
-      run: npm install twilio-cli -g && twilio plugins:install @twilio-labs/plugin-flex
+      run: npm install twilio-cli@3.6.0 -g && twilio plugins:install @twilio-labs/plugin-flex@5.1.2
     - name: Create Temp Files
       run: |
         touch ./public/appConfig.js

--- a/.github/workflows/plugin-hrm-form-e2e-test.yml
+++ b/.github/workflows/plugin-hrm-form-e2e-test.yml
@@ -51,7 +51,7 @@ jobs:
 
       # Build Flex-plugins
       - name: Install the Twilio CLI and plugins
-        run: npm install twilio-cli -g && twilio plugins:install @twilio-labs/plugin-flex
+        run: npm install twilio-cli@3.6.0 -g && twilio plugins:install @twilio-labs/plugin-flex@5.1.2
       - name: Install hrm-form-definitions Packages
         run: npm ci
         working-directory: ./hrm-form-definitions


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
This PR:
- Bumps node version used in CI runs to be v14.x.
- Pins build tools (`twilio-cli@3.6.0` and `@twilio-labs/plugin-flex@5.1.2`)