### PR TITLE
[Bug Fix]: Start New Chat appears after post survey initialization (reapply #982)

### DIFF
--- a/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
@@ -1,7 +1,10 @@
-import { ITask } from '@twilio/flex-ui';
+/* eslint-disable camelcase */
+import { ITask, StateHelper, TaskHelper, ChatOrchestrator } from '@twilio/flex-ui';
 
-import { afterCompleteTask } from '../../utils/setUpActions';
+import { afterCompleteTask, afterWrapupTask, setUpPostSurvey } from '../../utils/setUpActions';
 import { REMOVE_CONTACT_STATE } from '../../states/types';
+import * as HrmFormPlugin from '../../HrmFormPlugin';
+import * as ServerlessService from '../../services/ServerlessService';
 
 const mockFlexManager = {
   store: {
@@ -10,6 +13,7 @@ const mockFlexManager = {
 };
 
 jest.mock('@twilio/flex-ui', () => ({
+  ...(jest.requireActual('@twilio/flex-ui') as any),
   Manager: {
     getInstance: () => mockFlexManager,
   },
@@ -17,6 +21,10 @@ jest.mock('@twilio/flex-ui', () => ({
 
 jest.mock('../../HrmFormPlugin.tsx', () => ({}));
 jest.mock('../../states', () => ({}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('afterCompleteTask', () => {
   test('Dispatches a removeContactState action with the specified taskSid', () => {
@@ -29,5 +37,92 @@ describe('afterCompleteTask', () => {
       type: REMOVE_CONTACT_STATE,
       taskId: 'THIS IS THE TASK SID!',
     });
+  });
+});
+
+describe('afterWrapupTask', () => {
+  test('featureFlags.enable_post_survey === false should not trigger post survey', async () => {
+    const getConversationStateForTaskSpy = jest.spyOn(StateHelper, 'getConversationStateForTask');
+    const postSurveyInitSpy = jest.spyOn(ServerlessService, 'postSurveyInit').mockImplementationOnce(async () => ({}));
+
+    const task = <ITask>{
+      taskSid: 'THIS IS THE TASK SID!',
+      channelType: '',
+    };
+
+    afterWrapupTask(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: false } })({ task });
+
+    expect(getConversationStateForTaskSpy).not.toHaveBeenCalled();
+    expect(postSurveyInitSpy).not.toHaveBeenCalled();
+  });
+
+  test('featureFlags.enable_post_survey === true should not trigger post survey for non-chat task', async () => {
+    const task = ({
+      attributes: { channelSid: undefined },
+      taskSid: 'THIS IS THE TASK SID!',
+      channelType: 'voice',
+      taskChannelUniqueName: 'voice',
+    } as unknown) as ITask;
+
+    jest.spyOn(TaskHelper, 'isChatBasedTask').mockImplementation(() => false);
+    const getConversationStateForTaskSpy = jest.spyOn(StateHelper, 'getConversationStateForTask');
+    const postSurveyInitSpy = jest.spyOn(ServerlessService, 'postSurveyInit').mockImplementation(async () => ({}));
+
+    afterWrapupTask(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: true } })({ task });
+
+    expect(getConversationStateForTaskSpy).not.toHaveBeenCalled();
+    expect(postSurveyInitSpy).not.toHaveBeenCalled();
+  });
+
+  test('featureFlags.enable_post_survey === true should trigger post survey for chat task', async () => {
+    const task = ({
+      attributes: { channelSid: 'CHxxxxxx' },
+      taskSid: 'THIS IS THE TASK SID!',
+      channelType: 'web',
+      taskChannelUniqueName: 'chat',
+    } as unknown) as ITask;
+
+    jest.spyOn(TaskHelper, 'isChatBasedTask').mockImplementation(() => true);
+    jest.spyOn(TaskHelper, 'getTaskConversationSid').mockImplementationOnce(() => task.attributes.channelSid);
+    const removeAllListenersMock = jest.fn();
+    const getConversationStateForTaskSpy = jest
+      .spyOn(StateHelper, 'getConversationStateForTask')
+      .mockImplementationOnce(
+        () =>
+          ({
+            source: {
+              listenerCount: jest.fn(() => true),
+              eventNames: jest.fn(() => ['event1', 'event2']),
+              removeAllListeners: removeAllListenersMock,
+            },
+          } as any),
+      );
+    const postSurveyInitSpy = jest.spyOn(ServerlessService, 'postSurveyInit').mockImplementation(async () => ({}));
+
+    afterWrapupTask(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: true } })({ task });
+
+    expect(removeAllListenersMock).toHaveBeenCalledWith('event1');
+    expect(removeAllListenersMock).toHaveBeenCalledWith('event2');
+    expect(getConversationStateForTaskSpy).toHaveBeenCalled();
+    expect(postSurveyInitSpy).toHaveBeenCalled();
+  });
+});
+
+describe('setUpPostSurvey', () => {
+  test('featureFlags.enable_post_survey === false should not change ChatOrchestrator', async () => {
+    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations');
+    setUpPostSurvey(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: false } });
+
+    expect(setOrchestrationsSpy).not.toHaveBeenCalled();
+  });
+
+  test('featureFlags.enable_post_survey === true should change ChatOrchestrator', async () => {
+    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
+
+    setUpPostSurvey(<HrmFormPlugin.SetupObject>{ featureFlags: { enable_post_survey: true } });
+
+    expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
+    expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));
+    expect(setOrchestrationsSpy).toHaveBeenCalledWith('completed', expect.any(Function));
   });
 });


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand @mythilytm 

## Description
This PR reapplies the changes from https://github.com/techmatters/flex-plugins/pull/982 that are missing in current `master`.
It also changes some APIs that were deprecated in Flex 2 to the new ones.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1556)
- [x] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Start development server.
- Send a new webchat contact.
- Accept it in your local instance of Flex.
- Move the task to wrapup (either with end chat button in Flex or with the new end chat button in webchat if available).
- Confirm that:
  - The channel is still open, and the webchat can still interact with the post survey.
  - The counselor does not receives any further interactions.