### PR TITLE
CHI-1285: Fix welcome message

### DIFF
--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -444,11 +444,6 @@ export const StyledSearchTab = withStyles({
   selected: {
     backgroundColor: '#ffffff',
   },
-  labelIcon: {
-    '& > span > span': {
-      padding: 0,
-    },
-  },
 })(StyledTab);
 StyledSearchTab.displayName = 'StyledSearchTab';
 


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description

Fixed a couple of issues sending a welcome message, found because it broke the E2E tests

* Removed style from tabs that the new version of material was choking
* Migrated the Welcome Message listener & sender code to the Conversations API

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

TODO: Some unit test coverage for AfterAcceptTask handler

### Related Issues
CHI-1285

### Verification steps

* Start a webchat conversation
* Check that the Welcome Message is sent to the caller when the counsellor accepts the chat.