### PR TITLE
CHI-1106: Fixed zero artefact at the bottom of contact view.

### DIFF
--- a/plugin-hrm-form/src/components/caseList/CaseListTableRow.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTableRow.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { format, parseISO } from 'date-fns';
 import { Template } from '@twilio/flex-ui';
 import { connect, ConnectedProps } from 'react-redux';
+import { DefinitionVersionId } from 'hrm-form-definitions';
 
 import { getDefinitionVersion } from '../../services/ServerlessService';
 import { configurationBase, namespace, RootState } from '../../states';
@@ -23,6 +24,7 @@ import { Box, HiddenText } from '../../styles/HrmStyles';
 import { formatName, getShortSummary } from '../../utils';
 import { getContactTags, renderTag } from '../../utils/categories';
 import CategoryWithTooltip from '../common/CategoryWithTooltip';
+import { getConfig } from '../../HrmFormPlugin';
 
 const CHAR_LIMIT = 200;
 
@@ -36,23 +38,19 @@ type OwnProps = {
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleClickViewCase, ...props }) => {
-  const { status } = caseItem;
-  const statusString = status.charAt(0).toUpperCase() + status.slice(1);
-  const name = formatName(caseItem.childName);
-  const summary = caseItem.info && caseItem.info.summary;
-  const shortSummary = getShortSummary(summary, CHAR_LIMIT, 'case');
-  const counselor = formatName(counselorsHash[caseItem.twilioWorkerId]);
-  const opened = `${format(new Date(caseItem.createdAt), 'MMM d, yyyy')}`;
-  const beenUpdated = caseItem.createdAt !== caseItem.updatedAt;
-  const updated = beenUpdated ? `${format(new Date(caseItem.updatedAt), 'MMM d, yyyy')}` : '—';
-  const followUpDate =
-    caseItem.info && caseItem.info.followUpDate
-      ? `${format(parseISO(caseItem.info.followUpDate), 'MMM d, yyyy')}`
-      : '—';
-  const categories = getContactTags(caseItem.info.definitionVersion, caseItem.categories);
-
   const { updateDefinitionVersion, definitionVersions } = props;
-  const version = caseItem.info.definitionVersion;
+  const config = getConfig();
+  let version = caseItem.info.definitionVersion;
+  if (!Object.values(DefinitionVersionId).includes(version)) {
+    console.warn(
+      `Form definition version ${
+        typeof version === 'string' ? `'${version}'` : version
+      } does not exist in defined set: ${Object.values(
+        DefinitionVersionId,
+      )}. Falling back to to current configured version '${config.definitionVersion}' for case with id ${caseItem.id}`,
+    );
+    version = config.definitionVersion;
+  }
 
   useEffect(() => {
     const fetchDefinitionVersions = async (v: string) => {
@@ -63,60 +61,85 @@ const CaseListTableRow: React.FC<Props> = ({ caseItem, counselorsHash, handleCli
       fetchDefinitionVersions(version);
     }
   }, [definitionVersions, updateDefinitionVersion, version]);
+  try {
+    const { status } = caseItem;
+    const statusString = status.charAt(0).toUpperCase() + status.slice(1);
+    const name = formatName(caseItem.childName);
+    const summary = caseItem.info && caseItem.info.summary;
+    const shortSummary = getShortSummary(summary, CHAR_LIMIT, 'case');
+    const counselor = formatName(counselorsHash[caseItem.twilioWorkerId]);
+    const opened = `${format(new Date(caseItem.createdAt), 'MMM d, yyyy')}`;
+    const beenUpdated = caseItem.createdAt !== caseItem.updatedAt;
+    const updated = beenUpdated ? `${format(new Date(caseItem.updatedAt), 'MMM d, yyyy')}` : '—';
+    const followUpDate =
+      caseItem.info && caseItem.info.followUpDate
+        ? `${format(parseISO(caseItem.info.followUpDate), 'MMM d, yyyy')}`
+        : '—';
+    const categories = getContactTags(version, caseItem.categories);
 
-  const definitionVersion = definitionVersions[version];
+    const definitionVersion = definitionVersions[version];
 
-  // Get the status for a case from the value of CaseStatus.json of the current form definitions
-  const getCaseStatusLabel = (caseStatus: string) => {
-    return Object.values(definitionVersion.caseStatus).filter(status => status.value === caseStatus)[0].label;
-  };
+    // Get the status for a case from the value of CaseStatus.json of the current form definitions
+    const getCaseStatusLabel = (caseStatus: string) => {
+      return Object.values(definitionVersion.caseStatus).filter(status => status.value === caseStatus)[0].label;
+    };
 
-  return (
-    <CLTableRow data-testid="CaseList-TableRow" onClick={handleClickViewCase(caseItem)}>
-      <CLNumberCell>
-        <CLCaseNumberContainer>
-          <CLCaseIDButton tabIndex={0} onClick={handleClickViewCase(caseItem)}>
-            <HiddenText>
-              <Template code={statusString} />
-              <Template code="CaseList-THCase" />
-            </HiddenText>
-            {caseItem.id}
-          </CLCaseIDButton>
-          <CLTableBodyFont style={{ color: '#606B85', paddingTop: '2px', textAlign: 'center' }}>
-            {getCaseStatusLabel(caseItem.status)}
-          </CLTableBodyFont>
-        </CLCaseNumberContainer>
-      </CLNumberCell>
-      <CLNamesCell>
-        <CLTableBodyFont>{name}</CLTableBodyFont>
-      </CLNamesCell>
-      <CLTableCell>
-        <CLTableBodyFont>{counselor}</CLTableBodyFont>
-      </CLTableCell>
-      <CLSummaryCell>
-        <CLTableSummaryFont>{shortSummary}</CLTableSummaryFont>
-      </CLSummaryCell>
-      <CLTableCell>
-        <div style={{ display: 'inline-block', flexDirection: 'column' }}>
-          {categories &&
-            categories.map(category => (
-              <Box key={`category-tag-${category.label}`} marginBottom="5px">
-                <CategoryWithTooltip renderTag={renderTag} category={category.label} color={category.color} />
-              </Box>
-            ))}
-        </div>
-      </CLTableCell>
-      <CLTableCell>
-        <CLTableBodyFont style={{ textAlign: 'right' }}>{opened}</CLTableBodyFont>
-      </CLTableCell>
-      <CLTableCell>
-        <CLTableBodyFont style={{ textAlign: 'right' }}>{updated}</CLTableBodyFont>
-      </CLTableCell>
-      <CLTableCell>
-        <CLTableBodyFont style={{ textAlign: 'right' }}>{followUpDate}</CLTableBodyFont>
-      </CLTableCell>
-    </CLTableRow>
-  );
+    return (
+      <CLTableRow data-testid="CaseList-TableRow" onClick={handleClickViewCase(caseItem)}>
+        <CLNumberCell>
+          <CLCaseNumberContainer>
+            <CLCaseIDButton tabIndex={0} onClick={handleClickViewCase(caseItem)}>
+              <HiddenText>
+                <Template code={statusString} />
+                <Template code="CaseList-THCase" />
+              </HiddenText>
+              {caseItem.id}
+            </CLCaseIDButton>
+            <CLTableBodyFont style={{ color: '#606B85', paddingTop: '2px', textAlign: 'center' }}>
+              {getCaseStatusLabel(caseItem.status)}
+            </CLTableBodyFont>
+          </CLCaseNumberContainer>
+        </CLNumberCell>
+        <CLNamesCell>
+          <CLTableBodyFont>{name}</CLTableBodyFont>
+        </CLNamesCell>
+        <CLTableCell>
+          <CLTableBodyFont>{counselor}</CLTableBodyFont>
+        </CLTableCell>
+        <CLSummaryCell>
+          <CLTableSummaryFont>{shortSummary}</CLTableSummaryFont>
+        </CLSummaryCell>
+        <CLTableCell>
+          <div style={{ display: 'inline-block', flexDirection: 'column' }}>
+            {categories &&
+              categories.map(category => (
+                <Box key={`category-tag-${category.label}`} marginBottom="5px">
+                  <CategoryWithTooltip renderTag={renderTag} category={category.label} color={category.color} />
+                </Box>
+              ))}
+          </div>
+        </CLTableCell>
+        <CLTableCell>
+          <CLTableBodyFont style={{ textAlign: 'right' }}>{opened}</CLTableBodyFont>
+        </CLTableCell>
+        <CLTableCell>
+          <CLTableBodyFont style={{ textAlign: 'right' }}>{updated}</CLTableBodyFont>
+        </CLTableCell>
+        <CLTableCell>
+          <CLTableBodyFont style={{ textAlign: 'right' }}>{followUpDate}</CLTableBodyFont>
+        </CLTableCell>
+      </CLTableRow>
+    );
+  } catch (err) {
+    console.error('Error rendering case row.', err);
+    return (
+      <CLTableRow>
+        <CLTableCell colSpan={100}>
+          <CLTableBodyFont>INVALID ROW</CLTableBodyFont>
+        </CLTableCell>
+      </CLTableRow>
+    );
+  }
 };
 
 CaseListTableRow.displayName = 'CaseListTableRow';

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -127,12 +127,13 @@ const ContactDetailsHome: React.FC<Props> = function ({
       .map(r => `CSAM on ${format(new Date(r.createdAt), 'yyyy MM dd h:mm aaaaa')}m\n#${r.csamReportId}`)
       .join('\n\n');
 
-  const transcriptOrRecordingAvailable =
+  const transcriptOrRecordingAvailable = Boolean(
     ((featureFlags.enable_voice_recordings && channel === channelTypes.voice) ||
       (featureFlags.enable_transcripts && channel !== channelTypes.voice)) &&
-    canViewTranscript &&
-    savedContact.details.conversationMedia?.length &&
-    typeof savedContact.overview.conversationDuration === 'number';
+      canViewTranscript &&
+      savedContact.details.conversationMedia?.length &&
+      typeof savedContact.overview.conversationDuration === 'number',
+  );
 
   return (
     <DetailsContainer data-testid="ContactDetails-Container">

--- a/plugin-hrm-form/src/utils/definitionVersions.ts
+++ b/plugin-hrm-form/src/utils/definitionVersions.ts
@@ -7,7 +7,9 @@ import { getDefinitionVersions } from '../HrmFormPlugin';
 // eslint-disable-next-line import/no-unused-modules
 const getMissingDefinitionVersions = async (versions: DefinitionVersionId[]) => {
   const { definitionVersions } = getDefinitionVersions();
-  const missingDefinitionVersions: DefinitionVersionId[] = versions.filter(v => !definitionVersions[v]);
+  const missingDefinitionVersions: DefinitionVersionId[] = versions.filter(
+    v => Object.values(DefinitionVersionId).includes(v) && !definitionVersions[v],
+  );
 
   // eslint-disable-next-line sonarjs/prefer-immediate-return
   const definitions = await getDefinitionVersionsList(missingDefinitionVersions);


### PR DESCRIPTION


<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @mythilytm 

## Description

* Ensured 'Open Recording / Transcript' toggle is coerced to boolean so extra zero never appears
* Added 'Invalid Row'…fallback on case list to make it more resilient to bad case data.
* Added defensive code to ensure cases with missing / invalid definition versions use the configured definition version as a fallback

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1106

### Verification steps

* Open offline contact details with voice type channel, ensure there is no zero at the bottom
* Repeat for an offline text type channel
* Ensure that where transcripts & recordings ARE available, they still display correctly