### PR TITLE
CHI-1557: taskrouter events

### DIFF
--- a/plugin-hrm-form/src/components/FormNotEditable.jsx
+++ b/plugin-hrm-form/src/components/FormNotEditable.jsx
@@ -6,7 +6,7 @@ import { InfoTwoTone } from '@material-ui/icons';
 import { Row } from '../styles/HrmStyles';
 
 const FormNotEditable = () => (
-  <AppBar style={{ zIndex: 10 }} position="relative">
+  <AppBar style={{ zIndex: 'inherit' }} position="relative">
     <Toolbar style={{ backgroundColor: '#2196f3' }}>
       <Row>
         <InfoTwoTone style={{ fontSize: 26, marginRight: 10 }} />

--- a/plugin-hrm-form/src/components/FormNotEditable.jsx
+++ b/plugin-hrm-form/src/components/FormNotEditable.jsx
@@ -6,7 +6,7 @@ import { InfoTwoTone } from '@material-ui/icons';
 import { Row } from '../styles/HrmStyles';
 
 const FormNotEditable = () => (
-  <AppBar position="relative">
+  <AppBar style={{ zIndex: 10 }} position="relative">
     <Toolbar style={{ backgroundColor: '#2196f3' }}>
       <Row>
         <InfoTwoTone style={{ fontSize: 26, marginRight: 10 }} />

--- a/plugin-hrm-form/src/components/FormNotEditable.tsx
+++ b/plugin-hrm-form/src/components/FormNotEditable.tsx
@@ -5,7 +5,7 @@ import { InfoTwoTone } from '@material-ui/icons';
 
 import { Row } from '../styles/HrmStyles';
 
-const FormNotEditable = () => (
+const FormNotEditable: React.FC = () => (
   <AppBar style={{ zIndex: 'inherit' }} position="relative">
     <Toolbar style={{ backgroundColor: '#2196f3' }}>
       <Row>

--- a/twilio-iac/terraform-modules/taskRouter/default/main.tf
+++ b/twilio-iac/terraform-modules/taskRouter/default/main.tf
@@ -38,7 +38,7 @@ resource "twilio_taskrouter_workspaces_v1" "flex_task_assignment" {
   friendly_name      = "Flex Task Assignment"
   multi_task_enabled = true
   event_callback_url = "${var.serverless_url}/webhooks/taskrouterCallback"
-  events_filter = "task.created,task.canceled,task.completed,task.deleted,task.system-deleted" //Ignore the docs where it implies this should be 'EventsFilter=task.created, task.canceled, task.completed'
+  events_filter = "task.created,task.canceled,task.completed,task.deleted,task.wrapup,task.system-deleted,reservation.accepted,reservation.rejected,reservation.timeout,reservation.wrapup" //Ignore the docs where it implies this should be 'EventsFilter=task.created, task.canceled, task.completed'
 }
 
 //TaskQueue


### PR DESCRIPTION
Review after #1091 & #1097

<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @murilovmachado 

## Description

* Updates TaskRouter events in Terraform for new backend transfer handling
* Updates the 'form locked' bar CSS so it doesn't overlay the Twilio worker status dropdown

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1557

### Verification steps

* Initiate a transfer of a chat call (but do not accept it)
* When the blue 'form locked' bar appears, open the workers dropdown to change status (top right)
* It should render over the top of the blue bar, not underneath