### PR TITLE
Tests go to /agent-desktop before running

### DIFF
--- a/e2e-tests/tests/offlineContact.spec.ts
+++ b/e2e-tests/tests/offlineContact.spec.ts
@@ -15,7 +15,7 @@ test.describe.serial('Offline Contact (with Case)', () => {
     await Promise.all([
       // Wait for this to be sure counsellors dropdown is populated
       pluginPage.waitForResponse('**/populateCounselors'),
-      pluginPage.goto('/', { waitUntil: 'networkidle', timeout: 120000 }),
+      pluginPage.goto('/agent-desktop', { waitUntil: 'networkidle', timeout: 120000 }),
     ]);
     console.log('Plugin page visited.');
   });

--- a/e2e-tests/tests/webchat.spec.ts
+++ b/e2e-tests/tests/webchat.spec.ts
@@ -22,7 +22,7 @@ test.describe.serial('Web chat caller', () => {
     pluginPage = await browser.newPage();
     logPageTelemetry(pluginPage);
     console.log('Plugin page browser session launched.');
-    await pluginPage.goto('/', { waitUntil: 'networkidle', timeout: 120000 });
+    await pluginPage.goto('/agent-desktop', { waitUntil: 'networkidle', timeout: 120000 });
     console.log('Plugin page visited.');
     chatPage = await webchat.open(browser);
     console.log('Webchat browser session launched.');


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
This PR slightly tweaks tests to go to /agent-desktop view before running (required to run against actual Flex page).

## Verification steps
- Add `PLAYWRIGHT_BASEURL` env var before running the tests pointing to the e2e redirect url (I can share it :) ).
- `➜ npx playwright test`.
- Tests should pass.
- e2e should still pass in the CI (local run).