### PR TITLE
[Bug Fix]: Start New Chat appears after post survey initialization

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -68,7 +68,7 @@ const readConfig = () => {
   };
 };
 
-let cachedConfig;
+let cachedConfig: ReturnType<typeof readConfig>;
 
 try {
   cachedConfig = readConfig();

--- a/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
@@ -1,7 +1,10 @@
-import { ITask } from '@twilio/flex-ui';
+/* eslint-disable camelcase */
+import { ITask, StateHelper, TaskHelper, ChatOrchestrator } from '@twilio/flex-ui';
 
-import { afterCompleteTask } from '../../utils/setUpActions';
+import { afterCompleteTask, afterWrapupTask, setUpPostSurvey } from '../../utils/setUpActions';
 import { REMOVE_CONTACT_STATE } from '../../states/types';
+import * as HrmFormPlugin from '../../HrmFormPlugin';
+import * as ServerlessService from '../../services/ServerlessService';
 
 const mockFlexManager = {
   store: {
@@ -10,6 +13,7 @@ const mockFlexManager = {
 };
 
 jest.mock('@twilio/flex-ui', () => ({
+  ...(jest.requireActual('@twilio/flex-ui') as any),
   Manager: {
     getInstance: () => mockFlexManager,
   },
@@ -17,6 +21,10 @@ jest.mock('@twilio/flex-ui', () => ({
 
 jest.mock('../../HrmFormPlugin.tsx', () => ({}));
 jest.mock('../../states', () => ({}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('afterCompleteTask', () => {
   test('Dispatches a removeContactState action with the specified taskSid', () => {
@@ -29,5 +37,85 @@ describe('afterCompleteTask', () => {
       type: REMOVE_CONTACT_STATE,
       taskId: 'THIS IS THE TASK SID!',
     });
+  });
+});
+
+describe('afterWrapupTask', () => {
+  test('featureFlags.enable_post_survey === false should not trigger post survey', async () => {
+    const getChatChannelStateForTaskSpy = jest.spyOn(StateHelper, 'getChatChannelStateForTask');
+    const postSurveyInitSpy = jest.spyOn(ServerlessService, 'postSurveyInit').mockImplementationOnce(async () => ({}));
+
+    const task = <ITask>{
+      taskSid: 'THIS IS THE TASK SID!',
+      channelType: '',
+    };
+
+    afterWrapupTask(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: false } })({ task });
+
+    expect(getChatChannelStateForTaskSpy).not.toHaveBeenCalled();
+    expect(postSurveyInitSpy).not.toHaveBeenCalled();
+  });
+
+  test('featureFlags.enable_post_survey === true should not trigger post survey for non-chat task', async () => {
+    const task = ({
+      attributes: { channelSid: undefined },
+      taskSid: 'THIS IS THE TASK SID!',
+      channelType: 'voice',
+      taskChannelUniqueName: 'voice',
+    } as unknown) as ITask;
+
+    jest.spyOn(TaskHelper, 'isChatBasedTask').mockImplementation(() => false);
+    const getChatChannelStateForTaskSpy = jest.spyOn(StateHelper, 'getChatChannelStateForTask');
+    const postSurveyInitSpy = jest.spyOn(ServerlessService, 'postSurveyInit').mockImplementation(async () => ({}));
+
+    afterWrapupTask(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: true } })({ task });
+
+    expect(getChatChannelStateForTaskSpy).not.toHaveBeenCalled();
+    expect(postSurveyInitSpy).not.toHaveBeenCalled();
+  });
+
+  test('featureFlags.enable_post_survey === true should trigger post survey for chat task', async () => {
+    const task = ({
+      attributes: { channelSid: 'CHxxxxxx' },
+      taskSid: 'THIS IS THE TASK SID!',
+      channelType: 'web',
+      taskChannelUniqueName: 'chat',
+    } as unknown) as ITask;
+
+    jest.spyOn(TaskHelper, 'isChatBasedTask').mockImplementation(() => true);
+    jest.spyOn(TaskHelper, 'getTaskChatChannelSid').mockImplementationOnce(() => task.attributes.channelSid);
+    const getChatChannelStateForTaskSpy = jest.spyOn(StateHelper, 'getChatChannelStateForTask').mockImplementationOnce(
+      () =>
+        ({
+          source: {
+            removeAllListeners: jest.fn(),
+          },
+        } as any),
+    );
+    const postSurveyInitSpy = jest.spyOn(ServerlessService, 'postSurveyInit').mockImplementation(async () => ({}));
+
+    afterWrapupTask(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: true } })({ task });
+
+    expect(getChatChannelStateForTaskSpy).toHaveBeenCalled();
+    expect(postSurveyInitSpy).toHaveBeenCalled();
+  });
+});
+
+describe('setUpPostSurvey', () => {
+  test('featureFlags.enable_post_survey === false should not change ChatOrchestrator', async () => {
+    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations');
+    setUpPostSurvey(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: false } });
+
+    expect(setOrchestrationsSpy).not.toHaveBeenCalled();
+  });
+
+  test('featureFlags.enable_post_survey === true should change ChatOrchestrator', async () => {
+    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
+
+    setUpPostSurvey(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: true } });
+
+    expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
+    expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));
+    expect(setOrchestrationsSpy).toHaveBeenCalledWith('completed', expect.any(Function));
   });
 });

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -10,6 +10,7 @@ import {
   ActionFunction,
   ReplacedActionFunction,
   ChatOrchestratorEvent,
+  ChatChannelHelper,
 } from '@twilio/flex-ui';
 import { callTypes } from 'hrm-form-definitions';
 import type { ChatOrchestrationsEvents } from '@twilio/flex-ui/src/ChatOrchestrator';
@@ -330,6 +331,13 @@ export const afterWrapupTask = (setupObject: SetupObject) => async (payload: Act
   const { featureFlags } = setupObject;
 
   if (featureFlags.enable_post_survey) {
+    const channelState = StateHelper.getChatChannelStateForTask(payload.task);
+
+    channelState.source?.removeAllListeners('messageAdded');
+    channelState.source?.removeAllListeners('typingStarted');
+    channelState.source?.removeAllListeners('typingEnded');
+
+    // TODO: make this occur in taskrouter callback
     await triggerPostSurvey(setupObject, payload);
   }
 };

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -8,9 +8,11 @@ import {
   ChatOrchestrator,
   ITask,
   ActionFunction,
+  ReplacedActionFunction,
+  ChatOrchestratorEvent,
 } from '@twilio/flex-ui';
 import { callTypes } from 'hrm-form-definitions';
-import { ChatOrchestrationsEvents, ChatOrchestration } from '@twilio/flex-ui/src/ChatOrchestrator';
+// import type { ChatOrchestration } from '@twilio/flex-ui/src/ChatOrchestrator';
 
 import { DEFAULT_TRANSFER_MODE, getConfig } from '../HrmFormPlugin';
 import {
@@ -51,7 +53,6 @@ export const loadCurrentDefinitionVersion = async () => {
 
 /**
  * Given a taskSid, retrieves the state of the form (stored in redux) for that task
- * @param {string} taskSid
  */
 const getStateContactForms = (taskSid: string) => {
   return Manager.getInstance().store.getState()[namespace][contactFormsBase].tasks[taskSid];
@@ -78,7 +79,6 @@ const fromActionFunction = (fun: ActionFunction) => async (payload: ActionPayloa
 
 /**
  * Initializes an empty form (in redux store) for the task within payload
- * @param {{ task: any }} payload
  */
 export const initializeContactForm = (payload: ActionPayload) => {
   const { currentDefinitionVersion } = Manager.getInstance().store.getState()[namespace][configurationBase];
@@ -116,11 +116,9 @@ const handleTransferredTask = async (task: ITask) => {
 
 export const getTaskLanguage = ({ helplineLanguage }) => ({ task }) => task.attributes.language || helplineLanguage;
 
-/**
- * @param {string} messageKey
- * @returns {(setupObject: ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }) => import('@twilio/flex-ui').ActionFunction}
- */
-const sendMessageOfKey = messageKey => setupObject => async payload => {
+const sendMessageOfKey = (messageKey: string) => (setupObject: SetupObject): ActionFunction => async (
+  payload: ActionPayload,
+) => {
   const { getMessage } = setupObject;
   const taskLanguage = getTaskLanguage(setupObject)(payload);
   const message = await getMessage(messageKey)(taskLanguage);
@@ -197,10 +195,8 @@ const safeTransfer = async (transferFunction: () => Promise<any>, task: ITask): 
 
 /**
  * Custom override for TransferTask action. Saves the form to share with another counseler (if possible) and then starts the transfer
- * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
- * @returns {import('@twilio/flex-ui').ReplacedActionFunction}
  */
-export const customTransferTask = (setupObject: SetupObject) => async (
+export const customTransferTask = (setupObject: SetupObject): ReplacedActionFunction => async (
   payload: ActionPayloadWithOptions,
   original: ActionFunction,
 ) => {
@@ -250,7 +246,6 @@ export const hangupCall = fromActionFunction(saveEndMillis);
 
 /**
  * Override for WrapupTask action. Sends a message before leaving (if it should) and saves the end time of the conversation
- * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
  */
 export const wrapupTask = (setupObject: SetupObject) =>
   fromActionFunction(async payload => {
@@ -260,11 +255,9 @@ export const wrapupTask = (setupObject: SetupObject) =>
     await saveEndMillis(payload);
   });
 
-/**
- * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
- * @returns {import('@twilio/flex-ui').ActionFunction}
- */
-const decreaseChatCapacity = (setupObject: SetupObject) => async (payload: ActionPayload): Promise<void> => {
+const decreaseChatCapacity = (setupObject: SetupObject): ActionFunction => async (
+  payload: ActionPayload,
+): Promise<void> => {
   const { featureFlags } = setupObject;
   const { task } = payload;
   if (featureFlags.enable_manual_pulling && task.taskChannelUniqueName === 'chat') await adjustChatCapacity('decrease');
@@ -278,28 +271,47 @@ const isAseloCustomChannelTask = (task: CustomITask) =>
   (<string[]>Object.values(customChannelTypes)).includes(task.channelType);
 
 /**
- * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
+ * This function manipulates the default chat orchetrations to allow our implementation of post surveys.
+ * Since we rely on the same chat channel as the original contact for it, we don't want it to be "deactivated" by Flex.
+ * We also don't want the counselor to be part of the channel once the task is wrapped (or the post survey answers will be seen).
+ * Hence this function modifies the following orchestration events:
+ * - task wrapup: adds LeaveChatChannel and removes DeactivateChatChannel
+ * - task completed: removes DeactivateChatChannel
  */
+const setChatOrchestrationsForPostSurvey = () => {
+  const excludeDeactivateChatChannel = (orchestrations: ChatOrchestratorEvent[]) =>
+    orchestrations.filter(e => e !== ChatOrchestratorEvent.DeactivateChatChannel);
+
+  const includeLeaveChatChannel = (orchestrations: ChatOrchestratorEvent[]) =>
+    orchestrations.some(o => o === ChatOrchestratorEvent.LeaveChatChannel)
+      ? orchestrations
+      : [...orchestrations, ChatOrchestratorEvent.LeaveChatChannel];
+
+  const defaultWrapupOrchestrations = ChatOrchestrator.getOrchestrations('wrapup');
+
+  if (Array.isArray(defaultWrapupOrchestrations)) {
+    ChatOrchestrator.setOrchestrations('wrapup', task => {
+      return isAseloCustomChannelTask(task)
+        ? defaultWrapupOrchestrations
+        : includeLeaveChatChannel(excludeDeactivateChatChannel(defaultWrapupOrchestrations));
+    });
+  }
+
+  const defaultCompletedOrchestrations = ChatOrchestrator.getOrchestrations('completed');
+
+  if (Array.isArray(defaultCompletedOrchestrations)) {
+    ChatOrchestrator.setOrchestrations('completed', task => {
+      return isAseloCustomChannelTask(task)
+        ? defaultCompletedOrchestrations
+        : excludeDeactivateChatChannel(defaultCompletedOrchestrations);
+    });
+  }
+};
+
 export const setUpPostSurvey = (setupObject: SetupObject) => {
   const { featureFlags } = setupObject;
   if (featureFlags.enable_post_survey) {
-    const maybeExcludeDeactivateChatChannel = (event: keyof ChatOrchestrationsEvents) => {
-      const defaultOrchestrations = ChatOrchestrator.getOrchestrations(event);
-      if (Array.isArray(defaultOrchestrations)) {
-        const excludeDeactivateChatChannel = defaultOrchestrations.filter(
-          e => e !== ChatOrchestration.DeactivateChatChannel,
-        );
-
-        ChatOrchestrator.setOrchestrations(
-          event,
-          // Instead than setting the orchestrations as a list of actions (ChatOrchestration[]), we can set it to a callback with type (task: ITask) => ChatOrchestration[]
-          task => (isAseloCustomChannelTask(task) ? defaultOrchestrations : excludeDeactivateChatChannel),
-        );
-      }
-    };
-
-    maybeExcludeDeactivateChatChannel('wrapup');
-    maybeExcludeDeactivateChatChannel('completed');
+    setChatOrchestrationsForPostSurvey();
   }
 };
 

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -10,6 +10,7 @@ import {
   ActionFunction,
 } from '@twilio/flex-ui';
 import { callTypes } from 'hrm-form-definitions';
+import { ChatOrchestrationsEvents, ChatOrchestration } from '@twilio/flex-ui/src/ChatOrchestrator';
 
 import { DEFAULT_TRANSFER_MODE, getConfig } from '../HrmFormPlugin';
 import {
@@ -282,10 +283,12 @@ const isAseloCustomChannelTask = (task: CustomITask) =>
 export const setUpPostSurvey = (setupObject: SetupObject) => {
   const { featureFlags } = setupObject;
   if (featureFlags.enable_post_survey) {
-    const maybeExcludeDeactivateChatChannel = event => {
+    const maybeExcludeDeactivateChatChannel = (event: keyof ChatOrchestrationsEvents) => {
       const defaultOrchestrations = ChatOrchestrator.getOrchestrations(event);
       if (Array.isArray(defaultOrchestrations)) {
-        const excludeDeactivateChatChannel = defaultOrchestrations.filter(e => e !== 'DeactivateChatChannel');
+        const excludeDeactivateChatChannel = defaultOrchestrations.filter(
+          e => e !== ChatOrchestration.DeactivateChatChannel,
+        );
 
         ChatOrchestrator.setOrchestrations(
           event,
@@ -293,10 +296,10 @@ export const setUpPostSurvey = (setupObject: SetupObject) => {
           task => (isAseloCustomChannelTask(task) ? defaultOrchestrations : excludeDeactivateChatChannel),
         );
       }
-
-      maybeExcludeDeactivateChatChannel('wrapup');
-      maybeExcludeDeactivateChatChannel('completed');
     };
+
+    maybeExcludeDeactivateChatChannel('wrapup');
+    maybeExcludeDeactivateChatChannel('completed');
   }
 };
 

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -331,11 +331,13 @@ export const afterWrapupTask = (setupObject: SetupObject) => async (payload: Act
   const { featureFlags } = setupObject;
 
   if (featureFlags.enable_post_survey) {
-    const channelState = StateHelper.getChatChannelStateForTask(payload.task);
+    if (TaskHelper.isChatBasedTask(payload.task)) {
+      const channelState = StateHelper.getChatChannelStateForTask(payload.task);
 
-    channelState.source?.removeAllListeners('messageAdded');
-    channelState.source?.removeAllListeners('typingStarted');
-    channelState.source?.removeAllListeners('typingEnded');
+      channelState.source?.removeAllListeners('messageAdded');
+      channelState.source?.removeAllListeners('typingStarted');
+      channelState.source?.removeAllListeners('typingEnded');
+    }
 
     // TODO: make this occur in taskrouter callback
     await triggerPostSurvey(setupObject, payload);

--- a/plugin-hrm-form/src/utils/sharedState.js
+++ b/plugin-hrm-form/src/utils/sharedState.js
@@ -43,6 +43,7 @@ export const saveFormSharedState = async (form, task) => {
 /**
  * Restores the contact form from Sync Client (if there is any)
  * @param {import("@twilio/flex-ui").ITask} task
+ * @returns {Promise<import("../states/contacts/reducer").TaskEntry | null>}
  */
 export const loadFormSharedState = async task => {
   const { featureFlags, sharedStateClient, strings } = getConfig();


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand @mmythily 

## Description
This PR addressed two bugs:
1) Calls to `maybeExcludeDeactivateChatChannel` were moved to it's own definition in https://github.com/techmatters/flex-plugins/pull/947, causing the [ChatOrchestrator](https://assets.flex.twilio.com/docs/releases/flex-ui/1.23.3/ChatOrchestrator.html) to behave as default (channels are deactivated on wrapup). This caused the first bug where every chat contact was "closed" before the post survey had a chance to execute.
2) Counselors where still able to read the message after the task was wrapped, exposing the child's responses to the post survey. This is prevented by removing some listeners from the Flex UI on wrapup. Note: I would have preferred removing the counselor from the channel instead, so that could be done from taskrouter callback and not the UI, but doing so causes Flex to entirely unmount the chat from the UI, making imposible for the counselor to see the conversation when it should be available. Same occurs if we try to orchestrate `LeaveChatChannel` on wrapup, as can be seen in [732e6ec](https://github.com/techmatters/flex-plugins/commit/732e6eccd988d5b87894d6c6b595044155ae2a12).

Also played around with some TS.
Test are WIP, but this can be reviewed :)

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1468)
- [WIP] New tests added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Start development server.
- Send a new webchat contact.
- Accept it in your local instance of Flex.
- Move the task to wrapup (either with end chat button in Flex or with the new end chat button in webchat if available).
- Confirm that:
  - The channel is still open, and the webchat can still interact with the post survey.
  - The counselor does not receives any further interactions.