### PR TITLE
Remove newintab as a template string nd implement as a icon component

### DIFF
--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormScreen.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormScreen.tsx
@@ -4,7 +4,13 @@ import { Template } from '@twilio/flex-ui';
 
 import ActionHeader from '../case/ActionHeader';
 import { BottomButtonBar, Box, StyledNextStepButton } from '../../styles/HrmStyles';
-import { CSAMReportContainer, CSAMReportLayout, BoldDescriptionText, RegularText } from '../../styles/CSAMReport';
+import {
+  CSAMReportContainer,
+  CSAMReportLayout,
+  BoldDescriptionText,
+  RegularText,
+  StyledOpenInNew,
+} from '../../styles/CSAMReport';
 import { definitionObject, childDefinitionObject } from './CSAMReportFormDefinition';
 import { RequiredAsterisk } from '../common/forms/formGenerators';
 
@@ -95,6 +101,7 @@ const CSAMReportFormScreen: React.FC<Props> = ({
           <Box marginTop="20px" marginBottom="5px">
             <RegularText>
               <Template code="CSAMReportForm-ContactDetailsInfo" />
+              <StyledOpenInNew fontSize="inherit" />
             </RegularText>
             <Box padding="15px 15px 15px 20px">
               {counsellorFormElements.firstName}

--- a/plugin-hrm-form/src/styles/CSAMReport/index.tsx
+++ b/plugin-hrm-form/src/styles/CSAMReport/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { styled } from '@twilio/flex-ui';
 import { withStyles } from '@material-ui/core';
-import AttachFile from '@material-ui/icons/AttachFile';
-import CheckCircle from '@material-ui/icons/CheckCircle';
-import FileCopyOutlined from '@material-ui/icons/FileCopyOutlined';
+import { AttachFile, CheckCircle, FileCopyOutlined, OpenInNew } from '@material-ui/icons';
 
 import { FontOpenSans, StyledNextStepButton } from '../HrmStyles';
 import HrmTheme from '../HrmTheme';
@@ -114,3 +112,13 @@ StyledCheckCircle.displayName = 'StyledCheckCircle';
 
 export const StyledFileCopyOutlined = styleCopyCodeIcon(FileCopyOutlined);
 StyledFileCopyOutlined.displayName = 'StyledFileCopyOutlined';
+
+const StyledSmallIcon = withStyles({
+  root: {
+    width: '17px',
+    height: '17px',
+  },
+});
+
+export const StyledOpenInNew = StyledSmallIcon(OpenInNew);
+StyledOpenInNew.displayName = 'StyledOpenInNew';

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -64,12 +64,6 @@ a.link-text-decoration-none:hover { text-decoration: none; color: #1874e1; }
 a.link-text-decoration-none:focus { text-decoration: none; color: #1874e1; }
 a.link-text-decoration-none:active { text-decoration: none; color: #1874e1; }
 
-span.ContactDetailsInfo-open-in-new-icon {
-    width: 16px;
-    height: 16px;
-    font-size: 16px;
-}
-
 .editingContact .hiddenWhenEditingContact {
     display: none;
 }

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -362,7 +362,7 @@
   "CSAMReportForm-ContactDetails": "Contact details",
   "CSAMReportForm-ContactDetailsDescription": "Reports can be filed anonymously or with contact details if the caller would like to follow up or be available to provide further details to IWF.",
   "CSAMReportForm-LearnMore": "Learn more",
-  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>.   <span class=\"ContactDetailsInfo-open-in-new-icon material-icons\">open_in_new</span>",
+  "CSAMReportForm-ContactDetailsInfo": "Contact details will be recorded on the IWF database for 3 months, and then will then be deleted in accordance with the <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>.",
   "CSAMReportForm-ReportSent": "CSAM Report Sent!",
   "CSAMReportForm-CopyCode": "Copy confirmation code for sharing",
   "CSAMReportForm-Attachment": "CSAM Report has been filled",

--- a/plugin-hrm-form/src/translations/es-CL/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-CL/flexUI.json
@@ -468,7 +468,7 @@
     "CSAMReportForm-Attachment": "El informe CSAM ha sido completado",
     "CSAMReportForm-ContactDetails": "Detalles de contacto",
     "CSAMReportForm-ContactDetailsDescription": "Los informes se pueden presentar de forma anónima o con datos de contacto si la persona que llama desea hacer un seguimiento o estar disponible para proporcionar más detalles a IWF.",
-    "CSAMReportForm-ContactdetailsInfo": "Los datos de contacto se registrarán en la base de datos IWF durante 3 meses, y luego se eliminarán de acuerdo con <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>.   <span class=\"ContactDetailsInfo-open-in-new-icon material-icons\">open_in_new</span>",
+    "CSAMReportForm-ContactdetailsInfo": "Los datos de contacto se registrarán en la base de datos IWF durante 3 meses, y luego se eliminarán de acuerdo con <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>.",
     "CSAMReportForm-CopyCode": "Copiar código de confirmación para compartir",
     "CSAMReportForm-Header": "Presentar un Informe: material de abuso sexual infantil",
     "CSAMReportForm-LearnMore": "Aprender más",

--- a/plugin-hrm-form/src/translations/es-CO/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-CO/flexUI.json
@@ -462,7 +462,7 @@
     "CSAMReportForm-Attachment": "El informe CSAM ha sido completado",
     "CSAMReportForm-ContactDetails": "Detalles de contacto",
     "CSAMReportForm-ContactDetailsDescription": "Los informes se pueden presentar de forma anónima o con datos de contacto si la persona que llama desea hacer un seguimiento o estar disponible para proporcionar más detalles a IWF.",
-    "CSAMReportForm-ContactdetailsInfo": "Los datos de contacto se registrarán en la base de datos IWF durante 3 meses, y luego se eliminarán de acuerdo con <a class=\\\"link-text-decoration-none\\\" href=\\\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\\\" target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\">UK Data Protection Act</a>.   <span class=\\\"ContactDetailsInfo-open-in-new-icon material-icons\\\">open_in_new</span>",
+    "CSAMReportForm-ContactdetailsInfo": "Los datos de contacto se registrarán en la base de datos IWF durante 3 meses, y luego se eliminarán de acuerdo con <a class=\\\"link-text-decoration-none\\\" href=\\\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\\\" target=\\\"_blank\\\" rel=\\\"noopener noreferrer\\\">UK Data Protection Act</a>.",
     "CSAMReportForm-CopyCode": "Copiar código de confirmación para compartir",
     "CSAMReportForm-Header": "Presentar un Informe: material de abuso sexual infantil",
     "CSAMReportForm-LearnMore": "Aprender más",

--- a/plugin-hrm-form/src/translations/es-ES/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-ES/flexUI.json
@@ -532,7 +532,7 @@
   "CSAMReportForm-Attachment": "El informe CSAM ha sido completado",
   "CSAMReportForm-ContactDetails": "Detalles de contacto",
   "CSAMReportForm-ContactDetailsDescription": "Los informes se pueden presentar de forma anónima o con datos de contacto si la persona que llama desea hacer un seguimiento o estar disponible para proporcionar más detalles a IWF.",
-  "CSAMReportForm-ContactdetailsInfo": "Los datos de contacto se registrarán en la base de datos IWF durante 3 meses, y luego se eliminarán de acuerdo con <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>.   <span class=\"ContactDetailsInfo-open-in-new-icon material-icons\">open_in_new</span>",
+  "CSAMReportForm-ContactdetailsInfo": "Los datos de contacto se registrarán en la base de datos IWF durante 3 meses, y luego se eliminarán de acuerdo con <a class=\"link-text-decoration-none\" href=\"https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted\" target=\"_blank\" rel=\"noopener noreferrer\">UK Data Protection Act</a>.",
   "CSAMReportForm-CopyCode": "Copiar código de confirmación para compartir",
   "CSAMReportForm-Header": "Presentar un Informe: material de abuso sexual infantil",
   "CSAMReportForm-LearnMore": "Aprender más",


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand  

## Description
- Bug fix: Remove `newintab` icon as a template string and implement as an icon component
<!--
### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts
 -->
### Related Issues
Fixes #[1520](https://bugs.benetech.org/browse/CHI-1520)

### Verification steps
Go to `External Reports` dropdown > `Report as counselor' > Choose 'Provide contact details', and look for the icon next to the UK Data protection act link
![Open in new tab icon](https://user-images.githubusercontent.com/102122005/203153431-23a2fc1d-06ad-4c3e-9eb1-7feb1f416cde.png)
