### PR TITLE
Flex 2.0 Clean Up: Default fonts and colors

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -255,10 +255,15 @@ export default class HrmFormPlugin extends FlexPlugin {
     setUpComponents(setupObject);
     setUpActions(setupObject);
 
-    const managerConfiguration = {
+    const managerConfiguration: Flex.Config = {
       // colorTheme: HrmTheme,
       theme: {
         componentThemeOverrides: overrides,
+        tokens: {
+          backgroundColors: {
+            colorBackground: HrmTheme.colors.base2,
+          },
+        },
       },
     };
     manager.updateConfig(managerConfiguration);

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -1,3 +1,8 @@
+body,
+body p,
+body span {
+    font-family: Open Sans;
+}
 div.Twilio-ModalPopupWithEntryControl {
     padding-top: 7px;
     padding-bottom: 7px;


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @mythilytm 

## Description
This PR addresses the slide 6 of the [cleanup slide deck](https://benetech.box.com/s/9v97yt5yqhjx6fkeeijol13qrca0ywrg).
>bkgrnd color should be:  #F6F6F6
(Pane on right is wrong color)

>Body and p tags should be Open Sans. Right now they are showing as Segoe UI, which is a nice font but the form field font is Open Sans (the correct font) so it looks off (see second image). 

![Screenshot from 2022-11-10 14-52-36](https://user-images.githubusercontent.com/15805319/201170272-685a6784-3a1f-49b8-9713-42e0f71bf96e.png)


### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1426)
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Configure Flex to point to an account with Flex 2.
- `npm ci` && `npm run dev`.
- Confirm that the right pane has the proper background color (`#F6F6F6`).
- Confirm that the fonts that are not part of the form are using the proper font family (`Open Sans`).