### PR TITLE
CHI-1375: Fix case item view not updating

### DIFF
--- a/e2e-tests/caseList.ts
+++ b/e2e-tests/caseList.ts
@@ -158,13 +158,13 @@ export const caseList = (page: Page) => {
   // Close Edit case
   async function closeEditCase() {
     const caseEditClose = selectors.caseEditCloseButton;
-    caseEditClose.waitFor({ state: 'visible' });
+    await caseEditClose.waitFor({ state: 'visible' });
     await expect(caseEditClose).toContainText('Cancel');
     await caseEditClose.click();
   }
 
   // Verify case summary update
-  async function caseSummaryUpdate() {
+  async function verifyCaseSummaryUpdated() {
     const summaryText = selectors.caseSummaryText;
     await summaryText.waitFor({ state: 'visible' });
     await expect(summaryText).toContainText(`E2E Case Summary Test Edited on ${currentTime}`);
@@ -187,7 +187,7 @@ export const caseList = (page: Page) => {
     editCase,
     updateCaseSummary,
     closeEditCase,
-    caseSummaryUpdate,
+    verifyCaseSummaryUpdated,
     closeCase,
   };
 };

--- a/e2e-tests/tests/caselist.spec.ts
+++ b/e2e-tests/tests/caselist.spec.ts
@@ -57,9 +57,7 @@ test.describe.serial('Open and Edit a Case in Case List page', () => {
 
     await page.updateCaseSummary();
 
-    await page.closeEditCase();
-
-    await page.caseSummaryUpdate();
+    await page.verifyCaseSummaryUpdated();
 
     await page.closeCase();
   });

--- a/plugin-hrm-form/src/___tests__/components/case/CaseHome.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/CaseHome.test.tsx
@@ -269,22 +269,12 @@ describe('useState mocked', () => {
 
     screen.getByTestId('Case-InformationRow-ViewButton').click();
 
-    const { household, ...caseItemEntry } = { ...householdEntry, form: householdEntry.household };
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      value: {
-        info: { ...caseItemEntry, index: 0 },
-        screen: NewCaseSubroutes.Household,
-        action: CaseItemAction.View,
-      },
-      taskId: 'task1',
-      type: UPDATE_TEMP_INFO,
-    });
     expect(store.dispatch).toHaveBeenCalledWith({
       routing: {
         route: 'new-case',
         subroute: NewCaseSubroutes.Household,
         action: CaseItemAction.View,
+        id: 'HOUSEHOLD_ID',
       },
       taskId: 'task1',
       type: 'CHANGE_ROUTE',
@@ -296,7 +286,6 @@ describe('useState mocked', () => {
     const store = mockStore(initialState);
     store.dispatch = jest.fn();
 
-    const { perpetrator, ...caseItemEntry } = { ...perpetratorEntry, form: perpetratorEntry.perpetrator };
     render(
       <StorelessThemeProvider themeConf={{}}>
         <Provider store={store}>
@@ -308,19 +297,11 @@ describe('useState mocked', () => {
     screen.getByTestId('Case-InformationRow-ViewButton').click();
 
     expect(store.dispatch).toHaveBeenCalledWith({
-      value: {
-        info: { ...caseItemEntry, index: 0 },
-        screen: NewCaseSubroutes.Perpetrator,
-        action: CaseItemAction.View,
-      },
-      taskId: 'task1',
-      type: UPDATE_TEMP_INFO,
-    });
-    expect(store.dispatch).toHaveBeenCalledWith({
       routing: {
         route: 'new-case',
         subroute: NewCaseSubroutes.Perpetrator,
         action: CaseItemAction.View,
+        id: 'PERPETRATOR_ID',
       },
       taskId: 'task1',
       type: 'CHANGE_ROUTE',

--- a/plugin-hrm-form/src/___tests__/components/case/ViewCaseItem.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/ViewCaseItem.test.tsx
@@ -37,13 +37,6 @@ const household = {
   relationshipToChild: 'Friend',
 };
 
-const caseItemEntry: CaseItemEntry = {
-  form: household,
-  createdAt: '2020-06-29T22:26:00.208Z',
-  twilioWorkerId: 'worker1',
-  id: null,
-};
-
 const state = {
   [namespace]: {
     [configurationBase]: {
@@ -66,12 +59,26 @@ const state = {
       tasks: {
         task1: {
           taskSid: 'task1',
-          temporaryCaseInfo: { screen: 'view-household', info: caseItemEntry, action: CaseItemAction.View },
           connectedCase: {
             createdAt: 1593469560208,
             twilioWorkerId: 'worker1',
             status: 'open',
-            info: null,
+            info: {
+              households: [
+                {
+                  household: {},
+                  createdAt: '2020-06-29T22:26:00.208Z',
+                  twilioWorkerId: 'worker1',
+                  id: 'HOUSEHOLD_1',
+                },
+                {
+                  household,
+                  createdAt: '2020-06-29T22:26:00.208Z',
+                  twilioWorkerId: 'worker1',
+                  id: 'HOUSEHOLD_2',
+                },
+              ],
+            },
           },
         },
       },
@@ -108,6 +115,7 @@ describe('Test ViewHousehold', () => {
         route: 'tabbed-forms',
         subroute: NewCaseSubroutes.Household,
         action: CaseItemAction.View,
+        id: 'HOUSEHOLD_2',
       },
       canEdit: () => true,
     };

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -161,7 +161,7 @@ const AddEditCaseItem: React.FC<Props> = ({
 
     return splitInHalf(disperseInputs(7)(generatedForm));
   }, [
-    createUpdatedTemporaryFormContent,
+    temporaryCaseInfo,
     formDefinition,
     initialForm,
     firstElementRef,

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -65,6 +65,28 @@ const getTemporaryFormContent = (temporaryCaseInfo: TemporaryCaseInfo): CaseItem
   return null;
 };
 
+const createUpdatedTemporaryFormContent = (
+  payload: CaseItemPayload,
+  initialForm: CaseItemPayload,
+  temporaryCaseInfo: TemporaryCaseInfo,
+): AddTemporaryCaseInfo | EditTemporaryCaseInfo => {
+  const isEdited = !isEqual(initialForm, payload);
+  if (isEditTemporaryCaseInfo(temporaryCaseInfo)) {
+    return {
+      ...temporaryCaseInfo,
+      info: { ...temporaryCaseInfo.info, form: payload },
+      isEdited: isEdited || temporaryCaseInfo.isEdited,
+    };
+  } else if (isAddTemporaryCaseInfo(temporaryCaseInfo)) {
+    return {
+      ...temporaryCaseInfo,
+      info: payload,
+      isEdited: isEdited || temporaryCaseInfo.isEdited,
+    };
+  }
+  throw new Error(UNSUPPORTED_TEMPORARY_INFO_TYPE_MESSAGE);
+};
+
 export type AddEditCaseItemProps = {
   task: CustomITask | StandaloneITask;
   counselor: string;
@@ -125,29 +147,9 @@ const AddEditCaseItem: React.FC<Props> = ({
   const { getValues } = methods;
 
   const [l, r] = React.useMemo(() => {
-    const createUpdatedTemporaryFormContent = (
-      payload: CaseItemPayload,
-    ): AddTemporaryCaseInfo | EditTemporaryCaseInfo => {
-      const isEdited = !isEqual(initialForm, payload);
-      if (isEditTemporaryCaseInfo(temporaryCaseInfo)) {
-        return {
-          ...temporaryCaseInfo,
-          info: { ...temporaryCaseInfo.info, form: payload },
-          isEdited,
-        };
-      } else if (isAddTemporaryCaseInfo(temporaryCaseInfo)) {
-        return {
-          ...temporaryCaseInfo,
-          info: payload,
-          isEdited,
-        };
-      }
-      throw new Error(UNSUPPORTED_TEMPORARY_INFO_TYPE_MESSAGE);
-    };
-
     const updateCallBack = () => {
       const formValues = getValues();
-      updateTempInfo(createUpdatedTemporaryFormContent(formValues), task.taskSid);
+      updateTempInfo(createUpdatedTemporaryFormContent(formValues, initialForm, temporaryCaseInfo), task.taskSid);
     };
 
     const generatedForm = createFormFromDefinition(formDefinition)([])(initialForm, firstElementRef)(
@@ -159,12 +161,12 @@ const AddEditCaseItem: React.FC<Props> = ({
 
     return splitInHalf(disperseInputs(7)(generatedForm));
   }, [
+    createUpdatedTemporaryFormContent,
     formDefinition,
     initialForm,
     firstElementRef,
     customFormHandlers,
     layout.splitFormAt,
-    temporaryCaseInfo,
     getValues,
     updateTempInfo,
     task.taskSid,
@@ -212,10 +214,9 @@ const AddEditCaseItem: React.FC<Props> = ({
     setConnectedCase(updatedCase, task.taskSid, connectedCaseState.caseHasBeenEdited);
   };
 
-  async function close() {
+  function close() {
     if (isEditTemporaryCaseInfo(temporaryCaseInfo)) {
-      updateTempInfo({ ...temporaryCaseInfo, action: CaseItemAction.View }, task.taskSid);
-      changeRoute({ ...routing, action: CaseItemAction.View }, task.taskSid);
+      changeRoute({ ...routing, id: temporaryCaseInfo.info.id, action: CaseItemAction.View }, task.taskSid);
     } else {
       exitItem();
     }
@@ -270,13 +271,6 @@ const AddEditCaseItem: React.FC<Props> = ({
             added={added}
             updatingCounsellor={updatingCounsellorName}
             updated={updated}
-          />
-          <CloseCaseDialog
-            data-testid="CloseCase-Dialog"
-            openDialog={openDialog}
-            setDialog={() => setOpenDialog(false)}
-            handleDontSaveClose={close}
-            handleSaveUpdate={methods.handleSubmit(saveAndLeave, onError)}
           />
           <Container>
             <Box paddingBottom={`${BottomButtonBarHeight}px`}>

--- a/plugin-hrm-form/src/components/case/Timeline.tsx
+++ b/plugin-hrm-form/src/components/case/Timeline.tsx
@@ -46,38 +46,11 @@ const Timeline: React.FC<Props> = props => {
   const [mockedMessage, setMockedMessage] = useState(null);
 
   const handleViewNoteClick = (activity: NoteActivity) => {
-    const { twilioWorkerId } = activity;
-    const info: CaseItemEntry = {
-      id: activity.id,
-      form: { ...activity.note },
-      twilioWorkerId,
-      createdAt: parseISO(activity.date).toISOString(),
-      updatedAt: activity.updatedAt ? parseISO(activity.updatedAt).toISOString() : undefined,
-      updatedBy: activity.updatedBy,
-    };
-    updateTempInfo({ screen: NewCaseSubroutes.Note, action: CaseItemAction.View, info }, taskSid);
-    changeRoute({ route, subroute: NewCaseSubroutes.Note, action: CaseItemAction.View }, taskSid);
+    changeRoute({ route, subroute: NewCaseSubroutes.Note, action: CaseItemAction.View, id: activity.id }, taskSid);
   };
 
   const handleViewReferralClick = (activity: ReferralActivity) => {
-    const { twilioWorkerId } = activity;
-    const info: CaseItemEntry = {
-      id: activity.id,
-      form: { ...activity.referral },
-      twilioWorkerId,
-      createdAt: parseISO(activity.createdAt).toISOString(),
-      updatedAt: activity.updatedAt ? parseISO(activity.updatedAt).toISOString() : undefined,
-      updatedBy: activity.updatedBy,
-    };
-    updateTempInfo(
-      {
-        screen: NewCaseSubroutes.Referral,
-        action: CaseItemAction.View,
-        info: { ...info },
-      },
-      taskSid,
-    );
-    changeRoute({ route, subroute: NewCaseSubroutes.Referral, action: CaseItemAction.View }, taskSid);
+    changeRoute({ route, subroute: NewCaseSubroutes.Referral, action: CaseItemAction.View, id: activity.id }, taskSid);
   };
 
   const handleViewConnectedCaseActivityClick = activity => {

--- a/plugin-hrm-form/src/components/case/ViewCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/ViewCaseItem.tsx
@@ -12,8 +12,8 @@ import { CaseState } from '../../states/case/reducer';
 import SectionEntry from '../SectionEntry';
 import ActionHeader from './ActionHeader';
 import type { CustomITask, StandaloneITask } from '../../types/types';
-import { isViewTemporaryCaseInfo, temporaryCaseInfoHistory } from '../../states/case/types';
-import { AppRoutesWithCaseAndAction, CaseItemAction } from '../../states/routing/types';
+import { caseItemHistory } from '../../states/case/types';
+import { AppRoutesWithCaseActionAndId, CaseItemAction } from '../../states/routing/types';
 import * as CaseActions from '../../states/case/actions';
 import * as RoutingActions from '../../states/routing/actions';
 import { CaseSectionApi } from '../../states/case/sections/api';
@@ -21,14 +21,14 @@ import { CaseSectionApi } from '../../states/case/sections/api';
 const mapStateToProps = (state: RootState, ownProps: ViewCaseItemProps) => {
   const counselorsHash = state[namespace][configurationBase].counselors.hash;
   const caseState: CaseState = state[namespace][connectedCaseBase];
-  const { temporaryCaseInfo } = caseState.tasks[ownProps.task.taskSid];
+  const { connectedCase } = caseState.tasks[ownProps.task.taskSid];
 
-  return { counselorsHash, temporaryCaseInfo };
+  return { counselorsHash, connectedCase };
 };
 
 export type ViewCaseItemProps = {
   task: CustomITask | StandaloneITask;
-  routing: AppRoutesWithCaseAndAction;
+  routing: AppRoutesWithCaseActionAndId;
   definitionVersion: DefinitionVersion;
   exitItem: () => void;
   sectionApi: CaseSectionApi<unknown>;
@@ -43,29 +43,21 @@ const ViewCaseItem: React.FC<Props> = ({
   task,
   routing,
   counselorsHash,
-  temporaryCaseInfo,
   updateTempInfo,
   changeRoute,
   exitItem,
   definitionVersion,
   sectionApi,
+  connectedCase,
   canEdit,
 }) => {
-  if (!isViewTemporaryCaseInfo(temporaryCaseInfo))
-    throw new Error('This component only supports temporary case info of the ViewTemporaryCaseInfo type');
+  const item = sectionApi.toForm(sectionApi.getSectionItemById(connectedCase.info, routing.id));
 
-  const { addingCounsellorName, added, updatingCounsellorName, updated } = temporaryCaseInfoHistory(
-    temporaryCaseInfo,
-    counselorsHash,
-  );
+  const { addingCounsellorName, added, updatingCounsellorName, updated } = caseItemHistory(item, counselorsHash);
   const formDefinition = sectionApi.getSectionFormDefinition(definitionVersion).filter(fd => !isNonSaveable(fd));
-  const { form } = temporaryCaseInfo.info;
 
   const onEditCaseItemClick = () => {
-    updateTempInfo(
-      { screen: temporaryCaseInfo.screen, action: CaseItemAction.Edit, info: temporaryCaseInfo.info },
-      task.taskSid,
-    );
+    updateTempInfo({ screen: routing.subroute, action: CaseItemAction.Edit, info: item }, task.taskSid);
     changeRoute({ ...routing, action: CaseItemAction.Edit }, task.taskSid);
   };
 
@@ -82,7 +74,7 @@ const ViewCaseItem: React.FC<Props> = ({
         />
         {formDefinition.length === 1 && formDefinition[0].type === 'textarea' ? (
           <FullWidthFormTextContainer data-testid="Case-ViewCaseItemScreen-FullWidthTextArea">
-            {form[formDefinition[0].name]}
+            {item.form[formDefinition[0].name]}
           </FullWidthFormTextContainer>
         ) : (
           <Box paddingTop="10px">
@@ -91,7 +83,7 @@ const ViewCaseItem: React.FC<Props> = ({
                 <SectionEntry
                   key={`entry-${e.label}`}
                   description={<Template code={e.label} />}
-                  value={form[e.name]}
+                  value={item.form[e.name]}
                   definition={e}
                 />
               ))}

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -84,6 +84,7 @@ class SearchForm extends Component {
     return contactsCount > 0 || casesCount > 0;
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   render() {
     const {
       firstName,

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -215,7 +215,7 @@ class SearchForm extends Component {
                 name="office"
                 label={this.props.helplineInformation.label}
                 placeholder="--"
-                field={getField(helpline)}
+                field={getField(helpline ?? '')}
                 options={[{ label: '', value: '' }, ...helplineOptions]}
                 {...this.defaultEventHandlers('helpline')}
               />

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -161,12 +161,14 @@ const SearchResults: React.FC<Props> = ({
           <div style={{ width: '300px' }}>
             <StyledTabs selectedTabName={currentPage} onTabSelected={tabSelected}>
               <TwilioTab
+                key="SearchResultsIndex-Contacts"
                 label={<Template code="SearchResultsIndex-Contacts" />}
                 uniqueName={SearchPages.resultsContacts}
               >
                 {[]}
               </TwilioTab>
               <TwilioTab
+                key="SearchResultsIndex-Cases"
                 label={
                   <StyledTabLabel>
                     <StyledFolderIcon />

--- a/plugin-hrm-form/src/states/case/sections/note.ts
+++ b/plugin-hrm-form/src/states/case/sections/note.ts
@@ -36,6 +36,6 @@ export const noteSectionApi: CaseSectionApi<NoteEntry> = {
   getSectionFormDefinition: (definitionVersions: DefinitionVersion) => definitionVersions.caseForms.NoteForm,
   getSectionLayoutDefinition: (definitionVersions: DefinitionVersion) =>
     definitionVersions.layoutVersion.case.notes ?? {},
-  getMostRecentSectionItem: getMostRecentSectionItem('notes'),
-  getSectionItemById: getSectionItemById('notes'),
+  getMostRecentSectionItem: getMostRecentSectionItem('counsellorNotes'),
+  getSectionItemById: getSectionItemById('counsellorNotes'),
 };

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -2,6 +2,7 @@ import { DefinitionVersionId, HelplineEntry } from 'hrm-form-definitions';
 
 import type * as t from '../../types/types';
 import { CaseItemAction, CaseSectionSubroute, NewCaseSubroutes } from '../routing/types';
+import { CaseItemEntry } from '../../types/types';
 
 // Action types
 export const SET_CONNECTED_CASE = 'SET_CONNECTED_CASE';
@@ -19,16 +20,6 @@ type ViewContact = {
   timeOfContact: string;
   counselor: string;
 };
-
-export type ViewTemporaryCaseInfo = {
-  screen: CaseSectionSubroute;
-  action: CaseItemAction.View;
-  info: t.CaseItemEntry;
-};
-
-export function isViewTemporaryCaseInfo(tci: TemporaryCaseInfo): tci is ViewTemporaryCaseInfo {
-  return tci && (<ViewTemporaryCaseInfo>tci).action === CaseItemAction.View;
-}
 
 export type EditTemporaryCaseInfo = {
   screen: CaseSectionSubroute;
@@ -54,7 +45,7 @@ export function isAddTemporaryCaseInfo(tci: TemporaryCaseInfo): tci is AddTempor
 
 export type ViewContactInfo = { screen: typeof NewCaseSubroutes.ViewContact; info: ViewContact };
 
-export type TemporaryCaseInfo = ViewContactInfo | ViewTemporaryCaseInfo | AddTemporaryCaseInfo | EditTemporaryCaseInfo;
+export type TemporaryCaseInfo = ViewContactInfo | AddTemporaryCaseInfo | EditTemporaryCaseInfo;
 
 type SetConnectedCaseAction = {
   type: typeof SET_CONNECTED_CASE;
@@ -180,14 +171,14 @@ export type CaseDetails = {
 };
 
 export const temporaryCaseInfoHistory = (
-  temporaryCaseInfo: EditTemporaryCaseInfo | ViewTemporaryCaseInfo,
+  temporaryCaseInfo: EditTemporaryCaseInfo,
   counselorsHash: Record<string, string>,
-) => {
-  const addingCounsellorName = counselorsHash[temporaryCaseInfo.info.twilioWorkerId] || 'Unknown';
-  const added = new Date(temporaryCaseInfo.info.createdAt);
-  const updatingCounsellorName = temporaryCaseInfo.info.updatedBy
-    ? counselorsHash[temporaryCaseInfo.info.updatedBy] || 'Unknown'
-    : undefined;
-  const updated = temporaryCaseInfo.info.updatedAt ? new Date(temporaryCaseInfo.info.updatedAt) : undefined;
+) => caseItemHistory(temporaryCaseInfo.info, counselorsHash);
+
+export const caseItemHistory = (info: CaseItemEntry, counselorsHash: Record<string, string>) => {
+  const addingCounsellorName = counselorsHash[info.twilioWorkerId] || 'Unknown';
+  const added = new Date(info.createdAt);
+  const updatingCounsellorName = info.updatedBy ? counselorsHash[info.updatedBy] || 'Unknown' : undefined;
+  const updated = info.updatedAt ? new Date(info.updatedAt) : undefined;
   return { addingCounsellorName, added, updatingCounsellorName, updated };
 };

--- a/plugin-hrm-form/src/states/routing/types.ts
+++ b/plugin-hrm-form/src/states/routing/types.ts
@@ -34,33 +34,51 @@ export enum CaseItemAction {
   View = 'view',
 }
 
-export type AppRoutesWithCaseAndAction =
+export type AppRoutesWithCaseAndAction = (
   | {
-      route: 'tabbed-forms';
-      subroute?: CaseSectionSubroute;
-      action: CaseItemAction;
-      autoFocus?: boolean;
-    }
-  | {
-      route: 'new-case';
-      subroute?: CaseSectionSubroute;
-      action: CaseItemAction;
+      route: 'tabbed-forms' | 'new-case';
       autoFocus?: boolean;
     }
   | {
       route: 'select-call-type';
-      subroute?: CaseSectionSubroute;
-      action: CaseItemAction;
-    };
+    }
+) & {
+  subroute?: CaseSectionSubroute;
+  action: CaseItemAction.Add | CaseItemAction.Edit;
+};
+
+export type AppRoutesWithCaseActionAndId = (
+  | {
+      route: 'tabbed-forms' | 'new-case';
+      autoFocus?: boolean;
+    }
+  | {
+      route: 'select-call-type';
+    }
+) & {
+  subroute?: CaseSectionSubroute;
+  action: CaseItemAction.View;
+  id: string;
+};
 
 export function isAppRoutesWithCaseAndAction(appRoute: AppRoutes): appRoute is AppRoutesWithCaseAndAction {
-  return Object.values(<any>NewCaseSectionSubroutes).includes(appRoute.subroute);
+  return (
+    Object.values(<any>NewCaseSectionSubroutes).includes(appRoute.subroute) &&
+    !(<AppRoutesWithCaseActionAndId>appRoute).id
+  );
+}
+export function isAppRoutesWithCaseActionAndId(appRoute: AppRoutes): appRoute is AppRoutesWithCaseActionAndId {
+  return (
+    Object.values(<any>NewCaseSectionSubroutes).includes(appRoute.subroute) &&
+    Boolean((<AppRoutesWithCaseActionAndId>appRoute).id)
+  );
 }
 
 // Routes that may lead to Case screen (maybe we need an improvement here)
 export type AppRoutesWithCase =
   // TODO: enum the possible subroutes on each route
   | AppRoutesWithCaseAndAction
+  | AppRoutesWithCaseActionAndId
   | {
       route: 'tabbed-forms';
       subroute?: TabbedFormSubroutes | typeof NewCaseOtherSubroutes[keyof typeof NewCaseOtherSubroutes];
@@ -77,6 +95,10 @@ export type AppRoutesWithCase =
     };
 
 export function isAppRouteWithCase(appRoute: AppRoutes): appRoute is AppRoutesWithCase {
+  return ['tabbed-forms', 'new-case', 'select-call-type'].includes(appRoute.route);
+}
+
+export function isTabbedFormsRoute(appRoute: AppRoutes): appRoute is AppRoutesWithCase {
   return ['tabbed-forms', 'new-case', 'select-call-type'].includes(appRoute.route);
 }
 


### PR DESCRIPTION
This PR changes ViewCaseInfo.tsx to read the information it wants to display directly from the tasks `connectedCase` rather than passing a TemporaryCaseInfo.

At the moment it creates a TCI if the user clicks 'Edit' to pass to `AddEditCaseItem.tsx`

Question: It seems like `AddEditCaseItem.tsx` doesn't need to be passed a TCI info either really, it could just create one when initially opened and remove it when closed, would this work and be cleaner? I could do this as extra work in this PR or as a follow up if we think it's worth doing

Primary reviewer:

@GPaoloni 

## Description
* Refactor ViewCaseItem.tsx to look up data using ID rather than have it passed as TemporaryCaseInfo. 
* Other minor fixes / refactors

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added (existing ones updated)
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1375

### Verification steps

See ticket, but also test switching tasks with edited forms to check dialog behaviour works as expected