### PR TITLE
CHI-1426 fix send button styles

### DIFF
--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -44,6 +44,10 @@ button.Twilio-TaskCanvasHeader-EndButton {
 }
 button.Twilio-MessageInput-SendButton {
     background: rgba(216, 27, 96, 0.8);
+    color: #f6f6f6;
+}
+button.Twilio-MessageInput-SendButton:hover {
+    background-color: rgba(0, 0, 0, 0.2);
 }
 
 a.link-text-decoration-none { text-decoration: none; color: #1874e1; }


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
Fixes styling of send message button to match current behavior

### Verification steps
Add text to message box, button should have a white airplane. Hover over box and background should turn grey to match current behavior.