### PR TITLE
Added helplineLanguage option to be set via tf

### DIFF
--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -65,7 +65,8 @@ locals {
     "pdfImagesSource": "https://tl-public-chat.s3.amazonaws.com",
     "logo_url": "https://aselo-logo.s3.amazonaws.com/145+transparent+background+no+TM.png",
     "multipleOfficeSupport": var.multi_office_support,
-    "serverless_base_url": var.serverless_url
+    "serverless_base_url": var.serverless_url,
+    "helplineLanguage": var.helpline_language
   }})
 }
 

--- a/twilio-iac/terraform-modules/flex/default/variables.tf
+++ b/twilio-iac/terraform-modules/flex/default/variables.tf
@@ -35,6 +35,12 @@ variable "definition_version" {
   type        = string
 }
 
+variable "helpline_language" {
+  description = "Keyword that determines the language to be used as default across the helpline"
+  type        = string
+  default = ""
+}
+
 variable "feature_flags" {
   description = "Map of feature flag settings. All values should be boolean"
   type = map(bool)
@@ -72,6 +78,7 @@ variable "custom_flex_messaging_flow_enabled" {
   type = bool
   default = null
 }
+
 variable "custom_flex_webchat_flow_enabled" {
   description = "Enable or disable Flex Webchat Messaging Flow"
   type = bool

--- a/twilio-iac/terraform-modules/flex/service-configuration/main.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/main.tf
@@ -65,7 +65,8 @@ locals {
     "pdfImagesSource": "https://tl-public-chat.s3.amazonaws.com",
     "logo_url": "https://aselo-logo.s3.amazonaws.com/145+transparent+background+no+TM.png",
     "multipleOfficeSupport": var.multi_office_support,
-    "serverless_base_url": var.serverless_url
+    "serverless_base_url": var.serverless_url,
+    "helplineLanguage": var.helpline_language
   }})
 }
 

--- a/twilio-iac/terraform-modules/flex/service-configuration/variables.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/variables.tf
@@ -35,6 +35,12 @@ variable "definition_version" {
   type        = string
 }
 
+variable "helpline_language" {
+  description = "Keyword that determines the language to be used as default across the helpline"
+  type        = string
+  default = ""
+}
+
 variable "feature_flags" {
   description = "Map of feature flag settings. All values should be boolean"
   type = map(bool)


### PR DESCRIPTION
## Description
This PR adds the option to set `helplineLanguage` service config attribute via terraform (under `flex` module).
I'm leaving the default value as `""` (empty string) since I believe that won't cause any issues in our UI code (if the helpline language is falsy, we don't use it).

@janorivera In order to set this in PL, you should pass down to the flex module the variable `helpline_language`.

Question here @stephenhand @janorivera:
I see that there are two different modules addressing the same, `terraform-modules/flex/default` and `/terraform-modules/flex/service-configuration`, the first being used almost everywhere, except in `teguio_staging`, `teguio_production` (>.<), `thailan_staging` and `zimbabwe_staging`. Is this correct, or we did something wrong along the way?
I see that the `default` one configures Flex flows (`messaging_flow` & `webchat_flow`) out of the box, so maybe the second is the most recent one, accordnig to the recent changes on "per channel boxed config"?

### Verification steps
- Provide `helpline_language` to the `module flex` from the `main.tf` for a given account.
- `terraform init`
- `terraform plan -var-file=....`