### PR TITLE
[Bug Fix] Flex 2.0: Canned Responses missing/not populating

### DIFF
--- a/plugin-hrm-form/src/components/CannedResponses.tsx
+++ b/plugin-hrm-form/src/components/CannedResponses.tsx
@@ -8,15 +8,13 @@ import { getConfig } from '../HrmFormPlugin';
 import { selectCannedResponses } from '../states/selectors/hrmStateSelectors';
 import { CannedResponsesContainer, FormSelect, FormSelectWrapper, FormOption } from '../styles/HrmStyles';
 
-// eslint-disable-next-line no-use-before-define
-type Props = Pick<MessageInputChildrenProps, 'conversationSid'>;
+type Props = Partial<MessageInputChildrenProps>;
 
-// eslint-disable-next-line react/display-name
 const CannedResponses: React.FC<Props> = props => {
   const cannedResponses = useSelector(selectCannedResponses);
   const { strings } = getConfig();
   const { conversationSid } = props;
-  const handleChange = event => {
+  const handleChange: React.ChangeEventHandler<HTMLSelectElement> = event => {
     Actions.invokeAction('SetInputText', {
       conversationSid,
       body: event.target.value,
@@ -44,5 +42,6 @@ const CannedResponses: React.FC<Props> = props => {
     </CannedResponsesContainer>
   );
 };
+CannedResponses.displayName = 'CannedResponses';
 
 export default withTheme(CannedResponses);

--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import * as Flex from '@twilio/flex-ui';
-import type { MessageInputChildrenProps } from '@twilio/flex-ui-core/src/components/channel/MessageInput/MessageInputImpl';
 
 import { AcceptTransferButton, RejectTransferButton, TransferButton } from '../components/transfer';
 import * as TransferHelpers from './transfer';

--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import * as Flex from '@twilio/flex-ui';
-import { ITask, ReservationStatuses, TaskChannelDefinition } from '@twilio/flex-ui';
+import type { MessageInputChildrenProps } from '@twilio/flex-ui-core/src/components/channel/MessageInput/MessageInputImpl';
 
 import { AcceptTransferButton, RejectTransferButton, TransferButton } from '../components/transfer';
 import * as TransferHelpers from './transfer';
@@ -350,5 +350,5 @@ export const removeActionsIfTransferring = () => {
  * Canned responses
  */
 export const setupCannedResponses = () => {
-  Flex.MessageInput.Content.add(<CannedResponses key="canned-responses" conversationSid={undefined} />);
+  Flex.MessageInput.Content.add(<CannedResponses key="canned-responses" />);
 };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
This PR loosens the type of the props for `CannedResponses`, as they are injected by a HoC. Because this component is not directly added to the UI as a child of the corresponding wrapper, but via `Flex.DynamicContentStore` `add` function, TS can't infer that this props will be provided, hence it complains. A workaround in a previous PR was to pass the required prop as `undefined`, but that seems to take precedence over the prop passed by the HoC, resulting in an `undefined` value even after the component has been properly rendered. The solution is simple: we tell TS that this are not required, even if we know they will provided by some HoC magic. I could not do a better TS trick for this without introducing `any` at some point. `Partial` seems a better option? 

Note: I don't think the issue on JM is caused by this but it's worth deploying to confirm. I'll continue investigating.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1551)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- `npm run dev` to start local server.
- Start a chat conversation and accept in the Flex end.
- Test out that the canned responses bundled in `dev` definition are working as expected.
- Set function `readConfig` to return `definitionVersion: 'jm-v1' as any,` (line 69 of `src/HrmFormPlugin.tsx`).
- Confirm that JM config is working as expected too.