### PR TITLE
 CHI1364 Tab Press Component tests and behavior fix in Flex 2.0

### DIFF
--- a/plugin-hrm-form/jest-standalone.config.js
+++ b/plugin-hrm-form/jest-standalone.config.js
@@ -5,7 +5,7 @@ module.exports = config => {
   config = config || {
     ...defaults,
     rootDir: '.',
-    setupFiles: ['./src/setupTests.js'],
+    setupFilesAfterEnv: ['./src/setupTests.js'],
     testEnvironment: 'jest-environment-jsdom',
     testTimeout: 2 * 60 * 1000, // 2 minutes in ms
     transformIgnorePatterns: [`/node_modules/(?!uuid/.+\\.js)`],

--- a/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
+++ b/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { getByTestId, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
 
 import './mockStyled';
 import TabPressWrapper from '../components/TabPressWrapper';
@@ -12,173 +15,211 @@ const getLastElement = component => component.getInstance().lastElementRef.curre
  */
 
 test('<TabPressWrapper> with no children', () => {
-  const component = renderer.create(<TabPressWrapper />);
+  const { container } = render(<TabPressWrapper />);
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
-
-  expect(firstElement).toBeNull();
-  expect(lastElement).toBeNull();
+  expect(container.getAttribute('tabIndex')).toBeNull();
 });
 
 test('<TabPressWrapper> with no children with tabIndex', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
-      <button id="noTabIndex1" type="button" />
-      <button id="noTabIndex2" type="button" />
+      <div id="noTabIndex1" data-testid="noTabIndex1" />
+      <div id="noTabIndex2" data-testid="noTabIndex2" />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
+  const firstElement = getByTestId(container, 'noTabIndex1');
+  userEvent.tab();
+  expect(firstElement).not.toHaveFocus();
+  expect(firstElement.getAttribute('tabIndex')).toBeNull();
 
-  expect(firstElement).toBeNull();
-  expect(lastElement).toBeNull();
+  const secondElement = getByTestId(container, 'noTabIndex2');
+  userEvent.tab();
+  expect(secondElement).not.toHaveFocus();
+  expect(secondElement.getAttribute('tabIndex')).toBeNull();
 });
 
 test('<TabPressWrapper> children with only one tabIndex', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
-      <button id="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex1" data-testid="tabbableButton" type="button" tabIndex={1} />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
-
-  expect(firstElement.props.id).toEqual('tabIndex1');
-  expect(lastElement).toBeNull();
+  const firstElement = getByTestId(container, 'tabbableButton');
+  userEvent.tab();
+  expect(firstElement).toHaveFocus();
 });
 
 test('<TabPressWrapper> children with tabIndexes: 1, 2 and 3', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
-      <button id="tabIndex1" type="button" tabIndex={1} />
-      <button id="tabIndex2" type="button" tabIndex={2} />
-      <button id="tabIndex3" type="button" tabIndex={3} />
+      <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex2" data-testid="tabIndex2" type="button" tabIndex={2} />
+      <button id="tabIndex3" data-testid="tabIndex3" type="button" tabIndex={3} />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
+  const firstElement = getByTestId(container, 'tabIndex1');
+  userEvent.tab();
+  expect(firstElement).toHaveFocus();
 
-  expect(firstElement.props.id).toEqual('tabIndex1');
-  expect(lastElement.props.id).toEqual('tabIndex3');
+  const secondElement = getByTestId(container, 'tabIndex2');
+  userEvent.tab();
+  expect(secondElement).toHaveFocus();
+
+  const lastElement = getByTestId(container, 'tabIndex3');
+  userEvent.tab();
+  expect(lastElement).toHaveFocus();
 });
 
 test('<TabPressWrapper> not only first level children with tabIndexes: 1, 2 and 3', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
       <div>
-        <button id="tabIndex1" type="button" tabIndex={1} />
+        <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
       </div>
       <div>
         <div>
-          <button id="tabIndex2" type="button" tabIndex={2} />
+          <button id="tabIndex2" data-testid="tabIndex2" type="button" tabIndex={2} />
         </div>
       </div>
-      <button id="tabIndex3" type="button" tabIndex={3} />
+      <button id="tabIndex3" data-testid="tabIndex3" type="button" tabIndex={3} />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
+  const firstElement = getByTestId(container, 'tabIndex1');
+  userEvent.tab();
+  expect(firstElement).toHaveFocus();
 
-  expect(firstElement.props.id).toEqual('tabIndex1');
-  expect(lastElement.props.id).toEqual('tabIndex3');
+  const secondElement = getByTestId(container, 'tabIndex2');
+  userEvent.tab();
+  expect(secondElement).toHaveFocus();
+
+  const lastElement = getByTestId(container, 'tabIndex3');
+  userEvent.tab();
+  expect(lastElement).toHaveFocus();
 });
 
 test('<TabPressWrapper> children with tabIndexes: 1 and 3', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
-      <button id="tabIndex1" type="button" tabIndex={1} />
-      <button id="tabIndex3" type="button" tabIndex={3} />
+      <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex3" data-testid="tabIndex3" type="button" tabIndex={3} />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
+  const firstElement = getByTestId(container, 'tabIndex1');
+  userEvent.tab();
+  expect(firstElement).toHaveFocus();
 
-  expect(firstElement.props.id).toEqual('tabIndex1');
-  expect(lastElement.props.id).toEqual('tabIndex3');
+  const secondElement = getByTestId(container, 'tabIndex3');
+  userEvent.tab();
+  expect(secondElement).toHaveFocus();
 });
 
 test('<TabPressWrapper> children with tabIndexes: 5 and 4', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
-      <button id="tabIndex5" type="button" tabIndex={5} />
-      <button id="tabIndex4" type="button" tabIndex={4} />
+      <button id="tabIndex5" data-testid="tabIndex5" type="button" tabIndex={5} />
+      <button id="tabIndex4" data-testid="tabIndex4" type="button" tabIndex={4} />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
+  const firstElement = getByTestId(container, 'tabIndex4');
+  userEvent.tab();
+  expect(firstElement).toHaveFocus();
 
-  expect(firstElement.props.id).toEqual('tabIndex4');
-  expect(lastElement.props.id).toEqual('tabIndex5');
+  const secondElement = getByTestId(container, 'tabIndex5');
+  userEvent.tab();
+  expect(secondElement).toHaveFocus();
 });
 
 test('<TabPressWrapper> children with tabIndexes: 1, 2 and 1', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
-      <button id="tabIndex1" type="button" tabIndex={1} />
-      <button id="tabIndex2" type="button" tabIndex={2} />
-      <button id="tabIndex1Again" type="button" tabIndex={1} />
+      <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex2" data-testid="tabIndex2" type="button" tabIndex={2} />
+      <button id="tabIndex1Again" data-testid="tabIndex1Again" type="button" tabIndex={1} />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
+  const firstElement = getByTestId(container, 'tabIndex1');
+  userEvent.tab();
+  expect(firstElement).toHaveFocus();
 
-  expect(firstElement.props.id).toEqual('tabIndex1');
-  expect(lastElement.props.id).toEqual('tabIndex2');
+  const secondElement = getByTestId(container, 'tabIndex1Again');
+  userEvent.tab();
+  expect(secondElement).toHaveFocus();
+
+  const lastElement = getByTestId(container, 'tabIndex2');
+  userEvent.tab();
+  expect(lastElement).toHaveFocus();
 });
 
 test('<TabPressWrapper> children with tabIndexes: 1, 2 and 2', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
-      <button id="tabIndex1" type="button" tabIndex={1} />
-      <button id="tabIndex2" type="button" tabIndex={2} />
-      <button id="tabIndex2Again" type="button" tabIndex={2} />
+      <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex2" data-testid="tabIndex2" type="button" tabIndex={2} />
+      <button id="tabIndex2Again" data-testid="tabIndex2Again" type="button" tabIndex={2} />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
+  const firstElement = getByTestId(container, 'tabIndex1');
+  userEvent.tab();
+  expect(firstElement).toHaveFocus();
 
-  expect(firstElement.props.id).toEqual('tabIndex1');
-  expect(lastElement.props.id).toEqual('tabIndex2Again');
+  const secondElement = getByTestId(container, 'tabIndex2');
+  userEvent.tab();
+  expect(secondElement).toHaveFocus();
+
+  const lastElement = getByTestId(container, 'tabIndex2Again');
+  userEvent.tab();
+  expect(lastElement).toHaveFocus();
 });
 
 test('<TabPressWrapper> complex children structure', () => {
-  const component = renderer.create(
+  const { container } = render(
     <TabPressWrapper>
       <div>
-        <button id="tabIndex7" type="button" tabIndex={7} />
+        <button id="tabIndex7" data-testid="tabIndex7" type="button" tabIndex={7} />
         <div />
         <button id="tabIndex6" type="button" tabIndex={6} />
         <button id="tabIndex3" type="button" tabIndex={3} />
       </div>
       <div>
         <button id="tabIndex3Again" type="button" tabIndex={3} />
-        <button id="tabIndex7Again" type="button" tabIndex={7} />
+        <button id="tabIndex7Again" data-testid="tabIndex7Again" type="button" tabIndex={7} />
         <button id="tabIndex6Again" type="button" tabIndex={6} />
       </div>
       <div>
         <div>
-          <button id="tabIndex2" type="button" tabIndex={2} />
+          <button id="tabIndex2" data-testid="tabIndex2" type="button" tabIndex={2} />
         </div>
       </div>
-      <button id="tabIndex2Again" type="button" tabIndex={2} />
+      <button id="tabIndex2Again" data-testid="tabIndex2Again" type="button" tabIndex={2} />
       <button id="tabIndex3AgainAgain" type="button" tabIndex={3} />
     </TabPressWrapper>,
   );
 
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
+  const firstElement = getByTestId(container, 'tabIndex2');
+  userEvent.tab();
+  expect(firstElement).toHaveFocus();
 
-  expect(firstElement.props.id).toEqual('tabIndex2');
-  expect(lastElement.props.id).toEqual('tabIndex7Again');
+  const secondElement = getByTestId(container, 'tabIndex2Again');
+  userEvent.tab();
+  expect(secondElement).toHaveFocus();
+
+  const lastElement = getByTestId(container, 'tabIndex7Again');
+  userEvent.tab();
+  userEvent.tab();
+  userEvent.tab();
+  userEvent.tab();
+  userEvent.tab();
+  userEvent.tab();
+  userEvent.tab();
+  expect(lastElement).toHaveFocus();
 });
 
 /**

--- a/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
+++ b/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { getByTestId, render } from '@testing-library/react';
+import { getByTestId, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -14,13 +14,14 @@ const getLastElement = component => component.getInstance().lastElementRef.curre
  * firstElement and lastElement tests
  */
 
-test('<TabPressWrapper> with no children', () => {
+test('<TabPressWrapper> with no children, and it should have no element that can be focused', () => {
   const { container } = render(<TabPressWrapper />);
-
+  userEvent.tab();
+  expect(container).not.toHaveFocus();
   expect(container.getAttribute('tabIndex')).toBeNull();
 });
 
-test('<TabPressWrapper> with no children with tabIndex', () => {
+test('<TabPressWrapper> with no children with a tabIndex, and not tabbable, this should have no elements that can be focused', () => {
   const { container } = render(
     <TabPressWrapper>
       <div id="noTabIndex1" data-testid="noTabIndex1" />
@@ -39,7 +40,7 @@ test('<TabPressWrapper> with no children with tabIndex', () => {
   expect(secondElement.getAttribute('tabIndex')).toBeNull();
 });
 
-test('<TabPressWrapper> children with only one tabIndex', () => {
+test('<TabPressWrapper> children with only one tabIndex, and after tabbing once, should focus on the first element', () => {
   const { container } = render(
     <TabPressWrapper>
       <button id="tabIndex1" data-testid="tabbableButton" type="button" tabIndex={1} />
@@ -51,7 +52,7 @@ test('<TabPressWrapper> children with only one tabIndex', () => {
   expect(firstElement).toHaveFocus();
 });
 
-test('<TabPressWrapper> children with tabIndexes: 1, 2 and 3', () => {
+test('<TabPressWrapper> children with tabIndexes: 1, 2 and 3. Tabbing through each element will show focus based on tabIndex', () => {
   const { container } = render(
     <TabPressWrapper>
       <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
@@ -73,7 +74,7 @@ test('<TabPressWrapper> children with tabIndexes: 1, 2 and 3', () => {
   expect(lastElement).toHaveFocus();
 });
 
-test('<TabPressWrapper> not only first level children with tabIndexes: 1, 2 and 3', () => {
+test('<TabPressWrapper> with second and third level children with tabIndexes: 1, 2 and 3. Tabbing through each element will show focus based on tabIndex', () => {
   const { container } = render(
     <TabPressWrapper>
       <div>
@@ -101,7 +102,7 @@ test('<TabPressWrapper> not only first level children with tabIndexes: 1, 2 and 
   expect(lastElement).toHaveFocus();
 });
 
-test('<TabPressWrapper> children with tabIndexes: 1 and 3', () => {
+test('<TabPressWrapper> children with tabIndexes: 1 and 3. Tabbing through each element will cycle focus based on tabIndex', () => {
   const { container } = render(
     <TabPressWrapper>
       <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
@@ -118,7 +119,7 @@ test('<TabPressWrapper> children with tabIndexes: 1 and 3', () => {
   expect(secondElement).toHaveFocus();
 });
 
-test('<TabPressWrapper> children with tabIndexes: 5 and 4', () => {
+test('<TabPressWrapper> children with tabIndexes: 5 and 4. Given 4 has higher priority, first element focused will be tabIndex of 4, followed by element with tabIndex of 5', () => {
   const { container } = render(
     <TabPressWrapper>
       <button id="tabIndex5" data-testid="tabIndex5" type="button" tabIndex={5} />
@@ -135,7 +136,7 @@ test('<TabPressWrapper> children with tabIndexes: 5 and 4', () => {
   expect(secondElement).toHaveFocus();
 });
 
-test('<TabPressWrapper> children with tabIndexes: 1, 2 and 1', () => {
+test('<TabPressWrapper> children with two tabIndexs out of order.  Given 1 has higher priority, first & second elements focused will be tabIndex of 1, followed by element with tabIndex of 2', () => {
   const { container } = render(
     <TabPressWrapper>
       <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
@@ -157,7 +158,7 @@ test('<TabPressWrapper> children with tabIndexes: 1, 2 and 1', () => {
   expect(lastElement).toHaveFocus();
 });
 
-test('<TabPressWrapper> children with tabIndexes: 1, 2 and 2', () => {
+test('<TabPressWrapper> children with tabIndexes with repeating tabIndexes. Tabbing through each element will cycle focus based on tabIndex chronology', () => {
   const { container } = render(
     <TabPressWrapper>
       <button id="tabIndex1" data-testid="tabIndex1" type="button" tabIndex={1} />
@@ -179,7 +180,7 @@ test('<TabPressWrapper> children with tabIndexes: 1, 2 and 2', () => {
   expect(lastElement).toHaveFocus();
 });
 
-test('<TabPressWrapper> complex children structure', () => {
+test('<TabPressWrapper> complex children structure. Tabbing through each element will cycle focus based on tabIndex chronology', async () => {
   const { container } = render(
     <TabPressWrapper>
       <div>
@@ -211,14 +212,15 @@ test('<TabPressWrapper> complex children structure', () => {
   userEvent.tab();
   expect(secondElement).toHaveFocus();
 
+  const elementCount = await screen.findAllByRole('button');
+  expect(elementCount).toHaveLength(9);
+
+  // Out of 9 focusable button elements, 2 have already been focused on, hence 7 more tab cycles will focus on the last element
+  for (let i = 0; i < 9 - 2; i++) {
+    userEvent.tab();
+  }
+
   const lastElement = getByTestId(container, 'tabIndex7Again');
-  userEvent.tab();
-  userEvent.tab();
-  userEvent.tab();
-  userEvent.tab();
-  userEvent.tab();
-  userEvent.tab();
-  userEvent.tab();
   expect(lastElement).toHaveFocus();
 });
 


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
- Modifies the tests for TabPressWrapper HOC to use UserEvent API to mock for user actions instead of react-test-renderer. 
- Adds'@testing-library/jest-dom/extend-expect' import and a small change in config file to help jest read certain failing tests when using toHaveFocus function

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added (modified)
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes # [CHI-1364](https://bugs.benetech.org/browse/CHI-1364)
