### PR TITLE
Fix Flex 2.0 UI - Agent Desktop (left pane)

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -4,7 +4,7 @@ import SyncClient from 'twilio-sync';
 
 import './styles/global-overrides.css';
 import reducers, { namespace, configurationBase, RootState } from './states';
-import HrmTheme from './styles/HrmTheme';
+import HrmTheme, { overrides } from './styles/HrmTheme';
 import { transferModes } from './states/DomainConstants';
 import { initLocalization } from './utils/pluginHelpers';
 import * as ActionFunctions from './utils/setUpActions';
@@ -265,8 +265,11 @@ export default class HrmFormPlugin extends FlexPlugin {
     setUpComponents(setupObject);
     setUpActions(setupObject);
 
-    const managerConfiguration: any = {
-      colorTheme: HrmTheme,
+    const managerConfiguration = {
+      // colorTheme: HrmTheme,
+      theme: {
+        componentThemeOverrides: overrides,
+      },
     };
     manager.updateConfig(managerConfiguration);
 

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { connect, ConnectedProps } from 'react-redux';
+import { connect, ConnectedProps, useSelector } from 'react-redux';
 import { TaskHelper } from '@twilio/flex-ui';
 import { bindActionCreators } from 'redux';
 
@@ -9,6 +9,7 @@ import FormNotEditable from './FormNotEditable';
 import { RootState, namespace, contactFormsBase, searchContactsBase, routingBase, configurationBase } from '../states';
 import * as GeneralActions from '../states/actions';
 import { updateHelpline as updateHelplineAction } from '../states/contacts/actions';
+import { selectWorkerTasks } from '../states/selectors/flexSelectors';
 import { hasTaskControl } from '../utils/transfer';
 import type { DefinitionVersion } from '../states/types';
 import { CustomITask, isOfflineContactTask, isInMyBehalfITask } from '../types/types';
@@ -36,6 +37,8 @@ const TaskView: React.FC<Props> = props => {
     recreateContactState,
   } = props;
 
+  const tasks = useSelector(selectWorkerTasks);
+
   React.useEffect(() => {
     if (shouldRecreateState) {
       recreateContactState(currentDefinitionVersion)(task.taskSid);
@@ -45,9 +48,9 @@ const TaskView: React.FC<Props> = props => {
   // Force a re-render on unmount (temporary fix NoTaskView issue with Offline Contacts)
   React.useEffect(() => {
     return () => {
-      if (isOfflineContactTask(task)) reRenderAgentDesktop();
+      if (isOfflineContactTask(task) && tasks.size === 0) reRenderAgentDesktop();
     };
-  }, [task]);
+  }, [task, tasks.size]);
 
   const contactInitialized = Boolean(contactForm);
   const helpline = contactForm?.helpline;

--- a/plugin-hrm-form/src/states/selectors/flexSelectors.ts
+++ b/plugin-hrm-form/src/states/selectors/flexSelectors.ts
@@ -1,4 +1,5 @@
 // This selectors should be used with useFlexSelector. For more information please see https://www.twilio.com/docs/flex/developer/ui/v2/migration-guide#state-management-changes
 import type { RootState } from '..';
 
+export const selectWorkerTasks = (state: RootState) => state.flex.worker.tasks;
 export const selectWorkerSid = (state: RootState) => state.flex.worker.worker.sid;

--- a/plugin-hrm-form/src/styles/CSAMReport/index.tsx
+++ b/plugin-hrm-form/src/styles/CSAMReport/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 import { withStyles } from '@material-ui/core';
 import AttachFile from '@material-ui/icons/AttachFile';
 import CheckCircle from '@material-ui/icons/CheckCircle';

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { ButtonBase, Input, Select, MenuItem, Tabs, Tab, withStyles, TableRow, TabProps } from '@material-ui/core';
 import type { ButtonBaseProps } from '@material-ui/core/ButtonBase';
 import AssignmentInd from '@material-ui/icons/AssignmentInd';
-import { Button, Icon, styled } from '@twilio/flex-ui';
+import { Button, Icon } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 import { getBackgroundWithHoverCSS } from '@twilio/flex-ui-core';
 
 import HrmTheme from './HrmTheme';

--- a/plugin-hrm-form/src/styles/HrmTheme.js
+++ b/plugin-hrm-form/src/styles/HrmTheme.js
@@ -69,7 +69,7 @@ const colors = {
   userUnavailableColor: '#999999',
 };
 
-const overrides = {
+export const overrides = {
   MainHeader: {
     Container: {
       background: colors.base2,

--- a/plugin-hrm-form/src/styles/callTypeButtons/index.tsx
+++ b/plugin-hrm-form/src/styles/callTypeButtons/index.tsx
@@ -3,7 +3,8 @@ import '@emotion/core';
 import Dialog from '@material-ui/core/Dialog';
 import ClearIcon from '@material-ui/icons/Clear';
 import { IconButton } from '@material-ui/core';
-import { Button, styled } from '@twilio/flex-ui';
+import { Button } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 import { getBackgroundWithHoverCSS } from '@twilio/flex-ui-core';
 
 import HrmTheme from '../HrmTheme';

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, IconButton, styled } from '@twilio/flex-ui';
+import { Button, IconButton } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 import { Typography, ButtonBase } from '@material-ui/core';
 
 import { FontOpenSans, FormInput, FormSelect, FormSelectWrapper, Row, Column } from '../HrmStyles';

--- a/plugin-hrm-form/src/styles/caseList/filters.ts
+++ b/plugin-hrm-form/src/styles/caseList/filters.ts
@@ -1,4 +1,4 @@
-import { styled } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 
 import { Flex } from '../HrmStyles';
 import HrmTheme from '../HrmTheme';

--- a/plugin-hrm-form/src/styles/caseList/index.ts
+++ b/plugin-hrm-form/src/styles/caseList/index.ts
@@ -1,4 +1,4 @@
-import { styled } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 import { Table, TableCell, TableRow, withStyles } from '@material-ui/core';
 
 import { Absolute, FontOpenSans, Flex } from '../HrmStyles';

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -8,6 +8,13 @@ div.Twilio-SideNav-Container {
 div.Twilio-MainHeader {
     margin-bottom: 5px;
 }
+div.Twilio-MainHeader div.Twilio-Icon {
+    color: rgb(18, 28, 45);
+}
+div.Twilio-MainHeader button span {
+    color: rgb(18, 28, 45);
+}
+/* Twilio-MainHeader-end */
 button.Twilio-TaskListFilter-TaskFilterButton {
     margin-right: 10px;
 }

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -14,7 +14,6 @@ div.Twilio-MainHeader div.Twilio-Icon {
 div.Twilio-MainHeader button span {
     color: rgb(18, 28, 45);
 }
-/* Twilio-MainHeader-end */
 button.Twilio-TaskListFilter-TaskFilterButton {
     margin-right: 10px;
 }
@@ -23,6 +22,9 @@ button.Twilio-TaskListFilter-TaskFilterButton > div.Twilio-Icon-Filter {
 }
 button.Twilio-TaskListFilter-TaskFilterButton > div.Twilio-Icon-FilterUp {
     margin-left: auto;
+}
+div.Twilio-TaskListBaseItem::before {
+    width: 0;
 }
 button.Twilio-TaskCanvasHeader-EndButton {
     border-radius: 4px;

--- a/plugin-hrm-form/src/styles/menu/index.js
+++ b/plugin-hrm-form/src/styles/menu/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 import Popper from '@material-ui/core/Popper';
 import Paper from '@material-ui/core/Paper';
 import MenuList from '@material-ui/core/MenuList';

--- a/plugin-hrm-form/src/styles/previousContactsBanner/index.ts
+++ b/plugin-hrm-form/src/styles/previousContactsBanner/index.ts
@@ -1,4 +1,4 @@
-import { styled } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 
 export const YellowBanner = styled('div')`
   display: flex;

--- a/plugin-hrm-form/src/styles/queuesStatus/index.ts
+++ b/plugin-hrm-form/src/styles/queuesStatus/index.ts
@@ -1,4 +1,4 @@
-import { styled } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 
 import { FontOpenSans } from '../HrmStyles';
 

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ButtonBase, Paper, Button, FormControlLabel, Switch, Collapse, withStyles } from '@material-ui/core';
-import { Tabs, TabsProps, styled } from '@twilio/flex-ui';
+import { Tabs, TabsProps } from '@twilio/flex-ui';
+import styled from '@emotion/styled';
 import Folder from '@material-ui/icons/Folder';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import Link from '@material-ui/icons/Link';
@@ -308,8 +309,8 @@ export const TagMiddleDot = styled('div')<ColorProps>`
 // ContactDetails styles
 export const ContactDetailsIcon = icon => styled(icon)`
   color: #000000;
-  width: 50px;
-  height: 50px;
+  width: 24px;
+  height: 24px;
   font-size: 16px;
 `;
 


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: 

## Description
This PR 
- Reintroduces component overrides (API slightly changed).
- Fixes a few UI issues with our plugin running Flex v2.
- Adds a check to prevent a weird re-render when swapping from offline to live contact tasks.
- Imports `styled` from `@emotion/styled`, which seems to restore most of our existing styles.

Before this PR (currently deployed to the v2 account):
![Screenshot from 2022-08-16 17-07-16](https://user-images.githubusercontent.com/15805319/184985977-d57cd1cf-5cb5-4037-b3d6-19d16b2b9eaa.png)

In this PR:
![Screenshot from 2022-08-16 23-39-21](https://user-images.githubusercontent.com/15805319/185022560-7b34e2d2-9aa0-4891-8192-da24020bb6d1.png)


Current issues:
- Task colors are not being taken into consideration (task list).
- Accept task, reject task and end chat buttons are behaving in a weird way.

Both of the above currently being discussed in a support ticket. 

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1289)
- [ ] New tests added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- Change `public/appConfig.js` to point to `const accountSid = 'ACxxxxxxxxxxx';` // a11y test account sid
- `rm -rf node_modules && npm ci`
- `npm start`