### PR TITLE
[Reopen] Flex 2.0 Clean Up: misc UI fixes II

### DIFF
--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -112,7 +112,7 @@ type TextareaDefinition = {
   type: 'textarea';
   placeholder?: string;
   rows?: number;
-  width?: number;
+  width?: number | string;
 } & ItemBase;
 
 type TimeRelatedInput = {

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
@@ -35,6 +35,7 @@ export const definitionObject: CSAMFormDefinitionObject = {
     label: 'Description (500 characters)',
     type: 'textarea',
     maxLength: { value: 500, message: '500 characters max.' },
+    width: '70%',
   },
   anonymous: {
     name: 'anonymous',

--- a/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
+++ b/plugin-hrm-form/src/components/case/CloseCaseDialog.tsx
@@ -28,17 +28,17 @@ export default function CloseCaseDialog({ setDialog, handleDontSaveClose, handle
             <WarningIcon style={{ color: '#f6ca4a' }} /> <br />
             <Template code="BottomBar-SaveOnClose" />
           </CloseDialogText>
-          <Row>
+          <Row style={{ justifyContent: 'space-evenly' }}>
             <StyledNextStepButton
               tabIndex={1}
               secondary
               onClick={handleDontSaveClose}
-              margin="15px auto"
+              margin="15px 0"
               style={{ background: '#fff' }}
             >
               <Template code="BottomBar-DontSave" />
             </StyledNextStepButton>
-            <StyledNextStepButton tabIndex={2} onClick={handleSaveUpdate} margin="15px auto">
+            <StyledNextStepButton tabIndex={2} onClick={handleSaveUpdate} margin="15px 0">
               <Template code="BottomBar-Save" />
             </StyledNextStepButton>
           </Row>

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -749,7 +749,7 @@ export const FormError = styled('span')`
 `;
 FormError.displayName = 'FormError';
 
-type FormInputProps = { error?: boolean; width?: number; fullWidth?: boolean };
+type FormInputProps = { error?: boolean; width?: number | string; fullWidth?: boolean };
 
 export const FormInput = styled('input')<FormInputProps>`
   /* ---------- Input ---------- */

--- a/plugin-hrm-form/src/styles/callTypeButtons/index.tsx
+++ b/plugin-hrm-form/src/styles/callTypeButtons/index.tsx
@@ -104,9 +104,24 @@ type ConfirmButtonProps = {
   disabled: boolean;
 };
 
-export const ConfirmButton = styled(Button)<ConfirmButtonProps>`
+const CloseDialogButton = styled(Button)`
+  padding: 0px 16px;
+  border: none;
+  outline: none;
+  align-self: center;
+  height: 28px;
+  font-size: 10px;
+  font-weight: bold;
+  letter-spacing: 2px;
+  white-space: nowrap;
+  border-radius: 100px;
+  text-transform: uppercase;
+`;
+
+export const ConfirmButton = styled(CloseDialogButton)<ConfirmButtonProps>`
   text-transform: uppercase;
   color: ${props => HrmTheme.colors.declineTextColor};
+  background: linear-gradient(to top, ${HrmTheme.colors.declineColor}, ${HrmTheme.colors.declineColor});
   ${p => getBackgroundWithHoverCSS(HrmTheme.colors.declineColor, true, false, p.disabled)};
 
   &:focus {
@@ -115,12 +130,14 @@ export const ConfirmButton = styled(Button)<ConfirmButtonProps>`
   }
 `;
 
-export const CancelButton = styled(Button)`
+export const CancelButton = styled(CloseDialogButton)`
   text-transform: uppercase;
   margin-left: 30px;
+  color: rgb(0, 0, 0);
+  background: linear-gradient(to top, ${HrmTheme.colors.buttonTextColor}, ${HrmTheme.colors.buttonTextColor});
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.2);
+    background-color: ${HrmTheme.colors.buttonHoverColor};
     background-blend-mode: color;
   }
 


### PR DESCRIPTION
This PR is a reopen of https://github.com/techmatters/flex-plugins/pull/1034.

<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @mythilytm 

## Description
This PR addresses slides 12, 16 and 17 of the [cleanup slide deck](https://benetech.box.com/s/9v97yt5yqhjx6fkeeijol13qrca0ywrg).

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1426)
- [n/a] New tests added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Configure Flex to point to an account with Flex 2.
- `npm ci` && `npm run dev`.
- Confirm that the CSAM form screen is as expected.
- Trigger the "save changes" dialog trying to add a case section an cancelling it, and confirm that the style is the expected.
- Trigger the "close contact" dialog trying to submit a contact, and confirm that the style is the expected.