### PR TITLE
Call type channel template strings masked

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -204,6 +204,7 @@ const setUpComponents = (setupObject: SetupObject) => {
     // Masks TaskInfoPanelContent - TODO: refactor to use a react component
     const { strings } = getConfig();
     strings.TaskInfoPanelContent = strings.TaskInfoPanelContentMasked;
+    strings.CallParticipantCustomerName = strings.MaskIdentifiers;
   }
 };
 

--- a/plugin-hrm-form/src/channels/setUpChannels.tsx
+++ b/plugin-hrm-form/src/channels/setUpChannels.tsx
@@ -169,6 +169,8 @@ const maskIdentifiersByChannel = channelType => {
    * }
    */
   channelType.templates.IncomingTaskCanvas.firstLine = 'MaskIdentifiers';
+  channelType.templates.CallCanvas.firstLine = 'MaskIdentifiers';
+
   // Task panel during an active call
   channelType.templates.TaskCanvasHeader.title = 'MaskIdentifiers';
   channelType.templates.MessageListItem = 'MaskIdentifiers';

--- a/plugin-hrm-form/src/channels/setUpChannels.tsx
+++ b/plugin-hrm-form/src/channels/setUpChannels.tsx
@@ -161,13 +161,11 @@ export const setupLineChatChannel = maskIdentifiers => {
 const maskIdentifiersByChannel = channelType => {
   // Task list and panel when a call comes in
   channelType.templates.TaskListItem.firstLine = 'MaskIdentifiers';
-  /*
-   * if (channelType === Flex.DefaultTaskChannels.Chat) {
-   *   channelType.templates.TaskListItem.secondLine = 'TaskLineWebChatAssignedMasked';
-   * } else {
-   *   channelType.templates.TaskListItem.secondLine = 'TaskLineChatAssignedMasked';
-   * }
-   */
+  if (channelType === Flex.DefaultTaskChannels.Chat) {
+    channelType.templates.TaskListItem.secondLine = 'TaskLineWebChatAssignedMasked';
+  } else {
+    channelType.templates.TaskListItem.secondLine = 'TaskLineChatAssignedMasked';
+  }
   channelType.templates.IncomingTaskCanvas.firstLine = 'MaskIdentifiers';
   channelType.templates.CallCanvas.firstLine = 'MaskIdentifiers';
 


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand  

## Description
- Mask call channel's phone number at incoming, active and at call end
![Incoming](https://user-images.githubusercontent.com/102122005/206591523-cbabfec3-c16e-44cb-b89a-55a988b21b1c.png)
![Active call](https://user-images.githubusercontent.com/102122005/206591525-b55c0e75-8857-4ba9-8fcd-651f6f8315fd.png)
![End call](https://user-images.githubusercontent.com/102122005/206591526-28492c5b-38ac-4697-a46b-942c802612db.png)

- The task card's second line where the latest message is shown got commented out and can reveal the user's information, hence, that is also made to work in this PR.

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [x] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Related Issues
Fixes # [1562](https://tech-matters.atlassian.net/browse/CHI-1562)

### Verification steps
1. Remove permission for 'viewIdentifiers' - Remove all conditions
2. Call flex from one of the listed phone numbers
3. Check the active call at all three stages of call - at incoming, active conversation, and after call ends. 