### PR TITLE
CHI-1441: Set E2E tests to run on a single worker and fix login test logic

### DIFF
--- a/.github/workflows/plugin-hrm-form-e2e-test.yml
+++ b/.github/workflows/plugin-hrm-form-e2e-test.yml
@@ -76,7 +76,7 @@ jobs:
 
       # Run E2E tests
       - name: Run Playwright tests
-        run: DEBUG=pw:api PLAYWRIGHT_USER_USERNAME=${{secrets.PLAYWRIGHT_USER_USERNAME}} PLAYWRIGHT_USER_PASSWORD=${{secrets.PLAYWRIGHT_USER_PASSWORD}} TWILIO_ACCOUNT_SID=${{secrets.E2E_DEV_ACCOUNT_SID}} TWILIO_AUTH_TOKEN=${{secrets.E2E_DEV_AUTH_TOKEN}} npx playwright test
+        run: DEBUG=pw:api PLAYWRIGHT_USER_USERNAME=${{secrets.PLAYWRIGHT_USER_USERNAME}} PLAYWRIGHT_USER_PASSWORD=${{secrets.PLAYWRIGHT_USER_PASSWORD}} TWILIO_ACCOUNT_SID=${{secrets.E2E_DEV_ACCOUNT_SID}} TWILIO_AUTH_TOKEN=${{secrets.E2E_DEV_AUTH_TOKEN}} npx playwright test --workers 1
         working-directory: ./e2e-tests
 
       # Upload artifacts

--- a/.github/workflows/plugin-hrm-form-pre-release-qa.yml
+++ b/.github/workflows/plugin-hrm-form-pre-release-qa.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Run E2E tests against actual E2E Flex instance
       - name: Run Playwright tests
-        run: DEBUG=pw:api PLAYWRIGHT_BASEURL=${{secrets.PLAYWRIGHT_BASEURL_E2E}} PLAYWRIGHT_USER_USERNAME=${{secrets.PLAYWRIGHT_USER_USERNAME}} PLAYWRIGHT_USER_PASSWORD=${{secrets.PLAYWRIGHT_USER_PASSWORD}} TWILIO_ACCOUNT_SID=${{secrets.E2E_DEV_ACCOUNT_SID}} TWILIO_AUTH_TOKEN=${{secrets.E2E_DEV_AUTH_TOKEN}} npx playwright test
+        run: DEBUG=pw:api PLAYWRIGHT_BASEURL=${{secrets.PLAYWRIGHT_BASEURL_E2E}} PLAYWRIGHT_USER_USERNAME=${{secrets.PLAYWRIGHT_USER_USERNAME}} PLAYWRIGHT_USER_PASSWORD=${{secrets.PLAYWRIGHT_USER_PASSWORD}} TWILIO_ACCOUNT_SID=${{secrets.E2E_DEV_ACCOUNT_SID}} TWILIO_AUTH_TOKEN=${{secrets.E2E_DEV_AUTH_TOKEN}} npx playwright test --workers 1
         working-directory: ./e2e-tests
 
       # Upload artifacts

--- a/e2e-tests/tests/login.spec.ts
+++ b/e2e-tests/tests/login.spec.ts
@@ -3,10 +3,10 @@ import { logPageTelemetry } from '../browser-logs';
 
 test('Plugin loads', async ({ page }) => {
   logPageTelemetry(page);
-  page.goto('/agent-desktop', { waitUntil: 'networkidle' });
+  await page.goto('/agent-desktop', { waitUntil: 'networkidle' });
   const callsWaitingLabel = page.locator(
     "div.Twilio-AgentDesktopView-default div[data-testid='Childline-voice']",
   );
-  await callsWaitingLabel.waitFor();
+  await callsWaitingLabel.waitFor({ state: 'visible' });
   await expect(callsWaitingLabel).toContainText('Calls');
 });

--- a/e2e-tests/tests/webchat.spec.ts
+++ b/e2e-tests/tests/webchat.spec.ts
@@ -37,6 +37,7 @@ test.describe.serial('Web chat caller', () => {
     ]);
   });
   test('Chat ', async () => {
+    test.setTimeout(120000);
     await chatPage.openChat();
     // await chatPage.selectHelpline('Fake Helpline'); // Step required in Aselo Dev, not in E2E
     const chatScript = [


### PR DESCRIPTION
Primary reviewer: @mythilytm 

## Description

Pin the E2E test runner to one worker. Tighten up the logic on the login E2E test

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1441

### Verification steps

Run E2E tests