### PR TITLE
Added a script to safely patch service configurations with updated feature flags.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,7 @@
   - [import-account-defaults](#import-account-defaults)
   - [import-tf](#import-tf)
   - [generate-chatbot-tf](#generate-chatbot-tf)
+  - [patch-feature-flags](#patch-feature-flags)
 
 ## generateDeploymentFiles
 This script generates deployment files for `flex-plugins` and `serverless` repos.
@@ -137,3 +138,16 @@ Example:
 ➜ npm run twilioResources -- generate-chatbot-tf --assistantSid=UAxxxxxxxxxxxx --referenceName=my_custom_bot --serverlessUrl=https://serverless-xxxx-production.twil.io
 ```
 will create a new file `my_custom_bot.tf` that contains the definition of the bot with the sid `UAxxxxxxxxxxxx`, and will replace all the occurrences of `https://serverless-xxxx-production.twil.io` for the dynamic form we use in the terraform setup (`${var.serverless_url}`).
+
+### patch-feature-flags
+
+This script allows you to safely update the feature flags specified in a Twilio Account's Service Configuration without affecting other settings
+
+You need to have `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` environment variables set (either passed in the command itself or in a `.env` file).
+You also must provide the following parameters to the script:
+- `-f / --flag`: Use this to specify a flag and what you wish to set it to. The value must take the form {flag_name}:{flag_set}, e.g. -f my_flag:true. Can be specified multiple times
+  Example:
+```
+➜ npm run twilioResources patch-feature-flags -- -f enable_voice_recordings:false -f enable_transcripts:true
+```
+will set the `enable_voice_recordings` to false, and the `enable_transcripts` flag to true, creating them if they didn't previously exist, or overwriting their previous setting if they did.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -128,10 +128,10 @@ From here you can either C&P the commands and run them manually, or rerun the sc
 Given an already existing chatbot assistant, living in a Twilio account, will generate the `.tf` file that represents that definition.
 It will create the file locally, so you need to grab it and drop it where it makes sense.
 
-You need to have `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` environemt variables set (either passed in the command itself or in a `.env` file).
+You need to have `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` environment variables set (either passed in the command itself or in a `.env` file).
 You also must provide the following parameters to the script: 
   - `assistantSid`: Target chatbot's assistant sid to generate the .tf from.
-  - `referenceName`: The reference name that will be used as the top level resurce (the name of the assistant resource in the .tf file).
+  - `referenceName`: The reference name that will be used as the top level resource (the name of the assistant resource in the .tf file).
   - `serverlessUrl`: \[optional\] The serverless url of the account. If present, will replace it for the dynamic form in the .tf file.
 Example: 
 ```

--- a/scripts/src/terraformSupplemental/updateFlexServiceConfiguration.ts
+++ b/scripts/src/terraformSupplemental/updateFlexServiceConfiguration.ts
@@ -3,7 +3,7 @@ import { logDebug, logSuccess } from '../helpers/log';
 
 const TWILIO_FLEX_CONFIGURATION_ENDPOINT = 'https://flex-api.twilio.com/v1/Configuration';
 
-export default async function updateFlexServiceConfiguration(payload: unknown) {
+export async function updateFlexServiceConfiguration(payload: unknown) {
   logDebug('Patching flex configuration with:', payload);
   const response = await axios.post(TWILIO_FLEX_CONFIGURATION_ENDPOINT, payload, {
     auth: {
@@ -21,4 +21,31 @@ export default async function updateFlexServiceConfiguration(payload: unknown) {
       }). Response: ${response.data === 'object' ? JSON.stringify(response.data) : response.data}`,
     );
   }
+}
+
+export async function patchFeatureFlags(flags: Record<string, boolean>) {
+  logDebug('Setting the following feature flags:', flags);
+
+  const response = await axios.get(TWILIO_FLEX_CONFIGURATION_ENDPOINT, {
+    auth: {
+      username: process.env.TWILIO_ACCOUNT_SID ?? '',
+      password: process.env.TWILIO_AUTH_TOKEN ?? '',
+    },
+  });
+  if (response.status === 200) {
+    logSuccess('Successfully retrieved Flex Service Configuration');
+  } else {
+    throw new Error(
+      `Error response from Flex Service Configuration GET, HTTP Status ${response.statusText} (${
+        response.status
+      }). Response: ${response.data === 'object' ? JSON.stringify(response.data) : response.data}`,
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { account_sid, ui_attributes, attributes } = response.data;
+  await updateFlexServiceConfiguration({
+    account_sid,
+    ui_attributes,
+    attributes: { ...attributes, feature_flags: { ...attributes.feature_flags, ...flags } },
+  });
 }


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description

Adds a command to the `twilioResources` set of scripts that allows the caller to specify a set of feature flags without affecting any other feature flags or service configuration settings. 

### Checklist
- [ ] Corresponding issue has been opened
- [X] New tests added
- N/A Strings are localized
- N/A Tested for chat contacts
- N/A Tested for call contacts

### Verification steps

Use the script to update Aselo Development