### PR TITLE
CHI-1521: Styling for custom task list headers now matches flex styling. 

### DIFF
--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -510,12 +510,11 @@ export const HeaderContainer = styled(Row)`
   justify-items: flex-start;
   background-color: ${HrmTheme.colors.base2};
   border-width: 0px;
-  text-transform: uppercase;
+  text-transform: capitalize;
   color: #192b33;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 1.67px;
-  line-height: 12px;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
   padding: 0px;
 `;
 HeaderContainer.displayName = 'HeaderContainer';

--- a/plugin-hrm-form/src/styles/HrmTheme.ts
+++ b/plugin-hrm-form/src/styles/HrmTheme.ts
@@ -1,3 +1,6 @@
+import { DeepPartial } from 'redux';
+import type { Theme } from '@twilio/flex-ui';
+
 const colors = {
   /*
    * base1: '#ffffff',
@@ -69,8 +72,10 @@ const colors = {
   userUnavailableColor: '#999999',
 };
 
+type ThemeOverrides = DeepPartial<Omit<Theme, 'tokens' | 'isLight'>>;
+
 // eslint-disable-next-line import/no-unused-modules
-export const overrides = {
+export const overrides: ThemeOverrides = {
   MainHeader: {
     Container: {
       background: colors.base2,


### PR DESCRIPTION
Primary reviewer: @acedeywin 

## Description

* Styling for custom task list headers now matches flex styling
* HrmTheme is now TS

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes CHI-1521

### Verification steps

See ticket