### PR TITLE
CHI-1580: fix transfer state

### DIFF
--- a/plugin-hrm-form/src/___tests__/helpers.ts
+++ b/plugin-hrm-form/src/___tests__/helpers.ts
@@ -1,4 +1,4 @@
-import { ITask, TaskReservationStatus, TaskTaskStatus } from '@twilio/flex-ui';
+import { ITask } from '@twilio/flex-ui';
 
 const defaultsNNS = {
   sid: 'sid',
@@ -56,7 +56,7 @@ const defaultsNNS = {
  *  wrapUp: () => Promise<ReturnType<createTask>>
  * }}
  */
-export function createTask(attributes = {}, namesNsids = {}) {
+export function createTask(attributes = {}, namesNsids = {}): ITask {
   const {
     sid,
     taskSid,
@@ -72,7 +72,8 @@ export function createTask(attributes = {}, namesNsids = {}) {
 
   return {
     attributes,
-    source: '',
+    formattedAttributes: null,
+    source: null,
     sourceObject: null,
     addOns: null,
     age: 0,
@@ -98,9 +99,6 @@ export function createTask(attributes = {}, namesNsids = {}) {
     workflowSid,
     workerSid,
     channelType,
-    accept() {
-      return Promise.resolve({ ...this, dateUpdated: new Date(), status: 'accepted', taskStatus: 'assigned' });
-    },
     complete() {
       return Promise.resolve({ ...this, dateUpdated: new Date(), status: 'completed', taskStatus: 'completed' });
     },
@@ -125,6 +123,36 @@ export function createTask(attributes = {}, namesNsids = {}) {
     kick() {
       return Promise.resolve(this);
     },
+    endConference() {
+      return Promise.resolve(this);
+    },
+    async addVoiceParticipant() {
+      return this;
+    },
+    async updateWorkerParticipant() {
+      return this;
+    },
+    async updateCustomerParticipant() {
+      return this;
+    },
+    async issueCallToWorker() {
+      return this;
+    },
+    async setEndConferenceOnExit() {
+      return this;
+    },
+    async dequeue() {
+      return this;
+    },
+    async getParticipants() {
+      return null;
+    },
+    async redirectCall() {
+      return null;
+    },
+    async getChannels() {
+      return null;
+    },
     setAttributes(newAttributes) {
       this.attributes = newAttributes;
       return Promise.resolve(this);
@@ -133,4 +161,8 @@ export function createTask(attributes = {}, namesNsids = {}) {
       return Promise.resolve({ ...this, dateUpdated: new Date(), status: 'wrapping', taskStatus: 'wrapping' });
     },
   };
+}
+
+export async function acceptTask(task: ITask): Promise<ITask> {
+  return { ...task, dateUpdated: new Date(), status: 'accepted', taskStatus: 'assigned' };
 }

--- a/plugin-hrm-form/src/___tests__/utils/transfer.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/transfer.test.ts
@@ -3,9 +3,11 @@ import * as Flex from '@twilio/flex-ui';
 import { omit } from 'lodash';
 
 import '../mockGetConfig';
+import each from 'jest-each';
+
 import * as TransferHelpers from '../../utils/transfer';
 import { transferModes, transferStatuses } from '../../states/DomainConstants';
-import { createTask } from '../helpers';
+import { acceptTask, createTask } from '../helpers';
 
 const members = new Map();
 members.set('some_40identity', { source: { sid: 'member1' } });
@@ -66,21 +68,61 @@ describe('Transfer mode, status and conditionals helpers', () => {
     expect(TransferHelpers.isColdTransfer(task3)).toBe(false); // not transferred
   });
 
-  test('isTransferring', async () => {
-    const task1 = createTask({ transferMeta: { transferStatus: transferStatuses.transferring } });
-    const task2 = createTask({ transferMeta: { transferStatus: transferStatuses.accepted } });
-    const task3 = createTask({ transferMeta: { transferStatus: transferStatuses.rejected } });
-    const task4 = createTask();
-
-    expect(TransferHelpers.isTransferring(task1)).toBe(true); // transferring
-    expect(TransferHelpers.isTransferring(task2)).toBe(false); // accepted
-    expect(TransferHelpers.isTransferring(task3)).toBe(false); // rejected
-    expect(TransferHelpers.isTransferring(task4)).toBe(false); // not transferred
+  // TODO: refactor with nice syntax once Twilio lets us update jest
+  each(
+    [
+      {
+        task: createTask({ transferMeta: { transferStatus: transferStatuses.transferring } }),
+        expectedResult: true,
+        description: 'transferring state',
+      },
+      {
+        task: createTask({ transferMeta: { transferStatus: transferStatuses.accepted } }),
+        expectedResult: false,
+        description: 'accepted state',
+      },
+      {
+        task: createTask({ transferMeta: { transferStatus: transferStatuses.rejected } }),
+        expectedResult: false,
+        description: 'rejected state',
+      },
+      { task: createTask(), expectedResult: false, description: 'no attributes' },
+      {
+        task: createTask(
+          {
+            transferMeta: {
+              transferStatus: transferStatuses.accepted,
+              transferModes: transferModes.cold,
+              sidWithTaskControl: 'AN SID',
+            },
+          },
+          { sid: 'AN SID' },
+        ),
+        expectedResult: false,
+        description: 'cold transfer with control',
+      },
+      {
+        task: createTask(
+          {
+            transferMeta: {
+              transferStatus: transferStatuses.accepted,
+              transferModes: transferModes.cold,
+              sidWithTaskControl: 'AN SID',
+            },
+          },
+          { sid: 'ANOTHER SID' },
+        ),
+        expectedResult: false,
+        description: 'cold transfer without control',
+      },
+    ].map(tc => ({ ...tc, toString: () => `${tc.description} should return ${tc.expectedResult}` })),
+  ).test('isTransferring with %s', async ({ task, expectedResult }) => {
+    expect(TransferHelpers.isTransferring(task)).toBe(expectedResult);
   });
 
   test('shouldShowTransferButton', async () => {
     const task1 = createTask({ transferMeta: { transferStatus: transferStatuses.transferring } });
-    const [task2c, task2r] = await Promise.all([task1.accept(), task1.accept()]);
+    const [task2c, task2r] = await Promise.all([acceptTask(task1), acceptTask(task1)]);
     await TransferHelpers.setTransferAccepted(task2c);
     await TransferHelpers.setTransferRejected(task2r);
     const [task3c, task3r] = await Promise.all([task2c.wrapUp(), task2c.wrapUp()]);
@@ -101,7 +143,7 @@ describe('Transfer mode, status and conditionals helpers', () => {
       { transferMeta: { originalReservation: 'task1', transferStatus: transferStatuses.transferring } },
       { sid: 'task2' },
     );
-    const task2Accepted = await task2.accept();
+    const task2Accepted = await acceptTask(task2);
     const task3 = {
       ...task2Accepted,
       sid: 'task3',
@@ -199,6 +241,7 @@ describe('Transfer mode, status and conditionals helpers', () => {
 });
 
 describe('Kick, close and helpers', () => {
+  const mockFlexActionsInvoke = Flex.Actions.invokeAction as jest.Mock;
   const task = createTask(
     {
       ignoreAgent: 'some@identity',
@@ -213,7 +256,7 @@ describe('Kick, close and helpers', () => {
 
   test('closeCallOriginal', async () => {
     const expected1 = { sid: 'reservation2', targetSid: 'some@identity' };
-    Flex.Actions.invokeAction.mockClear();
+    mockFlexActionsInvoke.mockClear();
     expect(Flex.Actions.invokeAction).not.toHaveBeenCalled();
 
     await TransferHelpers.closeCallOriginal(task);
@@ -224,7 +267,7 @@ describe('Kick, close and helpers', () => {
 
   test('closeCallSelf', async () => {
     const expected1 = { sid: 'reservation2' };
-    Flex.Actions.invokeAction.mockClear();
+    mockFlexActionsInvoke.mockClear();
     expect(Flex.Actions.invokeAction).not.toHaveBeenCalled();
 
     await TransferHelpers.closeCallSelf(task);

--- a/plugin-hrm-form/src/___tests__/utils/transfer.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/transfer.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 import * as Flex from '@twilio/flex-ui';
 import { omit } from 'lodash';
-
 import '../mockGetConfig';
 import each from 'jest-each';
 

--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -45,4 +45,4 @@ export const transferStatuses = {
   transferring: 'transferring',
   accepted: 'accepted',
   rejected: 'rejected',
-};
+} as const;

--- a/plugin-hrm-form/src/utils/transfer.js
+++ b/plugin-hrm-form/src/utils/transfer.js
@@ -26,10 +26,19 @@ export const isWarmTransfer = task =>
 export const isColdTransfer = task =>
   Boolean(task.attributes.transferMeta && task.attributes.transferMeta.mode === transferModes.cold);
 
-export const isTransferring = task =>
-  Boolean(
-    task.attributes.transferMeta && task.attributes.transferMeta.transferStatus === transferStatuses.transferring,
+export const isTransferring = task => {
+  const { transferMeta } = task.attributes;
+  /*
+   * Cold transfers are always in an 'accepted' state so we cannot use this to establish if it's still in progress
+   * Checking if a cold transfer is not under our control suffices for current use cases, but it's tech debt
+   * We should use the tranferStatus in both warm & cold transfers to simplify our state logic
+   */
+  return Boolean(
+    transferMeta &&
+      (transferMeta.transferStatus === transferStatuses.transferring ||
+        (isColdTransfer(task) && !hasTaskControl(task))),
   );
+};
 
 /**
  * @param {ITask} task

--- a/plugin-hrm-form/src/utils/transfer.ts
+++ b/plugin-hrm-form/src/utils/transfer.ts
@@ -2,31 +2,20 @@
 import { Actions, ITask, TaskHelper, StateHelper } from '@twilio/flex-ui';
 
 import { transferStatuses, transferModes } from '../states/DomainConstants';
+import { CustomITask, isOfflineContactTask, isTwilioTask } from '../types/types';
 
-/**
- * @param {ITask} task
- */
-export const hasTransferStarted = task => Boolean(task.attributes && task.attributes.transferMeta);
+export const hasTransferStarted = (task: ITask) => Boolean(task.attributes && task.attributes.transferMeta);
 
-/**
- * @param {ITask} task
- */
-export const isOriginalReservation = task =>
+export const isOriginalReservation = (task: ITask) =>
   Boolean(task.attributes.transferMeta && task.attributes.transferMeta.originalReservation === task.sid);
 
-/**
- * @param {ITask} task
- */
-export const isWarmTransfer = task =>
+export const isWarmTransfer = (task: ITask) =>
   Boolean(task.attributes.transferMeta && task.attributes.transferMeta.mode === transferModes.warm);
 
-/**
- * @param {ITask} task
- */
-export const isColdTransfer = task =>
+export const isColdTransfer = (task: ITask) =>
   Boolean(task.attributes.transferMeta && task.attributes.transferMeta.mode === transferModes.cold);
 
-export const isTransferring = task => {
+export const isTransferring = (task: ITask) => {
   const { transferMeta } = task.attributes;
   /*
    * Cold transfers are always in an 'accepted' state so we cannot use this to establish if it's still in progress
@@ -40,19 +29,13 @@ export const isTransferring = task => {
   );
 };
 
-/**
- * @param {ITask} task
- */
-export const shouldShowTransferButton = task =>
+export const shouldShowTransferButton = (task: ITask) =>
   TaskHelper.isTaskAccepted(task) &&
   task.taskStatus === 'assigned' &&
   task.status === 'accepted' &&
   (!isTransferring(task) || hasTaskControl(task));
 
-/**
- * @param {ITask} task
- */
-export const shouldShowTransferControls = task =>
+export const shouldShowTransferControls = (task: ITask) =>
   !isOriginalReservation(task) && isTransferring(task) && hasTaskControl(task) && TaskHelper.isTaskAccepted(task);
 
 /**
@@ -63,14 +46,10 @@ export const shouldShowTransferControls = task =>
  * - this is not the original reservation and a transfer was initiated and then accepted
  * @param {import('../types/types').CustomITask} task
  */
-export const hasTaskControl = task =>
-  !hasTransferStarted(task) || task.attributes.transferMeta.sidWithTaskControl === task.sid;
+export const hasTaskControl = (task: CustomITask) =>
+  isTwilioTask(task) && (!hasTransferStarted(task) || task.attributes.transferMeta.sidWithTaskControl === task.sid);
 
-/**
- * @param {ITask} task
- * @param {string} sidWithTaskControl
- */
-const setTaskControl = async (task, sidWithTaskControl) => {
+const setTaskControl = async (task: ITask, sidWithTaskControl: string) => {
   const updatedAttributes = {
     ...task.attributes,
     transferMeta: {
@@ -84,17 +63,15 @@ const setTaskControl = async (task, sidWithTaskControl) => {
 
 /**
  * Takes control of the given task
- * @param {ITask} task
  */
-export const takeTaskControl = async task => {
+export const takeTaskControl = async (task: ITask) => {
   await setTaskControl(task, task.sid);
 };
 
 /**
  * Returns control of the given task to original counselor (only for call tasks for now)
- * @param {ITask} task
  */
-export const returnTaskControl = async task => {
+export const returnTaskControl = async (task: ITask) => {
   if (TaskHelper.isCallTask(task)) {
     await setTaskControl(task, task.attributes.transferMeta.originalReservation);
   }
@@ -105,7 +82,7 @@ export const returnTaskControl = async task => {
  * @param {string} newStatus
  * @returns {(task: ITask) => Promise<void>}
  */
-export const updateTransferStatus = newStatus => async task => {
+export const updateTransferStatus = (newStatus: keyof typeof transferStatuses) => async (task: ITask) => {
   const updatedAttributes = {
     ...task.attributes,
     transferStarted: true,
@@ -127,7 +104,11 @@ export const setTransferRejected = updateTransferStatus(transferStatuses.rejecte
  * @param {string} documentName name to retrieve the form or null if there were no form to save
  * @param {string} counselorName
  */
-export const setTransferMeta = async (payload, documentName, counselorName) => {
+export const setTransferMeta = async (
+  payload: { task: ITask; options: { mode: string }; targetSid: string },
+  documentName: string,
+  counselorName: string,
+) => {
   const { task, options, targetSid } = payload;
   const { mode } = options;
   const targetType = targetSid.startsWith('WK') ? 'worker' : 'queue';
@@ -155,7 +136,7 @@ export const setTransferMeta = async (payload, documentName, counselorName) => {
 /**
  * @param {ITask} task
  */
-export const clearTransferMeta = async task => {
+export const clearTransferMeta = async (task: ITask) => {
   const { transferMeta, transferStarted, ...attributes } = task.attributes;
 
   await task.setAttributes(attributes);
@@ -163,10 +144,8 @@ export const clearTransferMeta = async task => {
 
 /**
  * Kicks the other participant in call and then closes the original task
- * @param {ITask} task
- * @returns {Promise<void>}
  */
-export const closeCallOriginal = async task => {
+export const closeCallOriginal = async (task: ITask) => {
   await setTransferAccepted(task);
   await takeTaskControl(task);
   await Actions.invokeAction('KickParticipant', {
@@ -176,11 +155,11 @@ export const closeCallOriginal = async task => {
 };
 
 /**
- * Hangs the current call and closes the task being transfered to the new counselor (i.e. this task)
+ * Hangs the current call and closes the task being transferred to the new counselor (i.e. this task)
  * @param {ITask} task
  * @returns {Promise<void>}
  */
-export const closeCallSelf = async task => {
+export const closeCallSelf = async (task: ITask) => {
   await setTransferRejected(task);
   await returnTaskControl(task);
   await Actions.invokeAction('CompleteTask', { sid: task.sid });

--- a/plugin-hrm-form/src/utils/transfer.ts
+++ b/plugin-hrm-form/src/utils/transfer.ts
@@ -41,13 +41,14 @@ export const shouldShowTransferControls = (task: ITask) =>
 /**
  * Indicates if the current counselor has sole control over the task. Used to know if counselor should send form to hrm backend and prevent the form from being edited
  * A counselor controls a task if
+ * - It isn't a Twilio task
+ *  OR
  * - transfer was not initiated
  * - this is the original reservation and a transfer was initiated and then rejected
  * - this is not the original reservation and a transfer was initiated and then accepted
- * @param {import('../types/types').CustomITask} task
  */
 export const hasTaskControl = (task: CustomITask) =>
-  isTwilioTask(task) && (!hasTransferStarted(task) || task.attributes.transferMeta.sidWithTaskControl === task.sid);
+  !isTwilioTask(task) || !hasTransferStarted(task) || task.attributes.transferMeta.sidWithTaskControl === task.sid;
 
 const setTaskControl = async (task: ITask, sidWithTaskControl: string) => {
   const updatedAttributes = {


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description

* Fixes the logic for rendering 'End Chat' and 'Transfer' so they aren't present when a transfer is in progress by enhancing the 'isTransferring' helper to work for cold transfers (outgoing cold transfers at any rate

### Checklist
- [X] Corresponding issue has been opened
- [x] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [x] Tested for call contacts

### Related Issues
Fixes CHI-1580

### Verification steps

* See ticket
* Regression test voice calls