### PR TITLE
CHI-1609: Fix issue where function to look up value translations for printing doesn't fall back to untranslated value

### DIFF
--- a/plugin-hrm-form/src/components/case/casePrint/presentValuesFromStrings.ts
+++ b/plugin-hrm-form/src/components/case/casePrint/presentValuesFromStrings.ts
@@ -2,6 +2,6 @@ import { presentValue } from '../../../utils';
 
 export const presentValueFromStrings = (strings: Record<string, string>) =>
   presentValue(
-    code => strings[code],
+    code => strings[code] ?? code,
     codes => codes.join('\n'),
   );


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description

* Added fallback to use raw string value if no mapping is found in presentValueFromStrings

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1609

### Verification steps

* View PDFs for cases and compare the values in various sections and compare them to what is expected