### PR TITLE
CHI-1443: Fix perp / household copy

### DIFF
--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -154,7 +154,7 @@ const AddEditCaseItem: React.FC<Props> = ({
   }
 
   const save = async () => {
-    const { info, id } = connectedCase;
+    const { info, id: caseId } = connectedCase;
     const rawForm = workingCopy.form;
     const form = transformValues(formDefinition)(rawForm);
     const now = new Date().toISOString();
@@ -188,7 +188,7 @@ const AddEditCaseItem: React.FC<Props> = ({
         }
       });
     }
-    const updatedCase = await updateCase(id, { info: newInfo });
+    const updatedCase = await updateCase(caseId, { info: newInfo });
     setConnectedCase(updatedCase, task.taskSid);
   };
 


### PR DESCRIPTION
Primary reviewer: @acedeywin 

## Description

* Fix bug where 'id' was being shadowed in AddEditCaseItem save function - breaking the copy function

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1443

### Verification steps

See ticket