### PR TITLE
CHI-1367: Fix for blank screen viewing contact in new case

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
@@ -216,7 +216,7 @@ describe('test reducer', () => {
         }),
       ).toThrow();
     });
-    test('should throw if connected case has no connected contacts array', async () => {
+    test('should add empty connected contacts array if connected case has no connected contacts array', async () => {
       const startingState = {
         tasks: {
           task1: {
@@ -226,16 +226,25 @@ describe('test reducer', () => {
         },
       };
 
-      expect(() =>
-        reduce(startingState, {
-          type: UPDATE_CASE_CONTACT,
-          taskId: task.taskSid,
-          contact: {
-            id: 'AN ID',
-            b: 100,
+      const expected = {
+        tasks: {
+          task1: {
+            ...state.tasks.task1,
+            connectedCase: { ...connectedCase, connectedContacts: [] },
           },
-        }),
-      ).toThrow();
+        },
+      };
+
+      const result = reduce(startingState, {
+        type: UPDATE_CASE_CONTACT,
+        taskId: task.taskSid,
+        contact: {
+          id: 'AN ID',
+          b: 100,
+        },
+      });
+
+      expect(result).toStrictEqual(expected);
     });
     test('should throw if target taskId has no connected case', async () => {
       const startingState = {

--- a/plugin-hrm-form/src/states/case/reducer.ts
+++ b/plugin-hrm-form/src/states/case/reducer.ts
@@ -117,7 +117,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
             ...state.tasks[action.taskId],
             connectedCase: {
               ...state.tasks[action.taskId].connectedCase,
-              connectedContacts: state.tasks[action.taskId].connectedCase.connectedContacts.map(cc =>
+              connectedContacts: (state.tasks[action.taskId].connectedCase.connectedContacts ?? []).map(cc =>
                 cc.id === action.contact.id ? action.contact : cc,
               ),
             },


### PR DESCRIPTION
Primary reviewer: @mmythily 

## Description

Added defensive code to handle an undefined 'connectedContacts' property in the UPDATE_CASE_CONTACT reducer.

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes CHI-1367

### Verification steps

See bug ticket