### PR TITLE
CHI-1335: remove copy icon from contact view via search

### DIFF
--- a/plugin-hrm-form/src/components/search/ContactPreview/ConnectContact.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ConnectContact.tsx
@@ -34,4 +34,5 @@ const ConnectContact: React.FC<Props> = ({ callType, onOpenConnectDialog }) => {
 };
 ConnectContact.displayName = 'ConnectContact';
 
+// eslint-disable-next-line import/no-unused-modules
 export default ConnectContact;

--- a/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
@@ -7,7 +7,6 @@ import TagsAndCounselor from './TagsAndCounselor';
 import { contactType } from '../../../types';
 import { ContactWrapper } from '../../../styles/search';
 import { Flex } from '../../../styles/HrmStyles';
-import ConnectContact from './ConnectContact';
 
 const ContactPreview = ({ contact, handleOpenConnectDialog, handleViewDetails, showConnectIcon }) => {
   const { counselor } = contact;

--- a/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
@@ -15,9 +15,6 @@ const ContactPreview = ({ contact, handleOpenConnectDialog, handleViewDetails, s
 
   return (
     <Flex>
-      {showConnectIcon && (
-        <ConnectContact callType={contact.overview.callType} onOpenConnectDialog={handleOpenConnectDialog} />
-      )}
       <ContactWrapper key={contact.contactId}>
         <ChildNameAndDate
           channel={contact.overview.channel}

--- a/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
@@ -8,7 +8,7 @@ import { contactType } from '../../../types';
 import { ContactWrapper } from '../../../styles/search';
 import { Flex } from '../../../styles/HrmStyles';
 
-const ContactPreview = ({ contact, handleOpenConnectDialog, handleViewDetails, showConnectIcon }) => {
+const ContactPreview = ({ contact, handleViewDetails, showConnectIcon }) => {
   const { counselor } = contact;
   const { callSummary } = contact.details.caseInformation;
 
@@ -38,7 +38,6 @@ ContactPreview.displayName = 'ContactPreview';
 
 ContactPreview.propTypes = {
   contact: contactType.isRequired,
-  handleOpenConnectDialog: PropTypes.func.isRequired,
   handleViewDetails: PropTypes.func.isRequired,
   showConnectIcon: PropTypes.bool.isRequired,
 };

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -33,26 +33,23 @@ import {
   BoldText,
   StyledCount,
 } from '../../../styles/search';
-import ConnectDialog from '../ConnectDialog';
 import Pagination from '../../Pagination';
 import SearchResultsBackButton from './SearchResultsBackButton';
 import * as SearchActions from '../../../states/search/actions';
 import * as CaseActions from '../../../states/case/actions';
 import * as RoutingActions from '../../../states/routing/actions';
 import { SearchPages, SearchPagesType } from '../../../states/search/types';
-import { namespace, searchContactsBase, configurationBase, contactFormsBase } from '../../../states';
+import { namespace, searchContactsBase, configurationBase } from '../../../states';
 
 export const CONTACTS_PER_PAGE = 20;
 export const CASES_PER_PAGE = 20;
 
 type OwnProps = {
   task: CustomITask;
-  currentIsCaller: boolean;
   searchContactsResults: SearchContactResult;
   searchCasesResults: SearchCaseResult;
   onlyDataContacts: boolean;
   closedCases: boolean;
-  handleSelectSearchResult?: (contact: SearchContact) => void;
   handleSearchContacts: (offset: number) => void;
   handleSearchCases: (offset: number) => void;
   toggleNonDataContacts: () => void;
@@ -69,12 +66,11 @@ type Props = OwnProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof m
 
 const SearchResults: React.FC<Props> = ({
   task,
-  currentIsCaller,
+
   searchContactsResults,
   searchCasesResults,
   onlyDataContacts,
   closedCases,
-  handleSelectSearchResult,
   handleSearchContacts,
   handleSearchCases,
   toggleNonDataContacts,
@@ -83,28 +79,13 @@ const SearchResults: React.FC<Props> = ({
   handleViewDetails,
   changeSearchPage,
   setConnectedCase,
-  changeRoute,
   currentPage,
   showConnectIcon,
   counselorsHash,
-  isCallTypeCaller,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
-  const [currentContact, setCurrentContact] = useState(null);
-  const [anchorEl, setAnchorEl] = useState(null);
   const [contactsPage, setContactsPage] = useState(0);
   const [casesPage, setCasesPage] = useState(0);
-
-  const handleCloseDialog = () => {
-    setCurrentContact(null);
-    setAnchorEl(null);
-  };
-
-  const handleConfirmDialog = () => {
-    if (handleSelectSearchResult) {
-      handleSelectSearchResult(currentContact);
-    }
-  };
 
   const handleContactsChangePage = newPage => {
     setContactsPage(newPage);
@@ -124,12 +105,6 @@ const SearchResults: React.FC<Props> = ({
   const handleToggleClosedCases = () => {
     setCasesPage(0);
     toggleClosedCases();
-  };
-
-  const handleOpenConnectDialog = contact => e => {
-    e.stopPropagation();
-    setAnchorEl(e.currentTarget);
-    setCurrentContact(contact);
   };
 
   const handleClickViewCase = currentCase => () => {
@@ -181,15 +156,6 @@ const SearchResults: React.FC<Props> = ({
           </div>
         </Row>
       </ResultsHeader>
-      <ConnectDialog
-        task={task}
-        anchorEl={anchorEl}
-        currentIsCaller={currentIsCaller}
-        contact={currentContact}
-        handleConfirm={handleConfirmDialog}
-        handleClose={handleCloseDialog}
-        isCallTypeCaller={isCallTypeCaller}
-      />
       <ListContainer>
         <ScrollableList>
           <StyledResultsContainer>
@@ -273,7 +239,6 @@ const SearchResults: React.FC<Props> = ({
                     showConnectIcon={showConnectIcon}
                     key={contact.contactId}
                     contact={contact}
-                    handleOpenConnectDialog={handleOpenConnectDialog(contact)}
                     handleViewDetails={() => handleViewDetails(contact)}
                   />
                 ))}
@@ -342,13 +307,11 @@ const mapStateToProps = (state, ownProps) => {
   const taskSearchState = searchContactsState.tasks[taskId];
   const isStandaloneSearch = taskId === standaloneTaskSid;
   const { counselors } = state[namespace][configurationBase];
-  const { isCallTypeCaller } = state[namespace][contactFormsBase];
 
   return {
     currentPage: taskSearchState.currentPage,
     showConnectIcon: !isStandaloneSearch,
     counselorsHash: counselors.hash,
-    isCallTypeCaller,
   };
 };
 


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @murilovmachado 

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Feature Modification

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [x] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes CHI-1335

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Agent Desktop > Create offline contact > Search for Contacts and Cases
Search for a Counsellor
Verify that the Copy Button as shown in the image below has been removed

<img width="634" alt="Screen Shot 2022-07-19 at 2 58 19 PM" src="https://user-images.githubusercontent.com/40429848/186917513-84a78d3e-ddf3-4d92-b353-815b5c0d13dd.png">
