### PR TITLE
Added delete events to the taskrouter callback

### DIFF
--- a/twilio-iac/terraform-modules/taskRouter/default/main.tf
+++ b/twilio-iac/terraform-modules/taskRouter/default/main.tf
@@ -20,7 +20,7 @@ resource "twilio_taskrouter_workspaces_v1" "flex_task_assignment" {
   friendly_name      = "Flex Task Assignment"
   multi_task_enabled = true
   event_callback_url = "${var.serverless_url}/webhooks/taskrouterCallback"
-  events_filter = "task.created,task.canceled,task.completed" //Ignore the docs where it implies this should be 'EventsFilter=task.created, task.canceled, task.completed'
+  events_filter = "task.created,task.canceled,task.completed,task.deleted,task.system-deleted" //Ignore the docs where it implies this should be 'EventsFilter=task.created, task.canceled, task.completed'
 }
 
 //TaskQueue

--- a/twilio-iac/terraform-modules/taskRouter/ecpat/main.tf
+++ b/twilio-iac/terraform-modules/taskRouter/ecpat/main.tf
@@ -19,7 +19,7 @@ resource "twilio_taskrouter_workspaces_v1" "flex_task_assignment" {
   friendly_name      = "Flex Task Assignment"
   multi_task_enabled = true
   event_callback_url = "${var.serverless_url}/webhooks/taskrouterCallback"
-  events_filter = "task.created,task.canceled,task.completed" //Ignore the docs where it implies this should be 'EventsFilter=task.created, task.canceled, task.completed'
+  events_filter = "task.created,task.canceled,task.completed,task.deleted,task.system-deleted" //Ignore the docs where it implies this should be 'EventsFilter=task.created, task.canceled, task.completed'
 }
 
 // TaskQueue


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
Enables task deletion events to raise the taskrouter callback. Will impact on new helplines accordingly to the changes in https://github.com/techmatters/serverless/pull/278. 
For already existing accounts this change must be done manually.

I'm adding the ecpat config but haven applied the changes, is just to reflect the state once we do so (anyways I think there are still lots of things not in sync between the account and tf state). 