### PR TITLE
[WIP] UI functionality for external transcript viewing

### DIFF
--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -25,6 +25,7 @@ import { DetailsContext, toggleDetailSectionExpanded } from '../../states/contac
 import { getPermissionsForContact, PermissionActions } from '../../permissions';
 import { createDraft, ContactDetailsRoute } from '../../states/contacts/existingContacts';
 import { getConfig } from '../../HrmFormPlugin';
+import TranscriptSection from './TranscriptSection';
 
 // TODO: complete this type
 type OwnProps = {
@@ -40,6 +41,7 @@ type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchT
 /* eslint-disable complexity */
 // eslint-disable-next-line sonarjs/cognitive-complexity
 const ContactDetailsHome: React.FC<Props> = function ({
+  contactId,
   context,
   detailsExpanded,
   showActionIcons = false,
@@ -295,9 +297,11 @@ const ContactDetailsHome: React.FC<Props> = function ({
           buttonDataTestid="ContactDetails-Section-Transcript"
           showEditButton={false}
         >
-          <SectionActionButton type="button" onClick={() => console.log('>>>> Pressed')}>
-            <Template code="ContactDetails-LoadTranscript-Button" />
-          </SectionActionButton>
+          {/* <TranscriptSection contactId={contactId} transcriptUrl={savedContact.details.mediaUrls[0].url} /> */}
+          <TranscriptSection
+            contactId={contactId}
+            transcriptUrl="https://tl-aselo-docs-as-development.s3.amazonaws.com/transcripts/2022/08/09/20220809131844-WT1d7624f7c9d015a52d825e3be75ea105.json"
+          />
         </ContactDetailsSection>
       )}
     </DetailsContainer>

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { format } from 'date-fns';
 import { Actions, Insights, Template } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
@@ -138,15 +138,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
       savedContact.details.conversationMedia?.length,
     // && typeof savedContact.overview.conversationDuration === 'number',
   );
-  const transcriptAvailable = true;
-  /*
-   * const transcriptAvailable = Boolean(
-   *   featureFlags.enable_transcripts &&
-   *     isChatChannel(channel) &&
-   *     canViewTranscript &&
-   *     savedContact.details.mediaUrls?.some(m => m.type === ContactMediaType.TRANSCRIPT),
-   * );
-   */
+  const showTranscriptSection = featureFlags.enable_transcripts && isChatChannel(channel);
 
   return (
     <DetailsContainer data-testid="ContactDetails-Container">
@@ -289,7 +281,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
           </SectionActionButton>
         </SectionTitleContainer>
       )}
-      {transcriptAvailable && (
+      {showTranscriptSection && (
         <ContactDetailsSection
           sectionTitle={<Template code="ContactDetails-Transcript" />}
           expanded={detailsExpanded[TRANSCRIPT]}
@@ -297,10 +289,12 @@ const ContactDetailsHome: React.FC<Props> = function ({
           buttonDataTestid="ContactDetails-Section-Transcript"
           showEditButton={false}
         >
-          {/* <TranscriptSection contactId={contactId} transcriptUrl={savedContact.details.mediaUrls[0].url} /> */}
           <TranscriptSection
             contactId={contactId}
-            transcriptUrl="https://tl-aselo-docs-as-development.s3.amazonaws.com/transcripts/2022/08/09/20220809131844-WT1d7624f7c9d015a52d825e3be75ea105.json"
+            canViewTranscript={canViewTranscript}
+            transcriptAvailable={savedContact.details.mediaUrls?.some(m => m.type === ContactMediaType.TRANSCRIPT)}
+            // transcriptUrl="https://tl-aselo-docs-as-development.s3.amazonaws.com/transcripts/2022/08/09/20220809131844-WT1d7624f7c9d015a52d825e3be75ea105.json"
+            transcriptUrl={savedContact.details.mediaUrls ? savedContact.details.mediaUrls[0].url : undefined}
           />
         </ContactDetailsSection>
       )}

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
@@ -1,5 +1,13 @@
 import { styled } from '@twilio/flex-ui';
 
+import { FontOpenSans } from '../../styles/HrmStyles';
+
+export const ItalicFont = styled(FontOpenSans)`
+font-size: 12px;
+  font-style: italic;
+  line-height: 17px;
+`;
+
 export const MessageList = styled('div')`
   display: flex;
   flex-direction: column;

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
@@ -1,0 +1,41 @@
+import { styled } from '@twilio/flex-ui';
+
+export const MessageList = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 6px 0;
+  width: 100%;
+`;
+MessageList.displayName = 'MessageList';
+
+type MessageBubbleProps = {
+  isFromMe: boolean;
+};
+export const MessageBubble = styled('div')<MessageBubbleProps>`
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  padding: 3px;
+  ${p => (p.isFromMe ? 'margin-left: auto;' : 'margin-right: auto;')}
+  ${p => (p.isFromMe ? 'border-color: blue;' : 'border-color: black;')}
+  ${p => (p.isFromMe ? 'align-items: right;' : 'align-items: left;')}
+`;
+
+export const MessageBubbleHeader = styled('div')`
+  display: flex;
+  flex-direction: row;
+  font-size: 12px;
+  font-weight: 600;
+`;
+
+export const MessageBubbleBody = styled('div')`
+  display: flex;
+  font-size: 12px;
+  font-weight: 500;
+`;

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.tsx
@@ -1,0 +1,55 @@
+import { Template } from '@twilio/flex-ui';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+import { contactFormsBase, namespace, RootState } from '../../states';
+import { getFileDownloadUrl } from '../../services/ServerlessService';
+import { SectionActionButton } from '../../styles/search';
+
+type OwnProps = {
+  contactId: string;
+  transcriptUrl: string;
+};
+// eslint-disable-next-line no-use-before-define
+type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
+
+const TranscriptSection: React.FC<Props> = ({ contactId, transcriptUrl, transcript }) => {
+  const [loading, setLoading] = useState(false);
+
+  if (loading) {
+    return <CircularProgress size={50} />;
+  }
+
+  if (!transcript) {
+    const fetchAndLoadTranscript = async () => {
+      try {
+        setLoading(true);
+        const [, fileNameAtAws] = transcriptUrl.split('s3.amazonaws.com/');
+        const transcriptPreSignedUrl = await getFileDownloadUrl(fileNameAtAws, '');
+        const transcriptJson = await fetch(transcriptPreSignedUrl.downloadUrl);
+        const transcriptParsed = await transcriptJson.json();
+        console.log('>>>>>>>>>>>>>>', transcriptParsed);
+        setLoading(false);
+      } catch (err) {
+        console.error(`Error loading the transcript for contact ${contactId}, transcriptUrl ${transcriptUrl}`, err);
+      }
+    };
+
+    return (
+      <SectionActionButton type="button" onClick={fetchAndLoadTranscript}>
+        <Template code="ContactDetails-LoadTranscript-Button" />
+      </SectionActionButton>
+    );
+  }
+
+  return <div>TranscriptSection</div>;
+};
+
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
+  transcript: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.transcript,
+});
+
+const mapDispatchToProps = {};
+
+export default connect(mapStateToProps, mapDispatchToProps)(TranscriptSection);

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.tsx
@@ -1,4 +1,4 @@
-import { Template, MessageListItem, MessageList } from '@twilio/flex-ui';
+import { Template } from '@twilio/flex-ui';
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -8,6 +8,8 @@ import { contactFormsBase, namespace, RootState } from '../../states';
 import { getFileDownloadUrl } from '../../services/ServerlessService';
 import { SectionActionButton } from '../../styles/search';
 import { loadTranscript } from '../../states/contacts/existingContacts';
+import { FontOpenSans } from '../../styles/HrmStyles';
+import { MessageList, MessageBubble, MessageBubbleBody, MessageBubbleHeader } from './TranscriptSection.styles';
 
 type OwnProps = {
   contactId: string;
@@ -16,7 +18,7 @@ type OwnProps = {
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
-const TranscriptSection: React.FC<Props> = ({ contactId, transcriptUrl, transcript, loadTranscript }) => {
+const TranscriptSection: React.FC<Props> = ({ contactId, myIdentity, transcriptUrl, transcript, loadTranscript }) => {
   const [loading, setLoading] = useState(false);
 
   if (loading) {
@@ -45,30 +47,29 @@ const TranscriptSection: React.FC<Props> = ({ contactId, transcriptUrl, transcri
       </SectionActionButton>
     );
   }
-
   console.log(transcript);
   return (
-    <div className="Twilio-MessageList">
+    <MessageList>
       {transcript.messages.map(m => {
+        const isFromMe = m.from === myIdentity;
+
         return (
-          <div className="Twilio-MessageListItem-BubbleContainer" key={m.sid}>
-            <div className="Twilio-MessageBubble-default">
-              <div className="Twilio-MessageBubble-Header">
-                <div className="Twilio-MessageBubble-UserName">{m.from}</div>
-                <div className="Twilio-MessageBubble-Time">{format(new Date(m.dateCreated), 'h:mm aaaaa')}m</div>
-              </div>
-              <div className="Twilio-MessageBubble-Body">{m.body}</div>
-              <div className="Twilio-MessageBubble-end" />
-            </div>
-          </div>
+          <MessageBubble key={m.sid} isFromMe={isFromMe}>
+            <MessageBubbleHeader>
+              <FontOpenSans>{m.from}</FontOpenSans>
+              <FontOpenSans>{format(new Date(m.dateCreated), 'h:mm aaaaa')}m</FontOpenSans>
+            </MessageBubbleHeader>
+            <MessageBubbleBody>{m.body}</MessageBubbleBody>
+          </MessageBubble>
         );
       })}
-    </div>
+    </MessageList>
   );
 };
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   transcript: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.transcript,
+  myIdentity: state.flex.chat.session.client.user.identity,
 });
 
 const mapDispatchToProps = {

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.tsx
@@ -1,11 +1,13 @@
-import { Template } from '@twilio/flex-ui';
+import { Template, MessageListItem, MessageList } from '@twilio/flex-ui';
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import { format } from 'date-fns';
 
 import { contactFormsBase, namespace, RootState } from '../../states';
 import { getFileDownloadUrl } from '../../services/ServerlessService';
 import { SectionActionButton } from '../../styles/search';
+import { loadTranscript } from '../../states/contacts/existingContacts';
 
 type OwnProps = {
   contactId: string;
@@ -14,7 +16,7 @@ type OwnProps = {
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
-const TranscriptSection: React.FC<Props> = ({ contactId, transcriptUrl, transcript }) => {
+const TranscriptSection: React.FC<Props> = ({ contactId, transcriptUrl, transcript, loadTranscript }) => {
   const [loading, setLoading] = useState(false);
 
   if (loading) {
@@ -29,7 +31,8 @@ const TranscriptSection: React.FC<Props> = ({ contactId, transcriptUrl, transcri
         const transcriptPreSignedUrl = await getFileDownloadUrl(fileNameAtAws, '');
         const transcriptJson = await fetch(transcriptPreSignedUrl.downloadUrl);
         const transcriptParsed = await transcriptJson.json();
-        console.log('>>>>>>>>>>>>>>', transcriptParsed);
+        // TODO: the current example of a transcript contains more stuff. Here we only want the transcript itself probably?
+        loadTranscript(contactId, transcriptParsed.transcript);
         setLoading(false);
       } catch (err) {
         console.error(`Error loading the transcript for contact ${contactId}, transcriptUrl ${transcriptUrl}`, err);
@@ -43,13 +46,33 @@ const TranscriptSection: React.FC<Props> = ({ contactId, transcriptUrl, transcri
     );
   }
 
-  return <div>TranscriptSection</div>;
+  console.log(transcript);
+  return (
+    <div className="Twilio-MessageList">
+      {transcript.messages.map(m => {
+        return (
+          <div className="Twilio-MessageListItem-BubbleContainer" key={m.sid}>
+            <div className="Twilio-MessageBubble-default">
+              <div className="Twilio-MessageBubble-Header">
+                <div className="Twilio-MessageBubble-UserName">{m.from}</div>
+                <div className="Twilio-MessageBubble-Time">{format(new Date(m.dateCreated), 'h:mm aaaaa')}m</div>
+              </div>
+              <div className="Twilio-MessageBubble-Body">{m.body}</div>
+              <div className="Twilio-MessageBubble-end" />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
 };
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   transcript: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.transcript,
 });
 
-const mapDispatchToProps = {};
+const mapDispatchToProps = {
+  loadTranscript,
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(TranscriptSection);

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -167,6 +167,16 @@ export const getFileDownloadUrl = async (fileNameAtAws: string, fileName: string
 };
 
 /**
+ * Gets a file download url from S3, using the object url as constructed by AWS
+ */
+export const getFileDownloadUrlFromUrl = async (objectUrl: string, fileName: string = undefined) => {
+  const [bucketName, fileNameAtAws] = objectUrl.replace('https://', '').split('.s3.amazonaws.com/');
+  const body = { bucketName, fileNameAtAws, fileName };
+  const response = await fetchProtectedApi('/getFileDownloadUrl', body);
+  return response;
+};
+
+/**
  * Gets a file upload url to the corresponding S3 bucket
  */
 export const getFileUploadUrl = async (fileName: string, mimeType: string) => {

--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -19,6 +19,19 @@ export const channelTypes = {
 
 export type ChannelTypes = typeof channelTypes[keyof typeof channelTypes];
 
+const chatChannels = [
+  channelTypes.whatsapp,
+  channelTypes.facebook,
+  channelTypes.web,
+  channelTypes.sms,
+  channelTypes.twitter,
+  channelTypes.instagram,
+  channelTypes.line,
+];
+
+export const isVoiceChannel = (channel: string) => channel === channelTypes.voice;
+export const isChatChannel = (channel: string) => chatChannels.includes(channel as any);
+
 export type ChannelColors = {
   [C in ChannelTypes]: string;
 };

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -17,6 +17,7 @@ import {
   EXISTING_CONTACT_SET_CATEGORIES_GRID_VIEW_ACTION,
   EXISTING_CONTACT_TOGGLE_CATEGORY_EXPANDED_ACTION,
   EXISTING_CONTACT_UPDATE_DRAFT_ACTION,
+  EXISTING_CONTACT_LOAD_TRANSCRIPT,
   ExistingContactAction,
   ExistingContactsState,
   LOAD_CONTACT_ACTION,
@@ -26,6 +27,7 @@ import {
   setCategoriesGridViewReducer,
   toggleCategoryExpandedReducer,
   updateDraftReducer,
+  loadTranscriptReducer,
 } from './existingContacts';
 import { CSAMReportEntry } from '../../types/types';
 import {
@@ -295,6 +297,9 @@ export function reduce(
     }
     case RELEASE_CONTACT_ACTION: {
       return { ...state, existingContacts: releaseContactReducer(state.existingContacts, action) };
+    }
+    case EXISTING_CONTACT_LOAD_TRANSCRIPT: {
+      return { ...state, existingContacts: loadTranscriptReducer(state.existingContacts, action) };
     }
     case EXISTING_CONTACT_TOGGLE_CATEGORY_EXPANDED_ACTION: {
       return { ...state, existingContacts: toggleCategoryExpandedReducer(state.existingContacts, action) };

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -287,7 +287,7 @@
   "ContactDetails-GeneralDetails-SolvedProblem": "Did the child feel we solved their problem?",
   "ContactDetails-GeneralDetails-WouldRecommend": "Would the child recommend us to a friend?",
   "ContactDetails-LoadRecording-Button": "Open Recording",
-  "ContactDetails-LoadTranscript-Button": "View Transcript",
+  "ContactDetails-LoadTranscript-Button": "Load Transcript",
   "ContactDetails-Transcript": "Transcript",
   "ContactDetails-ActionHeaderAdded": "Added on {{date}} at {{time}} by {{counsellor}}",
   "SectionName-CallerInformation": "Caller Information",
@@ -299,6 +299,8 @@
   "SectionName-Referral": "Referral",
   "SectionName-Notes": "Notes",
   "SectionName-CaseSummary": "Case Summary",
+  "TranscriptSection-TranscriptNotAvailableDifficulties": "Transcript is not available due to technical difficulties. Please contact your support team or supervisor.",
+  "TranscriptSection-TranscriptNotAvailableCheckLater": "Transcript is not available. Please check back later.",
 
   "Contact-EditCaller":"Edit Caller Information",
   "Contact-EditChild":"Edit Child Information",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -288,6 +288,7 @@
   "ContactDetails-GeneralDetails-WouldRecommend": "Would the child recommend us to a friend?",
   "ContactDetails-LoadRecording-Button": "Open Recording",
   "ContactDetails-LoadTranscript-Button": "View Transcript",
+  "ContactDetails-Transcript": "Transcript",
   "ContactDetails-ActionHeaderAdded": "Added on {{date}} at {{time}} by {{counsellor}}",
   "SectionName-CallerInformation": "Caller Information",
   "SectionName-ChildInformation": "Child Information",

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -91,6 +91,13 @@ type TwilioStoredMedia = {
 
 export type ConversationMedia = TwilioStoredMedia;
 
+export enum ContactMediaType {
+  // RECORDING = 'recording',
+  TRANSCRIPT = 'transcript',
+}
+
+export type ContactMediaUrl = { url: string; type: ContactMediaType };
+
 // Information about a single contact, as expected from DB (we might want to reuse this type in backend) - (is this a correct placement for this?)
 export type ContactRawJson = {
   definitionVersion?: DefinitionVersionId;
@@ -100,6 +107,7 @@ export type ContactRawJson = {
   caseInformation: { categories: {} } & { [key: string]: string | boolean | {} }; // having {} makes type looser here because of this https://github.com/microsoft/TypeScript/issues/17867. Possible/future solution https://github.com/microsoft/TypeScript/pull/29317
   contactlessTask: { [key: string]: string | boolean };
   conversationMedia: ConversationMedia[];
+  mediaUrls?: ContactMediaUrl[];
 };
 
 // Information about a single contact, as expected from search contacts endpoint (we might want to reuse this type in backend) - (is this a correct placement for this?)


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
This PR adds logic to download the transcript from the S3 location if possible.
Notes:
- The view of the transcript have zero styling. I have tried several times to re-use Twilio stuff, but they rely on the task/channel. If the goal for us is to "import the transcript from S3", as I have understood, we may need to add our own styles.
- Currently, when we export the transcripts , we include the `from` attribute from the messages, which represent the `identity` of the sender within the Twilio Chat Service (`➜ twilio api:chat:v2:services:users:fetch --service-sid=<service sid> --sid=<identity> -o=json`). To retrieve it's friendly name, we have to do some manipulation, either in Flex when loading the transcript, or in the process of exporting the transcript. I think the second is better as it will save some API calls from the client (and sound more like ETL?).

WIP:
- Play around with Twilio stuff to see if I can reuse the webchat styles?
- Tests.

### Checklist
- [ ] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1342)
- [ ] New tests added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- Un-comment line 296 of `src/components/contact/ContactDetailsHome.tsx` to point to a fixed existing transcript object.
- Comment lines 40 to 54 of `src/components/contact/TranscriptSection.tsx` so the transcript is shown as if it were the corresponding one for this contact.
- `npm run dev`.
- Search and open the transcript section of any contact.