### PR TITLE
Implement permissions for access to externally stored transcripts

### DIFF
--- a/plugin-hrm-form/src/___tests__/permissions/index.test.js
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.js
@@ -2,7 +2,13 @@ import each from 'jest-each';
 
 import { getConfig } from '../../HrmFormPlugin';
 import * as fetchRulesModule from '../../permissions/fetchRules';
-import { getPermissionsForCase, getPermissionsForContact, PermissionActions } from '../../permissions';
+import {
+  getPermissionsForCase,
+  getPermissionsForContact,
+  PermissionActions,
+  CaseActions,
+  ContactActions,
+} from '../../permissions';
 
 jest.mock('../../HrmFormPlugin');
 
@@ -34,91 +40,89 @@ describe('Test that all actions work fine (everyone)', () => {
   });
 });
 
-describe('Test different scenarios (random action) for Cases', () => {
-  const PermissionActionsValues = Object.values(PermissionActions);
-  const getRandomAction = () =>
-    PermissionActionsValues[Math.floor(Math.random() * 100) % PermissionActionsValues.length];
-
+describe('Test different scenarios (all CasesActions)', () => {
   each(
-    [
-      {
-        action: getRandomAction(),
-        conditionsSets: [['everyone']],
-        workerSid: 'not creator',
-        isSupervisor: false,
-        expectedResult: true,
-        expectedDescription: 'is not creator nor supervisor, case is open',
-      },
-      {
-        action: getRandomAction(),
-        conditionsSets: [['everyone']],
-        workerSid: 'not creator',
-        isSupervisor: false,
-        expectedResult: true,
-        expectedDescription: 'is not creator nor supervisor, case is close',
-        status: 'close',
-      },
-      {
-        action: getRandomAction(),
-        conditionsSets: [],
-        workerSid: 'creator',
-        isSupervisor: true,
-        expectedResult: false,
-        expectedDescription: 'user is creator, supervisor, case is open',
-      },
-      {
-        action: getRandomAction(),
-        conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-        workerSid: 'not creator',
-        isSupervisor: true,
-        expectedResult: true,
-        expectedDescription: 'user is supervisor but not creator, case open',
-      },
-      {
-        action: getRandomAction(),
-        conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-        workerSid: 'not creator',
-        isSupervisor: true,
-        expectedResult: true,
-        expectedDescription: 'user is supervisor but not creator, case closed',
-        status: 'closed',
-      },
-      {
-        action: getRandomAction(),
-        conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-        workerSid: 'not creator',
-        isSupervisor: false,
-        expectedResult: false,
-        expectedDescription: 'user is not supervisor nor creator',
-      },
-      {
-        action: getRandomAction(),
-        conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-        workerSid: 'creator',
-        isSupervisor: false,
-        expectedResult: true,
-        expectedDescription: 'user is creator and case is open',
-      },
-      {
-        action: getRandomAction(),
-        conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-        workerSid: 'creator',
-        isSupervisor: false,
-        expectedResult: false,
-        expectedDescription: 'user is creator but case is closed',
-        status: 'closed',
-      },
-      {
-        action: getRandomAction(),
-        conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-        workerSid: 'not creator',
-        isSupervisor: false,
-        expectedResult: false,
-        expectedDescription: 'case is open but user is not creator',
-      },
-    ].map(t => ({ ...t, prettyConditionsSets: t.conditionsSets.map(arr => `[${arr.join(',')}]`) })),
+    Object.values(CaseActions)
+      .flatMap(action => [
+        {
+          action,
+          conditionsSets: [['everyone']],
+          workerSid: 'not creator',
+          isSupervisor: false,
+          expectedResult: true,
+          expectedDescription: 'is not creator nor supervisor, case is open',
+        },
+        {
+          action,
+          conditionsSets: [['everyone']],
+          workerSid: 'not creator',
+          isSupervisor: false,
+          expectedResult: true,
+          expectedDescription: 'is not creator nor supervisor, case is close',
+          status: 'close',
+        },
+        {
+          action,
+          conditionsSets: [],
+          workerSid: 'creator',
+          isSupervisor: true,
+          expectedResult: false,
+          expectedDescription: 'user is creator, supervisor, case is open',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
+          workerSid: 'not creator',
+          isSupervisor: true,
+          expectedResult: true,
+          expectedDescription: 'user is supervisor but not creator, case open',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
+          workerSid: 'not creator',
+          isSupervisor: true,
+          expectedResult: true,
+          expectedDescription: 'user is supervisor but not creator, case closed',
+          status: 'closed',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
+          workerSid: 'not creator',
+          isSupervisor: false,
+          expectedResult: false,
+          expectedDescription: 'user is not supervisor nor creator',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
+          workerSid: 'creator',
+          isSupervisor: false,
+          expectedResult: true,
+          expectedDescription: 'user is creator and case is open',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
+          workerSid: 'creator',
+          isSupervisor: false,
+          expectedResult: false,
+          expectedDescription: 'user is creator but case is closed',
+          status: 'closed',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
+          workerSid: 'not creator',
+          isSupervisor: false,
+          expectedResult: false,
+          expectedDescription: 'case is open but user is not creator',
+        },
+      ])
+      .map(t => ({ ...t, prettyConditionsSets: t.conditionsSets.map(arr => `[${arr.join(',')}]`) })),
   ).test(
-    `Should return $expectedResult when $expectedDescription and conditionsSets are $prettyConditionsSets`,
+    `Should return $expectedResult for action $action when $expectedDescription and conditionsSets are $prettyConditionsSets`,
     ({ action, conditionsSets, workerSid, isSupervisor, status = 'open', expectedResult }) => {
       const rules = buildRules(conditionsSets);
       jest.spyOn(fetchRulesModule, 'fetchRules').mockReturnValueOnce(rules);
@@ -136,76 +140,78 @@ describe('Test different scenarios (random action) for Cases', () => {
   );
 });
 
-describe('Test different scenarios for Contacts', () => {
+describe('Test different scenarios (all ContactActions)', () => {
   each(
-    [
-      {
-        action: 'editContact',
-        conditionsSets: [['everyone']],
-        workerSid: 'not owner',
-        isSupervisor: false,
-        expectedResult: true,
-        expectedDescription: 'is not owner nor supervisor',
-      },
-      {
-        action: 'editContact',
-        conditionsSets: [],
-        workerSid: 'owner',
-        isSupervisor: true,
-        expectedResult: false,
-        expectedDescription: 'user is owner and supervisor',
-      },
-      {
-        action: 'editContact',
-        conditionsSets: [['isOwner']],
-        workerSid: 'owner',
-        isSupervisor: false,
-        expectedResult: true,
-        expectedDescription: 'is a owner but not a supervisor',
-      },
-      {
-        action: 'editContact',
-        conditionsSets: [['isSupervisor']],
-        workerSid: 'not owner',
-        isSupervisor: true,
-        expectedResult: true,
-        expectedDescription: 'is a supervisor but not a owner',
-      },
-      {
-        action: 'editContact',
-        conditionsSets: [['isOwner']],
-        workerSid: 'not owner',
-        isSupervisor: true,
-        expectedResult: false,
-        expectedDescription: 'is not a owner but a supervisorr',
-      },
-      {
-        action: 'editContact',
-        conditionsSets: [['isSupervisor']],
-        workerSid: 'owner',
-        isSupervisor: false,
-        expectedResult: false,
-        expectedDescription: 'is a supervisor but not a owner',
-      },
-      {
-        action: 'editContact',
-        conditionsSets: [['isSupervisor'], ['isOwner']],
-        workerSid: 'not owner',
-        isSupervisor: true,
-        expectedResult: true,
-        expectedDescription: 'user is supervisor but not owner',
-      },
-      {
-        action: 'editContact',
-        conditionsSets: [['isSupervisor'], ['isOwner']],
-        workerSid: 'not owner',
-        isSupervisor: false,
-        expectedResult: false,
-        expectedDescription: 'user is supervisor but not owner',
-      },
-    ].map(t => ({ ...t, prettyConditionsSets: t.conditionsSets.map(arr => `[${arr.join(',')}]`) })),
+    Object.values(ContactActions)
+      .flatMap(action => [
+        {
+          action,
+          conditionsSets: [['everyone']],
+          workerSid: 'not owner',
+          isSupervisor: false,
+          expectedResult: true,
+          expectedDescription: 'is not owner nor supervisor',
+        },
+        {
+          action,
+          conditionsSets: [],
+          workerSid: 'owner',
+          isSupervisor: true,
+          expectedResult: false,
+          expectedDescription: 'user is owner and supervisor',
+        },
+        {
+          action,
+          conditionsSets: [['isOwner']],
+          workerSid: 'owner',
+          isSupervisor: false,
+          expectedResult: true,
+          expectedDescription: 'is a owner but not a supervisor',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor']],
+          workerSid: 'not owner',
+          isSupervisor: true,
+          expectedResult: true,
+          expectedDescription: 'is a supervisor but not a owner',
+        },
+        {
+          action,
+          conditionsSets: [['isOwner']],
+          workerSid: 'not owner',
+          isSupervisor: true,
+          expectedResult: false,
+          expectedDescription: 'is not a owner but a supervisorr',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor']],
+          workerSid: 'owner',
+          isSupervisor: false,
+          expectedResult: false,
+          expectedDescription: 'is a supervisor but not a owner',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor'], ['isOwner']],
+          workerSid: 'not owner',
+          isSupervisor: true,
+          expectedResult: true,
+          expectedDescription: 'user is supervisor but not owner',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor'], ['isOwner']],
+          workerSid: 'not owner',
+          isSupervisor: false,
+          expectedResult: false,
+          expectedDescription: 'user is supervisor but not owner',
+        },
+      ])
+      .map(t => ({ ...t, prettyConditionsSets: t.conditionsSets.map(arr => `[${arr.join(',')}]`) })),
   ).test(
-    `Should return $expectedResult when $expectedDescription and conditionsSets are $prettyConditionsSets`,
+    `Should return $expectedResult for action $action when $expectedDescription and conditionsSets are $prettyConditionsSets`,
     ({ action, conditionsSets, workerSid, isSupervisor, expectedResult }) => {
       const rules = buildRules(conditionsSets);
       jest.spyOn(fetchRulesModule, 'fetchRules').mockReturnValueOnce(rules);

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -320,7 +320,7 @@ const Case: React.FC<Props> = ({
 
     const renderCaseItemPage = (
       sectionApi: CaseSectionApi<unknown>,
-      editPermission: string,
+      editPermission: typeof PermissionActions[keyof typeof PermissionActions],
       extraAddEditProps: Partial<AddEditCaseItemProps> = {},
     ) => {
       if (isViewCaseSectionRoute(routing)) {

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -141,13 +141,17 @@ const ContactDetailsHome: React.FC<Props> = function ({
   );
 
   const twilioStoredTranscript =
-    featureFlags.enable_twilio_transcripts && savedContact.details.conversationMedia?.find(isTwilioStoredMedia);
+    featureFlags.enable_twilio_transcripts &&
+    canViewTwilioTranscript &&
+    savedContact.details.conversationMedia?.find(isTwilioStoredMedia);
   const externalStoredTranscript =
-    featureFlags.enable_external_transcripts && savedContact.details.conversationMedia?.find(isS3StoredTranscript);
+    featureFlags.enable_external_transcripts &&
+    can(PermissionActions.VIEW_EXTERNAL_TRANSCRIPT) &&
+    savedContact.details.conversationMedia?.find(isS3StoredTranscript);
   const showTranscriptSection = Boolean(
     isChatChannel(channel) &&
       savedContact.details.conversationMedia?.length &&
-      ((canViewTwilioTranscript && twilioStoredTranscript) || externalStoredTranscript),
+      (twilioStoredTranscript || externalStoredTranscript),
   );
 
   return (

--- a/plugin-hrm-form/src/permissions/br.json
+++ b/plugin-hrm-form/src/permissions/br.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/ca.json
+++ b/plugin-hrm-form/src/permissions/ca.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/cl.json
+++ b/plugin-hrm-form/src/permissions/cl.json
@@ -18,5 +18,6 @@
 "editChildIsAtRisk":  [["everyone"]],
 "editFollowUpDate":  [["everyone"]],
 "editContact":  [["everyone"]],
-"viewPostSurvey":  [["isSupervisor"]]
+"viewPostSurvey":  [["isSupervisor"]],
+"viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/co.json
+++ b/plugin-hrm-form/src/permissions/co.json
@@ -18,5 +18,6 @@
 "editChildIsAtRisk":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editFollowUpDate":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editContact":  [["isSupervisor"],["isOwner"]],
-"viewPostSurvey": [["isSupervisor"]]
+"viewPostSurvey": [["isSupervisor"]],
+"viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/demo.json
+++ b/plugin-hrm-form/src/permissions/demo.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"], ["isOwner"]]
+  "editContact": [["isSupervisor"], ["isOwner"]],
+  "viewExternalTranscript": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/dev.json
+++ b/plugin-hrm-form/src/permissions/dev.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"], ["isOwner"]]
+  "editContact": [["isSupervisor"], ["isOwner"]],
+  "viewExternalTranscript": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/e2e.json
+++ b/plugin-hrm-form/src/permissions/e2e.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"], ["isOwner"]]
+  "editContact": [["isSupervisor"], ["isOwner"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/et.json
+++ b/plugin-hrm-form/src/permissions/et.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/hu.json
+++ b/plugin-hrm-form/src/permissions/hu.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"], ["isOwner"]]
+  "editContact": [["isSupervisor"], ["isOwner"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/in.json
+++ b/plugin-hrm-form/src/permissions/in.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"], ["isCreator", "isCaseOpen"]]
+  "editContact": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -2,7 +2,7 @@ import { getConfig } from '../HrmFormPlugin';
 import type * as t from '../types/types';
 import { fetchRules } from './fetchRules';
 
-export const PermissionActions = {
+export const CaseActions = {
   CLOSE_CASE: 'closeCase',
   REOPEN_CASE: 'reopenCase',
   CASE_STATUS_TRANSITION: 'caseStatusTransition',
@@ -21,8 +21,16 @@ export const PermissionActions = {
   EDIT_PERPETRATOR: 'editPerpetrator',
   EDIT_INCIDENT: 'editIncident',
   EDIT_DOCUMENT: 'editDocument',
+} as const;
+export const ContactActions = {
   EDIT_CONTACT: 'editContact',
-};
+  VIEW_EXTERNAL_TRANSCRIPT: 'viewExternalTranscript',
+} as const;
+
+export const PermissionActions = {
+  ...CaseActions,
+  ...ContactActions,
+} as const;
 
 type PermissionActionsKeys = keyof typeof PermissionActions;
 export type PermissionActionType = typeof PermissionActions[PermissionActionsKeys];

--- a/plugin-hrm-form/src/permissions/jm.json
+++ b/plugin-hrm-form/src/permissions/jm.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/mw.json
+++ b/plugin-hrm-form/src/permissions/mw.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/ph.json
+++ b/plugin-hrm-form/src/permissions/ph.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/pl.json
+++ b/plugin-hrm-form/src/permissions/pl.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/ro.json
+++ b/plugin-hrm-form/src/permissions/ro.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"], ["isOwner"]]
+  "editContact": [["isSupervisor"], ["isOwner"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/th.json
+++ b/plugin-hrm-form/src/permissions/th.json
@@ -18,5 +18,6 @@
 "editChildIsAtRisk":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editFollowUpDate":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editContact":  [["isSupervisor"],["isOwner"]],
-"viewPostSurvey":  [["isSupervisor"]]
+"viewPostSurvey":  [["isSupervisor"]],
+"viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/uk.json
+++ b/plugin-hrm-form/src/permissions/uk.json
@@ -19,5 +19,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/za.json
+++ b/plugin-hrm-form/src/permissions/za.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/plugin-hrm-form/src/permissions/zm.json
+++ b/plugin-hrm-form/src/permissions/zm.json
@@ -17,5 +17,6 @@
   "editCaseSummary": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "editContact": [["isSupervisor"]]
+  "editContact": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand or @murilovmachado 

## Description
This PR adds `viewExternalTranscript` permission based behavior to decide if a worker should be able to see external transcripts for a given contact or not.
This PR is not really needed as permissions for this should be addressed [in the hrm side](https://github.com/techmatters/hrm/pull/254), but it ain't hurt right?

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1102)
- [ ] New tests added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- `npm run dev`
- Search for the contact with first name `Transcript`.
- Confirm that using `dev` permissions you can see the transcript.
- Change the rule `viewExternalTranscript` to `[]` (empty array, a.k.a. no one is allowed).
- Check that you can't access the transcript for the same contact.