### PR TITLE
CHI-1442: Fix completed task action setup. Migrated setup actions to TS

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -216,7 +216,6 @@ const setUpActions = (setupObject: SetupObject) => {
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject);
   const beforeCompleteAction = ActionFunctions.beforeCompleteTask(setupObject);
   const afterWrapupAction = ActionFunctions.afterWrapupTask(setupObject);
-  const afterCompleteAction = ActionFunctions.afterCompleteTask(setupObject);
 
   Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.initializeContactForm);
 
@@ -235,7 +234,7 @@ const setUpActions = (setupObject: SetupObject) => {
 
   Flex.Actions.addListener('afterWrapupTask', afterWrapupAction);
 
-  Flex.Actions.addListener('afterCompleteTask', afterCompleteAction);
+  Flex.Actions.addListener('afterCompleteTask', ActionFunctions.afterCompleteTask);
 };
 
 export default class HrmFormPlugin extends FlexPlugin {

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -19,6 +19,7 @@ import { Case, CustomITask } from '../types/types';
 import { formatCategories } from '../utils/formatters';
 import { getDefinitionVersions } from '../HrmFormPlugin';
 import { shouldSendInsightsData } from '../utils/setUpActions';
+import { ITask } from '@twilio/flex-ui';
 
 /*
  * 'Any' is the best we can do, since we're limited by Twilio here.
@@ -382,7 +383,7 @@ const getInsightsUpdateFunctionsForConfig = (
 export const buildInsightsData = (task: CustomITask, contactForm: TaskEntry, caseForm: Case) => {
   const previousAttributes = task.attributes;
 
-  if (!shouldSendInsightsData(task)) return previousAttributes;
+  if (!shouldSendInsightsData(task as ITask)) return previousAttributes;
 
   const { currentDefinitionVersion } = getDefinitionVersions();
 


### PR DESCRIPTION
Primary reviewer: @mmythily 

## Description

The changes to the action setup for post survey wrapup were broken, not sure how this was causing the display artifacts but an error being thrown in the setup must've prevented some styles being dynamically applied later?

The problem was that the 'afterCompleteTask' was being treated like an action that needed to be bound with the `setUpObject` when actually it could be used as is.

I migrated `setupActions.js` to TypeScript whilst I was in there. Worth noting that if setupActions had been TS then it wouldn't have compiled with this bug

@mmythily - it might be worth doing trying to do some extra testing around these changes, because the `afterCompleteTask` couldn't have been executing prior to this fix - would be worth you having a look and checking it's actually doing what you intended


### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Strings are localized
- N/A Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes CHI-1442

### Verification steps

Review the UI of the agent desktop and the forms to see if it is as expected