### PR TITLE
Implement permissions configuration for masking PII 

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -15,14 +15,11 @@ import { changeLanguage } from './states/configuration/actions';
 import { issueSyncToken } from './services/ServerlessService';
 import { getPermissionsForMasking, PermissionActions } from './permissions';
 
-
 const PLUGIN_NAME = 'HrmFormPlugin';
 
 export const DEFAULT_TRANSFER_MODE = transferModes.cold;
 
 let sharedStateClient: SyncClient;
-
-// const maskIdentifiers = false;
 
 const readConfig = () => {
   const manager = Flex.Manager.getInstance();
@@ -192,7 +189,7 @@ const setUpComponents = (setupObject: SetupObject) => {
 
   if (maskIdentifiers) {
     const { strings } = getConfig();
-    Components.maskIdentifiersForDefaultChannels()
+    Components.maskIdentifiersForDefaultChannels();
     strings.TaskInfoPanelContent = strings.TaskInfoPanelContentMasked;
     Flex.MessagingCanvas.defaultProps.memberDisplayOptions = {
       theirDefaultName: 'XXXXXX',

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -13,7 +13,7 @@ import setUpMonitoring from './utils/setUpMonitoring';
 import * as TransferHelpers from './utils/transfer';
 import { changeLanguage } from './states/configuration/actions';
 import { issueSyncToken } from './services/ServerlessService';
-import { getPermissionsForMasking, PermissionActions } from './permissions';
+import { getPermissionsForViewingIdentifiers, PermissionActions } from './permissions';
 
 const PLUGIN_NAME = 'HrmFormPlugin';
 
@@ -154,8 +154,8 @@ const setUpLocalization = (config: ReturnType<typeof getConfig>) => {
 
 const setUpComponents = (setupObject: SetupObject) => {
   const { helpline, featureFlags } = setupObject;
-  const { mask } = getPermissionsForMasking();
-  const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
+  const { canView } = getPermissionsForViewingIdentifiers();
+  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
   // setUp (add) dynamic components
   Components.setUpQueuesStatusWriter(setupObject);

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -13,6 +13,8 @@ import setUpMonitoring from './utils/setUpMonitoring';
 import * as TransferHelpers from './utils/transfer';
 import { changeLanguage } from './states/configuration/actions';
 import { issueSyncToken } from './services/ServerlessService';
+import { getPermissionsForMasking, PermissionActions } from './permissions';
+
 
 const PLUGIN_NAME = 'HrmFormPlugin';
 
@@ -20,7 +22,7 @@ export const DEFAULT_TRANSFER_MODE = transferModes.cold;
 
 let sharedStateClient: SyncClient;
 
-const maskIdentifiers = false;
+// const maskIdentifiers = false;
 
 const readConfig = () => {
   const manager = Flex.Manager.getInstance();
@@ -155,6 +157,8 @@ const setUpLocalization = (config: ReturnType<typeof getConfig>) => {
 
 const setUpComponents = (setupObject: SetupObject) => {
   const { helpline, featureFlags } = setupObject;
+  const { mask } = getPermissionsForMasking();
+  const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
 
   // setUp (add) dynamic components
   Components.setUpQueuesStatusWriter(setupObject);
@@ -162,9 +166,9 @@ const setUpComponents = (setupObject: SetupObject) => {
   Components.setUpAddButtons(setupObject);
   Components.setUpNoTasksUI(setupObject);
   Components.setUpCustomCRMContainer();
-  Components.setupTwitterChatChannel();
-  Components.setupInstagramChatChannel();
-  Components.setupLineChatChannel();
+  Components.setupTwitterChatChannel(maskIdentifiers);
+  Components.setupInstagramChatChannel(maskIdentifiers);
+  Components.setupLineChatChannel(maskIdentifiers);
   if (featureFlags.enable_transfers) {
     Components.setUpTransferComponents();
     Components.setUpIncomingTransferMessage();
@@ -188,6 +192,7 @@ const setUpComponents = (setupObject: SetupObject) => {
 
   if (maskIdentifiers) {
     const { strings } = getConfig();
+    Components.maskIdentifiersForDefaultChannels()
     strings.TaskInfoPanelContent = strings.TaskInfoPanelContentMasked;
     Flex.MessagingCanvas.defaultProps.memberDisplayOptions = {
       theirDefaultName: 'XXXXXX',

--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -14,7 +14,7 @@ jest.mock('../../components/CSAMReport/CSAMReportFormDefinition');
 
 jest.mock('../../permissions', () => ({
   getPermissionsForViewingIdentifiers: jest.fn(() => ({
-    mask: () => true,
+    canView: () => true,
   })),
   PermissionActions: {},
 }));

--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -8,8 +8,16 @@ import '../mockStyled';
 import { UnconnectedPreviousContactsBanner } from '../../components/PreviousContactsBanner';
 import { channelTypes } from '../../states/DomainConstants';
 import { SearchPages } from '../../states/search/types';
+import { mockPartialConfiguration } from '../mockGetConfig';
 
 jest.mock('../../components/CSAMReport/CSAMReportFormDefinition');
+
+jest.mock('../../permissions', () => ({
+  getPermissionsForMasking: jest.fn(() => ({
+    mask: () => true,
+  })),
+  PermissionActions: {},
+}));
 
 expect.extend(toHaveNoViolations);
 

--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -13,7 +13,7 @@ import { mockPartialConfiguration } from '../mockGetConfig';
 jest.mock('../../components/CSAMReport/CSAMReportFormDefinition');
 
 jest.mock('../../permissions', () => ({
-  getPermissionsForMasking: jest.fn(() => ({
+  getPermissionsForViewingIdentifiers: jest.fn(() => ({
     mask: () => true,
   })),
   PermissionActions: {},

--- a/plugin-hrm-form/src/___tests__/mockGetConfig.ts
+++ b/plugin-hrm-form/src/___tests__/mockGetConfig.ts
@@ -28,6 +28,7 @@ const baseMockConfig = {
     enable_transfers: true,
     enable_save_insights: true,
   },
+  isSupervisor: false,
 };
 
 const mockGetConfig = jest.fn(() => baseMockConfig);

--- a/plugin-hrm-form/src/___tests__/permissions/index.test.js
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.js
@@ -9,7 +9,7 @@ import {
   PermissionActions,
   CaseActions,
   ContactActions,
-  ViewIdentifiersAction
+  ViewIdentifiersAction,
 } from '../../permissions';
 
 jest.mock('../../HrmFormPlugin');
@@ -233,8 +233,7 @@ describe('Test different scenarios (all ContactActions)', () => {
 describe('Test different scenarios for ViewIdentifiersAction', () => {
   each(
     Object.values(ViewIdentifiersAction)
-      .flatMap(
-        action => [
+      .flatMap(action => [
         {
           action,
           conditionsSets: [['everyone']],

--- a/plugin-hrm-form/src/___tests__/permissions/index.test.js
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.js
@@ -5,9 +5,11 @@ import * as fetchRulesModule from '../../permissions/fetchRules';
 import {
   getPermissionsForCase,
   getPermissionsForContact,
+  getPermissionsForViewingIdentifiers,
   PermissionActions,
   CaseActions,
   ContactActions,
+  ViewIdentifiersAction
 } from '../../permissions';
 
 jest.mock('../../HrmFormPlugin');
@@ -225,6 +227,65 @@ describe('Test different scenarios (all ContactActions)', () => {
       const { can } = getPermissionsForContact('owner');
 
       expect(can(action)).toBe(expectedResult);
+    },
+  );
+});
+describe('Test different scenarios for ViewIdentifiersAction', () => {
+  each(
+    Object.values(ViewIdentifiersAction)
+      .flatMap(
+        action => [
+        {
+          action,
+          conditionsSets: [['everyone']],
+          isSupervisor: false,
+          expectedResult: true,
+          expectedDescription: 'is not a supervisor',
+        },
+        {
+          action,
+          conditionsSets: [],
+          isSupervisor: true,
+          expectedResult: false,
+          expectedDescription: 'user is supervisor',
+        },
+        {
+          action,
+          conditionsSets: [],
+          isSupervisor: false,
+          expectedResult: false,
+          expectedDescription: 'user is not a supervisor',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor']],
+          isSupervisor: true,
+          expectedResult: true,
+          expectedDescription: 'user is a supervisor',
+        },
+        {
+          action,
+          conditionsSets: [['isSupervisor']],
+          isSupervisor: false,
+          expectedResult: false,
+          expectedDescription: 'user is not a supervisor',
+        },
+      ])
+      .map(t => ({ ...t, prettyConditionsSets: t.conditionsSets.map(arr => `[${arr.join(',')}]`) })),
+  ).test(
+    `Should return $expectedResult for action $action when $expectedDescription and conditionsSets are $prettyConditionsSets`,
+    ({ action, conditionsSets, isSupervisor, expectedResult }) => {
+      const rules = buildRules(conditionsSets);
+      jest.spyOn(fetchRulesModule, 'fetchRules').mockReturnValueOnce(rules);
+
+      getConfig.mockReturnValueOnce({
+        isSupervisor,
+        permissionConfig: 'wareva',
+      });
+
+      const { canView } = getPermissionsForViewingIdentifiers();
+
+      expect(canView(action)).toBe(expectedResult);
     },
   );
 });

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -17,6 +17,7 @@ import { StyledLink } from '../styles/search';
 import { ChannelTypes, channelTypes } from '../states/DomainConstants';
 import { changeRoute as changeRouteAction } from '../states/routing/actions';
 import { getFormattedNumberFromTask, getNumberFromTask } from '../utils/task';
+import { getPermissionsForMasking, PermissionActions } from '../permissions';
 
 type OwnProps = {
   task: CustomITask;
@@ -46,7 +47,8 @@ const PreviousContactsBanner: React.FC<Props> = ({
   changeRoute,
   editContactFormOpen,
 }) => {
-  const maskIdentifiers = false;
+  const { mask } = getPermissionsForMasking();
+  const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
 
   useEffect(() => {
     if (isTwilioTask(task) && previousContacts === undefined) {

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -17,7 +17,7 @@ import { StyledLink } from '../styles/search';
 import { ChannelTypes, channelTypes } from '../states/DomainConstants';
 import { changeRoute as changeRouteAction } from '../states/routing/actions';
 import { getFormattedNumberFromTask, getNumberFromTask } from '../utils/task';
-import { getPermissionsForMasking, PermissionActions } from '../permissions';
+import { getPermissionsForViewingIdentifiers, PermissionActions } from '../permissions';
 
 type OwnProps = {
   task: CustomITask;
@@ -47,8 +47,8 @@ const PreviousContactsBanner: React.FC<Props> = ({
   changeRoute,
   editContactFormOpen,
 }) => {
-  const { mask } = getPermissionsForMasking();
-  const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
+  const { canView } = getPermissionsForViewingIdentifiers();
+  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
   useEffect(() => {
     if (isTwilioTask(task) && previousContacts === undefined) {
@@ -110,7 +110,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
           &nbsp;
           {maskIdentifiers ? (
             <Bold>
-              <Template code="maskIdentifiers" />
+              <Template code="MaskIdentifiers" />
             </Bold>
           ) : (
             <Bold>{contactIdentifier}</Bold>

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -110,7 +110,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
           &nbsp;
           {maskIdentifiers ? (
             <Bold>
-              <Template code="MaskIdentifiers" />
+              <Template code="maskIdentifiers" />
             </Bold>
           ) : (
             <Bold>{contactIdentifier}</Bold>

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintContact.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintContact.tsx
@@ -8,7 +8,7 @@ import { Text, View } from '@react-pdf/renderer';
 import styles from './styles';
 import { getConfig } from '../../../HrmFormPlugin';
 import { mapChannel, mapChannelForInsights, presentValue, formatStringToDateAndTime } from '../../../utils';
-import { getPermissionsForMasking, PermissionActions } from '../../../permissions';
+import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
 
 type OwnProps = {
   sectionName: string;
@@ -26,8 +26,8 @@ const CasePrintContact: React.FC<Props> = ({ sectionName, contact, counselor }) 
   const formattedChannel =
     channel === 'default' ? mapChannelForInsights(rawJson.contactlessTask?.channel) : mapChannel(channel);
 
-  const { mask } = getPermissionsForMasking();
-  const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
+  const { canView } = getPermissionsForViewingIdentifiers();
+  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
   return (
     <View>
       <View style={styles.sectionHeader}>

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintContact.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintContact.tsx
@@ -8,6 +8,7 @@ import { Text, View } from '@react-pdf/renderer';
 import styles from './styles';
 import { getConfig } from '../../../HrmFormPlugin';
 import { mapChannel, mapChannelForInsights, presentValue, formatStringToDateAndTime } from '../../../utils';
+import { getPermissionsForMasking, PermissionActions } from '../../../permissions';
 
 type OwnProps = {
   sectionName: string;
@@ -25,7 +26,8 @@ const CasePrintContact: React.FC<Props> = ({ sectionName, contact, counselor }) 
   const formattedChannel =
     channel === 'default' ? mapChannelForInsights(rawJson.contactlessTask?.channel) : mapChannel(channel);
 
-  const maskIdentifiers = false;
+  const { mask } = getPermissionsForMasking();
+  const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
   return (
     <View>
       <View style={styles.sectionHeader}>

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -23,7 +23,7 @@ import { ContactDetailsSections, ContactDetailsSectionsType } from '../common/Co
 import { unNestInformation } from '../../services/ContactService';
 import { configurationBase, contactFormsBase, namespace, RootState } from '../../states';
 import { DetailsContext, toggleDetailSectionExpanded } from '../../states/contacts/contactDetails';
-import { getPermissionsForContact, getPermissionsForMasking, PermissionActions } from '../../permissions';
+import { getPermissionsForContact, getPermissionsForViewingIdentifiers, PermissionActions } from '../../permissions';
 import { createDraft, ContactDetailsRoute } from '../../states/contacts/existingContacts';
 import { getConfig } from '../../HrmFormPlugin';
 import TranscriptSection from './TranscriptSection';
@@ -155,8 +155,8 @@ const ContactDetailsHome: React.FC<Props> = function ({
       (twilioStoredTranscript || externalStoredTranscript),
   );
 
-  const mask = getPermissionsForMasking();
-  const maskIdentifiers = mask.mask(PermissionActions.MASK_IDENTIFIERS);
+  const { canView } = getPermissionsForViewingIdentifiers();
+  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
   return (
     <DetailsContainer data-testid="ContactDetails-Container">
@@ -182,7 +182,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
         {maskIdentifiers ? (
           <SectionEntry
             description={<Template code="ContactDetails-GeneralDetails-PhoneNumber" />}
-            value={strings.maskIdentifiers}
+            value={strings.MaskIdentifiers}
           />
         ) : (
           <SectionEntry

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -23,7 +23,7 @@ import { ContactDetailsSections, ContactDetailsSectionsType } from '../common/Co
 import { unNestInformation } from '../../services/ContactService';
 import { configurationBase, contactFormsBase, namespace, RootState } from '../../states';
 import { DetailsContext, toggleDetailSectionExpanded } from '../../states/contacts/contactDetails';
-import { getPermissionsForContact, PermissionActions } from '../../permissions';
+import { getPermissionsForContact, getPermissionsForMasking, PermissionActions } from '../../permissions';
 import { createDraft, ContactDetailsRoute } from '../../states/contacts/existingContacts';
 import { getConfig } from '../../HrmFormPlugin';
 import TranscriptSection from './TranscriptSection';
@@ -155,7 +155,8 @@ const ContactDetailsHome: React.FC<Props> = function ({
       (twilioStoredTranscript || externalStoredTranscript),
   );
 
-  const maskIdentifiers = false;
+  const mask = getPermissionsForMasking();
+  const maskIdentifiers = mask.mask(PermissionActions.MASK_IDENTIFIERS);
 
   return (
     <DetailsContainer data-testid="ContactDetails-Container">
@@ -181,7 +182,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
         {maskIdentifiers ? (
           <SectionEntry
             description={<Template code="ContactDetails-GeneralDetails-PhoneNumber" />}
-            value={strings.MaskIdentifiers}
+            value={strings.maskIdentifiers}
           />
         ) : (
           <SectionEntry

--- a/plugin-hrm-form/src/components/search/ContactPreview/ChildNameAndDate.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ChildNameAndDate.tsx
@@ -10,7 +10,7 @@ import { ViewButton } from '../../../styles/case';
 import { isNonDataCallType } from '../../../states/ValidationRules';
 import CallTypeIcon from '../../common/icons/CallTypeIcon';
 import { channelTypes, ChannelTypes } from '../../../states/DomainConstants';
-import { getPermissionsForMasking, PermissionActions } from '../../../permissions';
+import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
 
 type OwnProps = {
   channel: ChannelTypes;
@@ -37,8 +37,8 @@ const getNumber = (channel, number) => {
 const ChildNameAndDate: React.FC<Props> = ({ channel, callType, name, number, date, onClickFull }) => {
   const dateString = `${format(new Date(date), 'MMM d, yyyy h:mm aaaaa')}m`;
   const showNumber = isNonDataCallType(callType) && Boolean(number);
-  const { mask } = getPermissionsForMasking();
-  const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
+  const { canView } = getPermissionsForViewingIdentifiers();
+  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
   return (
     <Row>
@@ -47,10 +47,10 @@ const ChildNameAndDate: React.FC<Props> = ({ channel, callType, name, number, da
       </Flex>
       {showNumber && maskIdentifiers && (
         <PrevNameText>
-          <Template code="maskIdentifiers" />{' '}
+          <Template code="MaskIdentifiers" />{' '}
         </PrevNameText>
       )}
-      <PrevNameText>{showNumber && maskIdentifiers ? getNumber(channel, number) : name}</PrevNameText>
+      <PrevNameText>{showNumber && !maskIdentifiers ? getNumber(channel, number) : name}</PrevNameText>
 
       <ContactButtonsWrapper>
         <Flex marginRight="20px">

--- a/plugin-hrm-form/src/components/search/ContactPreview/ChildNameAndDate.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ChildNameAndDate.tsx
@@ -10,6 +10,7 @@ import { ViewButton } from '../../../styles/case';
 import { isNonDataCallType } from '../../../states/ValidationRules';
 import CallTypeIcon from '../../common/icons/CallTypeIcon';
 import { channelTypes, ChannelTypes } from '../../../states/DomainConstants';
+import { getPermissionsForMasking, PermissionActions } from '../../../permissions';
 
 type OwnProps = {
   channel: ChannelTypes;
@@ -36,7 +37,8 @@ const getNumber = (channel, number) => {
 const ChildNameAndDate: React.FC<Props> = ({ channel, callType, name, number, date, onClickFull }) => {
   const dateString = `${format(new Date(date), 'MMM d, yyyy h:mm aaaaa')}m`;
   const showNumber = isNonDataCallType(callType) && Boolean(number);
-  const maskIdentifiers = false;
+  const { mask } = getPermissionsForMasking();
+  const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
 
   return (
     <Row>
@@ -45,10 +47,10 @@ const ChildNameAndDate: React.FC<Props> = ({ channel, callType, name, number, da
       </Flex>
       {showNumber && maskIdentifiers && (
         <PrevNameText>
-          <Template code="MaskIdentifiers" />{' '}
+          <Template code="maskIdentifiers" />{' '}
         </PrevNameText>
       )}
-      <PrevNameText>{showNumber && !maskIdentifiers ? getNumber(channel, number) : name}</PrevNameText>
+      <PrevNameText>{showNumber && maskIdentifiers ? getNumber(channel, number) : name}</PrevNameText>
 
       <ContactButtonsWrapper>
         <Flex marginRight="20px">

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -24,7 +24,7 @@ import { getConfig } from '../../../HrmFormPlugin';
 import { namespace, configurationBase, searchContactsBase, contactFormsBase } from '../../../states';
 import { localizedSource } from '../../PreviousContactsBanner';
 import { getFormattedNumberFromTask, getNumberFromTask } from '../../../utils/task';
-import { getPermissionsForMasking, PermissionActions } from '../../../permissions';
+import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
 
 const getField = value => ({
   value,
@@ -147,8 +147,8 @@ class SearchForm extends Component {
     };
 
     const source = localizedSource[task.channelType];
-    const { mask } = getPermissionsForMasking();
-    const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
+    const { canView } = getPermissionsForViewingIdentifiers();
+    const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
     return (
       <>
@@ -242,7 +242,7 @@ class SearchForm extends Component {
                       <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={source} />{' '}
                       {maskIdentifiers ? (
                         <Bold>
-                          <Template code="maskIdentifiers" />
+                          <Template code="MaskIdentifiers" />
                         </Bold>
                       ) : (
                         <Bold>{checkBoxName}</Bold>

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -24,6 +24,7 @@ import { getConfig } from '../../../HrmFormPlugin';
 import { namespace, configurationBase, searchContactsBase, contactFormsBase } from '../../../states';
 import { localizedSource } from '../../PreviousContactsBanner';
 import { getFormattedNumberFromTask, getNumberFromTask } from '../../../utils/task';
+import { getPermissionsForMasking, PermissionActions } from '../../../permissions';
 
 const getField = value => ({
   value,
@@ -146,7 +147,8 @@ class SearchForm extends Component {
     };
 
     const source = localizedSource[task.channelType];
-    const maskIdentifiers = false;
+    const { mask } = getPermissionsForMasking();
+    const maskIdentifiers = mask(PermissionActions.MASK_IDENTIFIERS);
 
     return (
       <>
@@ -240,7 +242,7 @@ class SearchForm extends Component {
                       <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={source} />{' '}
                       {maskIdentifiers ? (
                         <Bold>
-                          <Template code="MaskIdentifiers" />
+                          <Template code="maskIdentifiers" />
                         </Bold>
                       ) : (
                         <Bold>{checkBoxName}</Bold>

--- a/plugin-hrm-form/src/permissions/br.json
+++ b/plugin-hrm-form/src/permissions/br.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/ca.json
+++ b/plugin-hrm-form/src/permissions/ca.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/cl.json
+++ b/plugin-hrm-form/src/permissions/cl.json
@@ -19,5 +19,6 @@
 "editFollowUpDate":  [["everyone"]],
 "editContact":  [["everyone"]],
 "viewPostSurvey":  [["isSupervisor"]],
-"viewExternalTranscript": [["isSupervisor"]]
+"viewExternalTranscript": [["isSupervisor"]],
+"viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/co.json
+++ b/plugin-hrm-form/src/permissions/co.json
@@ -19,5 +19,6 @@
 "editFollowUpDate":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editContact":  [["isSupervisor"],["isOwner"]],
 "viewPostSurvey": [["isSupervisor"]],
-"viewExternalTranscript": [["isSupervisor"]]
+"viewExternalTranscript": [["isSupervisor"]],
+"viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/demo.json
+++ b/plugin-hrm-form/src/permissions/demo.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewExternalTranscript": [["everyone"]]
+  "viewExternalTranscript": [["everyone"]],
+  "maskIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/demo.json
+++ b/plugin-hrm-form/src/permissions/demo.json
@@ -19,5 +19,5 @@
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
   "viewExternalTranscript": [["everyone"]],
-  "maskIdentifiers": [["everyone"]]
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/dev.json
+++ b/plugin-hrm-form/src/permissions/dev.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewExternalTranscript": [["everyone"]]
+  "viewExternalTranscript": [["everyone"]],
+  "maskIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/dev.json
+++ b/plugin-hrm-form/src/permissions/dev.json
@@ -19,5 +19,5 @@
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
   "viewExternalTranscript": [["everyone"]],
-  "maskIdentifiers": [["everyone"]]
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/e2e.json
+++ b/plugin-hrm-form/src/permissions/e2e.json
@@ -19,5 +19,5 @@
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
   "viewExternalTranscript": [["isSupervisor"]],
-  "maskIdentifiers": [["everyone"]]
+  "maskIdentifiers": []
 }

--- a/plugin-hrm-form/src/permissions/e2e.json
+++ b/plugin-hrm-form/src/permissions/e2e.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "maskIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/e2e.json
+++ b/plugin-hrm-form/src/permissions/e2e.json
@@ -19,5 +19,5 @@
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
   "viewExternalTranscript": [["isSupervisor"]],
-  "maskIdentifiers": []
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/et.json
+++ b/plugin-hrm-form/src/permissions/et.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/hu.json
+++ b/plugin-hrm-form/src/permissions/hu.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/in.json
+++ b/plugin-hrm-form/src/permissions/in.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -26,10 +26,14 @@ export const ContactActions = {
   EDIT_CONTACT: 'editContact',
   VIEW_EXTERNAL_TRANSCRIPT: 'viewExternalTranscript',
 } as const;
+const MaskIDActions = {
+  MASK_IDENTIFIERS: 'maskIdentifiers',
+} as const;
 
 export const PermissionActions = {
   ...CaseActions,
   ...ContactActions,
+  ...MaskIDActions
 } as const;
 
 type PermissionActionsKeys = keyof typeof PermissionActions;
@@ -109,5 +113,38 @@ export const getPermissionsForContact = (twilioWorkerId: t.SearchContact['overvi
 
   return {
     can,
+  };
+};
+
+export const getPermissionsForMasking = () => {
+  const { isSupervisor, permissionConfig } = getConfig();
+
+  if (!permissionConfig) return { mask: undefined };
+
+  const conditionsState: Partial<{ [condition in Condition]: boolean }> = {
+    isSupervisor,
+    everyone: true,
+  };
+
+  const checkCondition = (condition: Condition) => conditionsState[condition];
+  const checkConditionsSet = (conditionsSet: ConditionSet) => conditionsSet.every(checkCondition);
+  const checkConditionsSets = (conditionsSets: ConditionSets) => conditionsSets.some(checkConditionsSet);
+
+  const rules = fetchRules(permissionConfig);
+
+  const rulesAreValid = Object.values(PermissionActions).every(action => rules[action]);
+  if (!rulesAreValid) throw new Error(`Rules file for ${permissionConfig} is incomplete.`);
+
+  const mask = (action: PermissionActionType): boolean => {
+    if (!rules[action]) {
+      console.error(`Cannot find rules for ${action}. Returning false.`);
+      return isSupervisor;
+    }
+
+    return checkConditionsSets(rules[action]);
+  };
+
+  return {
+    mask,
   };
 };

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -33,7 +33,7 @@ const MaskIDActions = {
 export const PermissionActions = {
   ...CaseActions,
   ...ContactActions,
-  ...MaskIDActions
+  ...MaskIDActions,
 } as const;
 
 type PermissionActionsKeys = keyof typeof PermissionActions;

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -26,14 +26,14 @@ export const ContactActions = {
   EDIT_CONTACT: 'editContact',
   VIEW_EXTERNAL_TRANSCRIPT: 'viewExternalTranscript',
 } as const;
-const MaskIDActions = {
-  MASK_IDENTIFIERS: 'maskIdentifiers',
+const ViewIdentifiersAction = {
+  VIEW_IDENTIFIERS: 'viewIdentifiers',
 } as const;
 
 export const PermissionActions = {
   ...CaseActions,
   ...ContactActions,
-  ...MaskIDActions,
+  ...ViewIdentifiersAction,
 } as const;
 
 type PermissionActionsKeys = keyof typeof PermissionActions;
@@ -116,10 +116,10 @@ export const getPermissionsForContact = (twilioWorkerId: t.SearchContact['overvi
   };
 };
 
-export const getPermissionsForMasking = () => {
+export const getPermissionsForViewingIdentifiers = () => {
   const { isSupervisor, permissionConfig } = getConfig();
 
-  if (!permissionConfig) return { mask: undefined };
+  if (!permissionConfig) return { canView: undefined };
 
   const conditionsState: Partial<{ [condition in Condition]: boolean }> = {
     isSupervisor,
@@ -135,7 +135,7 @@ export const getPermissionsForMasking = () => {
   const rulesAreValid = Object.values(PermissionActions).every(action => rules[action]);
   if (!rulesAreValid) throw new Error(`Rules file for ${permissionConfig} is incomplete.`);
 
-  const mask = (action: PermissionActionType): boolean => {
+  const canView = (action: PermissionActionType): boolean => {
     if (!rules[action]) {
       console.error(`Cannot find rules for ${action}. Returning false.`);
       return isSupervisor;
@@ -145,6 +145,6 @@ export const getPermissionsForMasking = () => {
   };
 
   return {
-    mask,
+    canView,
   };
 };

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -26,7 +26,7 @@ export const ContactActions = {
   EDIT_CONTACT: 'editContact',
   VIEW_EXTERNAL_TRANSCRIPT: 'viewExternalTranscript',
 } as const;
-const ViewIdentifiersAction = {
+export const ViewIdentifiersAction = {
   VIEW_IDENTIFIERS: 'viewIdentifiers',
 } as const;
 

--- a/plugin-hrm-form/src/permissions/jm.json
+++ b/plugin-hrm-form/src/permissions/jm.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/mw.json
+++ b/plugin-hrm-form/src/permissions/mw.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/ph.json
+++ b/plugin-hrm-form/src/permissions/ph.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/pl.json
+++ b/plugin-hrm-form/src/permissions/pl.json
@@ -19,5 +19,6 @@
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
   "viewPostSurvey": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/ro.json
+++ b/plugin-hrm-form/src/permissions/ro.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/th.json
+++ b/plugin-hrm-form/src/permissions/th.json
@@ -19,5 +19,6 @@
 "editFollowUpDate":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editContact":  [["isSupervisor"],["isOwner"]],
 "viewPostSurvey":  [["isSupervisor"]],
-"viewExternalTranscript": [["isSupervisor"]]
+"viewExternalTranscript": [["isSupervisor"]],
+"viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/uk.json
+++ b/plugin-hrm-form/src/permissions/uk.json
@@ -20,5 +20,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/za.json
+++ b/plugin-hrm-form/src/permissions/za.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/zm.json
+++ b/plugin-hrm-form/src/permissions/zm.json
@@ -19,5 +19,5 @@
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
   "viewExternalTranscript": [["isSupervisor"]],
-  "maskIdentifiers": [["everyone"]]
+  "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/zm.json
+++ b/plugin-hrm-form/src/permissions/zm.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewExternalTranscript": [["isSupervisor"]]
+  "viewExternalTranscript": [["isSupervisor"]],
+  "maskIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -371,9 +371,8 @@
   "BottomBar-Save": "Yes, Save",
 
   "CaseSummary-None": "- No case summary -",
-  "maskIdentifiers": "XXXXXX",
-  "TaskLineWebChatAssignedMasked":  "{{#if helper.chat.isCustomerOnline}} {{{icon name='GreenIndicator'}}} {{else}} {{{icon name='GreyIndicator'}}} {{/if}}  {{helper.durationSinceUpdate}} | {{#if helper.chat.typers.length}} typing ... {{else}} {{#if helper.chat.lastMessage}} {{worker.fullName}}: {{helper.chat.lastMessage.body}} {{else}}No messages{{/if}}{{/if}}"
-  ,
+  "MaskIdentifiers": "XXXXXX",
+  "TaskLineWebChatAssignedMasked":  "{{#if helper.chat.isCustomerOnline}} {{{icon name='GreenIndicator'}}} {{else}} {{{icon name='GreyIndicator'}}} {{/if}}  {{helper.durationSinceUpdate}} | {{#if helper.chat.typers.length}} typing ... {{else}} {{#if helper.chat.lastMessage}} {{worker.fullName}}: {{helper.chat.lastMessage.body}} {{else}}No messages{{/if}}{{/if}}",
   "TaskLineChatAssignedMasked":
   "{{helper.durationSinceUpdate}} | {{#if helper.chat.typers.length}} typing ... {{else}} {{#if helper.chat.lastMessage}} {{worker.fullName}}: {{helper.chat.lastMessage.body}} {{else}}No messages{{/if}}{{/if}}",
   "TaskInfoPanelContentMasked": "<h1>TASK CONTEXT</h1><h2>Task type</h2><p>{{task.channelType}}</p><h2>Task created on</h2><p>{{task.dateCreated}}</p><h2>Task priority</h2><p>{{task.priority}}</p><h2>Task queue</h2><p>{{task.queueName}}</p><h2>Task Sid</h2><p>{{task.taskSid}}</p><h2>Reservation Sid</h2><p>{{task.sid}}</p><hr /><h1>CUSTOMER CONTEXT</h1><h2>Customer name / phone number</h2><p>XXXXXXXXXXX</p><h2>Country</h2><p>{{task.attributes.caller_country}}</p><hr /><h1>ADDONS</h1><p>No add-ons enabled. To expand your experience, visit</p><a href=\"https://www.twilio.com/marketplaceadd-ons\" target=\"blank\">Twilio Marketplace</a>"

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -371,7 +371,7 @@
   "BottomBar-Save": "Yes, Save",
 
   "CaseSummary-None": "- No case summary -",
-  "MaskIdentifiers": "XXXXXX",
+  "maskIdentifiers": "XXXXXX",
   "TaskLineWebChatAssignedMasked":  "{{#if helper.chat.isCustomerOnline}} {{{icon name='GreenIndicator'}}} {{else}} {{{icon name='GreyIndicator'}}} {{/if}}  {{helper.durationSinceUpdate}} | {{#if helper.chat.typers.length}} typing ... {{else}} {{#if helper.chat.lastMessage}} {{worker.fullName}}: {{helper.chat.lastMessage.body}} {{else}}No messages{{/if}}{{/if}}"
   ,
   "TaskLineChatAssignedMasked":

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -429,7 +429,7 @@ export const setupCannedResponses = () => {
   Flex.MessageInput.Content.add(<CannedResponses key="canned-responses" />);
 };
 
-export const setupTwitterChatChannel = (maskIdentifiers) => {
+export const setupTwitterChatChannel = maskIdentifiers => {
   const icon = <TwitterIcon width="24px" height="24px" color="white" />;
 
   const TwitterChatChannel = Flex.DefaultTaskChannels.createChatTaskChannel(
@@ -464,7 +464,7 @@ export const setupTwitterChatChannel = (maskIdentifiers) => {
   Flex.TaskChannels.register(TwitterChatChannel);
 };
 
-export const setupInstagramChatChannel = (maskIdentifiers) => {
+export const setupInstagramChatChannel = maskIdentifiers => {
   const icon = <InstagramIcon width="24px" height="24px" color="white" />;
 
   const InstagramChatChannel = Flex.DefaultTaskChannels.createChatTaskChannel(
@@ -493,7 +493,7 @@ export const setupInstagramChatChannel = (maskIdentifiers) => {
   Flex.TaskChannels.register(InstagramChatChannel);
 };
 
-export const setupLineChatChannel = (maskIdentifiers) => {
+export const setupLineChatChannel = maskIdentifiers => {
   const icon = <LineIcon width="24px" height="24px" color="white" />;
 
   const LineChatChannel = Flex.DefaultTaskChannels.createChatTaskChannel('line', task => task.channelType === 'line');
@@ -519,10 +519,9 @@ export const setupLineChatChannel = (maskIdentifiers) => {
   Flex.TaskChannels.register(LineChatChannel);
 };
 
-// const maskIdentifiers = false;
 const maskIdentifiersByChannel = channelType => {
   // Task list and panel when a call comes in
-  channelType.templates.TaskListItem.firstLine = 'MaskIdentifiers';
+  channelType.templates.TaskListItem.firstLine = 'maskIdentifiers';
   /*
    * if (channelType === Flex.DefaultTaskChannels.Chat) {
    *   channelType.templates.TaskListItem.secondLine = 'TaskLineWebChatAssignedMasked';
@@ -530,15 +529,15 @@ const maskIdentifiersByChannel = channelType => {
    *   channelType.templates.TaskListItem.secondLine = 'TaskLineChatAssignedMasked';
    * }
    */
-  channelType.templates.IncomingTaskCanvas.firstLine = 'MaskIdentifiers';
+  channelType.templates.IncomingTaskCanvas.firstLine = 'maskIdentifiers';
   // Task panel during an active call
-  channelType.templates.TaskCanvasHeader.title = 'MaskIdentifiers';
-  channelType.templates.MessageListItem = 'MaskIdentifiers';
+  channelType.templates.TaskCanvasHeader.title = 'maskIdentifiers';
+  channelType.templates.MessageListItem = 'maskIdentifiers';
   // Task Status in Agents page
-  channelType.templates.TaskCard.firstLine = 'MaskIdentifiers';
+  channelType.templates.TaskCard.firstLine = 'maskIdentifiers';
   // Supervisor
-  channelType.templates.Supervisor.TaskCanvasHeader.title = 'MaskIdentifiers';
-  channelType.templates.Supervisor.TaskOverviewCanvas.title = 'MaskIdentifiers';
+  channelType.templates.Supervisor.TaskCanvasHeader.title = 'maskIdentifiers';
+  channelType.templates.Supervisor.TaskOverviewCanvas.title = 'maskIdentifiers';
 };
 
 export const maskIdentifiersForDefaultChannels = () => {
@@ -549,5 +548,3 @@ export const maskIdentifiersForDefaultChannels = () => {
   maskIdentifiersByChannel(Flex.DefaultTaskChannels.ChatMessenger);
   maskIdentifiersByChannel(Flex.DefaultTaskChannels.ChatWhatsApp);
 };
-
-// if (maskIdentifiers) maskIdentifiersForDefaultChannels();

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -521,7 +521,7 @@ export const setupLineChatChannel = maskIdentifiers => {
 
 const maskIdentifiersByChannel = channelType => {
   // Task list and panel when a call comes in
-  channelType.templates.TaskListItem.firstLine = 'maskIdentifiers';
+  channelType.templates.TaskListItem.firstLine = 'MaskIdentifiers';
   /*
    * if (channelType === Flex.DefaultTaskChannels.Chat) {
    *   channelType.templates.TaskListItem.secondLine = 'TaskLineWebChatAssignedMasked';
@@ -529,15 +529,15 @@ const maskIdentifiersByChannel = channelType => {
    *   channelType.templates.TaskListItem.secondLine = 'TaskLineChatAssignedMasked';
    * }
    */
-  channelType.templates.IncomingTaskCanvas.firstLine = 'maskIdentifiers';
+  channelType.templates.IncomingTaskCanvas.firstLine = 'MaskIdentifiers';
   // Task panel during an active call
-  channelType.templates.TaskCanvasHeader.title = 'maskIdentifiers';
-  channelType.templates.MessageListItem = 'maskIdentifiers';
+  channelType.templates.TaskCanvasHeader.title = 'MaskIdentifiers';
+  channelType.templates.MessageListItem = 'MaskIdentifiers';
   // Task Status in Agents page
-  channelType.templates.TaskCard.firstLine = 'maskIdentifiers';
+  channelType.templates.TaskCard.firstLine = 'MaskIdentifiers';
   // Supervisor
-  channelType.templates.Supervisor.TaskCanvasHeader.title = 'maskIdentifiers';
-  channelType.templates.Supervisor.TaskOverviewCanvas.title = 'maskIdentifiers';
+  channelType.templates.Supervisor.TaskCanvasHeader.title = 'MaskIdentifiers';
+  channelType.templates.Supervisor.TaskOverviewCanvas.title = 'MaskIdentifiers';
 };
 
 export const maskIdentifiersForDefaultChannels = () => {

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -429,7 +429,7 @@ export const setupCannedResponses = () => {
   Flex.MessageInput.Content.add(<CannedResponses key="canned-responses" />);
 };
 
-export const setupTwitterChatChannel = () => {
+export const setupTwitterChatChannel = (maskIdentifiers) => {
   const icon = <TwitterIcon width="24px" height="24px" color="white" />;
 
   const TwitterChatChannel = Flex.DefaultTaskChannels.createChatTaskChannel(
@@ -464,7 +464,7 @@ export const setupTwitterChatChannel = () => {
   Flex.TaskChannels.register(TwitterChatChannel);
 };
 
-export const setupInstagramChatChannel = () => {
+export const setupInstagramChatChannel = (maskIdentifiers) => {
   const icon = <InstagramIcon width="24px" height="24px" color="white" />;
 
   const InstagramChatChannel = Flex.DefaultTaskChannels.createChatTaskChannel(
@@ -493,7 +493,7 @@ export const setupInstagramChatChannel = () => {
   Flex.TaskChannels.register(InstagramChatChannel);
 };
 
-export const setupLineChatChannel = () => {
+export const setupLineChatChannel = (maskIdentifiers) => {
   const icon = <LineIcon width="24px" height="24px" color="white" />;
 
   const LineChatChannel = Flex.DefaultTaskChannels.createChatTaskChannel('line', task => task.channelType === 'line');
@@ -519,7 +519,7 @@ export const setupLineChatChannel = () => {
   Flex.TaskChannels.register(LineChatChannel);
 };
 
-const maskIdentifiers = false;
+// const maskIdentifiers = false;
 const maskIdentifiersByChannel = channelType => {
   // Task list and panel when a call comes in
   channelType.templates.TaskListItem.firstLine = 'MaskIdentifiers';
@@ -541,7 +541,7 @@ const maskIdentifiersByChannel = channelType => {
   channelType.templates.Supervisor.TaskOverviewCanvas.title = 'MaskIdentifiers';
 };
 
-const maskIdentifiersForDefaultChannels = () => {
+export const maskIdentifiersForDefaultChannels = () => {
   maskIdentifiersByChannel(Flex.DefaultTaskChannels.Call);
   maskIdentifiersByChannel(Flex.DefaultTaskChannels.Chat);
   maskIdentifiersByChannel(Flex.DefaultTaskChannels.ChatSms);
@@ -550,4 +550,4 @@ const maskIdentifiersForDefaultChannels = () => {
   maskIdentifiersByChannel(Flex.DefaultTaskChannels.ChatWhatsApp);
 };
 
-if (maskIdentifiers) maskIdentifiersForDefaultChannels();
+// if (maskIdentifiers) maskIdentifiersForDefaultChannels();


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
- Implemented permissions configuration for viewing / masking PII and identifiers - `viewIdentifiers`. 
- `viewIdentifiers` allows permission to view/mask all the aselo components where user handler, ip address and contact details appear and twilio strings when a cal/chat comes in. 
- Added permission configuration to all helplines with all being set to 'everyone'
- Updated test suite for `getPermissionsForViewingIdentifiers` handler 

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [x] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Related Issues
Fixes # 1471

### Verification steps
- Change permission config condition set for `dev` and check whether identifiers are masked. 