### PR TITLE
UI styling for external transcript viewing

### DIFF
--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -5,6 +5,7 @@ import { Actions, Insights, Template } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 import { callTypes } from 'hrm-form-definitions';
 
+import { Flex } from '../../styles/HrmStyles';
 import { isS3StoredTranscript, isTwilioStoredMedia } from '../../types/types';
 import {
   DetailsContainer,
@@ -299,12 +300,14 @@ const ContactDetailsHome: React.FC<Props> = function ({
           buttonDataTestid="ContactDetails-Section-Transcript"
           showEditButton={false}
         >
-          <TranscriptSection
-            contactId={contactId}
-            twilioStoredTranscript={twilioStoredTranscript}
-            externalStoredTranscript={externalStoredTranscript}
-            loadConversationIntoOverlay={loadConversationIntoOverlay}
-          />
+          <Flex justifyContent="center" flexDirection="row" paddingTop="20px">
+            <TranscriptSection
+              contactId={contactId}
+              twilioStoredTranscript={twilioStoredTranscript}
+              externalStoredTranscript={externalStoredTranscript}
+              loadConversationIntoOverlay={loadConversationIntoOverlay}
+            />
+          </Flex>
         </ContactDetailsSection>
       )}
     </DetailsContainer>

--- a/plugin-hrm-form/src/components/contact/MessageItem.tsx
+++ b/plugin-hrm-form/src/components/contact/MessageItem.tsx
@@ -32,7 +32,9 @@ const MessageItem: React.FC<Props> = ({ isCounsellor, isGroupedWithPrevious, mes
       <MessageBubbleContainer isCounsellor={isCounsellor}>
         <MessageBubleInnerContainer>
           <MessageBubbleHeader>
-            <MessageBubbleNameText isCounsellor={isCounsellor}>{message.from}</MessageBubbleNameText>
+            <MessageBubbleNameText isCounsellor={isCounsellor}>
+              {message.friendlyName || message.from}
+            </MessageBubbleNameText>
             <MessageBubbleDateText isCounsellor={isCounsellor}>
               {format(new Date(message.dateCreated), 'hh:mm a')}
             </MessageBubbleDateText>

--- a/plugin-hrm-form/src/components/contact/MessageItem.tsx
+++ b/plugin-hrm-form/src/components/contact/MessageItem.tsx
@@ -16,31 +16,31 @@ import {
 import { TranscriptMessage } from '../../states/contacts/existingContacts';
 
 type Props = {
-  isCounsellor: boolean;
+  isCounselor: boolean;
   isGroupedWithPrevious: boolean;
   message: TranscriptMessage;
 };
 
-const MessageItem: React.FC<Props> = ({ isCounsellor, isGroupedWithPrevious, message }) => {
+const MessageItem: React.FC<Props> = ({ isCounselor, isGroupedWithPrevious, message }) => {
   return (
-    <MessageItemContainer isCounsellor={isCounsellor} isGroupedWithPrevious={isGroupedWithPrevious}>
-      {!isCounsellor && (
+    <MessageItemContainer isCounselor={isCounselor} isGroupedWithPrevious={isGroupedWithPrevious}>
+      {!isCounselor && (
         <AvatarContainer isGroupedWithPrevious={isGroupedWithPrevious}>
           {!isGroupedWithPrevious && <Icon icon="DefaultAvatar" />}
         </AvatarContainer>
       )}
-      <MessageBubbleContainer isCounsellor={isCounsellor}>
+      <MessageBubbleContainer isCounselor={isCounselor}>
         <MessageBubleInnerContainer>
           <MessageBubbleHeader>
-            <MessageBubbleNameText isCounsellor={isCounsellor}>
+            <MessageBubbleNameText isCounselor={isCounselor}>
               {message.friendlyName || message.from}
             </MessageBubbleNameText>
-            <MessageBubbleDateText isCounsellor={isCounsellor}>
+            <MessageBubbleDateText isCounselor={isCounselor}>
               {format(new Date(message.dateCreated), 'hh:mm a')}
             </MessageBubbleDateText>
           </MessageBubbleHeader>
           <MessageBubbleBody>
-            <MessageBubbleBodyText isCounsellor={isCounsellor}>{message.body}</MessageBubbleBodyText>
+            <MessageBubbleBodyText isCounselor={isCounselor}>{message.body}</MessageBubbleBodyText>
           </MessageBubbleBody>
         </MessageBubleInnerContainer>
       </MessageBubbleContainer>

--- a/plugin-hrm-form/src/components/contact/MessageItem.tsx
+++ b/plugin-hrm-form/src/components/contact/MessageItem.tsx
@@ -34,7 +34,7 @@ const MessageItem: React.FC<Props> = ({ isCounsellor, isGroupedWithPrevious, mes
           <MessageBubbleHeader>
             <MessageBubbleNameText isCounsellor={isCounsellor}>{message.from}</MessageBubbleNameText>
             <MessageBubbleDateText isCounsellor={isCounsellor}>
-              {format(new Date(message.dateCreated), 'h:mm a..aaa')}
+              {format(new Date(message.dateCreated), 'hh:mm a')}
             </MessageBubbleDateText>
           </MessageBubbleHeader>
           <MessageBubbleBody>

--- a/plugin-hrm-form/src/components/contact/MessageItem.tsx
+++ b/plugin-hrm-form/src/components/contact/MessageItem.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Icon } from '@twilio/flex-ui';
+import format from 'date-fns/format';
+
+import {
+  MessageItemContainer,
+  MessageBubbleContainer,
+  MessageBubbleBody,
+  MessageBubbleHeader,
+  AvatarContainer,
+  MessageBubleInnerContainer,
+  MessageBubbleNameText,
+  MessageBubbleDateText,
+  MessageBubbleBodyText,
+} from './TranscriptSection.styles';
+import { TranscriptMessage } from '../../states/contacts/existingContacts';
+
+type Props = {
+  isCounsellor: boolean;
+  isGroupedWithPrevious: boolean;
+  message: TranscriptMessage;
+};
+
+const MessageItem: React.FC<Props> = ({ isCounsellor, isGroupedWithPrevious, message }) => {
+  return (
+    <MessageItemContainer isCounsellor={isCounsellor} isGroupedWithPrevious={isGroupedWithPrevious}>
+      {!isCounsellor && (
+        <AvatarContainer isGroupedWithPrevious={isGroupedWithPrevious}>
+          {!isGroupedWithPrevious && <Icon icon="DefaultAvatar" />}
+        </AvatarContainer>
+      )}
+      <MessageBubbleContainer isCounsellor={isCounsellor}>
+        <MessageBubleInnerContainer>
+          <MessageBubbleHeader>
+            <MessageBubbleNameText isCounsellor={isCounsellor}>{message.from}</MessageBubbleNameText>
+            <MessageBubbleDateText isCounsellor={isCounsellor}>
+              {format(new Date(message.dateCreated), 'h:mm a..aaa')}
+            </MessageBubbleDateText>
+          </MessageBubbleHeader>
+          <MessageBubbleBody>
+            <MessageBubbleBodyText isCounsellor={isCounsellor}>{message.body}</MessageBubbleBodyText>
+          </MessageBubbleBody>
+        </MessageBubleInnerContainer>
+      </MessageBubbleContainer>
+    </MessageItemContainer>
+  );
+};
+
+export default MessageItem;

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
@@ -1,49 +1,129 @@
 import { styled } from '@twilio/flex-ui';
 
-import { FontOpenSans } from '../../styles/HrmStyles';
+import { sectionTitleFontStyle } from '../../styles/search';
+import { FontOpenSans, Row } from '../../styles/HrmStyles';
 
 export const ItalicFont = styled(FontOpenSans)`
   font-size: 12px;
   font-style: italic;
   line-height: 17px;
 `;
+ItalicFont.displayName = 'ItalicFont';
+
+export const LoadTranscriptButton = styled('button')`
+  height: 28px;
+  width: 30%;
+  background-color: ${props => (props.theme.colors as any).secondaryButtonColor};
+  border-radius: 4px;
+  border-style: none;
+`;
+
+export const LoadTranscriptButtonText = styled(FontOpenSans)`
+  ${sectionTitleFontStyle}
+  text-align: center;
+`;
+LoadTranscriptButtonText.displayName = 'LoadTranscriptButtonText';
 
 export const MessageList = styled('div')`
   display: flex;
   flex-direction: column;
   align-items: center;
   margin: 6px 0;
+  padding: 0 3.75%;
+  padding-bottom: 50px;
   width: 100%;
 `;
 MessageList.displayName = 'MessageList';
 
+export const MessageItemContainer = styled(Row)<{ isCounsellor: boolean; isGroupedWithPrevious: boolean }>`
+  flex-wrap: nowrap;
+  width: 100%;
+  align-items: start;
+  padding: 0 15px;
+  margin-top: ${({ isGroupedWithPrevious }) => (isGroupedWithPrevious ? '4px' : '20px')};
+`;
+MessageItemContainer.displayName = 'MessageItemContainer';
+
 type MessageBubbleProps = {
-  isFromMe: boolean;
+  isCounsellor: boolean;
 };
-export const MessageBubble = styled('div')<MessageBubbleProps>`
-  display: flex;
-  flex-direction: column;
-  width: 50%;
-  margin-top: 5px;
-  margin-bottom: 5px;
+// width: 50%;
+export const MessageBubbleContainer = styled(Row)<MessageBubbleProps>`
   border-radius: 4px;
-  border-style: solid;
   border-width: 1px;
   padding: 3px;
-  ${p => (p.isFromMe ? 'margin-left: auto;' : 'margin-right: auto;')}
-  ${p => (p.isFromMe ? 'border-color: blue;' : 'border-color: black;')}
-  ${p => (p.isFromMe ? 'align-items: right;' : 'align-items: left;')}
+  overflow: hidden;
+  ${p => (p.isCounsellor ? 'margin-left: auto;' : 'margin-right: auto;')}
+  ${p => (p.isCounsellor ? 'border-color: blue;' : 'border-color: black;')}
+  ${p => (p.isCounsellor ? 'align-items: right;' : 'align-items: left;')}
+  background-color: ${props => (props.isCounsellor ? '#057d9e' : props.theme.colors.base2)};
 `;
+MessageBubbleContainer.displayName = 'MessageBubbleContainer';
+
+export const MessageBubleInnerContainer = styled('div')`
+  display: flex;
+  flex-flow: column nowrap;
+  flex:grow: 1;
+  flex-shrink: 1;
+  padding: 0 12px 8px 12px;
+  `;
+MessageBubleInnerContainer.displayName = 'MessageBubleInnerContainer';
 
 export const MessageBubbleHeader = styled('div')`
   display: flex;
   flex-direction: row;
-  font-size: 12px;
-  font-weight: 600;
+  justify-content: space-between;
 `;
+MessageBubbleHeader.displayName = 'MessageBubbleHeader';
+
+export const MessageBubbleNameText = styled(FontOpenSans)<{ isCounsellor: boolean }>`
+  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 700;
+  margin-right: 8px;
+  color: ${({ isCounsellor }) => (isCounsellor ? '#FFFFFF' : '#222222')};
+`;
+
+export const MessageBubbleDateText = styled(FontOpenSans)<{ isCounsellor: boolean }>`
+  white-space: nowrap;
+  font-size: 10px;
+  color: ${({ isCounsellor }) => (isCounsellor ? '#FFFFFF' : '#222222')};
+`;
+MessageBubbleDateText.displayName = 'MessageBubbleDateText';
 
 export const MessageBubbleBody = styled('div')`
   display: flex;
-  font-size: 12px;
-  font-weight: 500;
+  margin-top: 3px;
+  overflow-wrap: break-word;
+  max-width: 440px;
+  min-width: 100px;
 `;
+MessageBubbleBody.displayName = 'MessageBubbleBody';
+
+export const MessageBubbleBodyText = styled(FontOpenSans)<{ isCounsellor: boolean }>`
+  font-size: 12px;
+  line-height: 1.54;
+  overflow-wrap: break-word;
+  color: ${({ isCounsellor }) => (isCounsellor ? '#FFFFFF' : '#222222')};
+`;
+MessageBubbleBodyText.displayName = 'MessageBubbleBodyText';
+/*
+ * padding-bottom: 8px;
+ *   padding-left: 12px;
+ *   padding-right: 12px;
+ *   margin-top: 3px;
+ */
+
+export const AvatarContainer = styled('div')<{ isGroupedWithPrevious: boolean }>`
+  margin-right: 12px;
+  width: 24px;
+  heigth: 24px;
+  border-radius: 18px;
+  background: ${props => (props.isGroupedWithPrevious ? 'transparent' : props.theme.colors.base2)};
+`;
+AvatarContainer.displayName = 'AvatarContainer';
+
+/*
+ * ${({ isCounsellor }) => isCounsellor && 'padding-: auto;'}
+ * ${({ isCounsellor }) => isCounsellor && 'padding-right: auto;'}
+ */

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
@@ -113,3 +113,30 @@ export const AvatarContainer = styled('div')<{ isGroupedWithPrevious: boolean }>
   background: ${props => (props.isGroupedWithPrevious ? 'transparent' : props.theme.colors.base2)};
 `;
 AvatarContainer.displayName = 'AvatarContainer';
+
+export const DateRulerContainer = styled('div')`
+  display: flex;
+  flex-flow: row nowrap;
+  -webkit-box-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  width: 100%;
+`;
+DateRulerContainer.displayName = 'DateRulerContainer';
+
+export const DateRulerHr = styled('hr')`
+  flex: 1 1 1px;
+  margin: auto;
+  border-color: rgb(198, 202, 215);
+`;
+DateRulerHr.displayName = 'DateRulerHr';
+
+export const DateRulerDateText = styled(FontOpenSans)`
+  flex: 0 1 auto;
+  margin-left: 12px;
+  margin-right: 12px;
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: rgb(34, 34, 34);
+`;
+DateRulerDateText.displayName = 'DateRulerDateText';

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
@@ -47,16 +47,14 @@ MessageItemContainer.displayName = 'MessageItemContainer';
 type MessageBubbleProps = {
   isCounsellor: boolean;
 };
-// width: 50%;
+
 export const MessageBubbleContainer = styled(Row)<MessageBubbleProps>`
   border-radius: 4px;
-  border-width: 1px;
-  padding: 3px;
   overflow: hidden;
   ${p => (p.isCounsellor ? 'margin-left: auto;' : 'margin-right: auto;')}
-  ${p => (p.isCounsellor ? 'border-color: blue;' : 'border-color: black;')}
-  ${p => (p.isCounsellor ? 'align-items: right;' : 'align-items: left;')}
+  align-items: ${p => (p.isCounsellor ? 'right' : 'left')};
   background-color: ${props => (props.isCounsellor ? '#057d9e' : props.theme.colors.base2)};
+  padding: 5px 12px 8px 12px;
 `;
 MessageBubbleContainer.displayName = 'MessageBubbleContainer';
 
@@ -65,8 +63,7 @@ export const MessageBubleInnerContainer = styled('div')`
   flex-flow: column nowrap;
   flex:grow: 1;
   flex-shrink: 1;
-  padding: 0 12px 8px 12px;
-  `;
+`;
 MessageBubleInnerContainer.displayName = 'MessageBubleInnerContainer';
 
 export const MessageBubbleHeader = styled('div')`
@@ -107,12 +104,6 @@ export const MessageBubbleBodyText = styled(FontOpenSans)<{ isCounsellor: boolea
   color: ${({ isCounsellor }) => (isCounsellor ? '#FFFFFF' : '#222222')};
 `;
 MessageBubbleBodyText.displayName = 'MessageBubbleBodyText';
-/*
- * padding-bottom: 8px;
- *   padding-left: 12px;
- *   padding-right: 12px;
- *   margin-top: 3px;
- */
 
 export const AvatarContainer = styled('div')<{ isGroupedWithPrevious: boolean }>`
   margin-right: 12px;
@@ -122,8 +113,3 @@ export const AvatarContainer = styled('div')<{ isGroupedWithPrevious: boolean }>
   background: ${props => (props.isGroupedWithPrevious ? 'transparent' : props.theme.colors.base2)};
 `;
 AvatarContainer.displayName = 'AvatarContainer';
-
-/*
- * ${({ isCounsellor }) => isCounsellor && 'padding-: auto;'}
- * ${({ isCounsellor }) => isCounsellor && 'padding-right: auto;'}
- */

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.styles.tsx
@@ -35,7 +35,7 @@ export const MessageList = styled('div')`
 `;
 MessageList.displayName = 'MessageList';
 
-export const MessageItemContainer = styled(Row)<{ isCounsellor: boolean; isGroupedWithPrevious: boolean }>`
+export const MessageItemContainer = styled(Row)<{ isCounselor: boolean; isGroupedWithPrevious: boolean }>`
   flex-wrap: nowrap;
   width: 100%;
   align-items: start;
@@ -45,15 +45,15 @@ export const MessageItemContainer = styled(Row)<{ isCounsellor: boolean; isGroup
 MessageItemContainer.displayName = 'MessageItemContainer';
 
 type MessageBubbleProps = {
-  isCounsellor: boolean;
+  isCounselor: boolean;
 };
 
 export const MessageBubbleContainer = styled(Row)<MessageBubbleProps>`
   border-radius: 4px;
   overflow: hidden;
-  ${p => (p.isCounsellor ? 'margin-left: auto;' : 'margin-right: auto;')}
-  align-items: ${p => (p.isCounsellor ? 'right' : 'left')};
-  background-color: ${props => (props.isCounsellor ? '#057d9e' : props.theme.colors.base2)};
+  ${p => (p.isCounselor ? 'margin-left: auto;' : 'margin-right: auto;')}
+  align-items: ${p => (p.isCounselor ? 'right' : 'left')};
+  background-color: ${props => (props.isCounselor ? '#057d9e' : props.theme.colors.base2)};
   padding: 5px 12px 8px 12px;
 `;
 MessageBubbleContainer.displayName = 'MessageBubbleContainer';
@@ -73,18 +73,18 @@ export const MessageBubbleHeader = styled('div')`
 `;
 MessageBubbleHeader.displayName = 'MessageBubbleHeader';
 
-export const MessageBubbleNameText = styled(FontOpenSans)<{ isCounsellor: boolean }>`
+export const MessageBubbleNameText = styled(FontOpenSans)<{ isCounselor: boolean }>`
   white-space: nowrap;
   font-size: 10px;
   font-weight: 700;
   margin-right: 8px;
-  color: ${({ isCounsellor }) => (isCounsellor ? '#FFFFFF' : '#222222')};
+  color: ${({ isCounselor }) => (isCounselor ? '#FFFFFF' : '#222222')};
 `;
 
-export const MessageBubbleDateText = styled(FontOpenSans)<{ isCounsellor: boolean }>`
+export const MessageBubbleDateText = styled(FontOpenSans)<{ isCounselor: boolean }>`
   white-space: nowrap;
   font-size: 10px;
-  color: ${({ isCounsellor }) => (isCounsellor ? '#FFFFFF' : '#222222')};
+  color: ${({ isCounselor }) => (isCounselor ? '#FFFFFF' : '#222222')};
 `;
 MessageBubbleDateText.displayName = 'MessageBubbleDateText';
 
@@ -97,11 +97,11 @@ export const MessageBubbleBody = styled('div')`
 `;
 MessageBubbleBody.displayName = 'MessageBubbleBody';
 
-export const MessageBubbleBodyText = styled(FontOpenSans)<{ isCounsellor: boolean }>`
+export const MessageBubbleBodyText = styled(FontOpenSans)<{ isCounselor: boolean }>`
   font-size: 12px;
   line-height: 1.54;
   overflow-wrap: break-word;
-  color: ${({ isCounsellor }) => (isCounsellor ? '#FFFFFF' : '#222222')};
+  color: ${({ isCounselor }) => (isCounselor ? '#FFFFFF' : '#222222')};
 `;
 MessageBubbleBodyText.displayName = 'MessageBubbleBodyText';
 

--- a/plugin-hrm-form/src/components/contact/TranscriptSection.tsx
+++ b/plugin-hrm-form/src/components/contact/TranscriptSection.tsx
@@ -59,7 +59,7 @@ const renderGroupedMessages = (groupedMessages: TranscriptMessagesGrouped) =>
         <MessageItem
           key={m.sid}
           message={m}
-          isCounsellor={m.isCounsellor}
+          isCounselor={m.isCounselor}
           isGroupedWithPrevious={m.isGroupedWithPrevious}
         />
       )),

--- a/plugin-hrm-form/src/states/contacts/existingContacts.ts
+++ b/plugin-hrm-form/src/states/contacts/existingContacts.ts
@@ -22,6 +22,8 @@ export type TranscriptMessage = {
   sid: string;
   dateCreated: Date;
   from: string;
+  friendlyName?: string;
+  isCounsellor: boolean;
   body: string;
   index: number;
   type: string;

--- a/plugin-hrm-form/src/states/contacts/existingContacts.ts
+++ b/plugin-hrm-form/src/states/contacts/existingContacts.ts
@@ -23,7 +23,7 @@ export type TranscriptMessage = {
   dateCreated: Date;
   from: string;
   friendlyName?: string;
-  isCounsellor: boolean;
+  isCounselor: boolean;
   body: string;
   index: number;
   type: string;

--- a/plugin-hrm-form/src/states/contacts/existingContacts.ts
+++ b/plugin-hrm-form/src/states/contacts/existingContacts.ts
@@ -18,7 +18,7 @@ type RecursivePartial<T> = {
 export type SearchContactDraftChanges = RecursivePartial<SearchContact>;
 
 // TODO: Update this type when the Lambda worker is "done"
-type TranscriptMessage = {
+export type TranscriptMessage = {
   sid: string;
   dateCreated: Date;
   from: string;

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -391,10 +391,13 @@ export const ContactAddedFont = styled(FontOpenSans)`
 `;
 ContactAddedFont.displayName = 'ContactAddedFont';
 
-export const SectionTitleText = styled(FontOpenSans)`
+export const sectionTitleFontStyle = `
   font-size: 12px;
   font-weight: 600;
   line-height: 13px;
+`;
+export const SectionTitleText = styled(FontOpenSans)`
+  ${sectionTitleFontStyle}
   margin-right: auto;
 `;
 SectionTitleText.displayName = 'SectionTitleText';


### PR DESCRIPTION
Primary reviewer: @mythilytm or @murilovmachado ?

## Description
This PR adds styles to kinda-match the Twilio ones when viewing external transcripts.

NOTE: There's one subtle detail that I have not addressed in this PR (kinda realized this just now), that is the missing "horizontal ruler with date" displayed in the Twilio chat. I'll add this one in a subsequent PR as that needs some extra handling of the messages list, but I'd like to get some early feedback on this styles if possible.

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1343)
- [ ] New tests added
- [x] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- `npm run dev`.
- Search for the contacts that have first name "Transcript".
- Open the one that contains an external transcript, and load.
- Compare the UI styles with the ones provided in the mocks.
- Play with the different places where we can search contacts.