### PR TITLE
CHI-1400 & CHI-1417

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseDetails.tsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Template } from '@twilio/flex-ui';
+import { DefinitionVersionId } from 'hrm-form-definitions';
 
 import CaseTags from './CaseTags';
 import CaseDetailsHeader from './caseDetails/CaseDetailsHeader';
@@ -22,21 +23,39 @@ import { Box } from '../../styles/HrmStyles';
 import { PermissionActions } from '../../permissions';
 import { getLocaleDateTime } from '../../utils/helpers';
 
-const CaseDetails = ({
+type Props = {
+  caseId: string;
+  name: string;
+  categories: { [category: string]: { [subcategory: string]: boolean } };
+  counselor: string;
+  createdAt: string;
+  updatedAt: string | undefined;
+  followUpDate: string | undefined;
+  statusLabel: string;
+  definitionVersionName: DefinitionVersionId;
+  office: string | undefined;
+  childIsAtRisk: boolean;
+  isOrphanedCase: boolean | undefined;
+  editCaseSummary: () => void;
+  handlePrintCase: () => void;
+  can: (action: string) => boolean;
+};
+
+const CaseDetails: React.FC<Props> = ({
   caseId,
   name,
   categories,
   counselor,
   createdAt,
-  updatedAt,
-  followUpDate,
-  status,
+  updatedAt = '',
+  followUpDate = '',
+  statusLabel,
   can,
-  office,
+  office = '',
   childIsAtRisk,
   handlePrintCase,
   definitionVersionName,
-  isOrphanedCase,
+  isOrphanedCase = false,
   editCaseSummary,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
@@ -68,7 +87,7 @@ const CaseDetails = ({
         </Box>
         {editButton && (
           <Box style={{ display: 'inline-block' }} alignSelf="flex-end" marginTop="-20px" marginRight="50px">
-            <ViewButton secondary roundCorners onClick={editCaseSummary} data-testid="Case-EditButton">
+            <ViewButton onClick={editCaseSummary} data-testid="Case-EditButton">
               <Template code="Case-EditButton" />
             </ViewButton>
           </Box>
@@ -87,7 +106,7 @@ const CaseDetails = ({
               name="Details_CaseStatus"
               aria-labelledby="CaseDetailsStatusLabel"
               disabled={true}
-              defaultValue={status === 'open' ? 'Open' : 'Closed'}
+              defaultValue={statusLabel}
             />
           </div>
           <div style={{ paddingRight: '20px' }}>
@@ -160,29 +179,5 @@ const CaseDetails = ({
 };
 
 CaseDetails.displayName = 'CaseDetails';
-CaseDetails.propTypes = {
-  caseId: PropTypes.number.isRequired,
-  name: PropTypes.string.isRequired,
-  categories: PropTypes.object.isRequired,
-  counselor: PropTypes.string.isRequired,
-  createdAt: PropTypes.string.isRequired,
-  status: PropTypes.string.isRequired,
-  can: PropTypes.func.isRequired,
-  office: PropTypes.string,
-  followUpDate: PropTypes.string,
-  updatedAt: PropTypes.string,
-  childIsAtRisk: PropTypes.bool.isRequired,
-  handlePrintCase: PropTypes.func.isRequired,
-  definitionVersion: PropTypes.shape({}).isRequired,
-  definitionVersionName: PropTypes.string.isRequired,
-  isOrphanedCase: PropTypes.bool,
-};
-
-CaseDetails.defaultProps = {
-  office: '',
-  followUpDate: '',
-  updatedAt: '',
-  isOrphanedCase: false,
-};
 
 export default CaseDetails;

--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -118,6 +118,7 @@ const CaseHome: React.FC<Props> = ({
     version,
   } = caseDetails;
   const fullName = splitFullName(name);
+  const statusLabel = definitionVersion.caseStatus[status]?.label ?? status;
 
   const itemRowRenderer = (itemTypeName: string, viewSubroute: CaseSectionSubroute, items: EntryInfo[]) => {
     const itemRows = () => {
@@ -217,9 +218,9 @@ const CaseHome: React.FC<Props> = ({
       <CaseContainer data-testid="CaseHome-CaseDetailsComponent">
         <Box marginLeft="25px" marginTop="13px">
           <CaseDetailsComponent
-            caseId={id}
+            caseId={id.toString()}
             name={fullName}
-            status={status}
+            statusLabel={statusLabel}
             can={can}
             counselor={caseCounselor}
             categories={categories}

--- a/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
+++ b/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-max-depth */
 /* eslint-disable react/prop-types */
 import { v4 as uuidV4 } from 'uuid';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Template } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 import { FieldValues, FormProvider, SubmitErrorHandler, useForm } from 'react-hook-form';
@@ -65,49 +65,59 @@ const EditCaseSummary: React.FC<Props> = ({
   connectedCaseState,
   setConnectedCase,
   updateTempInfo,
+  definitionVersion,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const { temporaryCaseInfo } = connectedCaseState;
-
-  if (!isEditTemporaryCaseInfo(temporaryCaseInfo)) {
-    return null;
-  }
+  const editTemporaryCaseInfo = temporaryCaseInfo as EditTemporaryCaseInfo;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const firstElementRef = useFocus();
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const formDefinition: FormDefinition = [
-    {
-      name: 'caseStatus',
-      label: 'Case-CaseStatus',
-      type: 'select',
-      options: [
-        { value: 'open', label: 'Open' },
-        { value: 'closed', label: 'Closed' },
-      ],
-    },
-    {
-      name: 'date',
-      type: 'date-input',
-      label: 'Case-CaseDetailsFollowUpDate',
-    },
-    {
-      name: 'inImminentPhysicalDanger',
-      label: 'Case-ChildIsAtRisk',
-      type: 'checkbox',
-    },
-    {
-      name: 'caseSummary',
-      label: 'SectionName-CaseSummary',
-      type: 'textarea',
-    },
-  ];
+  const formDefinition: FormDefinition = useMemo(() => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    try {
+      let caseStatusOptions = [];
+      if (definitionVersion) {
+        const caseStatusList = Object.values(definitionVersion.caseStatus);
+        const currentStatusItem = caseStatusList.find(cs => cs.value === connectedCaseState.prevStatus);
+        const availableStatusTransitions: string[] = currentStatusItem
+          ? [...(currentStatusItem.transitions ?? []), currentStatusItem.value]
+          : [];
+        caseStatusOptions = caseStatusList.filter(option => availableStatusTransitions.includes(option.value));
+      }
+      return [
+        {
+          name: 'caseStatus',
+          label: 'Case-CaseStatus',
+          type: 'select',
+          options: caseStatusOptions,
+        },
+        {
+          name: 'date',
+          type: 'date-input',
+          label: 'Case-CaseDetailsFollowUpDate',
+        },
+        {
+          name: 'inImminentPhysicalDanger',
+          label: 'Case-ChildIsAtRisk',
+          type: 'checkbox',
+        },
+        {
+          name: 'caseSummary',
+          label: 'SectionName-CaseSummary',
+          type: 'textarea',
+        },
+      ];
+    } catch (e) {
+      console.error('Failed to render edit case summary form', e);
+      return [];
+    }
+  }, [connectedCaseState.prevStatus, definitionVersion]);
 
   // Grab initial values in first render only. If getTemporaryFormContent(temporaryCaseInfo), cherrypick the values using formDefinition, if not build the object with getInitialValue
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const [initialForm] = React.useState(() => {
-    const { caseStatus, caseSummary, date, inImminentPhysicalDanger } = temporaryCaseInfo.info.form;
+    const { caseStatus, caseSummary, date, inImminentPhysicalDanger } = editTemporaryCaseInfo.info.form;
     return {
       caseStatus,
       caseSummary,
@@ -130,8 +140,8 @@ const EditCaseSummary: React.FC<Props> = ({
       const isEdited = !isEqual(initialForm, payload);
 
       return {
-        ...temporaryCaseInfo,
-        info: { ...temporaryCaseInfo.info, form: payload },
+        ...editTemporaryCaseInfo,
+        info: { ...editTemporaryCaseInfo.info, form: payload },
         isEdited,
       };
     };
@@ -142,7 +152,11 @@ const EditCaseSummary: React.FC<Props> = ({
     };
     const generatedForm = createFormFromDefinition(formDefinition)([])(initialForm, firstElementRef)(updateCallBack);
     return splitAt(3)(disperseInputs(7)(generatedForm));
-  }, [formDefinition, initialForm, firstElementRef, temporaryCaseInfo, getValues, updateTempInfo, task.taskSid]);
+  }, [formDefinition, initialForm, firstElementRef, editTemporaryCaseInfo, getValues, updateTempInfo, task.taskSid]);
+
+  if (!isEditTemporaryCaseInfo(temporaryCaseInfo)) {
+    return null;
+  }
 
   const save = async () => {
     const { info, id } = connectedCaseState.connectedCase;

--- a/plugin-hrm-form/src/styles/GlobalOverrides.js
+++ b/plugin-hrm-form/src/styles/GlobalOverrides.js
@@ -48,12 +48,8 @@ injectGlobal`
   .editingContact .hiddenWhenEditingContact {
     display: none;
   }
-  
-  .Twilio-View-case-list {
-    background-color: #f6f6f6;
-  }
 
-  .Twilio-View-search {
+  .Twilio-ViewCollection {
     background-color: #f6f6f6;
   }
 


### PR DESCRIPTION

Primary reviewer: @acedeywin 

## Description

* Styling on case list background is fixed (random white rectangles are gone)
* Custom Case status transitions are presented as options to the counsellor on the Edit Case Summary form, respecting the available transitions specified in the definition.
* Custom Case statuses are displayed in the case details section as expected
* Converted CaseDetails.jsx to TypeScript

### Checklist
- [X] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Strings are localized
- [X] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes CHI-1400, CHI-1417

### Verification steps

See tickets