### PR TITLE
Fixed hungarian messages not working as expected

### DIFF
--- a/plugin-hrm-form/src/utils/pluginHelpers.js
+++ b/plugin-hrm-form/src/utils/pluginHelpers.js
@@ -44,7 +44,7 @@ const bundledMessages = {
   'es-CL': esCLMessages,
   'es-CO': esCOMessages,
   'es-ES': esESMessages,
-  'hu-HU': huHUTranslation,
+  'hu-HU': huHUMessages,
   'pt-BR': ptBRMessages,
   'th-TH': thTHMessages,
 };
@@ -85,7 +85,7 @@ export const getMessage = messageKey => async language => {
   try {
     if (!language) return defaultMessages[messageKey];
 
-    if (language in bundledMessages) return bundledMessages[language][messageKey] || defaultMessages[messageKey];
+    if (language in bundledMessages) return bundledMessages[language][messageKey];
 
     // If no translation for this language, try to fetch it
     const body = { language };
@@ -93,7 +93,9 @@ export const getMessage = messageKey => async language => {
     const messages = await (typeof messagesJSON === 'string'
       ? JSON.parse(messagesJSON)
       : Promise.resolve(messagesJSON));
-    return messages[messageKey] || defaultMessages[messageKey];
+    if (messages[messageKey]) return messages[messageKey];
+
+    return defaultMessages[messageKey];
   } catch (err) {
     window.alert(translationErrorMsg);
     console.error(translationErrorMsg, err);


### PR DESCRIPTION
## Description
This PR:
- Fixes a subtle bug where default messages were returned in cases where it shouldn't.
- Fixes the `hu-HU` messages not working as intended cause a bad reference.

### Verification steps
- Start development server.
- Submit a new task via webchat (or any other chat) but do not accept it inmediately.
- Edit the task attributes from Twilio console, adding `"language": "hu-HU",`.
- Accept the task and confirm that the translated messages are sent.