### PR TITLE
CHI-1578: Fix transfer state

### DIFF
--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -275,7 +275,7 @@ export const setUpCaseList = () => {
       key="CaseListSideLink"
       onClick={() => Flex.Actions.invokeAction('NavigateToView', { viewName: 'case-list' })}
       reserveSpace={false}
-      showLabel={false}
+      showLabel={true}
     />,
   );
 };
@@ -292,7 +292,7 @@ export const setUpStandaloneSearch = () => {
       key="StandaloneSearchSideLink"
       onClick={() => Flex.Actions.invokeAction('NavigateToView', { viewName: 'search' })}
       reserveSpace={false}
-      showLabel={false}
+      showLabel={true}
     />,
   );
 };


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

## Description

* Fix shared state client client to read `.data` from client, not `.value`
* Migrate shared state client to TS

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Found investigating CHI-1578

### Verification steps

* Start a chat call
* Partially complete the form
* Transfer to counsellor
* Verify the data is present when the receiving counsellor accepts the task

Repeat for queue transfers and call transfers