### PR TITLE
End Chat and Transfer buttons style mouseover states

### DIFF
--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -481,7 +481,6 @@ export const TransferStyledButton = styled('button')<TransferStyledButtonProps>`
   color: ${props => (props.color ? props.color : '#000')};
   letter-spacing: 0px;
   text-transform: none;
-  font-weight: bold;
   margin-right: 1em;
   padding: 0px 16px;
   height: ${props => (props.taller ? 35 : 28)}px;
@@ -492,6 +491,15 @@ export const TransferStyledButton = styled('button')<TransferStyledButtonProps>`
   align-self: center;
   &:hover {
     cursor: pointer;
+    border: 1px solid gray;
+    padding: 0px 15px;
+  }
+  &:focus {
+    outline: auto;
+    outline-color: #1976d2;
+  }
+  &:active {
+    background: rgb(172, 179, 181);
   }
 `;
 TransferStyledButton.displayName = 'TransferStyledButton';

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -87,3 +87,15 @@ span.ContactDetailsInfo-open-in-new-icon {
     letter-spacing: inherit;
     font-size: 14px;
 }
+button.Twilio-TaskCanvasHeader-EndButton {
+    padding: 3px 16px;
+    font-weight: normal;
+    min-width: auto;
+}
+button.Twilio-TaskCanvasHeader-EndButton:hover{
+    border: 1px solid rgb(70, 70, 70);
+    background-color: rgb(220, 84, 84);
+}
+button.Twilio-TaskCanvasHeader-EndButton:active {
+    border: 2px solid black;
+}


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @acedeywin 

## Description
- End Chat and Transfer buttons mouseover states and work to ensure style fidelity
<!-- 
### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts
-- >
### Related Issues
Fixes #1522
