### PR TITLE
Switch style fixed in Cases page

### DIFF
--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -273,7 +273,14 @@ const SearchResults: React.FC<Props> = ({
                   )}{' '}
                 </StyledCount>
                 <StyledFormControlLabel
-                  control={<StyledSwitch checked={closedCases} onChange={handleToggleClosedCases} />}
+                  control={
+                    <StyledSwitch
+                      color="default"
+                      size="small"
+                      checked={closedCases}
+                      onChange={handleToggleClosedCases}
+                    />
+                  }
                   label={
                     <SwitchLabel>
                       <Template code="SearchResultsIndex-ClosedCases" />


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
 - Search Form > Cases page > Switch style needed update

<!--
### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts
-->
### Related Issues
Fixes #....

### Verification steps
- In 'Search Contacts' page, switch in contacts is fine, but now, Cases switch looks the same as switch in contacts. 
<img width="123" alt="Screenshot 2022-11-23 at 3 16 21 PM" src="https://user-images.githubusercontent.com/102122005/203638894-ad2f5e67-793f-4abf-9a34-807eca9af830.png">

<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->