### PR TITLE
End Chat button and Caselist background style changes

### DIFF
--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -3,6 +3,11 @@ body p,
 body span {
     font-family: Open Sans;
 }
+
+div.Twilio-ViewCollection{
+    background-color: #f6f6f6;
+}
+
 div.Twilio-ModalPopupWithEntryControl {
     padding-top: 7px;
     padding-bottom: 7px;
@@ -83,11 +88,11 @@ a.link-text-decoration-none:active { text-decoration: none; color: #1874e1; }
 }
 button.Twilio-TaskCanvasHeader-EndButton {
     padding: 3px 16px;
-    font-weight: normal;
+    font-weight: 600;
     min-width: auto;
 }
 button.Twilio-TaskCanvasHeader-EndButton:hover{
-    border: 1px solid rgb(70, 70, 70);
+    border: 1px solid #BAC0C2;
     background-color: rgb(220, 84, 84);
 }
 button.Twilio-TaskCanvasHeader-EndButton:active {

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -4,10 +4,6 @@ body span {
     font-family: Open Sans;
 }
 
-div.Twilio-ViewCollection{
-    background-color: #f6f6f6;
-}
-
 div.Twilio-ModalPopupWithEntryControl {
     padding-top: 7px;
     padding-bottom: 7px;
@@ -97,4 +93,8 @@ button.Twilio-TaskCanvasHeader-EndButton:hover{
 }
 button.Twilio-TaskCanvasHeader-EndButton:active {
     border: 2px solid black;
+}
+
+div.Twilio-ViewCollection{
+    background-color: #f6f6f6;
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @GPaoloni 

## Description
- Changed End Chat button's font weight to `600`, and hover state background-color to `#BAC0C2`
- Override background inconsistency for Case list page to be the same color through out 

### Checklist
- [x] Corresponding issue has been opened
- [n/x] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes #[CHI-1522](https://bugs.benetech.org/browse/CHI-1522) , [CHI-1524](https://bugs.benetech.org/browse/CHI-1524)

### Verification steps
- Check End Chat button for styling based on [CHI-1522](https://bugs.benetech.org/browse/CHI-1522)
![Screenshot 2022-12-02 at 11 28 08 AM](https://user-images.githubusercontent.com/102122005/205343884-5edf2e48-cd00-4a5e-8c13-75ea04ba7812.png)

- Check Case List page
![Screenshot 2022-12-02 at 11 29 57 AM](https://user-images.githubusercontent.com/102122005/205343888-ff2dd6ec-0c75-4f66-86d1-0b00706f31bf.png)
