### PR TITLE
CHI-1525: Fix button saving states

### DIFF
--- a/plugin-hrm-form/src/components/contact/EditContactSection.tsx
+++ b/plugin-hrm-form/src/components/contact/EditContactSection.tsx
@@ -162,6 +162,7 @@ const EditContactSection: React.FC<Props> = ({
               data-testid="EditContact-SaveContact-Button"
             >
               <span style={{ visibility: isSubmitting ? 'hidden' : 'inherit' }}>
+                {/* eslint-disable-next-line react/jsx-max-depth */}
                 <Template code="BottomBar-SaveContact" />
               </span>
               {isSubmitting ? <CircularProgress size={12} style={{ position: 'absolute' }} /> : null}

--- a/plugin-hrm-form/src/components/contact/EditContactSection.tsx
+++ b/plugin-hrm-form/src/components/contact/EditContactSection.tsx
@@ -161,7 +161,10 @@ const EditContactSection: React.FC<Props> = ({
               data-fs-id="Contact-SaveContact-Button"
               data-testid="EditContact-SaveContact-Button"
             >
-              {isSubmitting ? <CircularProgress size={12} /> : <Template code="BottomBar-SaveContact" />}
+              <span style={{ visibility: isSubmitting ? 'hidden' : 'inherit' }}>
+                <Template code="BottomBar-SaveContact" />
+              </span>
+              {isSubmitting ? <CircularProgress size={12} style={{ position: 'absolute' }} /> : null}
             </StyledNextStepButton>
           </Box>
         </BottomButtonBar>

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
@@ -135,7 +135,10 @@ class BottomBar extends Component {
                 data-fs-id="Contact-SaveContact-Button"
                 data-testid="BottomBar-SaveContact-Button"
               >
-                {isSubmitting ? <CircularProgress size={12} /> : <Template code="BottomBar-SaveCaseContact" />}
+                <span style={{ visibility: isSubmitting ? 'hidden' : 'inherit' }}>
+                  <Template code="BottomBar-SaveCaseContact" />
+                </span>
+                {isSubmitting ? <CircularProgress size={12} style={{ position: 'absolute' }} /> : null}
               </StyledNextStepButton>
             </>
           )}

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -1,13 +1,11 @@
-import React, { Component } from 'react';
+import React, { Component, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
-import PropTypes from 'prop-types';
 import { Template } from '@twilio/flex-ui';
 import { CircularProgress } from '@material-ui/core';
 import FolderIcon from '@material-ui/icons/Folder';
-import { callTypes } from 'hrm-form-definitions';
+import { SubmitErrorHandler } from 'react-hook-form';
 
-import { taskType } from '../../types';
 import { Box, BottomButtonBar, StyledNextStepButton } from '../../styles/HrmStyles';
 import * as CaseActions from '../../states/case/actions';
 import * as RoutingActions from '../../states/routing/actions';
@@ -19,28 +17,33 @@ import { namespace, contactFormsBase, connectedCaseBase } from '../../states';
 import { isNonDataCallType } from '../../states/ValidationRules';
 import { recordBackendError, recordingErrorHandler } from '../../fullStory';
 import { CustomITask } from '../../types/types';
-import { SubmitErrorHandler } from 'react-hook-form';
 
 type BottomBarProps = {
-  handleSubmitIfValid: (handleSubmit: ()=> void, onError: SubmitErrorHandler<unknown>) => () => void,
-  optionalButtons?: { onClick: () => void, label: string}[],
-  showNextButton: boolean,
-  showSubmitButton: boolean,
-  nextTab: () => void,
-  task: CustomITask,
-
+  handleSubmitIfValid: (handleSubmit: () => void, onError: SubmitErrorHandler<unknown>) => () => void;
+  optionalButtons?: { onClick: () => void; label: string }[];
+  showNextButton: boolean;
+  showSubmitButton: boolean;
+  nextTab: () => void;
+  task: CustomITask;
 };
 
-class BottomBar extends Component<BottomBarProps & ReturnType<typeof mapDispatchToProps> & ReturnType<typeof mapStateToProps>> {
-  static displayName = 'BottomBar';
+const BottomBar: React.FC<
+  BottomBarProps & ReturnType<typeof mapDispatchToProps> & ReturnType<typeof mapStateToProps>
+> = ({
+  showNextButton,
+  showSubmitButton,
+  handleSubmitIfValid,
+  optionalButtons,
+  contactForm,
+  task,
+  changeRoute,
+  setConnectedCase,
+  nextTab,
+  caseForm,
+}) => {
+  const [isSubmitting, setSubmitting] = useState(false);
 
-
-  state = {
-    isSubmitting: false,
-  };
-
-  handleOpenNewCase = async () => {
-    const { task, contactForm } = this.props;
+  const handleOpenNewCase = async () => {
     const { taskSid } = task;
     const { strings } = getConfig();
 
@@ -48,21 +51,18 @@ class BottomBar extends Component<BottomBarProps & ReturnType<typeof mapDispatch
 
     try {
       const caseFromDB = await createCase(task, contactForm);
-      this.props.changeRoute({ route: 'new-case' }, taskSid);
-      this.props.setConnectedCase(caseFromDB, taskSid);
+      changeRoute({ route: 'new-case' }, taskSid);
+      setConnectedCase(caseFromDB, taskSid);
     } catch (error) {
       recordBackendError('Open New Case', error);
       window.alert(strings['Error-Backend']);
     }
   };
 
-  handleSubmit = async () => {
-    // eslint-disable-next-line react/prop-types
-    const { task, contactForm, caseForm } = this.props;
+  const handleSubmit = async () => {
+    if (isSubmitting || !hasTaskControl(task)) return;
 
-    if (this.state.isSubmitting || !hasTaskControl(task)) return;
-
-    this.setState({ isSubmitting: true });
+    setSubmitting(true);
 
     try {
       await submitContactForm(task, contactForm, caseForm);
@@ -73,77 +73,74 @@ class BottomBar extends Component<BottomBarProps & ReturnType<typeof mapDispatch
         await completeTask(task);
       }
     } finally {
-      this.setState({ isSubmitting: false });
+      setSubmitting(false);
     }
   };
 
-  onError = recordingErrorHandler('Tabbed HRM Form', () => {
+  const onError = recordingErrorHandler('Tabbed HRM Form', () => {
     const { strings } = getConfig();
     window.alert(strings['Error-Form']);
   });
 
-  render() {
-    const { showNextButton, showSubmitButton, handleSubmitIfValid, optionalButtons, contactForm } = this.props;
-    const { isSubmitting } = this.state;
+  const showBottomBar = showNextButton || showSubmitButton;
+  const { featureFlags } = getConfig();
 
-    const showBottomBar = showNextButton || showSubmitButton;
-    const { featureFlags } = getConfig();
+  if (!showBottomBar) return null;
 
-    if (!showBottomBar) return null;
+  return (
+    <>
+      <BottomButtonBar>
+        {optionalButtons &&
+          optionalButtons.map((i, index) => (
+            <Box key={`optional-button-${index}`} marginRight="15px">
+              <StyledNextStepButton type="button" roundCorners secondary onClick={i.onClick} disabled={isSubmitting}>
+                <Template code={i.label} />
+              </StyledNextStepButton>
+            </Box>
+          ))}
 
-    return (
-      <>
-        <BottomButtonBar>
-          {optionalButtons &&
-            optionalButtons.map((i, index) => (
-              <Box key={`optional-button-${index}`} marginRight="15px">
-                <StyledNextStepButton type="button" roundCorners secondary onClick={i.onClick} disabled={isSubmitting}>
-                  <Template code={i.label} />
+        {showNextButton && (
+          <StyledNextStepButton type="button" roundCorners={true} onClick={nextTab}>
+            <Template code="BottomBar-Next" />
+          </StyledNextStepButton>
+        )}
+        {showSubmitButton && (
+          <>
+            {featureFlags.enable_case_management && !isNonDataCallType(contactForm.callType) && (
+              <Box marginRight="15px">
+                <StyledNextStepButton
+                  type="button"
+                  roundCorners
+                  secondary
+                  onClick={handleSubmitIfValid(handleOpenNewCase, onError)}
+                  data-fs-id="Contact-SaveAndAddToCase-Button"
+                  data-testid="BottomBar-SaveAndAddToCase-Button"
+                >
+                  <FolderIcon style={{ fontSize: '16px', marginRight: '10px' }} />
+                  <Template code="BottomBar-AddContactToNewCase" />
                 </StyledNextStepButton>
               </Box>
-            ))}
-
-          {showNextButton && (
-            <StyledNextStepButton type="button" roundCorners={true} onClick={this.props.nextTab}>
-              <Template code="BottomBar-Next" />
+            )}
+            <StyledNextStepButton
+              roundCorners={true}
+              onClick={handleSubmitIfValid(handleSubmit, onError)}
+              disabled={isSubmitting}
+              data-fs-id="Contact-SaveContact-Button"
+              data-testid="BottomBar-SaveContact-Button"
+            >
+              <span style={{ visibility: isSubmitting ? 'hidden' : 'inherit' }}>
+                <Template code="BottomBar-SaveCaseContact" />
+              </span>
+              {isSubmitting ? <CircularProgress size={12} style={{ position: 'absolute' }} /> : null}
             </StyledNextStepButton>
-          )}
-          {showSubmitButton && (
-            <>
-              {featureFlags.enable_case_management && !isNonDataCallType(contactForm.callType) && (
-                <Box marginRight="15px">
-                  <StyledNextStepButton
-                    type="button"
-                    roundCorners
-                    secondary
-                    onClick={handleSubmitIfValid(this.handleOpenNewCase, this.onError)}
-                    data-fs-id="Contact-SaveAndAddToCase-Button"
-                    data-testid="BottomBar-SaveAndAddToCase-Button"
-                  >
-                    <FolderIcon style={{ fontSize: '16px', marginRight: '10px' }} />
-                    <Template code="BottomBar-AddContactToNewCase" />
-                  </StyledNextStepButton>
-                </Box>
-              )}
-              <StyledNextStepButton
-                roundCorners={true}
-                onClick={handleSubmitIfValid(this.handleSubmit, this.onError)}
-                disabled={isSubmitting}
-                data-fs-id="Contact-SaveContact-Button"
-                data-testid="BottomBar-SaveContact-Button"
-              >
-                <span style={{ visibility: isSubmitting ? 'hidden' : 'inherit' }}>
-                  <Template code="BottomBar-SaveCaseContact" />
-                </span>
-                {isSubmitting ? <CircularProgress size={12} style={{ position: 'absolute' }} /> : null}
-              </StyledNextStepButton>
-            </>
-          )}
-        </BottomButtonBar>
-      </>
-    );
-  }
-}
+          </>
+        )}
+      </BottomButtonBar>
+    </>
+  );
+};
+
+BottomBar.displayName = 'BottomBar';
 
 const mapStateToProps = (state, ownProps: BottomBarProps) => {
   const contactForm = state[namespace][contactFormsBase].tasks[ownProps.task.taskSid];


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description

* Fix styling of 'submit' buttons so they retain the same shape they have with text when the spinner is showing
* Refactored BottomBar.jsx to a functional TSX component

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1525

### Verification steps

See Ticket
Also regression around the contact tabbed forms