### PR TITLE
fix: style regression in CasePrintContact after flex 2 merge

### DIFF
--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintContact.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintContact.tsx
@@ -47,9 +47,9 @@ const CasePrintContact: React.FC<Props> = ({ sectionName, contact, counselor }) 
           <Text style={styles['sectionItemFirstColumn']}>{strings['ContactDetails-GeneralDetails-Channel']}</Text>
           <Text style={styles['sectionItemSecondColumn']}>{formattedChannel}</Text>
         </View>
-        <View style={styles.sectionItemRowOdd}>
-          <Text style={styles.sectionItemFirstColumn}>{strings['ContactDetails-GeneralDetails-PhoneNumber']}</Text>
-          <Text style={styles.sectionItemSecondColumn}>
+        <View style={styles['sectionItemRowOdd']}>
+          <Text style={styles['sectionItemFirstColumn']}>{strings['ContactDetails-GeneralDetails-PhoneNumber']}</Text>
+          <Text style={styles['sectionItemSecondColumn']}>
             {maskIdentifiers ? strings.MaskIdentifers : presentValue(number, strings)}
           </Text>
         </View>


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
This fixes a regression where some styles were still being called with dot notation which cause a TS error.


### Verification steps
Run hrm plugin locally and you shouldn't get a TS error anymore. App should be useable.