### PR TITLE
[Bug Fix] Flex 2.0: mixed-checkbox fields not three-way

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -232,7 +232,7 @@ export default class HrmFormPlugin extends FlexPlugin {
    * Use this to modify any UI components or attach to the actions framework
    */
   init(flex: typeof Flex, manager: Flex.Manager) {
-    loadCSS('https://use.fontawesome.com/releases/v5.15.1/css/solid.css');
+    loadCSS('https://use.fontawesome.com/releases/v5.15.4/css/solid.css');
 
     setUpMonitoring(this, manager.workerClient, manager.serviceConfiguration);
 

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -900,7 +900,8 @@ const CheckboxBase = styled.input<FormInputProps>`
     top: 50%;
     left: 7px;
     transform: translate(-50%, -50%);
-    content: '\f00c';
+    content: '';
+    font-weight: 900;
   }
   &[type='checkbox']::before {
     width: 13px;
@@ -922,8 +923,9 @@ export const FormCheckbox = styled(CheckboxBase)`
   }
   &[type='checkbox']:checked::after {
     font-family: 'Font Awesome 5 Free';
-    content: '\f00c';
+    content: '\\f00c ';
     color: #ffffff;
+    font-weight: 900;
   }
 
   &[type='checkbox']:focus:not(:focus-visible) {
@@ -943,13 +945,15 @@ export const FormMixedCheckbox = styled(CheckboxBase)`
   }
   &[class~='mixed-checkbox'][type='checkbox'][aria-checked='false']::after {
     font-family: 'Font Awesome 5 Free';
-    content: '\f00d';
+    content: '\\f00d ';
     color: #ffffff;
+    font-weight: 900;
   }
   &[class~='mixed-checkbox'][type='checkbox'][aria-checked='true']::after {
     font-family: 'Font Awesome 5 Free';
-    content: '\f00c';
+    content: '\\f00c ';
     color: #ffffff;
+    font-weight: 900;
   }
   /* To disable the outline when focused */
   /* &[class~=mixed-checkbox][type=checkbox]:focus {
@@ -970,8 +974,6 @@ export const FormSelectWrapper = styled('div')<FormSelectProps>`
   height: 36px;
 
   &:after {
-    // font-family: 'Font Awesome 5 Free';
-    // content: '\f0dd';
     content: '';
     width: 0;
     height: 0;
@@ -1044,7 +1046,8 @@ export const CategoryCheckbox = styled(CheckboxBase)<CategoryCheckboxProps>`
 
   &[type='checkbox']:checked::after {
     font-family: 'Font Awesome 5 Free';
-    content: '\f00c';
+    content: '\\f00c ';
+    font-weight: 900;
     color: ${({ color }) => color};
   }
 

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -923,7 +923,7 @@ export const FormCheckbox = styled(CheckboxBase)`
   }
   &[type='checkbox']:checked::after {
     font-family: 'Font Awesome 5 Free';
-    content: '\\f00c ';
+    content: '\\f00c';
     color: #ffffff;
     font-weight: 900;
   }
@@ -945,13 +945,13 @@ export const FormMixedCheckbox = styled(CheckboxBase)`
   }
   &[class~='mixed-checkbox'][type='checkbox'][aria-checked='false']::after {
     font-family: 'Font Awesome 5 Free';
-    content: '\\f00d ';
+    content: '\\f00d';
     color: #ffffff;
     font-weight: 900;
   }
   &[class~='mixed-checkbox'][type='checkbox'][aria-checked='true']::after {
     font-family: 'Font Awesome 5 Free';
-    content: '\\f00c ';
+    content: '\\f00c';
     color: #ffffff;
     font-weight: 900;
   }
@@ -1046,7 +1046,7 @@ export const CategoryCheckbox = styled(CheckboxBase)<CategoryCheckboxProps>`
 
   &[type='checkbox']:checked::after {
     font-family: 'Font Awesome 5 Free';
-    content: '\\f00c ';
+    content: '\\f00c';
     font-weight: 900;
     color: ${({ color }) => color};
   }

--- a/plugin-hrm-form/src/styles/caseList/filters.ts
+++ b/plugin-hrm-form/src/styles/caseList/filters.ts
@@ -302,7 +302,8 @@ export const FiltersCheckbox = styled('input')`
   &[type='checkbox']:checked::after {
     font-family: 'Font Awesome 5 Free';
     font-size: 11px;
-    content: '\f00c';
+    content: '\\f00c';
+    font-weight: 900;
     color: #ffffff;
   }
   &[type='checkbox']:indeterminate::after {


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand @robert-bo-davis 

## Description
This PR fixes the bug reported in the Jira ticket. This was just a UI bug, since the functionality is still preserved (and the values of the input correct). The cause was that new versions of `styled` are parsing a bit differently the unicode characters.
![Screenshot from 2022-11-10 02-41-46](https://user-images.githubusercontent.com/15805319/201010250-de5793a5-79ab-47bb-bc69-2721ff4be9db.png)
![Screenshot from 2022-11-10 02-41-52](https://user-images.githubusercontent.com/15805319/201010264-2b490cd5-67f6-4a60-8991-44cca021b78d.png)
![Screenshot from 2022-11-10 02-41-58](https://user-images.githubusercontent.com/15805319/201010283-39472db7-31c2-4d27-b722-8e9e800b26ac.png)

As a consequence of this changes, category check-boxes are also working as intended.
![Screenshot from 2022-11-10 02-42-36](https://user-images.githubusercontent.com/15805319/201010305-89c11554-fdee-459c-81c9-aa9912f7f971.png)



### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1493)
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Configure Flex to point to an account with Flex 2.
- `npm ci` && `npm run dev`.
- Open a new contact form (offline contact will suffice for this purpose).
- Confirm that 3 way check-boxes are working as expected (value & UI).