### PR TITLE
Cross platform tweaks for local E2E test runs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Primary reviewer:
 ### Checklist
 - [ ] Corresponding issue has been opened
 - [ ] New tests added
+- [ ] Feature flags added
 - [ ] Strings are localized
 - [ ] Tested for chat contacts
 - [ ] Tested for call contacts

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "npx playwright install",
-    "test": "npx playwright test",
-    "test:local": "run-s ssm:local test:local:run",
-    "test:local:run": "source .env && cross-env DEBUG=pw:api PLAYWRIGHT_BASEURL=http://localhost:3000 npm run test",
+    "test": "npx playwright test --workers 1",
+    "test:local": "run-s ssm:local  test:local:run",
+    "test:local:run": "cross-env DEBUG=pw:api PLAYWRIGHT_BASEURL=http://localhost:3000 npm run test",
     "lint": "eslint --ext ts .",
     "lint:fix": "npm run lint -- --fix .",
     "ssm:local": "npm run ssm:local:env",


### PR DESCRIPTION
Primary reviewer: @robert-bo-davis 

## Description

The call to 'source' in the local E2E test run jobs wasn't cross platform, and I believe it was only required because variables were not loading correctly from the `.env` file in the node process via `dotenv`

This was due to an issue where a bug in `dotenv`s bash parsing was incorrectly interpreting the hash at the start of a value as a comment. I have worked around this by quoting the value in the source SSM parameter, so now the values are loaded by that package correctly and call to `source` can be removed 

* Removed 'source' call in local NPM jobs now it should be redundant.
* Limited local runs to 1 worker. 
* Added feature flag check on PR template



### Verification steps

Run `npm run test:local` from the e2e-test folder