### PR TITLE
CHI-1275: Migrate ContactPreview to TS

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/case/ViewContact.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/ViewContact.test.tsx
@@ -12,7 +12,7 @@ import { mockGetDefinitionsResponse } from '../../mockGetConfig';
 import ViewContact from '../../../components/case/ViewContact';
 import { ContactDetailsSections } from '../../../components/common/ContactDetails';
 import { getDefinitionVersions } from '../../../HrmFormPlugin';
-import { SearchContact } from '../../../types/types';
+import { SearchAPIContact } from '../../../types/types';
 import { connectedCaseBase, contactFormsBase, RootState } from '../../../states';
 import { DetailsContext, TOGGLE_DETAIL_EXPANDED_ACTION } from '../../../states/contacts/contactDetails';
 
@@ -33,7 +33,7 @@ const task = {
   defaultFrom: '+12025550425',
 };
 
-const contact: SearchContact = {
+const contact: SearchAPIContact = {
   contactId: 'TEST ID',
   details: {
     definitionVersion: DefinitionVersionId.v1,

--- a/plugin-hrm-form/src/___tests__/components/contact/contactDetailsSectionFormApi.test.ts
+++ b/plugin-hrm-form/src/___tests__/components/contact/contactDetailsSectionFormApi.test.ts
@@ -7,7 +7,7 @@ import {
   ContactFormValues,
   IssueCategorizationSectionFormApi,
 } from '../../../components/contact/contactDetailsSectionFormApi';
-import { SearchContact } from '../../../types/types';
+import { SearchAPIContact } from '../../../types/types';
 import details from '../../../components/case/casePrint/styles/details';
 
 let definition: DefinitionVersion;
@@ -43,7 +43,7 @@ beforeAll(async () => {
   };
 });
 
-const emptySearchContact: SearchContact = {
+const emptySearchContact: SearchAPIContact = {
   contactId: '0',
   overview: {
     helpline: undefined,

--- a/plugin-hrm-form/src/___tests__/states/contacts/contactDetailsAdapter.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/contactDetailsAdapter.test.ts
@@ -3,7 +3,7 @@ import {
   retrieveCategories,
   searchContactToHrmServiceContact,
 } from '../../../states/contacts/contactDetailsAdapter';
-import { SearchContact } from '../../../types/types';
+import { SearchAPIContact } from '../../../types/types';
 
 describe('retrieveCategories', () => {
   test('falsy input, empty object output', () => expect(retrieveCategories(null)).toStrictEqual({}));
@@ -39,7 +39,7 @@ describe('retrieveCategories', () => {
 });
 
 describe('hrmServiceContactToSearchContact', () => {
-  const emptyOverview: SearchContact['overview'] = {
+  const emptyOverview: SearchAPIContact['overview'] = {
     helpline: undefined,
     dateTime: undefined,
     name: 'undefined undefined',
@@ -253,7 +253,7 @@ describe('hrmServiceContactToSearchContact', () => {
 });
 
 describe('searchContactToHrmServiceContact', () => {
-  const baseSearchContact: SearchContact = {
+  const baseSearchContact: SearchAPIContact = {
     contactId: '1337',
     overview: {
       taskId: 'A task',

--- a/plugin-hrm-form/src/___tests__/states/contacts/existingContacts.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/existingContacts.test.ts
@@ -22,9 +22,9 @@ import {
   updateDraft,
   updateDraftReducer,
 } from '../../../states/contacts/existingContacts';
-import { SearchContact } from '../../../types/types';
+import { SearchAPIContact } from '../../../types/types';
 
-const baseContact: SearchContact = {
+const baseContact: SearchAPIContact = {
   contactId: '1337',
   overview: {
     helpline: undefined,

--- a/plugin-hrm-form/src/___tests__/states/search/actions.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/search/actions.test.ts
@@ -4,7 +4,7 @@ import { mockGetDefinitionsResponse } from '../../mockGetConfig';
 import * as t from '../../../states/search/types';
 import * as actions from '../../../states/search/actions';
 import { ContactDetailsSections } from '../../../components/common/ContactDetails';
-import { SearchContact } from '../../../types/types';
+import { SearchAPIContact } from '../../../types/types';
 import { searchContacts } from '../../../services/ContactService';
 import { searchCases } from '../../../services/CaseService';
 import { CASES_PER_PAGE, CONTACTS_PER_PAGE } from '../../../components/search/SearchResults';
@@ -59,7 +59,7 @@ describe('test action creators', () => {
 
   test('viewContactDetails', () => {
     const contact: unknown = { contactId: 'fake contact', overview: {}, details: {}, counselor: '', tags: [] };
-    const typedContact = contact as SearchContact; // type casting to avoid writing an entire SearchContact
+    const typedContact = contact as SearchAPIContact; // type casting to avoid writing an entire SearchContact
 
     expect(actions.viewContactDetails(taskId)(typedContact)).toStrictEqual({
       type: t.VIEW_CONTACT_DETAILS,

--- a/plugin-hrm-form/src/___tests__/states/search/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/search/reducer.test.ts
@@ -2,7 +2,7 @@ import fromentries from 'fromentries';
 
 import * as t from '../../../states/search/types';
 import { handleSearchFormChange } from '../../../states/search/actions';
-import { SearchContact, SearchCaseResult } from '../../../types/types';
+import { SearchAPIContact, SearchCaseResult } from '../../../types/types';
 import { ContactDetailsSections } from '../../../components/common/ContactDetails';
 import {
   INITIALIZE_CONTACT_STATE,
@@ -109,7 +109,7 @@ describe('search reducer', () => {
     const contact: unknown = { contactId: 'fake contact', overview: {}, details: {}, counselor: '', tags: [] };
     const action: t.SearchActionType = {
       type: t.VIEW_CONTACT_DETAILS,
-      contact: contact as SearchContact, // type casting to avoid writing an entire SearchContact
+      contact: contact as SearchAPIContact, // type casting to avoid writing an entire SearchContact
       taskId: task.taskSid,
     };
     const result = reduce(state, action);

--- a/plugin-hrm-form/src/___tests__/states/search/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/search/reducer.test.ts
@@ -137,8 +137,8 @@ describe('search reducer', () => {
     const searchResult = {
       count: 2,
       contacts: [
-        { contactId: 'fake contact result 1', overview: {}, details: {}, counselor: '' },
-        { contactId: 'fake contact result 2', overview: {}, details: {}, counselor: '' },
+        { contactId: 'fake contact result 1', overview: {}, details: {}, counselorName: '' },
+        { contactId: 'fake contact result 2', overview: {}, details: {}, counselorName: '' },
       ],
     } as t.DetailedSearchContactsResult; // type casting to avoid writing an entire DetailedSearchContactsResult
     const action: t.SearchActionType = {

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { callTypes } from 'hrm-form-definitions';
 
 import { Flex, Row } from '../../styles/HrmStyles';
-import { isS3StoredTranscript, isTwilioStoredMedia, SearchContact } from '../../types/types';
+import { isS3StoredTranscript, isTwilioStoredMedia, SearchAPIContact } from '../../types/types';
 import {
   DetailsContainer,
   NameText,
@@ -71,7 +71,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
   if (!savedContact || !definitionVersion) return null;
 
   // Object destructuring on contact
-  const { overview, details, csamReports } = savedContact as SearchContact;
+  const { overview, details, csamReports } = savedContact as SearchAPIContact;
   const {
     counselor,
     dateTime,

--- a/plugin-hrm-form/src/components/contact/contactDetailsSectionFormApi.ts
+++ b/plugin-hrm-form/src/components/contact/contactDetailsSectionFormApi.ts
@@ -1,6 +1,6 @@
 import { DefinitionVersion, FormDefinition, LayoutDefinition } from 'hrm-form-definitions';
 
-import { ContactRawJson, InformationObject, SearchContact } from '../../types/types';
+import { ContactRawJson, InformationObject, SearchAPIContact } from '../../types/types';
 import {
   transformCategories,
   transformContactFormValues,

--- a/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/index.tsx
@@ -10,17 +10,17 @@ import { Container } from '../../../styles/HrmStyles';
 import GeneralContactDetails from '../../contact/ContactDetails';
 import ConnectDialog from '../ConnectDialog';
 import BackToSearchResultsButton from '../SearchResults/SearchResultsBackButton';
-import { SearchContact } from '../../../types/types';
+import { SearchAPIContact } from '../../../types/types';
 import { loadContact, releaseContact } from '../../../states/contacts/existingContacts';
 import { DetailsContext } from '../../../states/contacts/contactDetails';
 
 type OwnProps = {
   task: any;
   currentIsCaller: boolean;
-  contact: SearchContact;
+  contact: SearchAPIContact;
   showActionIcons: boolean;
   handleBack: () => void;
-  handleSelectSearchResult: (contact: SearchContact) => void;
+  handleSelectSearchResult: (contact: SearchAPIContact) => void;
 };
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const editContactFormOpen = state[namespace][contactFormsBase].editingContact;

--- a/plugin-hrm-form/src/components/search/ContactPreview/ChildNameAndDate.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ChildNameAndDate.tsx
@@ -13,7 +13,7 @@ import { channelTypes, ChannelTypes } from '../../../states/DomainConstants';
 import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
 
 type OwnProps = {
-  channel: ChannelTypes;
+  channel: ChannelTypes | 'default';
   callType: CallTypes;
   name?: string;
   number?: string;

--- a/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.tsx
@@ -4,12 +4,17 @@ import PropTypes from 'prop-types';
 import ChildNameAndDate from './ChildNameAndDate';
 import CallSummary from './CallSummary';
 import TagsAndCounselor from './TagsAndCounselor';
-import { contactType } from '../../../types';
 import { ContactWrapper } from '../../../styles/search';
 import { Flex } from '../../../styles/HrmStyles';
+import { SearchUIContact } from '../../../types/types';
 
-const ContactPreview = ({ contact, handleViewDetails, showConnectIcon }) => {
-  const { counselor } = contact;
+type ContactPreviewProps = {
+  contact: SearchUIContact,
+  handleViewDetails: () => void
+}
+
+const ContactPreview: React.FC<ContactPreviewProps> = ({ contact, handleViewDetails }) => {
+  const { counselorName } = contact;
   const { callSummary } = contact.details.caseInformation;
 
   return (
@@ -25,7 +30,7 @@ const ContactPreview = ({ contact, handleViewDetails, showConnectIcon }) => {
         />
         <CallSummary callSummary={callSummary} onClickFull={handleViewDetails} />
         <TagsAndCounselor
-          counselor={counselor}
+          counselor={counselorName}
           categories={contact.overview.categories}
           definitionVersion={contact.details.definitionVersion}
         />
@@ -35,11 +40,5 @@ const ContactPreview = ({ contact, handleViewDetails, showConnectIcon }) => {
 };
 
 ContactPreview.displayName = 'ContactPreview';
-
-ContactPreview.propTypes = {
-  contact: contactType.isRequired,
-  handleViewDetails: PropTypes.func.isRequired,
-  showConnectIcon: PropTypes.bool.isRequired,
-};
 
 export default ContactPreview;

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -9,7 +9,7 @@ import CasePreview from '../CasePreview';
 import {
   SearchContactResult,
   SearchCaseResult,
-  SearchContact,
+  SearchAPIContact,
   Case,
   CustomITask,
   standaloneTaskSid,
@@ -55,7 +55,7 @@ type OwnProps = {
   toggleNonDataContacts: () => void;
   toggleClosedCases: () => void;
   handleBack: () => void;
-  handleViewDetails: (contact: SearchContact) => void;
+  handleViewDetails: (contact: SearchAPIContact) => void;
   changeSearchPage: (SearchPagesType) => void;
   setConnectedCase: (currentCase: Case, taskSid: string) => void;
   currentPage: SearchPagesType;

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -80,7 +80,6 @@ const SearchResults: React.FC<Props> = ({
   changeSearchPage,
   setConnectedCase,
   currentPage,
-  showConnectIcon,
   counselorsHash,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
@@ -245,7 +244,6 @@ const SearchResults: React.FC<Props> = ({
                 contacts.length > 0 &&
                 contacts.map(contact => (
                   <ContactPreview
-                    showConnectIcon={showConnectIcon}
                     key={contact.contactId}
                     contact={contact}
                     handleViewDetails={() => handleViewDetails(contact)}
@@ -321,12 +319,10 @@ const mapStateToProps = (state, ownProps) => {
   const searchContactsState = state[namespace][searchContactsBase];
   const taskId = ownProps.task.taskSid;
   const taskSearchState = searchContactsState.tasks[taskId];
-  const isStandaloneSearch = taskId === standaloneTaskSid;
   const { counselors } = state[namespace][configurationBase];
 
   return {
     currentPage: taskSearchState.currentPage,
-    showConnectIcon: !isStandaloneSearch,
     counselorsHash: counselors.hash,
   };
 };

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -12,7 +12,7 @@ import SearchResults, { CONTACTS_PER_PAGE, CASES_PER_PAGE } from './SearchResult
 import ContactDetails from './ContactDetails';
 import Case from '../case';
 import { SearchPages } from '../../states/search/types';
-import { CustomITask, SearchContact, standaloneTaskSid } from '../../types/types';
+import { CustomITask, SearchAPIContact, standaloneTaskSid } from '../../types/types';
 import SearchResultsBackButton from './SearchResults/SearchResultsBackButton';
 import {
   handleSearchFormChange,
@@ -34,7 +34,7 @@ import { Flex } from '../../styles/HrmStyles';
 type OwnProps = {
   task: CustomITask;
   currentIsCaller?: boolean;
-  handleSelectSearchResult?: (contact: SearchContact) => void;
+  handleSelectSearchResult?: (contact: SearchAPIContact) => void;
 };
 
 // eslint-disable-next-line no-use-before-define

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -17,7 +17,7 @@ import { removeOfflineContact } from '../../services/formSubmissionHelpers';
 import { changeRoute } from '../../states/routing/actions';
 import { TaskEntry, emptyCategories } from '../../states/contacts/reducer';
 import { TabbedFormSubroutes, NewCaseSubroutes } from '../../states/routing/types';
-import { CustomITask, isOfflineContactTask, SearchContact } from '../../types/types';
+import { CustomITask, isOfflineContactTask, SearchAPIContact } from '../../types/types';
 import { TabbedFormsContainer, TabbedFormTabContainer, Box, StyledTabs, Row } from '../../styles/HrmStyles';
 import FormTab from '../common/forms/FormTab';
 import Search from '../search';
@@ -121,7 +121,7 @@ const TabbedForms: React.FC<Props> = ({
   const taskId = task.taskSid;
   const isCallerType = contactForm.callType === callTypes.caller;
 
-  const onSelectSearchResult = (searchResult: SearchContact) => {
+  const onSelectSearchResult = (searchResult: SearchAPIContact) => {
     const selectedIsCaller = searchResult.details.callType === callTypes.caller;
     if (isCallerType && selectedIsCaller && isCallTypeCaller) {
       const deTransformed = searchResultToContactForm(

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -80,7 +80,7 @@ export const getPermissionsForCase = (twilioWorkerId: t.Case['twilioWorkerId'], 
   };
 };
 
-export const getPermissionsForContact = (twilioWorkerId: t.SearchContact['overview']['counselor']) => {
+export const getPermissionsForContact = (twilioWorkerId: t.SearchAPIContact['overview']['counselor']) => {
   const { workerSid, isSupervisor, permissionConfig } = getConfig();
 
   if (!permissionConfig || !twilioWorkerId) return { can: undefined };

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -49,7 +49,14 @@ export const unNestInformationObject = (
 ): TaskEntry['childInformation'] | TaskEntry['callerInformation'] =>
   def.reduce((acc, e) => ({ ...acc, [e.name]: unNestInformation(e, obj) }), {});
 
-export async function searchContacts(searchParams, limit, offset): Promise<SearchContactResult> {
+export async function searchContacts(
+  searchParams,
+  limit,
+  offset,
+): Promise<{
+  count: number;
+  contacts: SearchContact[];
+}> {
   const queryParams = getQueryParams({ limit, offset });
 
   const options = {

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -24,7 +24,7 @@ import {
   InformationObject,
   isOfflineContactTask,
   isTwilioTask,
-  SearchContact,
+  SearchAPIContact,
   SearchContactResult,
 } from '../types/types';
 import { saveContactToExternalBackend } from '../dualWrite';
@@ -55,7 +55,7 @@ export async function searchContacts(
   offset,
 ): Promise<{
   count: number;
-  contacts: SearchContact[];
+  contacts: SearchAPIContact[];
 }> {
   const queryParams = getQueryParams({ limit, offset });
 

--- a/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
+++ b/plugin-hrm-form/src/states/contacts/contactDetailsAdapter.ts
@@ -3,7 +3,7 @@
  * a better solution later on.
  */
 
-import { SearchContact } from '../../types/types';
+import { SearchAPIContact } from '../../types/types';
 import { getNumberFromTask } from '../../utils';
 import { transformForm } from '../../services/ContactService';
 import { getConversationDuration } from '../../utils/conversationDuration';
@@ -37,7 +37,7 @@ export const retrieveCategories = (categories: Record<string, Record<string, boo
   return Object.entries(categories).reduce(catsReducer, {});
 };
 
-export const hrmServiceContactToSearchContact = (contact): SearchContact => {
+export const hrmServiceContactToSearchContact = (contact): SearchAPIContact => {
   const dateTime = contact.timeOfContact;
 
   const name = `${contact.rawJson.childInformation.name.firstName} ${contact.rawJson.childInformation.name.lastName}`;
@@ -70,7 +70,7 @@ export const hrmServiceContactToSearchContact = (contact): SearchContact => {
   };
 };
 
-export const searchContactToHrmServiceContact = (contact: SearchContact) => {
+export const searchContactToHrmServiceContact = (contact: SearchAPIContact) => {
   const {
     conversationDuration,
     createdBy,
@@ -98,7 +98,7 @@ export const searchContactToHrmServiceContact = (contact: SearchContact) => {
   };
 };
 
-export const taskFormToSearchContact = (task, form, date, counselor, temporaryId): SearchContact => {
+export const taskFormToSearchContact = (task, form, date, counselor, temporaryId): SearchAPIContact => {
   const details = transformForm(form);
   const dateTime = date;
   const name = `${details.childInformation.name.firstName} ${details.childInformation.name.lastName}`;

--- a/plugin-hrm-form/src/states/contacts/existingContacts.ts
+++ b/plugin-hrm-form/src/states/contacts/existingContacts.ts
@@ -1,6 +1,6 @@
 import { omit } from 'lodash';
 
-import { SearchContact } from '../../types/types';
+import { SearchAPIContact } from '../../types/types';
 import { hrmServiceContactToSearchContact } from './contactDetailsAdapter';
 
 export enum ContactDetailsRoute {
@@ -15,7 +15,7 @@ type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
 
-export type SearchContactDraftChanges = RecursivePartial<SearchContact>;
+export type SearchContactDraftChanges = RecursivePartial<SearchAPIContact>;
 
 // TODO: Update this type when the Lambda worker is "done"
 export type TranscriptMessage = {
@@ -37,8 +37,8 @@ type TranscriptResult = {
 export type ExistingContactsState = {
   [contactId: string]: {
     references: Set<string>;
-    savedContact: SearchContact;
-    draftContact?: RecursivePartial<SearchContact>;
+    savedContact: SearchAPIContact;
+    draftContact?: RecursivePartial<SearchAPIContact>;
     categories: {
       gridView: boolean;
       expanded: { [key: string]: boolean };
@@ -51,12 +51,12 @@ export const LOAD_CONTACT_ACTION = 'LOAD_CONTACT_ACTION';
 
 type LoadContactAction = {
   type: typeof LOAD_CONTACT_ACTION;
-  contacts: SearchContact[];
+  contacts: SearchAPIContact[];
   reference?: string;
   replaceExisting: boolean;
 };
 
-export const loadContact = (contact: SearchContact, reference, replaceExisting = false): LoadContactAction => ({
+export const loadContact = (contact: SearchAPIContact, reference, replaceExisting = false): LoadContactAction => ({
   type: LOAD_CONTACT_ACTION,
   contacts: [contact],
   reference,
@@ -258,7 +258,7 @@ export const EXISTING_CONTACT_UPDATE_DRAFT_ACTION = 'EXISTING_CONTACT_UPDATE_DRA
 type UpdateDraftAction = {
   type: typeof EXISTING_CONTACT_UPDATE_DRAFT_ACTION;
   contactId: string;
-  draft?: RecursivePartial<SearchContact>;
+  draft?: RecursivePartial<SearchAPIContact>;
 };
 
 export const updateDraft = (contactId: string, draft: SearchContactDraftChanges): UpdateDraftAction => ({

--- a/plugin-hrm-form/src/states/search/actions.ts
+++ b/plugin-hrm-form/src/states/search/actions.ts
@@ -4,11 +4,10 @@ import { ITask } from '@twilio/flex-ui';
 
 import * as t from './types';
 import { ConfigurationState } from '../configuration/reducer';
-import { Case, SearchContact } from '../../types/types';
+import { SearchContact } from '../../types/types';
 import { searchContacts as searchContactsApiCall } from '../../services/ContactService';
 import { searchCases as searchCasesApiCall } from '../../services/CaseService';
-import { ContactDetailsSectionsType } from '../../components/common/ContactDetails';
-import { addDetails } from './helpers';
+import { searchAPIContactToSearchUIContact } from './helpers';
 import { updateDefinitionVersion } from '../configuration/actions';
 import { getContactsMissingVersions, getCasesMissingVersions } from '../../utils/definitionVersions';
 import { getNumberFromTask } from '../../utils/task';
@@ -37,7 +36,7 @@ export const searchContacts = (dispatch: Dispatch<any>) => (taskId: string) => a
     dispatch({ type: t.SEARCH_CONTACTS_REQUEST, taskId });
 
     const searchResultRaw = await searchContactsApiCall(searchParams, limit, offset);
-    const contactsWithCounselorName = addDetails(counselorsHash, searchResultRaw.contacts);
+    const contactsWithCounselorName = searchAPIContactToSearchUIContact(counselorsHash, searchResultRaw.contacts);
     const searchResult = { ...searchResultRaw, contacts: contactsWithCounselorName };
 
     const definitions = await getContactsMissingVersions(searchResultRaw.contacts);

--- a/plugin-hrm-form/src/states/search/actions.ts
+++ b/plugin-hrm-form/src/states/search/actions.ts
@@ -4,7 +4,7 @@ import { ITask } from '@twilio/flex-ui';
 
 import * as t from './types';
 import { ConfigurationState } from '../configuration/reducer';
-import { SearchContact } from '../../types/types';
+import { SearchAPIContact } from '../../types/types';
 import { searchContacts as searchContactsApiCall } from '../../services/ContactService';
 import { searchCases as searchCasesApiCall } from '../../services/CaseService';
 import { searchAPIContactToSearchUIContact } from './helpers';
@@ -95,7 +95,7 @@ export const changeSearchPage = (taskId: string) => (page: t.SearchPagesType): t
   taskId,
 });
 
-export const viewContactDetails = (taskId: string) => (contact: SearchContact): t.SearchActionType => ({
+export const viewContactDetails = (taskId: string) => (contact: SearchAPIContact): t.SearchActionType => ({
   type: t.VIEW_CONTACT_DETAILS,
   contact,
   taskId,

--- a/plugin-hrm-form/src/states/search/helpers.ts
+++ b/plugin-hrm-form/src/states/search/helpers.ts
@@ -2,12 +2,11 @@
 import { ConfigurationState } from '../configuration/reducer';
 import { SearchContact } from '../../types/types';
 
-export const addDetails = (counselorsHash: ConfigurationState['counselors']['hash'], raw: SearchContact[]) => {
-  const detailed = raw.map(contact => {
+export const searchAPIContactToSearchUIContact = (
+  counselorsHash: ConfigurationState['counselors']['hash'],
+  raw: SearchContact[],
+): (SearchContact & { counselorName: string })[] =>
+  raw.map(contact => {
     const counselor = counselorsHash[contact.overview.counselor] || 'Unknown';
-    const det = { ...contact, counselor };
-    return det;
+    return { ...contact, counselorName: counselor };
   });
-
-  return detailed;
-};

--- a/plugin-hrm-form/src/states/search/helpers.ts
+++ b/plugin-hrm-form/src/states/search/helpers.ts
@@ -1,11 +1,11 @@
 /* eslint-disable sonarjs/prefer-immediate-return */
 import { ConfigurationState } from '../configuration/reducer';
-import { SearchContact } from '../../types/types';
+import { SearchAPIContact } from '../../types/types';
 
 export const searchAPIContactToSearchUIContact = (
   counselorsHash: ConfigurationState['counselors']['hash'],
-  raw: SearchContact[],
-): (SearchContact & { counselorName: string })[] =>
+  raw: SearchAPIContact[],
+): (SearchAPIContact & { counselorName: string })[] =>
   raw.map(contact => {
     const counselor = counselorsHash[contact.overview.counselor] || 'Unknown';
     return { ...contact, counselorName: counselor };

--- a/plugin-hrm-form/src/states/search/reducer.ts
+++ b/plugin-hrm-form/src/states/search/reducer.ts
@@ -2,7 +2,7 @@ import { omit } from 'lodash';
 
 import * as t from './types';
 import { INITIALIZE_CONTACT_STATE, RECREATE_CONTACT_STATE, REMOVE_CONTACT_STATE, GeneralActionType } from '../types';
-import { SearchContact, SearchCaseResult, standaloneTaskSid } from '../../types/types';
+import { SearchAPIContact, SearchCaseResult, standaloneTaskSid } from '../../types/types';
 import { ContactDetailsSections, ContactDetailsSectionsType } from '../../components/common/ContactDetails';
 
 type PreviousContacts = {
@@ -12,7 +12,7 @@ type PreviousContacts = {
 
 type TaskEntry = {
   currentPage: t.SearchPagesType;
-  currentContact: SearchContact;
+  currentContact: SearchAPIContact;
   form: t.SearchFormValues;
   detailsExpanded: {
     [key in ContactDetailsSectionsType]: boolean;

--- a/plugin-hrm-form/src/states/search/types.ts
+++ b/plugin-hrm-form/src/states/search/types.ts
@@ -1,5 +1,5 @@
 import { SearchContact, SearchCaseResult } from '../../types/types';
-import { addDetails } from './helpers';
+import { searchAPIContactToSearchUIContact } from './helpers';
 // Action types
 export const HANDLE_SEARCH_FORM_CHANGE = 'HANDLE_SEARCH_FORM_CHANGE';
 export const CHANGE_SEARCH_PAGE = 'CHANGE_SEARCH_PAGE';
@@ -40,7 +40,7 @@ export type SearchPagesType = typeof SearchPages[keyof typeof SearchPages];
 
 export type DetailedSearchContactsResult = {
   count: number;
-  contacts: ReturnType<typeof addDetails>;
+  contacts: ReturnType<typeof searchAPIContactToSearchUIContact>;
 };
 
 // Supported action object types

--- a/plugin-hrm-form/src/states/search/types.ts
+++ b/plugin-hrm-form/src/states/search/types.ts
@@ -1,4 +1,4 @@
-import { SearchContact, SearchCaseResult } from '../../types/types';
+import { SearchAPIContact, SearchCaseResult } from '../../types/types';
 import { searchAPIContactToSearchUIContact } from './helpers';
 // Action types
 export const HANDLE_SEARCH_FORM_CHANGE = 'HANDLE_SEARCH_FORM_CHANGE';
@@ -81,7 +81,7 @@ type SearchCasesFailureAction = { type: typeof SEARCH_CASES_FAILURE; error: any;
 // maybe we can migrate this to be handled by the routing instead later on?
 type SearchChangePageAction = { type: typeof CHANGE_SEARCH_PAGE; page: SearchPagesType; taskId: string };
 
-type SearchViewContactAction = { type: typeof VIEW_CONTACT_DETAILS; contact: SearchContact; taskId: string };
+type SearchViewContactAction = { type: typeof VIEW_CONTACT_DETAILS; contact: SearchAPIContact; taskId: string };
 
 type ViewPreviousContactsAction = {
   type: typeof VIEW_PREVIOUS_CONTACTS;

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -131,7 +131,7 @@ export type SearchContact = {
     categories: {};
     counselor: string;
     notes: string;
-    channel: string;
+    channel: ChannelTypes | 'default';
     conversationDuration: number;
     createdBy: string;
     taskId: string;
@@ -142,9 +142,11 @@ export type SearchContact = {
   csamReports: CSAMReportEntry[];
 };
 
+export type SearchUIContact = SearchContact & { counselorName: string };
+
 export type SearchContactResult = {
   count: number;
-  contacts: SearchContact[];
+  contacts: SearchUIContact[];
 };
 
 export type SearchCaseResult = {

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -120,7 +120,7 @@ export type ContactRawJson = {
 };
 
 // Information about a single contact, as expected from search contacts endpoint (we might want to reuse this type in backend) - (is this a correct placement for this?)
-export type SearchContact = {
+export type SearchAPIContact = {
   contactId: string;
   overview: {
     helpline: string;
@@ -142,7 +142,7 @@ export type SearchContact = {
   csamReports: CSAMReportEntry[];
 };
 
-export type SearchUIContact = SearchContact & { counselorName: string };
+export type SearchUIContact = SearchAPIContact & { counselorName: string };
 
 export type SearchContactResult = {
   count: number;

--- a/plugin-hrm-form/src/utils/definitionVersions.ts
+++ b/plugin-hrm-form/src/utils/definitionVersions.ts
@@ -1,6 +1,6 @@
 import { DefinitionVersionId } from 'hrm-form-definitions';
 
-import { Case, SearchContact } from '../types/types';
+import { Case, SearchAPIContact } from '../types/types';
 import { getDefinitionVersionsList } from '../services/ServerlessService';
 import { getDefinitionVersions } from '../HrmFormPlugin';
 
@@ -16,7 +16,7 @@ const getMissingDefinitionVersions = async (versions: DefinitionVersionId[]) => 
   return definitions;
 };
 
-export const getContactsMissingVersions = (contacts: SearchContact[]) =>
+export const getContactsMissingVersions = (contacts: SearchAPIContact[]) =>
   getMissingDefinitionVersions(contacts.map(c => c.details.definitionVersion));
 
 export const getCasesMissingVersions = async (cases: Case[]) =>


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description

* Move ContactPreview.jsx to TSX
* Some type fixes around the fact that the counsellor's name gets added to the type in search but not elsewhere

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Preparation for CHI-1275

### Verification steps

Search regression