### PR TITLE
End Chat button will wrapup task and trigger post survey

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -215,7 +215,7 @@ const setUpActions = (setupObject: SetupObject) => {
   const transferOverride = ActionFunctions.customTransferTask(setupObject);
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject);
   const beforeCompleteAction = ActionFunctions.beforeCompleteTask(setupObject);
-  const afterWrapupAction = ActionFunctions.afterWrapupAction(setupObject);
+  const afterWrapupAction = ActionFunctions.afterWrapupTask(setupObject);
 
   Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.initializeContactForm);
 

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -215,7 +215,7 @@ const setUpActions = (setupObject: SetupObject) => {
   const transferOverride = ActionFunctions.customTransferTask(setupObject);
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject);
   const beforeCompleteAction = ActionFunctions.beforeCompleteTask(setupObject);
-  const afterCompleteAction = ActionFunctions.afterCompleteTask(setupObject);
+  const afterWrapupAction = ActionFunctions.afterWrapupAction(setupObject);
 
   Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.initializeContactForm);
 
@@ -232,7 +232,7 @@ const setUpActions = (setupObject: SetupObject) => {
 
   Flex.Actions.addListener('beforeCompleteTask', beforeCompleteAction);
 
-  Flex.Actions.addListener('afterCompleteTask', afterCompleteAction);
+  Flex.Actions.addListener('afterWrapupTask', afterWrapupAction);
 };
 
 export default class HrmFormPlugin extends FlexPlugin {

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -218,7 +218,6 @@ const setUpActions = (setupObject: SetupObject) => {
   const afterWrapupAction = ActionFunctions.afterWrapupTask(setupObject);
   const afterCompleteAction = ActionFunctions.afterCompleteTask(setupObject);
 
-
   Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.initializeContactForm);
 
   Flex.Actions.addListener('afterAcceptTask', ActionFunctions.afterAcceptTask(setupObject));
@@ -235,7 +234,7 @@ const setUpActions = (setupObject: SetupObject) => {
   Flex.Actions.addListener('beforeCompleteTask', beforeCompleteAction);
 
   Flex.Actions.addListener('afterWrapupTask', afterWrapupAction);
-  
+
   Flex.Actions.addListener('afterCompleteTask', afterCompleteAction);
 };
 

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -216,6 +216,8 @@ const setUpActions = (setupObject: SetupObject) => {
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject);
   const beforeCompleteAction = ActionFunctions.beforeCompleteTask(setupObject);
   const afterWrapupAction = ActionFunctions.afterWrapupTask(setupObject);
+  const afterCompleteAction = ActionFunctions.afterCompleteTask(setupObject);
+
 
   Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.initializeContactForm);
 
@@ -233,6 +235,8 @@ const setUpActions = (setupObject: SetupObject) => {
   Flex.Actions.addListener('beforeCompleteTask', beforeCompleteAction);
 
   Flex.Actions.addListener('afterWrapupTask', afterWrapupAction);
+  
+  Flex.Actions.addListener('afterCompleteTask', afterCompleteAction);
 };
 
 export default class HrmFormPlugin extends FlexPlugin {

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -368,7 +368,7 @@ const triggerPostSurvey = async (setupObject, payload) => {
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
  * @returns {import('@twilio/flex-ui').ActionFunction}
  */
-export const afterCompleteTask = setupObject => async payload => {
+export const afterWrapupAction = setupObject => async payload => {
   const { featureFlags } = setupObject;
 
   if (featureFlags.enable_post_survey) {

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -376,11 +376,10 @@ export const afterCompleteTask = async payload => {
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
  * @returns {import('@twilio/flex-ui').ActionFunction}
  */
- export const afterWrapupTask = setupObject => async payload => {
+export const afterWrapupTask = setupObject => async payload => {
   const { featureFlags } = setupObject;
 
   if (featureFlags.enable_post_survey) {
     await triggerPostSurvey(setupObject, payload);
   }
 };
-

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -368,7 +368,7 @@ const triggerPostSurvey = async (setupObject, payload) => {
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
  * @returns {import('@twilio/flex-ui').ActionFunction}
  */
-export const afterWrapupAction = setupObject => async payload => {
+export const afterWrapupTask = setupObject => async payload => {
   const { featureFlags } = setupObject;
 
   if (featureFlags.enable_post_survey) {

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -365,15 +365,22 @@ const triggerPostSurvey = async (setupObject, payload) => {
 };
 
 /**
+ * @param {ReturnType<typeof getConfig>
+ * @returns {import('@twilio/flex-ui').ActionFunction}
+ */
+export const afterCompleteTask = async payload => {
+  removeContactForm(payload);
+};
+
+/**
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
  * @returns {import('@twilio/flex-ui').ActionFunction}
  */
-export const afterWrapupTask = setupObject => async payload => {
+ export const afterWrapupTask = setupObject => async payload => {
   const { featureFlags } = setupObject;
 
   if (featureFlags.enable_post_survey) {
     await triggerPostSurvey(setupObject, payload);
   }
-
-  removeContactForm(payload);
 };
+


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @GPaoloni 

## Description
- Refactored post survey to be triggered on task wrapup(End Chat button) as opposed to on task complete

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes #[1409](https://bugs.benetech.org/browse/CHI-1409)

### Verification steps
- The Serverless code required for this change to work has been deployed. If not, check into this branch (https://github.com/techmatters/serverless/pull/319) and deploy
- After a webchat based chat has been initiated, in Flex, 'END CHAT' for that task/conversation. This will trigger the post survey for the user in webchat