### PR TITLE
CHI-1560: Validate all form inputs in tests

### DIFF
--- a/hrm-form-definitions/form-definitions/zw-v1/caseForms/IncidentForm.json
+++ b/hrm-form-definitions/form-definitions/zw-v1/caseForms/IncidentForm.json
@@ -127,7 +127,7 @@
   {
     "name": "incidentDetails",
     "label": "Incident Details",
-    "type": "text-area",
+    "type": "textarea",
     "placeholder": "",
     "rows": 20,
     "width": 250

--- a/hrm-form-definitions/src/__tests__/specification/generate.test.ts
+++ b/hrm-form-definitions/src/__tests__/specification/generate.test.ts
@@ -1,4 +1,5 @@
 import { generateDefaultForm, generateDefaultItem } from '../../specification';
+import { FormInputType } from '../../formDefinition';
 
 describe('generateDefaultItem', () => {
   test('Definition specification specifies a default - returns default', () => {
@@ -17,7 +18,7 @@ describe('generateDefaultForm', () => {
     expect(generated).toHaveLength(0);
   });
   test('Item with default specified in items map - returns default in the array', () => {
-    const itemDefault = { type: 'input', name: 'myItemName', label: 'My Item' };
+    const itemDefault = { type: FormInputType.Input, name: 'myItemName', label: 'My Item' };
     const generated = generateDefaultForm({
       items: { myItem: { required: false, default: itemDefault } },
     });
@@ -29,7 +30,7 @@ describe('generateDefaultForm', () => {
     });
     expect(generated).toHaveLength(1);
     expect(generated).toContainEqual({
-      type: 'input',
+      type: FormInputType.Input,
       name: 'myItem',
       label: 'myItem',
     });
@@ -41,10 +42,10 @@ describe('generateDefaultForm', () => {
     expect(generated).toHaveLength(0);
   });
   describe('Ordering', () => {
-    const itemDefault1 = { type: 'input', name: 'myItemName1', label: 'My Item 1' };
-    const itemDefault2 = { type: 'input', name: 'myItemName2', label: 'My Item 2' };
-    const itemDefault3 = { type: 'input', name: 'myItemName3', label: 'My Item 3' };
-    const itemDefault4 = { type: 'input', name: 'myItemName3', label: 'My Item 4' };
+    const itemDefault1 = { type: FormInputType.Input, name: 'myItemName1', label: 'My Item 1' };
+    const itemDefault2 = { type: FormInputType.Input, name: 'myItemName2', label: 'My Item 2' };
+    const itemDefault3 = { type: FormInputType.Input, name: 'myItemName3', label: 'My Item 3' };
+    const itemDefault4 = { type: FormInputType.Input, name: 'myItemName3', label: 'My Item 4' };
 
     test('Multiple items without explicit ordering - adds them to array in declaration order', () => {
       const generated = generateDefaultForm({
@@ -61,7 +62,7 @@ describe('generateDefaultForm', () => {
         itemDefault3,
         itemDefault1,
         {
-          type: 'input',
+          type: FormInputType.Input,
           name: 'myItem5',
           label: 'myItem5',
         },
@@ -87,7 +88,7 @@ describe('generateDefaultForm', () => {
         itemDefault3,
         itemDefault4,
         {
-          type: 'input',
+          type: FormInputType.Input,
           name: 'myItem5',
           label: 'myItem5',
         },
@@ -109,7 +110,7 @@ describe('generateDefaultForm', () => {
         itemDefault1,
         itemDefault4,
         {
-          type: 'input',
+          type: FormInputType.Input,
           name: 'myItem5',
           label: 'myItem5',
         },

--- a/hrm-form-definitions/src/__tests__/specification/validate.test.ts
+++ b/hrm-form-definitions/src/__tests__/specification/validate.test.ts
@@ -1,5 +1,5 @@
 import each from 'jest-each';
-import { CategoriesDefinition, FormDefinition } from '../../formDefinition';
+import { CategoriesDefinition, FormDefinition, FormInputType } from '../../formDefinition';
 import { DefinitionSpecification, FormDefinitionSpecification } from '../../specification';
 
 import { validateCategoriesDefinition, validateFormDefinition } from '../../specification/validate';
@@ -35,7 +35,7 @@ describe('validateFormDefinition', () => {
           one: { required: true },
         },
       },
-      definition: [{ name: 'another', label: 'another', type: 'input' }],
+      definition: [{ name: 'another', label: 'another', type: FormInputType.Input }],
       expectedResult: {
         valid: false,
         issues: [],
@@ -52,8 +52,8 @@ describe('validateFormDefinition', () => {
         },
       },
       definition: [
-        { name: 'one', label: 'one', type: 'input' },
-        { name: 'one', label: 'one', type: 'input' },
+        { name: 'one', label: 'one', type: FormInputType.Input },
+        { name: 'one', label: 'one', type: FormInputType.Input },
       ],
       expectedResult: {
         valid: false,
@@ -78,7 +78,7 @@ describe('validateFormDefinition', () => {
           },
         },
       },
-      definition: [{ name: 'one', label: 'one', type: 'input' }],
+      definition: [{ name: 'one', label: 'one', type: FormInputType.Input }],
       expectedResult: {
         valid: false,
         issues: [],
@@ -99,7 +99,7 @@ describe('validateFormDefinition', () => {
           },
         },
       },
-      definition: [{ name: 'one', label: 'one', type: 'input' }],
+      definition: [{ name: 'one', label: 'one', type: FormInputType.Input }],
       expectedResult: {
         valid: true,
         issues: [],

--- a/hrm-form-definitions/src/__tests__/specification/validateDefinitions.test.ts
+++ b/hrm-form-definitions/src/__tests__/specification/validateDefinitions.test.ts
@@ -57,55 +57,6 @@ const testFormFileSpecification =
     return result;
   };
 
-/**
- * Given a particular DefinitionVersionId, will check that testFormFileSpecification is valid for aseloFormTemplates
- */
-const testFormAgainstAseloTemplates = async (definitionVersionId: DefinitionVersionId) => {
-  const definitionVersion = await loadDefinition(definitionVersionId);
-
-  const formFileSpecificationPaths = [
-    'caseForms.HouseholdForm',
-    'caseForms.IncidentForm',
-    'caseForms.NoteForm',
-    'caseForms.PerpetratorForm',
-    'caseForms.ReferralForm',
-    'caseForms.DocumentForm',
-    'tabbedForms.CallerInformationTab',
-    'tabbedForms.CaseInformationTab',
-    'tabbedForms.ChildInformationTab',
-    'callTypeButtons',
-  ];
-
-  const results = formFileSpecificationPaths.map((path) => {
-    const assertFun = testFormFileSpecification(definitionVersionId, path);
-    const specification = get(aseloFormTemplates, path);
-    const definition = get(definitionVersion, path);
-
-    return assertFun(specification, definition);
-  });
-
-  expect(results).not.toContainEqual({
-    valid: false,
-    issues: expect.anything(),
-    itemReports: expect.anything(),
-  });
-
-  const helplines = definitionVersion.helplineInformation.helplines.map((h) => h.value);
-  const categoriesDefinitions = helplines.map((helpline) => ({
-    helpline,
-    categoriesDefinition: definitionVersion.tabbedForms.IssueCategorizationTab(helpline),
-  }));
-
-  categoriesDefinitions.forEach(({ helpline, categoriesDefinition }) => {
-    const assertFun = testCategoriesDefinition(
-      definitionVersionId,
-      `tabbedForms.IssueCategorizationTab (helpline ${helpline})`,
-    );
-
-    assertFun(aseloFormTemplates.tabbedForms.IssueCategorizationTab, categoriesDefinition);
-  });
-};
-
 describe('Validate form definitions', () => {
   const definitionVersionsIds = Object.values(DefinitionVersionId).map((definitionId) => ({
     definitionId,

--- a/hrm-form-definitions/src/aseloForms.ts
+++ b/hrm-form-definitions/src/aseloForms.ts
@@ -4,7 +4,12 @@ import {
   FormDefinitionSpecification,
   FormItemDefinitionSpecification,
 } from './specification';
-import { OneToManyConfigSpecs, OneToOneConfigSpec, SelectOption } from './formDefinition';
+import {
+  FormInputType,
+  OneToManyConfigSpecs,
+  OneToOneConfigSpec,
+  SelectOption,
+} from './formDefinition';
 
 export type FormFileSpecification = FormDefinitionSpecification & DefinitionFileSpecification;
 export type JsonFileSpecification<T = any> = DefinitionSpecification<T> &
@@ -67,7 +72,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'firstName',
             label: 'First Name',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -76,7 +81,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'lastName',
             label: 'Last Name',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -85,7 +90,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'relationshipToChild',
             label: 'Relationship to child',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Caregiver', label: 'Caregiver' },
@@ -111,7 +116,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'streetAddress',
             label: 'Street Address',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
         province: {
@@ -119,7 +124,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'province',
             label: 'Province',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Central', label: 'Central' },
@@ -133,7 +138,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'district',
             label: 'District',
-            type: 'dependent-select',
+            type: FormInputType.DependentSelect,
             dependsOn: 'province',
             defaultOption: { value: '', label: '' },
             options: {
@@ -154,7 +159,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'phone1',
             label: 'Phone #1',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
         gender: {
@@ -162,7 +167,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'gender',
             label: 'Gender',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Boy', label: 'Boy' },
@@ -178,7 +183,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'age',
             label: 'Age',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               ...generateAgeRangeOptions(0, 60),
@@ -194,7 +199,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'language',
             label: 'Language',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'language1', label: 'language1' },
@@ -206,7 +211,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'ethnicity',
             label: 'Ethnicity',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
       },
@@ -219,7 +224,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'date',
             label: 'Date',
-            type: 'date-input',
+            type: FormInputType.DateInput,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -228,7 +233,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'duration',
             label: 'Duration',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Ongoing', label: 'Ongoing' },
@@ -243,7 +248,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'location',
             label: 'Location',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Unknown', label: 'Unknown' },
@@ -262,7 +267,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'isCaregiverAware',
             label: 'Is caregiver aware?',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         incidentWitnessed: {
@@ -270,7 +275,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'incidentWitnessed',
             label: 'Was the incident witnessed by anyone?',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         abuseReportedElsewhere: {
@@ -278,7 +283,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'abuseReportedElsewhere',
             label: 'Has abuse been reported elsewhere?',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         whereElseBeenReported: {
@@ -286,7 +291,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'whereElseBeenReported',
             label: 'Where else the incident has been reported?',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
       },
@@ -299,7 +304,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'note',
             label: 'Note',
-            type: 'textarea',
+            type: FormInputType.Textarea,
             placeholder: 'Type here to add note...',
             rows: 20,
             width: 500,
@@ -315,7 +320,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'firstName',
             label: 'First Name',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -324,7 +329,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'lastName',
             label: 'Last Name',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -333,7 +338,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'relationshipToChild',
             label: 'Relationship to child',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Caregiver', label: 'Caregiver' },
@@ -359,7 +364,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'streetAddress',
             label: 'Street Address',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
         province: {
@@ -367,7 +372,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'province',
             label: 'Province',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Central', label: 'Central' },
@@ -381,7 +386,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'district',
             label: 'District',
-            type: 'dependent-select',
+            type: FormInputType.DependentSelect,
             dependsOn: 'province',
             defaultOption: { value: '', label: '' },
             options: {
@@ -402,7 +407,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'phone1',
             label: 'Phone #1',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
         gender: {
@@ -410,7 +415,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'gender',
             label: 'Gender',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Boy', label: 'Boy' },
@@ -426,7 +431,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'age',
             label: 'Age',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               ...generateAgeRangeOptions(0, 60),
@@ -442,7 +447,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'language',
             label: 'Language',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'language1', label: 'language1' },
@@ -454,7 +459,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'ethnicity',
             label: 'Ethnicity',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
       },
@@ -467,7 +472,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'date',
             label: 'Date',
-            type: 'date-input',
+            type: FormInputType.DateInput,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -476,7 +481,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'referredTo',
             label: 'Referred To',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Clinic', label: 'Clinic' },
@@ -494,7 +499,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'comments',
             label: 'Comments',
-            type: 'textarea',
+            type: FormInputType.Textarea,
           },
         },
       },
@@ -517,7 +522,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'firstName',
             label: 'First Name',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -526,7 +531,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'lastName',
             label: 'Last Name',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -535,7 +540,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'relationshipToChild',
             label: 'Relationship to child',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'Caregiver', label: 'Caregiver' },
@@ -559,7 +564,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'streetAddress',
             label: 'Street Address',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
         province: {
@@ -567,7 +572,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'province',
             label: 'Province',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Central', label: 'Central' },
@@ -581,7 +586,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'district',
             label: 'District',
-            type: 'dependent-select',
+            type: FormInputType.DependentSelect,
             dependsOn: 'province',
             defaultOption: { value: '', label: '' },
             options: {
@@ -602,7 +607,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'phone1',
             label: 'Phone #1',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -611,7 +616,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'gender',
             label: 'Gender',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'Boy', label: 'Boy' },
@@ -625,7 +630,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'age',
             label: 'Age',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               ...generateAgeRangeOptions(0, 25),
@@ -640,7 +645,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'language',
             label: 'Language',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'language1', label: 'language1' },
@@ -652,7 +657,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'ethnicity',
             label: 'Ethnicity',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
       },
@@ -665,7 +670,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'callSummary',
             label: 'Contact Summary',
-            type: 'textarea',
+            type: FormInputType.Textarea,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -674,7 +679,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'repeatCaller',
             label: 'Repeat Caller?',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         actionTaken: {
@@ -682,7 +687,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'actionTaken',
             label: 'Action Taken',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: ' ' },
               { value: 'Action taken', label: 'Action taken' },
@@ -695,7 +700,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'okForCaseWorkerToCall',
             label: 'Ok for case worker to call?',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         didYouDiscussRightsWithTheChild: {
@@ -703,7 +708,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'didYouDiscussRightsWithTheChild',
             label: 'Did you discuss rights with the child?',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
       },
@@ -716,7 +721,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'firstName',
             label: 'First Name',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -725,7 +730,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'lastName',
             label: 'Last Name',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -734,7 +739,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'age',
             label: 'Age',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Unborn', label: 'Unborn' },
@@ -751,7 +756,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'gender',
             label: 'Gender',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Boy', label: 'Boy' },
@@ -767,7 +772,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'streetAddress',
             label: 'Street Address',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
         province: {
@@ -775,7 +780,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'province',
             label: 'Province',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: '', label: '' },
               { value: 'Central', label: 'Central' },
@@ -789,7 +794,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'district',
             label: 'District',
-            type: 'dependent-select',
+            type: FormInputType.DependentSelect,
             dependsOn: 'province',
             defaultOption: { value: '', label: '' },
             options: {
@@ -810,7 +815,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'phone1',
             label: 'Phone #1',
-            type: 'input',
+            type: FormInputType.Input,
             required: { value: true, message: 'RequiredFieldError' },
           },
         },
@@ -819,7 +824,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'language',
             label: 'Language',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'language1', label: 'language1' },
@@ -831,7 +836,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'ethnicity',
             label: 'Ethnicity',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
         schoolName: {
@@ -839,7 +844,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'schoolName',
             label: 'School Name',
-            type: 'input',
+            type: FormInputType.Input,
           },
         },
         gradeLevel: {
@@ -847,7 +852,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'gradeLevel',
             label: 'Grade Level',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'Grade 1 to 4', label: 'Grade 1 to 4' },
@@ -863,7 +868,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'livingSituation',
             label: 'Living Situation',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'Alternative care', label: 'Alternative care' },
@@ -888,7 +893,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'hivPositive',
             label: 'Child HIV Positive?',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         livingInConflictZone: {
@@ -896,7 +901,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'livingInConflictZone',
             label: 'Child living in conflict zone',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         inConflictWithTheLaw: {
@@ -904,7 +909,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'inConflictWithTheLaw',
             label: 'Child in conflict with the law',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         livingInPoverty: {
@@ -912,7 +917,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'livingInPoverty',
             label: 'Child living in poverty',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         memberOfAnEthnic: {
@@ -920,7 +925,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'memberOfAnEthnic',
             label: 'Child member of an ethnic, racial or religious minority',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         childWithDisability: {
@@ -928,7 +933,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'childWithDisability',
             label: 'Child with disability',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         LGBTQI: {
@@ -936,7 +941,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'LGBTQI+',
             label: 'LGBTQI+ / SOGIESC child',
-            type: 'mixed-checkbox',
+            type: FormInputType.MixedCheckbox,
           },
         },
         childOnTheMove: {
@@ -944,7 +949,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'childOnTheMove',
             label: 'Child on the move',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'Involuntary', label: 'Involuntary' },
@@ -957,7 +962,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
           default: {
             name: 'region',
             label: 'Region',
-            type: 'select',
+            type: FormInputType.Select,
             options: [
               { value: 'Unknown', label: '' },
               { value: 'Cities', label: 'Cities' },
@@ -1118,7 +1123,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
         default: {
           name: 'child',
           label: 'Child calling about self',
-          type: 'button',
+          type: FormInputType.Button,
           category: 'data',
         },
       },
@@ -1127,7 +1132,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
         default: {
           name: 'caller',
           label: 'Someone calling about a child',
-          type: 'button',
+          type: FormInputType.Button,
           category: 'data',
         },
       },
@@ -1136,7 +1141,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
         default: {
           name: 'silent',
           label: 'Silent',
-          type: 'button',
+          type: FormInputType.Button,
           category: 'non-data',
         },
       },
@@ -1145,7 +1150,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
         default: {
           name: 'blank',
           label: 'Blank',
-          type: 'button',
+          type: FormInputType.Button,
           category: 'non-data',
         },
       },
@@ -1154,7 +1159,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
         default: {
           name: 'joke',
           label: 'Joke',
-          type: 'button',
+          type: FormInputType.Button,
           category: 'non-data',
         },
       },
@@ -1163,7 +1168,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
         default: {
           name: 'hangup',
           label: 'Hang up',
-          type: 'button',
+          type: FormInputType.Button,
           category: 'non-data',
         },
       },
@@ -1172,7 +1177,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
         default: {
           name: 'wrongnumber',
           label: 'Wrong Number',
-          type: 'button',
+          type: FormInputType.Button,
           category: 'non-data',
         },
       },
@@ -1181,7 +1186,7 @@ export const aseloFormTemplates: AseloFormTemplateDefinitions = {
         default: {
           name: 'abusive',
           label: 'Abusive',
-          type: 'button',
+          type: FormInputType.Button,
           category: 'non-data',
         },
       },

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -13,12 +13,31 @@ export enum CaseSectionApiName {
   Documents = 'documents',
 }
 
+export enum FormInputType {
+  Input = 'input',
+  NumericInput = 'numeric-input',
+  Email = 'email',
+  RadioInput = 'radio-input',
+  ListboxMultiselect = 'listbox-multiselect',
+  Select = 'select',
+  DependentSelect = 'dependent-select',
+  Checkbox = 'checkbox',
+  MixedCheckbox = 'mixed-checkbox',
+  Textarea = 'textarea',
+  DateInput = 'date-input',
+  TimeInput = 'time-input',
+  FileUpload = 'file-upload',
+  Button = 'button',
+  CopyTo = 'copy-to',
+}
+
 /**
  * Types used for customizable forms
  */
 type ItemBase = {
   name: string;
   label: string;
+  type: FormInputType;
 } & RegisterOptions;
 
 type NonSaveable = {
@@ -29,27 +48,27 @@ export const isNonSaveable = (item: any): item is NonSaveable =>
   typeof item.saveable === 'boolean' && !item.saveable;
 
 type InputDefinition = {
-  type: 'input';
+  type: FormInputType.Input;
 } & ItemBase;
 
 type NumericInputDefinition = {
-  type: 'numeric-input';
+  type: FormInputType.NumericInput;
 } & ItemBase;
 
 type EmailInputDefinition = {
-  type: 'email';
+  type: FormInputType.Email;
 } & ItemBase;
 
 export type InputOption = { value: any; label: string };
 
 type RadioInputDefinition = {
-  type: 'radio-input';
+  type: FormInputType.RadioInput;
   options: InputOption[];
   defaultOption?: InputOption['value'];
 } & ItemBase;
 
 type ListboxMultiselectDefinition = {
-  type: 'listbox-multiselect';
+  type: FormInputType.ListboxMultiselect;
   options: InputOption[];
   height?: number;
   width?: number;
@@ -58,7 +77,7 @@ type ListboxMultiselectDefinition = {
 export type SelectOption = { value: any; label: string };
 
 type BaseSelectDefinition = {
-  type: 'select';
+  type: FormInputType.Select;
   defaultOption?: SelectOption['value'];
   unknownOption?: SelectOption['value'];
 } & ItemBase;
@@ -79,7 +98,7 @@ export const isSelectDefinitionWithReferenceOptions = (
 export type DependentOptions = { [dependeeValue: string]: SelectOption[] };
 
 type DependentSelectDefinitionBase = {
-  type: 'dependent-select';
+  type: FormInputType.DependentSelect;
   dependsOn: ItemBase['name'];
   defaultOption: SelectOption;
 } & ItemBase;
@@ -98,18 +117,18 @@ export const isDependentSelectDefinitionWithReferenceOptions = (
   item.type === 'dependent-select' && typeof (<any>item).optionsReferenceKey === 'string';
 
 type CheckboxDefinition = {
-  type: 'checkbox';
+  type: FormInputType.Checkbox;
   initialChecked?: boolean;
 } & ItemBase;
 
 export type MixedOrBool = boolean | 'mixed';
 type MixedCheckboxDefinition = {
-  type: 'mixed-checkbox';
+  type: FormInputType.MixedCheckbox;
   initialChecked?: MixedOrBool;
 } & ItemBase;
 
 type TextareaDefinition = {
-  type: 'textarea';
+  type: FormInputType.Textarea;
   placeholder?: string;
   rows?: number;
   width?: number | string;
@@ -120,27 +139,27 @@ type TimeRelatedInput = {
 } & ItemBase;
 
 type DateInputDefinition = {
-  type: 'date-input';
+  type: FormInputType.DateInput;
 } & TimeRelatedInput;
 
 type TimeInputDefinition = {
-  type: 'time-input';
+  type: FormInputType.TimeInput;
 } & TimeRelatedInput;
 
 type FileUploadDefinition = {
-  type: 'file-upload';
+  type: FormInputType.FileUpload;
   description: string;
   onChange: () => void;
 } & ItemBase;
 
 type CallTypeButtonInputDefinition = {
-  type: 'button';
+  type: FormInputType.Button;
   category: 'data' | 'non-data';
 } & ItemBase;
 
 type CopyToDefinition = ItemBase &
   NonSaveable & {
-    type: 'copy-to';
+    type: FormInputType.CopyTo;
     initialChecked: false;
     target: CaseSectionApiName;
   };

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -215,7 +215,7 @@ const setUpActions = (setupObject: SetupObject) => {
 
   ActionFunctions.setUpPostSurvey(setupObject);
 
-  // bind setupObject to the functions that requires some initializaton
+  // bind setupObject to the functions that requires some initialization
   const transferOverride = ActionFunctions.customTransferTask(setupObject);
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject);
   const beforeCompleteAction = ActionFunctions.beforeCompleteTask(setupObject);

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
@@ -1,4 +1,4 @@
-import type { FormItemDefinition } from 'hrm-form-definitions';
+import { FormItemDefinition, FormInputType } from 'hrm-form-definitions';
 
 import { getInitialValue } from '../common/forms/formGenerators';
 
@@ -31,7 +31,7 @@ export const definitionObject: CounselorCSAMFormDefinitionObject = {
   webAddress: {
     name: 'webAddress',
     label: 'Web address',
-    type: 'input',
+    type: FormInputType.Input,
     required: { value: true, message: 'RequiredFieldError' },
     maxLength: { value: 1000, message: '1000 characters max.' },
     validate: data => {
@@ -42,14 +42,14 @@ export const definitionObject: CounselorCSAMFormDefinitionObject = {
   description: {
     name: 'description',
     label: 'Description (500 characters)',
-    type: 'textarea',
+    type: FormInputType.Textarea,
     maxLength: { value: 500, message: '500 characters max.' },
     width: '70%',
   },
   anonymous: {
     name: 'anonymous',
     label: '',
-    type: 'radio-input',
+    type: FormInputType.RadioInput,
     options: [
       { value: 'anonymous', label: 'File anonymously' },
       { value: 'non-anonymous', label: 'Provide contact details' },
@@ -59,19 +59,19 @@ export const definitionObject: CounselorCSAMFormDefinitionObject = {
   firstName: {
     name: 'firstName',
     label: "Reporter's First Name",
-    type: 'input',
+    type: FormInputType.Input,
     maxLength: { value: 50, message: '50 characters max.' },
   },
   lastName: {
     name: 'lastName',
     label: "Reporter's Last Name",
-    type: 'input',
+    type: FormInputType.Input,
     maxLength: { value: 50, message: '50 characters max.' },
   },
   email: {
     name: 'email',
     label: 'Email Address',
-    type: 'email',
+    type: FormInputType.Email,
     required: { value: true, message: 'RequiredFieldError' },
     maxLength: { value: 100, message: '100 characters max.' },
   },
@@ -82,7 +82,7 @@ export const childDefinitionObject: ChildCSAMFormDefinitionObject = {
   childAge: {
     name: 'childAge',
     label: '',
-    type: 'radio-input',
+    type: FormInputType.RadioInput,
     options: [
       { value: 'under-13-years', label: 'Under 13 years old' },
       { value: '13-to-15-years', label: '13 to 15 years old' },
@@ -92,7 +92,7 @@ export const childDefinitionObject: ChildCSAMFormDefinitionObject = {
   ageVerified: {
     name: 'ageVerified',
     label: 'Yes, age of child has been verified',
-    type: 'checkbox',
+    type: FormInputType.Checkbox,
   },
 };
 

--- a/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
+++ b/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
@@ -4,8 +4,7 @@ import React, { useEffect, useMemo } from 'react';
 import { Template } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 import { FieldValues, FormProvider, SubmitErrorHandler, useForm } from 'react-hook-form';
-import type { DefinitionVersion, FormDefinition } from 'hrm-form-definitions';
-import { FormInputType } from 'hrm-form-definitions';
+import { DefinitionVersion, FormDefinition, FormInputType } from 'hrm-form-definitions';
 import { isEqual } from 'lodash';
 import { bindActionCreators } from 'redux';
 

--- a/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
+++ b/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
@@ -4,7 +4,8 @@ import React, { useEffect, useMemo } from 'react';
 import { Template } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 import { FieldValues, FormProvider, SubmitErrorHandler, useForm } from 'react-hook-form';
-import type { DefinitionVersion, FormDefinition, StatusInfo } from 'hrm-form-definitions';
+import type { DefinitionVersion, FormDefinition } from 'hrm-form-definitions';
+import { FormInputType } from 'hrm-form-definitions';
 import { isEqual } from 'lodash';
 import { bindActionCreators } from 'redux';
 
@@ -22,20 +23,20 @@ import ActionHeader from './ActionHeader';
 import { configurationBase, connectedCaseBase, namespace, RootState } from '../../states';
 import * as CaseActions from '../../states/case/actions';
 import * as RoutingActions from '../../states/routing/actions';
+import { changeRoute } from '../../states/routing/actions';
 import { getConfig } from '../../HrmFormPlugin';
 import { updateCase } from '../../services/CaseService';
 import { createFormFromDefinition, disperseInputs, splitAt } from '../common/forms/formGenerators';
 import type { CustomITask, StandaloneITask } from '../../types/types';
 import useFocus from '../../utils/useFocus';
 import { recordingErrorHandler } from '../../fullStory';
-import { caseItemHistory, CaseState, CaseSummaryWorkingCopy } from '../../states/case/types';
+import { caseItemHistory, CaseSummaryWorkingCopy } from '../../states/case/types';
 import CloseCaseDialog from './CloseCaseDialog';
 import {
   initialiseCaseSummaryWorkingCopy,
   removeCaseSummaryWorkingCopy,
   updateCaseSummaryWorkingCopy,
 } from '../../states/case/caseWorkingCopy';
-import { changeRoute } from '../../states/routing/actions';
 import { AppRoutes } from '../../states/routing/types';
 import { PermissionActions, PermissionActionType } from '../../permissions';
 
@@ -72,23 +73,23 @@ const EditCaseSummary: React.FC<Props> = ({
         {
           name: 'status',
           label: 'Case-CaseStatus',
-          type: 'select',
+          type: FormInputType.Select,
           options: connectedCaseState.availableStatusTransitions,
         },
         {
           name: 'followUpDate',
-          type: 'date-input',
+          type: FormInputType.DateInput,
           label: 'Case-CaseDetailsFollowUpDate',
         },
         {
           name: 'childIsAtRisk',
           label: 'Case-ChildIsAtRisk',
-          type: 'checkbox',
+          type: FormInputType.Checkbox,
         },
         {
           name: 'summary',
           label: 'SectionName-CaseSummary',
-          type: 'textarea',
+          type: FormInputType.Textarea,
         },
       ];
     } catch (e) {

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -8,7 +8,14 @@ import { useFormContext, RegisterOptions } from 'react-hook-form';
 import { get, pick } from 'lodash';
 import { format, startOfDay } from 'date-fns';
 import { Template } from '@twilio/flex-ui';
-import { FormItemDefinition, FormDefinition, InputOption, SelectOption, MixedOrBool } from 'hrm-form-definitions';
+import {
+  FormItemDefinition,
+  FormDefinition,
+  InputOption,
+  SelectOption,
+  MixedOrBool,
+  FormInputType,
+} from 'hrm-form-definitions';
 
 import {
   Box,
@@ -46,36 +53,36 @@ import UploadFileInput from './UploadFileInput';
  */
 export const getInitialValue = (def: FormItemDefinition) => {
   switch (def.type) {
-    case 'input':
-    case 'numeric-input':
-    case 'email':
-    case 'textarea':
-    case 'file-upload':
+    case FormInputType.Input:
+    case FormInputType.NumericInput:
+    case FormInputType.Email:
+    case FormInputType.Textarea:
+    case FormInputType.FileUpload:
       return '';
-    case 'date-input': {
+    case FormInputType.DateInput: {
       if (def.initializeWithCurrent) {
         return format(startOfDay(new Date()), 'yyyy-MM-dd');
       }
 
       return '';
     }
-    case 'time-input': {
+    case FormInputType.TimeInput: {
       if (def.initializeWithCurrent) {
         return format(new Date(), 'HH:mm');
       }
 
       return '';
     }
-    case 'radio-input':
+    case FormInputType.RadioInput:
       return def.defaultOption ?? '';
-    case 'listbox-multiselect':
+    case FormInputType.ListboxMultiselect:
       return [];
-    case 'select':
+    case FormInputType.Select:
       return def.defaultOption ? def.defaultOption : def.options[0].value;
-    case 'dependent-select':
+    case FormInputType.DependentSelect:
       return def.defaultOption.value;
-    case 'copy-to':
-    case 'checkbox':
+    case FormInputType.CopyTo:
+    case FormInputType.Checkbox:
       return Boolean(def.initialChecked);
     case 'mixed-checkbox':
       return def.initialChecked === undefined ? 'mixed' : def.initialChecked;
@@ -118,7 +125,7 @@ const bindCreateSelectOptions = (path: string) => (o: SelectOption) => (
 );
 
 /**
- * Helper function used to calclulate the element that should be focused for 'listbox-multiselect' type inputs
+ * Helper function used to calclulate the element that should be focused for FormInputType.ListboxMultiselect type inputs
  */
 const calculateNextFocusable = (currentValue: any[], options: InputOption[]) => {
   // If there's at least one selected option, return the index of the first one on the definition
@@ -131,7 +138,7 @@ const calculateNextFocusable = (currentValue: any[], options: InputOption[]) => 
 };
 
 /**
- * Helper function used to calclulate the tabIndex for each option of 'listbox-multiselect' type inputs
+ * Helper function used to calclulate the tabIndex for each option of FormInputType.ListboxMultiSelect type inputs
  */
 const calculateOptionsTabIndexes = (currentValue: any[], options: InputOption[]) =>
   options.map((option, index) => (index === calculateNextFocusable(currentValue, options) ? undefined : -1));
@@ -140,6 +147,7 @@ const calculateOptionsTabIndexes = (currentValue: any[], options: InputOption[])
  * Creates a Form with each input connected to RHF's wrapping Context, based on the definition.
  * @param {string[]} parents Array of parents. Allows you to easily create nested form fields. https://react-hook-form.com/api#register.
  * @param {() => void} updateCallback Callback called to update form state. When is the callback called is specified in the input type.
+ * @param customHandlers Set of additional handlers specific to file uploads.
  * @param {FormItemDefinition} def Definition for a single input.
  */
 export const getInputType = (parents: string[], updateCallback: () => void, customHandlers?: CustomHandlers) => (
@@ -155,7 +163,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
   const labelTextComponent = <Template code={`${def.label}`} className=".fullstory-unmask" />;
 
   switch (def.type) {
-    case 'input':
+    case FormInputType.Input:
       return (
         <ConnectForm key={path}>
           {({ errors, register }) => {
@@ -196,7 +204,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'numeric-input':
+    case FormInputType.NumericInput:
       return (
         <ConnectForm key={path}>
           {({ errors, register }) => {
@@ -240,7 +248,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'email':
+    case FormInputType.Email:
       return (
         <ConnectForm key={path}>
           {({ errors, register }) => {
@@ -285,7 +293,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'radio-input':
+    case FormInputType.RadioInput:
       return (
         <ConnectForm key={path}>
           {({ errors, register, setValue, watch }) => {
@@ -350,7 +358,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'listbox-multiselect':
+    case FormInputType.ListboxMultiselect:
       return (
         <ConnectForm key={path}>
           {({ errors, register, getValues }) => {
@@ -470,7 +478,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'select':
+    case FormInputType.Select:
       return (
         <ConnectForm key={path}>
           {({ errors, register }) => {
@@ -517,7 +525,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'dependent-select':
+    case FormInputType.DependentSelect:
       return (
         <ConnectForm key={path}>
           {({ errors, register, watch, setValue }) => {
@@ -593,8 +601,8 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'copy-to':
-    case 'checkbox':
+    case FormInputType.CopyTo:
+    case FormInputType.Checkbox:
       return (
         <ConnectForm key={path}>
           {({ errors, register }) => {
@@ -692,7 +700,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'textarea':
+    case FormInputType.Textarea:
       return (
         <ConnectForm key={path}>
           {({ errors, register }) => {
@@ -735,7 +743,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'time-input':
+    case FormInputType.TimeInput:
       return (
         <ConnectForm key={path}>
           {({ errors, register }) => {
@@ -777,7 +785,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'date-input':
+    case FormInputType.DateInput:
       return (
         <ConnectForm key={path}>
           {({ errors, register }) => {
@@ -819,7 +827,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
           }}
         </ConnectForm>
       );
-    case 'file-upload':
+    case FormInputType.FileUpload:
       return (
         <ConnectForm key={path}>
           {({ errors, clearErrors, register, setValue, watch }) => (
@@ -844,7 +852,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
         </ConnectForm>
       );
     default:
-      return null;
+      return <div>INVALID FORM INPUT: {path}</div>;
   }
 };
 

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -1,5 +1,5 @@
 import { isFuture } from 'date-fns';
-import type { FormDefinition, DefinitionVersion } from 'hrm-form-definitions';
+import { DefinitionVersion, FormDefinition, FormInputType } from 'hrm-form-definitions';
 
 import { channelTypes } from '../../states/DomainConstants';
 import { mapChannelForInsights } from '../../utils/mappers';
@@ -41,14 +41,14 @@ export const createContactlessTaskTabDefinition = ({
   return [
     {
       name: 'channel',
-      type: 'select',
+      type: FormInputType.Select,
       label: 'Channel',
       options: channelOptions,
       required: { value: true, message: 'RequiredFieldError' },
     },
     {
       name: 'createdOnBehalfOf',
-      type: 'select',
+      type: FormInputType.Select,
       label: 'Counsellor',
       options: counsellorOptions,
       // defaultOption: workerSid,
@@ -56,7 +56,7 @@ export const createContactlessTaskTabDefinition = ({
     },
     {
       name: 'date',
-      type: 'date-input',
+      type: FormInputType.DateInput,
       label: 'Date of Contact',
       initializeWithCurrent: true,
       required: { value: true, message: 'RequiredFieldError' },
@@ -75,7 +75,7 @@ export const createContactlessTaskTabDefinition = ({
     },
     {
       name: 'time',
-      type: 'time-input',
+      type: FormInputType.TimeInput,
       label: 'Time of Contact',
       initializeWithCurrent: true,
       required: { value: true, message: 'RequiredFieldError' },
@@ -83,7 +83,7 @@ export const createContactlessTaskTabDefinition = ({
     {
       name: 'helpline',
       label: helplineLabel,
-      type: 'select',
+      type: FormInputType.Select,
       defaultOption: defaultHelplineOption,
       options: helplineOptions,
       required: { value: true, message: 'RequiredFieldError' },


### PR DESCRIPTION

<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @GPaoloni 

## Description

* Fixed form validation tests so basic validations are run on ALL form inputs, not just ones that are defined in the base specification
* Added explicit check that the input type is supported to form definition validation tests
* Converted form definition input 'type' from a union string literal to a string enum, so the values can be iterated in tests
* Split each form definition being validated into a separate test, so failure reports are more granular & useful
* Fixed issue with zw IncidentForm.json

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes CHI-1560

### Verification steps

Automated PR checks validate these changes