### PR TITLE
fix: single terraform state bucket per environment

### DIFF
--- a/twilio-iac/aarambh-production/main.tf
+++ b/twilio-iac/aarambh-production/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-in-production"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-production"
+    key            = "twilio/in/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/cl-linealibre-staging/main.tf
+++ b/twilio-iac/cl-linealibre-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-cl-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/cl/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/ecpat-production/main.tf
+++ b/twilio-iac/ecpat-production/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-ph-production"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-production"
+    key            = "twilio/ph/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/ecpat-staging/main.tf
+++ b/twilio-iac/ecpat-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-ph-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/ph/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/endtoend-development/main.tf
+++ b/twilio-iac/endtoend-development/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-e2e-development"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-development"
+    key            = "twilio/e2e/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/flex2-staging/main.tf
+++ b/twilio-iac/flex2-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-f2-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/f2/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/kek-vonal-production/main.tf
+++ b/twilio-iac/kek-vonal-production/main.tf
@@ -7,10 +7,10 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-hu-production"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-production"
+    key            = "twilio/hu/terraform.tfstate"
     dynamodb_table = "terraform-locks"
-    region = "us-east-1"
+    region         = "us-east-1"
     encrypt        = true
   }
 }

--- a/twilio-iac/kek-vonal-staging/main.tf
+++ b/twilio-iac/kek-vonal-staging/main.tf
@@ -7,10 +7,10 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-ukr-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/ukr/terraform.tfstate"
     dynamodb_table = "terraform-locks"
-    region = "us-east-1"
+    region         = "us-east-1"
     encrypt        = true
   }
 }

--- a/twilio-iac/kidshelpphone-staging/main.tf
+++ b/twilio-iac/kidshelpphone-staging/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "/tl-terraform-state-staging"
+    bucket         = "tl-terraform-state-staging"
     key            = "twilio/ca/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true

--- a/twilio-iac/kidshelpphone-staging/main.tf
+++ b/twilio-iac/kidshelpphone-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-ca-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "/tl-terraform-state-staging"
+    key            = "twilio/ca/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/mt-kellimni-production/main.tf
+++ b/twilio-iac/mt-kellimni-production/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-mt-production"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-production"
+    key            = "twilio/mt/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/mt-kellimni-staging/main.tf
+++ b/twilio-iac/mt-kellimni-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-mt-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/mt/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/revengeporn-staging/main.tf
+++ b/twilio-iac/revengeporn-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-uk-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/uk/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/safespot-production/main.tf
+++ b/twilio-iac/safespot-production/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-jm-production"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-production"
+    key            = "twilio/jm/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/safespot-staging/main.tf
+++ b/twilio-iac/safespot-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-jm-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/jm/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/teguio-production/main.tf
+++ b/twilio-iac/teguio-production/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-co-production"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-production"
+    key            = "twilio/co/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/teguio-staging/main.tf
+++ b/twilio-iac/teguio-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-co-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/co/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/telefonulcopilului-staging/main.tf
+++ b/twilio-iac/telefonulcopilului-staging/main.tf
@@ -7,10 +7,10 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-ro-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/ro/terraform.tfstate"
     dynamodb_table = "terraform-locks"
-    region = "us-east-1"
+    region         = "us-east-1"
     encrypt        = true
   }
 }

--- a/twilio-iac/telefonzaufania-pl-staging/main.tf
+++ b/twilio-iac/telefonzaufania-pl-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-pl-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/pl/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/terraform-poc-account/main.tf
+++ b/twilio-iac/terraform-poc-account/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-terraform-poc"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-development"
+    key            = "twilio/poc/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/thailand-staging/main.tf
+++ b/twilio-iac/thailand-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-th-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/th/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }

--- a/twilio-iac/zimbabwe-staging/main.tf
+++ b/twilio-iac/zimbabwe-staging/main.tf
@@ -7,8 +7,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tl-terraform-state-twilio-zw-staging"
-    key            = "twilio/terraform.tfstate"
+    bucket         = "tl-terraform-state-staging"
+    key            = "twilio/zw/terraform.tfstate"
     dynamodb_table = "terraform-locks"
     encrypt        = true
   }


### PR DESCRIPTION
## Description
Move to a single s3 bucket per environment for terraform state.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes CHI-1568

### Verification steps
Checkout this branch, pick a helpline that you have configured locally befoe, and run `terraform init tf_args=-reconfigure` then `terraform plan tf_args="--var-file=.private.tfvars"` and verify that changes look appropriate for the helpline.