### PR TITLE
Changed CSAMForm validation to declarative props on definition object

### DIFF
--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReport.tsx
@@ -64,13 +64,8 @@ export const CSAMReportScreen: React.FC<Props> = ({
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const [initialForm] = React.useState(csamReportState.form); // grab initial values in first render only. This value should never change or will ruin the memoization below
-  const [isEmpty, setIsEmpty] = React.useState(true);
   const methods = useForm({ reValidateMode: 'onChange' });
   const firstElementRef = useFocus();
-
-  useEffect(() => {
-    confirmInput(methods.getValues());
-  }, [methods, methods.watch]);
 
   const currentCounselor = React.useMemo(() => {
     const { workerSid } = getConfig();
@@ -129,14 +124,6 @@ export const CSAMReportScreen: React.FC<Props> = ({
     changeRoute({ ...previousRoute }, taskSid);
   };
 
-  const confirmInput = form => {
-    if (form.childAge !== null && form.ageVerified) {
-      setIsEmpty(false);
-    } else {
-      setIsEmpty(true);
-    }
-  };
-
   const onValid = async form => {
     try {
       if (routing.subroute === 'child-form') {
@@ -176,7 +163,6 @@ export const CSAMReportScreen: React.FC<Props> = ({
   };
 
   const onSendAnotherReport = (route, subroute) => {
-    setIsEmpty(true);
     clearCSAMReportAction(taskSid);
     changeRoute({ route, subroute, previousRoute }, taskSid);
   };
@@ -188,7 +174,6 @@ export const CSAMReportScreen: React.FC<Props> = ({
       return (
         <FormProvider {...methods}>
           <CSAMReportFormScreen
-            isEmpty={isEmpty}
             childFormElements={formElements.childReportDefinition}
             counselor={currentCounselor}
             onClickClose={onClickClose}

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormDefinition.ts
@@ -88,11 +88,14 @@ export const childDefinitionObject: ChildCSAMFormDefinitionObject = {
       { value: '13-15', label: '13 to 15 years old' },
       { value: '16-17', label: '16 to 17 years old' },
     ],
+    required: { value: true, message: 'RequiredFieldError' },
   },
   ageVerified: {
     name: 'ageVerified',
     label: 'Yes, age of child has been verified',
     type: 'checkbox',
+    required: { value: true, message: 'RequiredFieldError' },
+    validate: Boolean,
   },
 };
 

--- a/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormScreen.tsx
+++ b/plugin-hrm-form/src/components/CSAMReport/CSAMReportFormScreen.tsx
@@ -22,7 +22,6 @@ type Props = {
   onClickClose: () => void;
   onSendReport: () => void;
   csamType: 'child-form' | 'counsellor-form';
-  isEmpty?: boolean;
 };
 
 const CSAMReportFormScreen: React.FC<Props> = ({
@@ -33,7 +32,6 @@ const CSAMReportFormScreen: React.FC<Props> = ({
   onClickClose,
   onSendReport,
   csamType,
-  isEmpty,
 }) => {
   return (
     <CSAMReportContainer style={{ padding: csamType === 'child-form' && '5px' }} data-testid="CSAMReport-FormScreen">
@@ -127,7 +125,6 @@ const CSAMReportFormScreen: React.FC<Props> = ({
           </StyledNextStepButton>
         </Box>
         <StyledNextStepButton
-          disabled={csamType === 'child-form' ? isEmpty : false}
           roundCorners
           onClick={onSendReport}
           data-testid={csamType === 'child-form' ? 'CSAMCLCReport-SubmitButton' : 'CSAMReport-SubmitButton'}


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @acedeywin 

## Description
This PR shows how would work the changes I suggested in [the following thread](https://github.com/techmatters/flex-plugins/pull/1077#discussion_r1044531178).

I strongly recommend reading [RHF docs](https://legacy.react-hook-form.com/v6/api/), in particular for this use case, the [register section](https://legacy.react-hook-form.com/v6/api/#register), where the different options for validation are explained.

## Verification Steps
- `npm run dev`.
- Start a contact -> Start a self generated CSAM report.
- Play around with different forms states:
  - Try to submit without changing the forms -> should error both fields.
  - Change the age range and submit -> should error the ageconfimed box.
  - Select and de-select the age confirmed -> should error.
  - Leave the form in a valid state and submit -> should succeed.