### PR TITLE
[Reopen] Flex 2.0 Clean Up: misc UI fixes

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseAddButton.jsx
+++ b/plugin-hrm-form/src/components/case/CaseAddButton.jsx
@@ -12,8 +12,8 @@ const CaseAddButton = ({ disabled, templateCode, onClick, withDivider }) => {
     <CaseAddButtonStyled disabled={disabled} onClick={onClick} data-testid={`${templateCode}-AddButton`}>
       {!disabled && (
         <>
-          <Add style={{ marginRight: 10, fontSize: 16, height: 17, color }} />
-          <CaseAddButtonFont style={{ marginRight: 20 }}>
+          <Add style={{ marginLeft: 20, marginRight: 10, fontSize: 16, height: 17, color }} />
+          <CaseAddButtonFont>
             <Template code={templateCode} />
           </CaseAddButtonFont>
         </>

--- a/plugin-hrm-form/src/components/case/CaseDetails.tsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.tsx
@@ -128,7 +128,7 @@ const CaseDetails: React.FC<Props> = ({
               aria-labelledby="CaseDetailsStatusLabel"
               disabled={true}
               defaultValue={childIsAtRisk ? 'Yes' : 'No'}
-              color={childIsAtRisk ? 'red' : '#d8d8d8'}
+              color={childIsAtRisk ? '#d22f2f' : '#d8d8d8'}
             />
           </div>
         </div>

--- a/plugin-hrm-form/src/components/case/CaseSummary.tsx
+++ b/plugin-hrm-form/src/components/case/CaseSummary.tsx
@@ -29,7 +29,7 @@ const CaseSummary: React.FC<Props> = ({ connectedCaseState }) => {
         <Template code="Case-CaseSummarySection" />
       </CaseSectionFont>
       <CaseSummaryTextArea
-        // rows={5} -> change the height (maybe needed when merging all the changes in Case)
+        rows={summary ? 5 : undefined}
         data-testid="Case-CaseSummary-TextArea"
         aria-labelledby="Case-CaseSummary-label"
         // Add Case summary doesn't show up as default value

--- a/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
+++ b/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
@@ -41,9 +41,9 @@ const CaseDetailsHeader: React.FC<OwnProps> = ({
   return (
     <DetailsHeaderContainer>
       <DetailsHeaderTextContainer>
-        <DetailsHeaderChildName variant="h6" data-testid="Case-DetailsHeaderChildName">
-          {childName}
-        </DetailsHeaderChildName>
+        <h6 style={{ padding: '6px 0' }}>
+          <DetailsHeaderChildName data-testid="Case-DetailsHeaderChildName">{childName}</DetailsHeaderChildName>
+        </h6>
         <DetailsHeaderCaseContainer>
           <DetailsHeaderCaseId id="Case-CaseId-label" data-testid="Case-DetailsHeaderCaseId">
             <Template code="Case-CaseNumber" />

--- a/plugin-hrm-form/src/components/common/CategoryWithTooltip.jsx
+++ b/plugin-hrm-form/src/components/common/CategoryWithTooltip.jsx
@@ -8,8 +8,8 @@ import { Tooltip } from '@material-ui/core';
  */
 export const getTag = category =>
   category.length > 17 && !category.toUpperCase().includes('UNSPECIFIED/OTHER')
-    ? `${category.substr(0, 15).trim()}...`
-    : category.substr(0, 17).trim();
+    ? `${category.substring(0, 15).trim()}...`
+    : category.substring(0, 17).trim();
 
 /**
  * Takes a render function (to render the children) and the category and returns

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -373,6 +373,7 @@ export const StyledTabs = withStyles({
     minHeight: 35,
     height: 35,
     flexShrink: 0,
+    padding: '0 7%',
   },
   indicator: {
     backgroundColor: 'transparent',

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -304,6 +304,11 @@ export const StyledPrintButton = styled(IconButton)`
   :focus {
     outline: auto;
   }
+
+  :hover {
+    background-color: rgba(0, 0, 0, 0.2);
+    background-blend-mode: color;
+  }
 `;
 
 StyledPrintButton.displayName = 'StyledPrintButton';

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, IconButton, styled } from '@twilio/flex-ui';
-import { Typography, ButtonBase } from '@material-ui/core';
+import { ButtonBase } from '@material-ui/core';
 
 import { FontOpenSans, FormInput, FormSelect, FormSelectWrapper, Row, Column } from '../HrmStyles';
 import HrmTheme from '../HrmTheme';
@@ -260,8 +260,9 @@ export const DetailsHeaderTextContainer = styled('div')`
 
 DetailsHeaderTextContainer.displayName = 'DetailsHeaderTextContainer';
 
-export const DetailsHeaderChildName = styled(Typography)`
-  font-weight: 600 !important;
+export const DetailsHeaderChildName = styled(FontOpenSans)`
+  font-weight: 600;
+  font-size: 20px;
 `;
 
 DetailsHeaderChildName.displayName = 'DetailsHeaderChildName';
@@ -274,23 +275,25 @@ export const DetailsHeaderCaseContainer = styled('div')`
 
 DetailsHeaderCaseContainer.displayName = 'DetailsHeaderCaseContainer';
 
-export const DetailsHeaderCounselor = styled('div')`
+export const DetailsHeaderCounselor = styled(FontOpenSans)`
+  font-size: 12px;
   font-style: italic;
   margin-top: 5px;
 `;
 
 DetailsHeaderCounselor.displayName = 'DetailsHeaderCounselor';
 
-export const DetailsHeaderCaseId = styled(Typography)`
-  font-weight: 600 !important;
+export const DetailsHeaderCaseId = styled(FontOpenSans)`
+  font-weight: 600;
+  font-size: 14px;
 `;
 
 DetailsHeaderCaseId.displayName = 'DetailsHeaderCaseId';
 
-export const DetailsHeaderOfficeName = styled(Typography)`
+export const DetailsHeaderOfficeName = styled(FontOpenSans)`
   padding-left: 10px;
-  font-size: 0.7rem !important;
-  font-weight: 300 !important;
+  font-size: 0.7rem;
+  font-weight: 300;
 `;
 
 DetailsHeaderOfficeName.displayName = 'DetailsHeaderOfficeName';

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -360,7 +360,7 @@ type CaseDetailsBorderProps = {
 };
 
 export const CaseDetailsBorder = styled('div')<CaseDetailsBorderProps>`
-  border-bottom: ${props => (props.sectionTypeId ? 'none' : '2px solid #e5e6e7')};
+  border-bottom: ${props => (props.sectionTypeId ? 'none' : '1px solid #e5e6e7')};
   margin-right: 25px;
   margin-bottom: ${props => (props.marginBottom ? props.marginBottom : '')};
   padding-bottom: ${props => (props.paddingBottom ? props.paddingBottom : '25px')};

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -153,6 +153,7 @@ const BaseTextArea = styled('textarea')`
   padding: 5px;
   border-style: none;
   border-radius: 2px;
+
   :focus {
     outline: none;
   }
@@ -168,12 +169,15 @@ export const TimelineRow = styled('div')`
 `;
 TimelineRow.displayName = 'TimelineRow';
 
-export const TimelineDate = styled('div')`
+export const TimelineDate = styled(FontOpenSans)`
+  font-size: 12px;
   min-width: 65px;
+  flex-shrink: 0;
 `;
 TimelineDate.displayName = 'TimelineDate';
 
-export const TimelineText = styled('span')`
+export const TimelineText = styled(FontOpenSans)`
+  font-size: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, IconButton, styled } from '@twilio/flex-ui';
 import { ButtonBase } from '@material-ui/core';
 
-import { FontOpenSans, FormInput, FormSelect, FormSelectWrapper, Row, Column } from '../HrmStyles';
+import { FontOpenSans, FormInput, Row, Column } from '../HrmStyles';
 import HrmTheme from '../HrmTheme';
 
 export const CaseLayout = styled('div')`
@@ -77,10 +77,12 @@ type ViewButtonProps = {
 export const ViewButton = styled(props => <Button roundCorners={false} {...props} />)`
   color: ${HrmTheme.colors.categoryTextColor};
   background-color: #ecedf1;
+  height: 28px;
   border-radius: 4px;
-  font-weight: normal;
+  font-family: Open Sans;
+  font-weight: 600;
   letter-spacing: normal;
-  font-size: 12px;
+  font-size: 14px;
   box-shadow: none;
   border: none;
 
@@ -137,16 +139,20 @@ export const CaseActionDetailFont = styled(FontOpenSans)`
 `;
 CaseActionDetailFont.displayName = 'CaseActionDetailFont';
 
+const placeHolderTextStyle = `
+  font-family: Open Sans;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 15px;
+`;
+
 const BaseTextArea = styled('textarea')`
   resize: none;
   background-color: ${HrmTheme.colors.base2};
-  font-family: Open Sans;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 15px;
+  ${placeHolderTextStyle}
   padding: 5px;
   border-style: none;
-  border-radius: 4px;
+  border-radius: 2px;
   :focus {
     outline: none;
   }
@@ -158,7 +164,7 @@ export const TimelineRow = styled('div')`
   background-color: #f6f6f67d;
   height: 40px;
   margin-bottom: 3px;
-  padding: 0 15px;
+  padding: 0 10px;
 `;
 TimelineRow.displayName = 'TimelineRow';
 
@@ -200,6 +206,7 @@ export const InformationBoldText = styled(TimelineDate)`
 InformationBoldText.displayName = 'InformationBoldText';
 
 export const PlaceHolderText = styled(TimelineText)`
+  ${placeHolderTextStyle}
   opacity: 0.5;
 `;
 PlaceHolderText.displayName = 'PlaceHolderText';

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -290,11 +290,11 @@ export const TagsWrapper = styled(Flex)`
 
 export const TagText = styled(FontOpenSans)`
   display: inline-block;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 400;
   line-height: 13px;
-  opacity: 0.65;
-  color: #192b33e8;
+  opacity: 1;
+  color: ${HrmTheme.colors.categoryTextColor};
 `;
 
 export const TagMiddleDot = styled('div')<ColorProps>`


### PR DESCRIPTION
This PR is a reopen of https://github.com/techmatters/flex-plugins/pull/1028

Merging as the previous one already got approved but was closed due to the base branch being deleted.

## Description
This PR addresses slides 8, 10, 11 of the [cleanup slide deck](https://benetech.box.com/s/9v97yt5yqhjx6fkeeijol13qrca0ywrg).

![Screenshot from 2022-11-10 17-17-49](https://user-images.githubusercontent.com/15805319/201197248-14e70fe5-161b-421f-8abf-3e958abe4650.png)
![Screenshot from 2022-11-11 17-31-26](https://user-images.githubusercontent.com/15805319/201426603-2105ab65-ce9b-4aea-9dc1-ff0ce2987a48.png)
![Screenshot from 2022-11-11 17-30-31](https://user-images.githubusercontent.com/15805319/201426499-c14b677b-c770-47fc-81cc-85d1fcb53c61.png)

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1426)
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Configure Flex to point to an account with Flex 2.
- `npm ci` && `npm run dev`.
- Confirm that the search tab in tabbed forms is not "to the left" anymore.
- Confirm that the case has the update desired styles.