### PR TITLE
chi-1336: fix child and caller info to be copied appropriately

### DIFF
--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -181,6 +181,8 @@ const ContactDetailsHome: React.FC<Props> = function ({
           showEditButton={enableEditing && can(PermissionActions.EDIT_CONTACT)}
           handleEditClick={() => navigate(ContactDetailsRoute.EDIT_CALLER_INFORMATION)}
           buttonDataTestid="ContactDetails-Section-CallerInformation"
+          handleOpenConnectDialog={handleOpenConnectDialog}
+          showActionIcons={showActionIcons}
         >
           {definitionVersion.tabbedForms.CallerInformationTab.map(e => (
             <SectionEntry

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -183,6 +183,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
           buttonDataTestid="ContactDetails-Section-CallerInformation"
           handleOpenConnectDialog={handleOpenConnectDialog}
           showActionIcons={showActionIcons}
+          callType="caller"
         >
           {definitionVersion.tabbedForms.CallerInformationTab.map(e => (
             <SectionEntry
@@ -204,6 +205,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
           buttonDataTestid="ContactDetails-Section-ChildInformation"
           handleOpenConnectDialog={handleOpenConnectDialog}
           showActionIcons={showActionIcons}
+          callType="child"
         >
           {definitionVersion.tabbedForms.ChildInformationTab.map(e => (
             <SectionEntry

--- a/plugin-hrm-form/src/components/contact/ContactDetailsSection.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsSection.tsx
@@ -1,7 +1,6 @@
-import React, { Dispatch } from 'react';
+import React from 'react';
 import { Template } from '@twilio/flex-ui';
 import { connect, ConnectedProps } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { ArrowDropDownTwoTone, ArrowRightTwoTone, Edit, Link } from '@material-ui/icons';
 
 import {
@@ -13,7 +12,6 @@ import {
   SectionActionButton,
 } from '../../styles/search';
 import { checkButtonData } from '../../states/contacts/actions';
-import { namespace, RootState, searchContactsBase } from '../../states';
 
 const ArrowDownIcon = ContactDetailsIcon(ArrowDropDownTwoTone);
 const ArrowRightIcon = ContactDetailsIcon(ArrowRightTwoTone);

--- a/plugin-hrm-form/src/components/contact/ContactDetailsSection.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsSection.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { Dispatch } from 'react';
 import { Template } from '@twilio/flex-ui';
+import { connect, ConnectedProps } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { ArrowDropDownTwoTone, ArrowRightTwoTone, Edit, Link } from '@material-ui/icons';
 
 import {
@@ -10,16 +12,19 @@ import {
   ContactDetailsIcon,
   SectionActionButton,
 } from '../../styles/search';
+import { checkButtonData } from '../../states/contacts/actions';
+import { namespace, RootState, searchContactsBase } from '../../states';
 
 const ArrowDownIcon = ContactDetailsIcon(ArrowDropDownTwoTone);
 const ArrowRightIcon = ContactDetailsIcon(ArrowRightTwoTone);
 const EditIcon = ContactDetailsIcon(Edit);
 const LinkIcon = ContactDetailsIcon(Link);
 
-type Props = {
+type OwnProps = {
   sectionTitle: string | JSX.Element;
   expanded: boolean;
   handleExpandClick: (event?: any) => void;
+  children: any;
   buttonDataTestid: string;
   hideIcon?: boolean;
   htmlElRef?: any;
@@ -27,7 +32,11 @@ type Props = {
   handleEditClick?: (event?: any) => void;
   handleOpenConnectDialog?: (event: any) => void;
   showActionIcons?: boolean;
+  task?: any;
 };
+
+// eslint-disable-next-line no-use-before-define
+type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ContactDetailsSection: React.FC<Props> = ({
   sectionTitle,
@@ -41,7 +50,13 @@ const ContactDetailsSection: React.FC<Props> = ({
   handleOpenConnectDialog,
   showActionIcons,
   handleEditClick,
+  ...props
 }) => {
+  const showCopyButton = () =>
+    buttonDataTestid === 'ContactDetails-Section-ChildInformation' ||
+    buttonDataTestid === 'ContactDetails-Section-CallerInformation';
+  const handleCopyInfo = () => props.checkButtonData(buttonDataTestid === 'ContactDetails-Section-CallerInformation');
+
   return (
     <>
       <SectionTitleContainer>
@@ -57,8 +72,13 @@ const ContactDetailsSection: React.FC<Props> = ({
           {!hideIcon && (expanded ? <ArrowDownIcon /> : <ArrowRightIcon />)}
           <SectionTitleText>{sectionTitle}</SectionTitleText>
         </SectionTitleButton>
-        {showActionIcons && buttonDataTestid === 'ContactDetails-Section-ChildInformation' && (
-          <SectionActionButton onClick={handleOpenConnectDialog}>
+        {showActionIcons && showCopyButton && (
+          <SectionActionButton
+            onClick={e => {
+              handleOpenConnectDialog(e);
+              handleCopyInfo();
+            }}
+          >
             <LinkIcon style={{ fontSize: '18px', padding: '0 6px' }} />
             <Template code="ContactCopyButton" />
           </SectionActionButton>
@@ -81,4 +101,10 @@ const ContactDetailsSection: React.FC<Props> = ({
 
 ContactDetailsSection.displayName = 'ContactDetailsSection';
 
-export default ContactDetailsSection;
+const mapDispatchToProps = {
+  checkButtonData,
+};
+
+const connector = connect(null, mapDispatchToProps);
+const connected = connector(ContactDetailsSection);
+export default connected;

--- a/plugin-hrm-form/src/components/contact/ContactDetailsSection.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsSection.tsx
@@ -11,7 +11,7 @@ import {
   ContactDetailsIcon,
   SectionActionButton,
 } from '../../styles/search';
-import { checkButtonData } from '../../states/contacts/actions';
+import { setCallType } from '../../states/contacts/actions';
 
 const ArrowDownIcon = ContactDetailsIcon(ArrowDropDownTwoTone);
 const ArrowRightIcon = ContactDetailsIcon(ArrowRightTwoTone);
@@ -31,6 +31,7 @@ type OwnProps = {
   handleOpenConnectDialog?: (event: any) => void;
   showActionIcons?: boolean;
   task?: any;
+  callType?: string;
 };
 
 // eslint-disable-next-line no-use-before-define
@@ -48,12 +49,11 @@ const ContactDetailsSection: React.FC<Props> = ({
   handleOpenConnectDialog,
   showActionIcons,
   handleEditClick,
+  callType,
   ...props
 }) => {
-  const showCopyButton = () =>
-    buttonDataTestid === 'ContactDetails-Section-ChildInformation' ||
-    buttonDataTestid === 'ContactDetails-Section-CallerInformation';
-  const handleCopyInfo = () => props.checkButtonData(buttonDataTestid === 'ContactDetails-Section-CallerInformation');
+  const showCopyButton = () => callType === 'child' || callType === 'caller';
+  const handleSetCallType = () => props.setCallType(callType === 'caller');
 
   return (
     <>
@@ -74,7 +74,7 @@ const ContactDetailsSection: React.FC<Props> = ({
           <SectionActionButton
             onClick={e => {
               handleOpenConnectDialog(e);
-              handleCopyInfo();
+              handleSetCallType();
             }}
           >
             <LinkIcon style={{ fontSize: '18px', padding: '0 6px' }} />
@@ -100,7 +100,7 @@ const ContactDetailsSection: React.FC<Props> = ({
 ContactDetailsSection.displayName = 'ContactDetailsSection';
 
 const mapDispatchToProps = {
-  checkButtonData,
+  setCallType,
 };
 
 const connector = connect(null, mapDispatchToProps);

--- a/plugin-hrm-form/src/components/search/ConnectDialog.jsx
+++ b/plugin-hrm-form/src/components/search/ConnectDialog.jsx
@@ -11,7 +11,7 @@ import TabPressWrapper from '../TabPressWrapper';
 import { contactType } from '../../types';
 import { hasTaskControl } from '../../utils/transfer';
 
-const ConnectDialog = ({ anchorEl, currentIsCaller, contact, handleConfirm, handleClose, task }) => {
+const ConnectDialog = ({ anchorEl, currentIsCaller, contact, handleConfirm, handleClose, task, buttonData }) => {
   const isOpen = Boolean(anchorEl);
   const id = isOpen ? 'simple-popover' : undefined;
 
@@ -23,7 +23,7 @@ const ConnectDialog = ({ anchorEl, currentIsCaller, contact, handleConfirm, hand
       case callTypes.child:
         return <Template code="ConnectDialog-Child" />;
       case callTypes.caller:
-        if (currentIsCaller) return <Template code="ConnectDialog-Caller" />;
+        if (currentIsCaller && buttonData) return <Template code="ConnectDialog-Caller" />;
         return <Template code="ConnectDialog-Child" />;
       default:
         return '';

--- a/plugin-hrm-form/src/components/search/ConnectDialog.jsx
+++ b/plugin-hrm-form/src/components/search/ConnectDialog.jsx
@@ -11,7 +11,7 @@ import TabPressWrapper from '../TabPressWrapper';
 import { contactType } from '../../types';
 import { hasTaskControl } from '../../utils/transfer';
 
-const ConnectDialog = ({ anchorEl, currentIsCaller, contact, handleConfirm, handleClose, task, buttonData }) => {
+const ConnectDialog = ({ anchorEl, currentIsCaller, contact, handleConfirm, handleClose, task, isCallTypeCaller }) => {
   const isOpen = Boolean(anchorEl);
   const id = isOpen ? 'simple-popover' : undefined;
 
@@ -23,7 +23,7 @@ const ConnectDialog = ({ anchorEl, currentIsCaller, contact, handleConfirm, hand
       case callTypes.child:
         return <Template code="ConnectDialog-Child" />;
       case callTypes.caller:
-        if (currentIsCaller && buttonData) return <Template code="ConnectDialog-Caller" />;
+        if (currentIsCaller && isCallTypeCaller) return <Template code="ConnectDialog-Caller" />;
         return <Template code="ConnectDialog-Child" />;
       default:
         return '';

--- a/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { Template } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 
-import { namespace, contactFormsBase, RootState, searchContactsBase } from '../../../states';
+import { namespace, contactFormsBase, RootState } from '../../../states';
 import { Container } from '../../../styles/HrmStyles';
 import GeneralContactDetails from '../../contact/ContactDetails';
 import ConnectDialog from '../ConnectDialog';
@@ -24,9 +24,9 @@ type OwnProps = {
 };
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
-  const { buttonData } = state[namespace][contactFormsBase];
+  const { isCallTypeCaller } = state[namespace][contactFormsBase];
 
-  return { editContactFormOpen, buttonData };
+  return { editContactFormOpen, isCallTypeCaller };
 };
 const mapDispatchToProps = {
   loadContactIntoState: loadContact,
@@ -45,7 +45,7 @@ const ContactDetails: React.FC<Props> = ({
   loadContactIntoState,
   releaseContactFromState,
   editContactFormOpen,
-  buttonData,
+  isCallTypeCaller,
 }: Props) => {
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -82,7 +82,7 @@ const ContactDetails: React.FC<Props> = ({
         contact={contact}
         handleConfirm={handleConfirmDialog}
         handleClose={handleCloseDialog}
-        buttonData={buttonData}
+        isCallTypeCaller={isCallTypeCaller}
       />
 
       <div className={`${editContactFormOpen ? 'editingContact' : ''} hiddenWhenEditingContact`}>

--- a/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { Template } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 
-import { namespace, contactFormsBase, RootState } from '../../../states';
+import { namespace, contactFormsBase, RootState, searchContactsBase } from '../../../states';
 import { Container } from '../../../styles/HrmStyles';
 import GeneralContactDetails from '../../contact/ContactDetails';
 import ConnectDialog from '../ConnectDialog';
@@ -24,7 +24,9 @@ type OwnProps = {
 };
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
-  return { editContactFormOpen };
+  const { buttonData } = state[namespace][contactFormsBase];
+
+  return { editContactFormOpen, buttonData };
 };
 const mapDispatchToProps = {
   loadContactIntoState: loadContact,
@@ -43,6 +45,7 @@ const ContactDetails: React.FC<Props> = ({
   loadContactIntoState,
   releaseContactFromState,
   editContactFormOpen,
+  buttonData,
 }: Props) => {
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -50,7 +53,6 @@ const ContactDetails: React.FC<Props> = ({
     loadContactIntoState(contact, task.taskSid);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contact]);
-
   const handleBackToResults = () => {
     releaseContactFromState(contact.contactId, task.taskSid);
     handleBack();
@@ -80,6 +82,7 @@ const ContactDetails: React.FC<Props> = ({
         contact={contact}
         handleConfirm={handleConfirmDialog}
         handleClose={handleCloseDialog}
+        buttonData={buttonData}
       />
 
       <div className={`${editContactFormOpen ? 'editingContact' : ''} hiddenWhenEditingContact`}>

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -40,7 +40,7 @@ import * as SearchActions from '../../../states/search/actions';
 import * as CaseActions from '../../../states/case/actions';
 import * as RoutingActions from '../../../states/routing/actions';
 import { SearchPages, SearchPagesType } from '../../../states/search/types';
-import { namespace, searchContactsBase, configurationBase } from '../../../states';
+import { namespace, searchContactsBase, configurationBase, contactFormsBase } from '../../../states';
 
 export const CONTACTS_PER_PAGE = 20;
 export const CASES_PER_PAGE = 20;
@@ -87,6 +87,7 @@ const SearchResults: React.FC<Props> = ({
   currentPage,
   showConnectIcon,
   counselorsHash,
+  buttonData,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const [currentContact, setCurrentContact] = useState(null);
@@ -187,6 +188,7 @@ const SearchResults: React.FC<Props> = ({
         contact={currentContact}
         handleConfirm={handleConfirmDialog}
         handleClose={handleCloseDialog}
+        buttonData={buttonData}
       />
       <ListContainer>
         <ScrollableList>
@@ -340,11 +342,13 @@ const mapStateToProps = (state, ownProps) => {
   const taskSearchState = searchContactsState.tasks[taskId];
   const isStandaloneSearch = taskId === standaloneTaskSid;
   const { counselors } = state[namespace][configurationBase];
+  const { buttonData } = state[namespace][contactFormsBase];
 
   return {
     currentPage: taskSearchState.currentPage,
     showConnectIcon: !isStandaloneSearch,
     counselorsHash: counselors.hash,
+    buttonData,
   };
 };
 

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -87,7 +87,7 @@ const SearchResults: React.FC<Props> = ({
   currentPage,
   showConnectIcon,
   counselorsHash,
-  buttonData,
+  isCallTypeCaller,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const [currentContact, setCurrentContact] = useState(null);
@@ -188,7 +188,7 @@ const SearchResults: React.FC<Props> = ({
         contact={currentContact}
         handleConfirm={handleConfirmDialog}
         handleClose={handleCloseDialog}
-        buttonData={buttonData}
+        isCallTypeCaller={isCallTypeCaller}
       />
       <ListContainer>
         <ScrollableList>
@@ -342,13 +342,13 @@ const mapStateToProps = (state, ownProps) => {
   const taskSearchState = searchContactsState.tasks[taskId];
   const isStandaloneSearch = taskId === standaloneTaskSid;
   const { counselors } = state[namespace][configurationBase];
-  const { buttonData } = state[namespace][contactFormsBase];
+  const { isCallTypeCaller } = state[namespace][contactFormsBase];
 
   return {
     currentPage: taskSearchState.currentPage,
     showConnectIcon: !isStandaloneSearch,
     counselorsHash: counselors.hash,
-    buttonData,
+    isCallTypeCaller,
   };
 };
 

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -161,6 +161,7 @@ const Search: React.FC<Props> = props => {
             contact={currentContact}
             handleBack={goToResultsOnContacts}
             handleSelectSearchResult={props.handleSelectSearchResult}
+            // buttonData={props.checkButtonData('ContactDetails-Section-ChildInformation')}
           />
         );
       case SearchPages.case:

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -88,7 +88,7 @@ const TabbedForms: React.FC<Props> = ({
   currentDefinitionVersion,
   csamReportEnabled,
   editContactFormOpen,
-  buttonData,
+  isCallTypeCaller,
 }) => {
   const methods = useForm({
     shouldFocusError: false,
@@ -121,7 +121,7 @@ const TabbedForms: React.FC<Props> = ({
 
   const onSelectSearchResult = (searchResult: SearchContact) => {
     const selectedIsCaller = searchResult.details.callType === callTypes.caller;
-    if (isCallerType && selectedIsCaller && buttonData) {
+    if (isCallerType && selectedIsCaller && isCallTypeCaller) {
       const deTransformed = searchResultToContactForm(
         currentDefinitionVersion.tabbedForms.CallerInformationTab,
         searchResult.details.callerInformation,
@@ -315,8 +315,8 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const contactForm = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];
   const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
   const { currentDefinitionVersion } = state[namespace][configurationBase];
-  const { buttonData } = state[namespace][contactFormsBase];
-  return { routing, contactForm, currentDefinitionVersion, editContactFormOpen, buttonData };
+  const { isCallTypeCaller } = state[namespace][contactFormsBase];
+  return { routing, contactForm, currentDefinitionVersion, editContactFormOpen, isCallTypeCaller };
 };
 
 const connector = connect(mapStateToProps);

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -88,6 +88,7 @@ const TabbedForms: React.FC<Props> = ({
   currentDefinitionVersion,
   csamReportEnabled,
   editContactFormOpen,
+  buttonData,
 }) => {
   const methods = useForm({
     shouldFocusError: false,
@@ -120,7 +121,7 @@ const TabbedForms: React.FC<Props> = ({
 
   const onSelectSearchResult = (searchResult: SearchContact) => {
     const selectedIsCaller = searchResult.details.callType === callTypes.caller;
-    if (isCallerType && selectedIsCaller) {
+    if (isCallerType && selectedIsCaller && buttonData) {
       const deTransformed = searchResultToContactForm(
         currentDefinitionVersion.tabbedForms.CallerInformationTab,
         searchResult.details.callerInformation,
@@ -314,7 +315,8 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const contactForm = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];
   const editContactFormOpen = state[namespace][contactFormsBase].editingContact;
   const { currentDefinitionVersion } = state[namespace][configurationBase];
-  return { routing, contactForm, currentDefinitionVersion, editContactFormOpen };
+  const { buttonData } = state[namespace][contactFormsBase];
+  return { routing, contactForm, currentDefinitionVersion, editContactFormOpen, buttonData };
 };
 
 const connector = connect(mapStateToProps);

--- a/plugin-hrm-form/src/states/contacts/actions.ts
+++ b/plugin-hrm-form/src/states/contacts/actions.ts
@@ -77,7 +77,7 @@ export const setEditContactPageClosed = (): t.ContactsActionType => ({
   editing: false,
 });
 
-export const checkButtonData = (buttonData: boolean): t.ContactsActionType => ({
-  type: t.CHECK_BUTTON_DATA,
-  buttonData,
+export const setCallType = (isCallTypeCaller: boolean): t.ContactsActionType => ({
+  type: t.SET_CALL_TYPE,
+  isCallTypeCaller,
 });

--- a/plugin-hrm-form/src/states/contacts/actions.ts
+++ b/plugin-hrm-form/src/states/contacts/actions.ts
@@ -76,3 +76,8 @@ export const setEditContactPageClosed = (): t.ContactsActionType => ({
   type: t.SET_EDITING_CONTACT,
   editing: false,
 });
+
+export const checkButtonData = (buttonData: boolean): t.ContactsActionType => ({
+  type: t.CHECK_BUTTON_DATA,
+  buttonData,
+});

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -54,6 +54,7 @@ export type TaskEntry = {
       expanded: { [key: string]: boolean };
     };
   };
+  buttonData: boolean;
 };
 
 type ContactsState = {
@@ -63,6 +64,7 @@ type ContactsState = {
   existingContacts: ExistingContactsState;
   contactDetails: ContactDetailsState;
   editingContact: boolean;
+  buttonData: boolean;
 };
 
 export const emptyCategories = [];
@@ -110,6 +112,7 @@ export const createNewTaskEntry = (definitions: DefinitionVersion) => (recreated
     categories: emptyCategories,
     csamReports: [],
     metadata,
+    buttonData: false,
   };
 };
 
@@ -121,6 +124,7 @@ const initialState: ContactsState = {
     [DetailsContext.CONTACT_SEARCH]: { detailsExpanded: {} },
   },
   editingContact: false,
+  buttonData: false,
 };
 
 // eslint-disable-next-line import/no-unused-modules,complexity
@@ -279,6 +283,9 @@ export function reduce(
           },
         },
       };
+    }
+    case t.CHECK_BUTTON_DATA: {
+      return { ...state, buttonData: action.buttonData };
     }
     case t.SET_EDITING_CONTACT: {
       return { ...state, editingContact: action.editing };

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -54,7 +54,7 @@ export type TaskEntry = {
       expanded: { [key: string]: boolean };
     };
   };
-  buttonData: boolean;
+  isCallTypeCaller: boolean;
 };
 
 type ContactsState = {
@@ -64,7 +64,7 @@ type ContactsState = {
   existingContacts: ExistingContactsState;
   contactDetails: ContactDetailsState;
   editingContact: boolean;
-  buttonData: boolean;
+  isCallTypeCaller: boolean;
 };
 
 export const emptyCategories = [];
@@ -112,7 +112,7 @@ export const createNewTaskEntry = (definitions: DefinitionVersion) => (recreated
     categories: emptyCategories,
     csamReports: [],
     metadata,
-    buttonData: false,
+    isCallTypeCaller: false,
   };
 };
 
@@ -124,7 +124,7 @@ const initialState: ContactsState = {
     [DetailsContext.CONTACT_SEARCH]: { detailsExpanded: {} },
   },
   editingContact: false,
-  buttonData: false,
+  isCallTypeCaller: false,
 };
 
 // eslint-disable-next-line import/no-unused-modules,complexity
@@ -284,8 +284,8 @@ export function reduce(
         },
       };
     }
-    case t.CHECK_BUTTON_DATA: {
-      return { ...state, buttonData: action.buttonData };
+    case t.SET_CALL_TYPE: {
+      return { ...state, isCallTypeCaller: action.isCallTypeCaller };
     }
     case t.SET_EDITING_CONTACT: {
       return { ...state, editingContact: action.editing };

--- a/plugin-hrm-form/src/states/contacts/types.ts
+++ b/plugin-hrm-form/src/states/contacts/types.ts
@@ -14,6 +14,7 @@ export const RESTORE_ENTIRE_FORM = 'RESTORE_ENTIRE_FORM';
 export const UPDATE_HELPLINE = 'UPDATE_HELPLINE';
 export const ADD_CSAM_REPORT_ENTRY = 'contacts/ADD_CSAM_REPORT_ENTRY';
 export const SET_EDITING_CONTACT = 'SET_EDITING_CONTACT';
+export const CHECK_BUTTON_DATA = 'CHECK_BUTTON_DATA';
 
 type UpdateFormAction = {
   type: typeof UPDATE_FORM;
@@ -69,6 +70,8 @@ type SetEditingContact = {
   editing: boolean;
 };
 
+type CheckButtonDataAction = { type: typeof CHECK_BUTTON_DATA; buttonData: boolean };
+
 export type ContactsActionType =
   | UpdateFormAction
   | SaveEndMillisAction
@@ -78,4 +81,5 @@ export type ContactsActionType =
   | RestoreEntireFormAction
   | UpdateHelpline
   | AddCSAMReportEntry
-  | SetEditingContact;
+  | SetEditingContact
+  | CheckButtonDataAction;

--- a/plugin-hrm-form/src/states/contacts/types.ts
+++ b/plugin-hrm-form/src/states/contacts/types.ts
@@ -14,7 +14,7 @@ export const RESTORE_ENTIRE_FORM = 'RESTORE_ENTIRE_FORM';
 export const UPDATE_HELPLINE = 'UPDATE_HELPLINE';
 export const ADD_CSAM_REPORT_ENTRY = 'contacts/ADD_CSAM_REPORT_ENTRY';
 export const SET_EDITING_CONTACT = 'SET_EDITING_CONTACT';
-export const CHECK_BUTTON_DATA = 'CHECK_BUTTON_DATA';
+export const SET_CALL_TYPE = 'SET_CALL_TYPE';
 
 type UpdateFormAction = {
   type: typeof UPDATE_FORM;
@@ -70,7 +70,7 @@ type SetEditingContact = {
   editing: boolean;
 };
 
-type CheckButtonDataAction = { type: typeof CHECK_BUTTON_DATA; buttonData: boolean };
+type CheckButtonDataAction = { type: typeof SET_CALL_TYPE; isCallTypeCaller: boolean };
 
 export type ContactsActionType =
   | UpdateFormAction


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @murilovmachado 

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Bug fix: Fix child and caller info to be copied appropriately

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [x] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes CHI-1336

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
1. Agent Desktop > Create offline contact > Search for Contacts and Cases
2. Search for a Counsellor
3. Select to View a contact (contact should have both child and caller)
4. Select Copy next to the Child section
5. Select Copy next to the Caller section
6. Say 'Yes' to the pop-up dialogue box
7. Verify that both the Caller and Child's tabs are populated appropriately 

<img width="1512" alt="Screenshot 2022-08-09 at 9 45 36 AM" src="https://user-images.githubusercontent.com/40429848/183609061-ce3a1723-199b-4649-961e-6d8ff6f52f58.png">
