### PR TITLE
[PoC] Added sync and parallel workflows to deploy dev and e2e

### DIFF
--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -9,6 +9,22 @@ on:
       changelog:
         description: Release Changelog - Add a comment about the changes to be included in this release.
         required: true
+  workflow_call:
+    secrets: 
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_DEFAULT_REGION:
+        required: true
+      AS_DEV_ACCOUNT_SID:
+        required: true
+      AS_DEV_AUTH_TOKEN:
+        required: true
+    inputs:
+      changelog:
+        description: Release Changelog - Add a comment about the changes to be included in this release.
+        required: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -25,6 +25,7 @@ on:
       changelog:
         description: Release Changelog - Add a comment about the changes to be included in this release.
         required: true
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/end_to_end_development.yml
+++ b/.github/workflows/end_to_end_development.yml
@@ -9,6 +9,22 @@ on:
       changelog:
         description: Release Changelog - Add a comment about the changes to be included in this release.
         required: true
+  workflow_call:
+    secrets: 
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_DEFAULT_REGION:
+        required: true
+      E2E_DEV_ACCOUNT_SID:
+        required: true
+      E2E_DEV_AUTH_TOKEN:
+        required: true
+    inputs:
+      changelog:
+        description: Release Changelog - Add a comment about the changes to be included in this release.
+        required: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/end_to_end_development.yml
+++ b/.github/workflows/end_to_end_development.yml
@@ -25,6 +25,7 @@ on:
       changelog:
         description: Release Changelog - Add a comment about the changes to be included in this release.
         required: true
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/test-parallel-worflows.yml
+++ b/.github/workflows/test-parallel-worflows.yml
@@ -33,8 +33,8 @@ jobs:
 
     steps:
       - name: Echo the result of deploy-dev
-        run: echo ${{ jobs.deploy-dev.result }}
+        run: echo ${{ deploy-dev.result }}
         shell: bash
       - name: Echo the result of deploy-e2e
-        run: echo ${{ jobs.deploy-e2e.result }}
+        run: echo ${{ deploy-e2e.result }}
         shell: bash

--- a/.github/workflows/test-parallel-worflows.yml
+++ b/.github/workflows/test-parallel-worflows.yml
@@ -32,9 +32,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Echo the result of deploy-dev
-        run: echo ${{ deploy-dev.result }}
-        shell: bash
-      - name: Echo the result of deploy-e2e
-        run: echo ${{ deploy-e2e.result }}
+      - name: Echo after
+        run: echo "Success!"
         shell: bash

--- a/.github/workflows/test-parallel-worflows.yml
+++ b/.github/workflows/test-parallel-worflows.yml
@@ -1,0 +1,40 @@
+name: Test sync workflow executions
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: This is dangerous! Are you sure you want to trigger this workflow? Type "Test sync workflow executions" to continue.
+        required: true
+
+jobs:
+  deploy-dev:
+    uses: techmatters/flex-plugins/.github/workflows/aselo_development.yml
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AS_DEV_ACCOUNT_SID: ${{ secrets.AS_DEV_ACCOUNT_SID }}
+      AS_DEV_AUTH_TOKEN: ${{ secrets.AS_DEV_AUTH_TOKEN }}
+
+  deploy-e2e: 
+    uses: techmatters/flex-plugins/.github/workflows/end_to_end_development.yml
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      E2E_DEV_ACCOUNT_SID: ${{ secrets.E2E_DEV_ACCOUNT_SID }}
+      E2E_DEV_AUTH_TOKEN: ${{ secrets.E2E_DEV_AUTH_TOKEN }}
+
+  do-something-after:
+    needs: [deploy-dev, deploy-e2e]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Echo the result of deploy-dev
+        runs: echo ${{ jobs.deploy-dev.result }}
+        shell: bash
+      - name: Echo the result of deploy-e2e
+        runs: echo ${{ jobs.deploy-e2e.result }}
+        shell: bash

--- a/.github/workflows/test-parallel-worflows.yml
+++ b/.github/workflows/test-parallel-worflows.yml
@@ -33,8 +33,8 @@ jobs:
 
     steps:
       - name: Echo the result of deploy-dev
-        runs: echo ${{ jobs.deploy-dev.result }}
+        run: echo ${{ jobs.deploy-dev.result }}
         shell: bash
       - name: Echo the result of deploy-e2e
-        runs: echo ${{ jobs.deploy-e2e.result }}
+        run: echo ${{ jobs.deploy-e2e.result }}
         shell: bash

--- a/.github/workflows/test-parallel-worflows.yml
+++ b/.github/workflows/test-parallel-worflows.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-dev:
-    uses: techmatters/flex-plugins/.github/workflows/aselo_development.yml
+    uses: techmatters/flex-plugins/.github/workflows/aselo_development.yml@gian_poc_reusable_workflows
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -18,7 +18,7 @@ jobs:
       AS_DEV_AUTH_TOKEN: ${{ secrets.AS_DEV_AUTH_TOKEN }}
 
   deploy-e2e: 
-    uses: techmatters/flex-plugins/.github/workflows/end_to_end_development.yml
+    uses: techmatters/flex-plugins/.github/workflows/end_to_end_development.yml@gian_poc_reusable_workflows
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-parallel-worflows.yml
+++ b/.github/workflows/test-parallel-worflows.yml
@@ -1,4 +1,4 @@
-name: Test sync workflow executions
+name: Test parallel workflow executions
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-parallel-worflows.yml
+++ b/.github/workflows/test-parallel-worflows.yml
@@ -6,6 +6,9 @@ on:
       confirm:
         description: This is dangerous! Are you sure you want to trigger this workflow? Type "Test sync workflow executions" to continue.
         required: true
+      changelog:
+        description: Release Changelog - Add a comment about the changes to be included in this release.
+        required: true
 
 jobs:
   deploy-dev:
@@ -16,6 +19,8 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       AS_DEV_ACCOUNT_SID: ${{ secrets.AS_DEV_ACCOUNT_SID }}
       AS_DEV_AUTH_TOKEN: ${{ secrets.AS_DEV_AUTH_TOKEN }}
+    with:
+      changelog: ${{ inputs.changelog }}
 
   deploy-e2e: 
     uses: techmatters/flex-plugins/.github/workflows/end_to_end_development.yml@gian_poc_reusable_workflows
@@ -25,6 +30,8 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       E2E_DEV_ACCOUNT_SID: ${{ secrets.E2E_DEV_ACCOUNT_SID }}
       E2E_DEV_AUTH_TOKEN: ${{ secrets.E2E_DEV_AUTH_TOKEN }}
+    with:
+      changelog: ${{ inputs.changelog }}
 
   do-something-after:
     needs: [deploy-dev, deploy-e2e]

--- a/.github/workflows/test-sync-worflows.yml
+++ b/.github/workflows/test-sync-worflows.yml
@@ -1,0 +1,43 @@
+name: Test sync workflow executions
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: This is dangerous! Are you sure you want to trigger this workflow? Type "Test sync workflow executions" to continue.
+        required: true
+
+jobs:
+  deploy-dev:
+    uses: techmatters/flex-plugins/.github/workflows/aselo_development.yml
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AS_DEV_ACCOUNT_SID: ${{ secrets.AS_DEV_ACCOUNT_SID }}
+      AS_DEV_AUTH_TOKEN: ${{ secrets.AS_DEV_AUTH_TOKEN }}
+
+  deploy-e2e: 
+    # This will wait for the above job to complete https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#example-requiring-successful-dependent-jobs
+    needs: deploy-dev
+
+    uses: techmatters/flex-plugins/.github/workflows/end_to_end_development.yml
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      E2E_DEV_ACCOUNT_SID: ${{ secrets.E2E_DEV_ACCOUNT_SID }}
+      E2E_DEV_AUTH_TOKEN: ${{ secrets.E2E_DEV_AUTH_TOKEN }}
+
+  do-something-after:
+    needs: [deploy-dev, deploy-e2e]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Echo the result of deploy-dev
+        runs: echo ${{ jobs.deploy-dev.result }}
+        shell: bash
+      - name: Echo the result of deploy-e2e
+        runs: echo ${{ jobs.deploy-e2e.result }}
+        shell: bash

--- a/.github/workflows/test-sync-worflows.yml
+++ b/.github/workflows/test-sync-worflows.yml
@@ -35,9 +35,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Echo the result of deploy-dev
-        run: echo ${{ deploy-dev.result }}
-        shell: bash
-      - name: Echo the result of deploy-e2e
-        run: echo ${{ deploy-e2e.result }}
+      - name: Echo after
+        run: echo "Success!"
         shell: bash

--- a/.github/workflows/test-sync-worflows.yml
+++ b/.github/workflows/test-sync-worflows.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-dev:
-    uses: techmatters/flex-plugins/.github/workflows/aselo_development.yml
+    uses: techmatters/flex-plugins/.github/workflows/aselo_development.yml@gian_poc_reusable_workflows
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -21,7 +21,7 @@ jobs:
     # This will wait for the above job to complete https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#example-requiring-successful-dependent-jobs
     needs: deploy-dev
 
-    uses: techmatters/flex-plugins/.github/workflows/end_to_end_development.yml
+    uses: techmatters/flex-plugins/.github/workflows/end_to_end_development.yml@gian_poc_reusable_workflows
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-sync-worflows.yml
+++ b/.github/workflows/test-sync-worflows.yml
@@ -36,8 +36,8 @@ jobs:
 
     steps:
       - name: Echo the result of deploy-dev
-        runs: echo ${{ jobs.deploy-dev.result }}
+        run: echo ${{ jobs.deploy-dev.result }}
         shell: bash
       - name: Echo the result of deploy-e2e
-        runs: echo ${{ jobs.deploy-e2e.result }}
+        run: echo ${{ jobs.deploy-e2e.result }}
         shell: bash

--- a/.github/workflows/test-sync-worflows.yml
+++ b/.github/workflows/test-sync-worflows.yml
@@ -36,8 +36,8 @@ jobs:
 
     steps:
       - name: Echo the result of deploy-dev
-        run: echo ${{ jobs.deploy-dev.result }}
+        run: echo ${{ deploy-dev.result }}
         shell: bash
       - name: Echo the result of deploy-e2e
-        run: echo ${{ jobs.deploy-e2e.result }}
+        run: echo ${{ deploy-e2e.result }}
         shell: bash

--- a/.github/workflows/test-sync-worflows.yml
+++ b/.github/workflows/test-sync-worflows.yml
@@ -6,6 +6,9 @@ on:
       confirm:
         description: This is dangerous! Are you sure you want to trigger this workflow? Type "Test sync workflow executions" to continue.
         required: true
+      changelog:
+        description: Release Changelog - Add a comment about the changes to be included in this release.
+        required: true
 
 jobs:
   deploy-dev:
@@ -16,6 +19,8 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       AS_DEV_ACCOUNT_SID: ${{ secrets.AS_DEV_ACCOUNT_SID }}
       AS_DEV_AUTH_TOKEN: ${{ secrets.AS_DEV_AUTH_TOKEN }}
+    with:
+      changelog: ${{ inputs.changelog }}
 
   deploy-e2e: 
     # This will wait for the above job to complete https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#example-requiring-successful-dependent-jobs
@@ -28,6 +33,8 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       E2E_DEV_ACCOUNT_SID: ${{ secrets.E2E_DEV_ACCOUNT_SID }}
       E2E_DEV_AUTH_TOKEN: ${{ secrets.E2E_DEV_AUTH_TOKEN }}
+    with:
+      changelog: ${{ inputs.changelog }}
 
   do-something-after:
     needs: [deploy-dev, deploy-e2e]


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @acedeywin 

## Description
This PR shows how to write [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows).

Two new workflows are introduced here, both to "deploy to all development" (dev and e2e accounts).

`test-sync-worflows.yml` performs the deployments one after the other. If one step fails the others will fail (this could modified using `if` flag).
![Screenshot from 2022-09-02 22-04-22](https://user-images.githubusercontent.com/15805319/188249951-aa736908-af5c-4164-92b2-9bf9061414d1.png)

`test-parallel-worflows.yml` performs the deployments in parallel, and if one fails it will continue with the others, but the final step will fail (as it depends "on all the previous ones").
![Screenshot from 2022-09-02 22-08-47](https://user-images.githubusercontent.com/15805319/188249956-5e8ca57d-246e-4af9-b917-816491934928.png)


To make a workflow "reusable", we need to specify the `workflow_call` event trigger, and the `inputs`, `environment` and `secrets` that it will require (I'm against using `secrets: inherit`, because of least privilege rule, but that is a thing..).
Nested workflows do not have access to the parent context, so we have to pass whatever it needs.

This requires some modifications across all of our workflows (and also updating the "new helpline script generators", but that can wait till we have a final shape for this, just mentioning as a memo). 
We'll also need to tune a bit the slack action, because sending `${{ github.workflow }}` as the action is wrong, in this case, because it always references the caller workflow.