### PR TITLE
[Bug Fix] "Next" button for data form is pushed off of the screen

### DIFF
--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -17,6 +17,7 @@ import PreviousContactsBanner from './PreviousContactsBanner';
 import { Flex } from '../styles/HrmStyles';
 import { isStandaloneITask } from './case/Case';
 import { getHelplineToSave } from '../services/HelplineService';
+import { YellowBannerHeight } from '../styles/previousContactsBanner';
 
 type OwnProps = {
   task: CustomITask;
@@ -84,12 +85,22 @@ const TaskView: React.FC<Props> = props => {
 
   const { featureFlags } = getConfig();
   const isFormLocked = !hasTaskControl(task);
+  const { enable_previous_contacts: enablePreviousContacts } = featureFlags;
 
   return (
-    <Flex flexDirection="column" height="100%" style={{ pointerEvents: isFormLocked ? 'none' : 'auto' }}>
-      {featureFlags.enable_previous_contacts && <PreviousContactsBanner task={task} />}
+    <Flex flexDirection="column" style={{ pointerEvents: isFormLocked ? 'none' : 'auto', height: '100%' }}>
+      {enablePreviousContacts && <PreviousContactsBanner task={task} />}
       {isFormLocked && <FormNotEditable />}
-      <HrmForm task={task} featureFlags={featureFlags} />
+      <Flex
+        flexDirection="column"
+        style={{
+          // This fixes a UI bug where the PreviousContactsBanner pushes the container down
+          height: enablePreviousContacts ? `calc(100% - ${YellowBannerHeight}` : '100%',
+          width: '100%',
+        }}
+      >
+        <HrmForm task={task} featureFlags={featureFlags} />
+      </Flex>
     </Flex>
   );
 };

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -17,7 +17,6 @@ import PreviousContactsBanner from './PreviousContactsBanner';
 import { Flex } from '../styles/HrmStyles';
 import { isStandaloneITask } from './case/Case';
 import { getHelplineToSave } from '../services/HelplineService';
-import { YellowBannerHeight } from '../styles/previousContactsBanner';
 
 type OwnProps = {
   task: CustomITask;
@@ -85,18 +84,18 @@ const TaskView: React.FC<Props> = props => {
 
   const { featureFlags } = getConfig();
   const isFormLocked = !hasTaskControl(task);
-  const { enable_previous_contacts: enablePreviousContacts } = featureFlags;
 
   return (
     <Flex flexDirection="column" style={{ pointerEvents: isFormLocked ? 'none' : 'auto', height: '100%' }}>
-      {enablePreviousContacts && <PreviousContactsBanner task={task} />}
+      {featureFlags.enable_previous_contacts && <PreviousContactsBanner task={task} />}
       {isFormLocked && <FormNotEditable />}
       <Flex
         flexDirection="column"
         style={{
           // This fixes a UI bug where the PreviousContactsBanner pushes the container down
-          height: enablePreviousContacts ? `calc(100% - ${YellowBannerHeight}` : '100%',
+          height: '100%',
           width: '100%',
+          overflow: 'auto',
         }}
       >
         <HrmForm task={task} featureFlags={featureFlags} />

--- a/plugin-hrm-form/src/styles/previousContactsBanner/index.ts
+++ b/plugin-hrm-form/src/styles/previousContactsBanner/index.ts
@@ -1,9 +1,11 @@
 import { styled } from '@twilio/flex-ui';
 
+export const YellowBannerHeight = '36px';
+
 export const YellowBanner = styled('div')`
   display: flex;
   background-color: #fdfad3;
-  height: 36px;
+  height: ${YellowBannerHeight};
   font-size: 13px;
   align-items: center;
   justify-content: center;

--- a/plugin-hrm-form/src/styles/previousContactsBanner/index.ts
+++ b/plugin-hrm-form/src/styles/previousContactsBanner/index.ts
@@ -1,6 +1,6 @@
 import { styled } from '@twilio/flex-ui';
 
-export const YellowBannerHeight = '36px';
+const YellowBannerHeight = '36px';
 
 export const YellowBanner = styled('div')`
   display: flex;


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand @mythilytm @murilovmachado 
(Mentioning multiple ppl cause maybe you have a smarter idea about fixing this one).

## Description
This PR fixes the bug mentioned in the Jira card, where the "previous contacts banner" will push down the content of the tabbed forms, causing the "Next" button to hidden under a scroll.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1552)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- `npm run dev`.
- Start a live contact form a number/ip that already exists in the DB.
- Confirm that the button bar is not being pushed below the limits of the screen.