### PR TITLE
Add ability to save Contact ID to Insights

### DIFF
--- a/hrm-form-definitions/form-definitions/demo-v1/insights/oneToManyConfigSpecs.json
+++ b/hrm-form-definitions/form-definitions/demo-v1/insights/oneToManyConfigSpecs.json
@@ -6,5 +6,12 @@
       "contactForm.childInformation.province",
       "contactForm.childInformation.district"
     ]
+  },
+  {
+    "attributeName": "conversation_attribute_10",
+    "insightsObject": "conversations",
+    "paths": [
+      "savedContact.id"
+    ]
   }
 ]

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -18,6 +18,7 @@ import fetchHrmApi from './fetchHrmApi';
 import { getDateTime } from '../utils/helpers';
 import { getConfig, getDefinitionVersions } from '../HrmFormPlugin';
 import {
+  Contact,
   ContactMediaType,
   ContactRawJson,
   ConversationMedia,
@@ -257,7 +258,7 @@ const saveContactToHrm = async (
     body: JSON.stringify(body),
   };
 
-  const responseJson = await fetchHrmApi(`/contacts`, options);
+  const responseJson: Contact = await fetchHrmApi(`/contacts`, options);
 
   return { responseJson, requestPayload: body };
 };

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { get, cloneDeep } from 'lodash';
+import { get, cloneDeep, merge } from 'lodash';
 import {
   DefinitionVersion,
   callTypes,
@@ -16,7 +16,7 @@ import { isNonDataCallType } from '../states/ValidationRules';
 import { mapChannelForInsights } from '../utils/mappers';
 import { getDateTime } from '../utils/helpers';
 import { TaskEntry } from '../states/contacts/reducer';
-import { Case, CustomITask } from '../types/types';
+import { Case, CustomITask, Contact } from '../types/types';
 import { formatCategories } from '../utils/formatters';
 import { getDefinitionVersions } from '../HrmFormPlugin';
 import { shouldSendInsightsData } from '../utils/setUpActions';
@@ -68,6 +68,7 @@ type InsightsUpdateFunction = (
   attributes: TaskAttributes,
   contactForm: TaskEntry,
   caseForm: Case,
+  savedContact: Contact,
 ) => InsightsAttributes;
 
 const sanitizeInsightsValue = (value: string | boolean) => {
@@ -318,10 +319,10 @@ export const processHelplineConfig = (
 };
 
 const applyCustomUpdate = (customUpdate: OneToManyConfigSpec): InsightsUpdateFunction => {
-  return (taskAttributes, contactForm, caseForm) => {
+  return (taskAttributes, contactForm, caseForm, savedContact) => {
     if (isNonDataCallType(contactForm.callType)) return {};
 
-    const dataSource = { taskAttributes, contactForm, caseForm };
+    const dataSource = { taskAttributes, contactForm, caseForm, savedContact };
     // concatenate the values, taken from dataSource using paths (e.g. 'contactForm.childInformation.province')
     const value = customUpdate.paths.map(path => sanitizeInsightsValue(get(dataSource, path, ''))).join(delimiter);
 
@@ -353,6 +354,7 @@ export const mergeAttributes = (
 ): TaskAttributes => {
   return {
     ...previousAttributes,
+    ...newAttributes,
     conversations: {
       ...previousAttributes.conversations,
       ...newAttributes.conversations,
@@ -380,17 +382,17 @@ const getInsightsUpdateFunctionsForConfig = (
  * Note: config parameter tells where to go to get helpline-specific tests.  It should
  * eventually match up with getConfig().  Also useful for testing.
  */
-export const buildInsightsData = (task: CustomITask, contactForm: TaskEntry, caseForm: Case) => {
-  const previousAttributes = task.attributes;
+export const buildInsightsData = (task: CustomITask, contactForm: TaskEntry, caseForm: Case, savedContact: Contact) => {
+  const previousAttributes = typeof task.attributes === 'string' ? JSON.parse(task.attributes) : task.attributes;
 
-  if (!shouldSendInsightsData(task as ITask)) return previousAttributes;
+  if (!shouldSendInsightsData({ ...task, attributes: previousAttributes } as ITask)) return previousAttributes;
 
   const { currentDefinitionVersion } = getDefinitionVersions();
 
   // eslint-disable-next-line sonarjs/prefer-immediate-return
   const finalAttributes: TaskAttributes = getInsightsUpdateFunctionsForConfig(currentDefinitionVersion.insights)
-    .map(f => f(previousAttributes, contactForm, caseForm))
-    .reduce((acc: TaskAttributes, curr: InsightsAttributes) => mergeAttributes(acc, curr), previousAttributes);
+    .map(f => f(previousAttributes, contactForm, caseForm, savedContact))
+    .reduce((acc: TaskAttributes, curr: InsightsAttributes) => merge(acc, curr), previousAttributes);
 
   return finalAttributes;
 };

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { get, cloneDeep, merge } from 'lodash';
+import { get, cloneDeep } from 'lodash';
 import {
   DefinitionVersion,
   callTypes,
@@ -392,7 +392,7 @@ export const buildInsightsData = (task: CustomITask, contactForm: TaskEntry, cas
   // eslint-disable-next-line sonarjs/prefer-immediate-return
   const finalAttributes: TaskAttributes = getInsightsUpdateFunctionsForConfig(currentDefinitionVersion.insights)
     .map(f => f(previousAttributes, contactForm, caseForm, savedContact))
-    .reduce((acc: TaskAttributes, curr: InsightsAttributes) => merge(acc, curr), previousAttributes);
+    .reduce((acc: TaskAttributes, curr: InsightsAttributes) => mergeAttributes(acc, curr), previousAttributes);
 
   return finalAttributes;
 };

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -131,7 +131,6 @@ export const assignOfflineContact = async (targetSid: string, taskAttributes: IT
 type OfflineContactComplete = {
   action: 'complete';
   taskSid: string;
-  targetSid: string;
   finalTaskAttributes: ITask['attributes'];
 };
 

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -128,21 +128,31 @@ export const assignOfflineContact = async (targetSid: string, taskAttributes: IT
   return response;
 };
 
-/**
- * Completes the task (offline contact) in behalf of targetSid worker updating with finalTaskAttributes.
- */
-export const assignOfflineContactComplete = async (
-  taskSid: string,
-  targetSid: string,
-  finalTaskAttributes: ITask['attributes'],
-) => {
-  const body = {
-    taskSid,
-    targetSid,
-    finalTaskAttributes: JSON.stringify(finalTaskAttributes),
-  };
+type OfflineContactComplete = {
+  action: 'complete';
+  taskSid: string;
+  targetSid: string;
+  finalTaskAttributes: ITask['attributes'];
+};
 
-  return fetchProtectedApi('/assignOfflineContactComplete', body);
+type OfflineContactRemove = {
+  action: 'remove';
+  taskSid: string;
+};
+
+/**
+ * Completes or removes the task (offline contact) in behalf of targetSid worker updating with finalTaskAttributes.
+ */
+export const assignOfflineContactResolve = async (payload: OfflineContactComplete | OfflineContactRemove) => {
+  const body =
+    payload.action === 'complete'
+      ? {
+          ...payload,
+          finalTaskAttributes: JSON.stringify(payload.finalTaskAttributes),
+        }
+      : payload;
+
+  return fetchProtectedApi('/assignOfflineContactResolve', body);
 };
 
 /**

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -118,13 +118,13 @@ export const getDefinitionVersionsList = async (missingDefinitionVersions: Defin
 /**
  * Creates a new task (offline contact) in behalf of targetSid worker with attributes. Other attributes for routing are added to the task in the implementation of assignOfflineContact serverless function
  */
-export const assignOfflineContact = async (targetSid: string, taskAttributes: ITask['attributes']) => {
+export const assignOfflineContactInit = async (targetSid: string, taskAttributes: ITask['attributes']) => {
   const body = {
     targetSid,
     taskAttributes: JSON.stringify(taskAttributes),
   };
 
-  const response = await fetchProtectedApi('/assignOfflineContact', body);
+  const response = await fetchProtectedApi('/assignOfflineContactInit', body);
   return response;
 };
 

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -116,16 +116,33 @@ export const getDefinitionVersionsList = async (missingDefinitionVersions: Defin
   );
 
 /**
- * Creates a new task (offline contact) in behalf of targetSid worker with finalTaskAttributes. Other attributes for routing are added to the task in the implementation of assignOfflineContact serverless function
+ * Creates a new task (offline contact) in behalf of targetSid worker with attributes. Other attributes for routing are added to the task in the implementation of assignOfflineContact serverless function
  */
-export const assignOfflineContact = async (targetSid: string, finalTaskAttributes: ITask['attributes']) => {
+export const assignOfflineContact = async (targetSid: string, taskAttributes: ITask['attributes']) => {
   const body = {
     targetSid,
-    finalTaskAttributes: JSON.stringify(finalTaskAttributes),
+    taskAttributes: JSON.stringify(taskAttributes),
   };
 
   const response = await fetchProtectedApi('/assignOfflineContact', body);
   return response;
+};
+
+/**
+ * Completes the task (offline contact) in behalf of targetSid worker updating with finalTaskAttributes.
+ */
+export const assignOfflineContactComplete = async (
+  taskSid: string,
+  targetSid: string,
+  finalTaskAttributes: ITask['attributes'],
+) => {
+  const body = {
+    taskSid,
+    targetSid,
+    finalTaskAttributes: JSON.stringify(finalTaskAttributes),
+  };
+
+  return fetchProtectedApi('/assignOfflineContactComplete', body);
 };
 
 /**

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -7,7 +7,7 @@ import { Case, CustomITask, isOfflineContactTask, offlineContactTaskSid } from '
 import { channelTypes } from '../states/DomainConstants';
 import { buildInsightsData } from './InsightsService';
 import { saveContact } from './ContactService';
-import { assignOfflineContact, assignOfflineContactResolve } from './ServerlessService';
+import { assignOfflineContactInit, assignOfflineContactResolve } from './ServerlessService';
 import { removeContactState } from '../states/actions';
 
 /**
@@ -43,7 +43,7 @@ export const submitContactForm = async (task: CustomITask, contactForm: Contact,
 
   if (isOfflineContactTask(task)) {
     const targetWorkerSid = contactForm.contactlessTask.createdOnBehalfOf as string;
-    const inBehalfTask = await assignOfflineContact(targetWorkerSid, task.attributes);
+    const inBehalfTask = await assignOfflineContactInit(targetWorkerSid, task.attributes);
     try {
       const savedContact = await saveContact(task, contactForm, workerSid, inBehalfTask.sid);
       const finalAttributes = buildInsightsData(inBehalfTask, contactForm, caseForm, savedContact);

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -50,7 +50,6 @@ export const submitContactForm = async (task: CustomITask, contactForm: Contact,
       await assignOfflineContactResolve({
         action: 'complete',
         taskSid: inBehalfTask.sid,
-        targetSid: targetWorkerSid,
         finalTaskAttributes: finalAttributes,
       });
       return savedContact;

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -55,7 +55,7 @@ export const submitContactForm = async (task: CustomITask, contactForm: Contact,
       return savedContact;
     } catch (err) {
       // If something went wrong remove the task for this offline contact
-      await assignOfflineContactResolve({ action: 'remove', taskSid: inBehalfTask.sid });
+      assignOfflineContactResolve({ action: 'remove', taskSid: inBehalfTask.sid });
       // TODO: should we do this? Should we care about removing the savedContact if it succeded? This step could break our "idempotence on contacts"
 
       // Raise error to caller

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -125,6 +125,26 @@ export type ContactRawJson = {
   conversationMedia: ConversationMedia[];
 };
 
+export type Contact = {
+  id: number;
+  accountSid: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  rawJson: ContactRawJson;
+  queueName: string;
+  twilioWorkerId?: string;
+  createdBy?: string;
+  helpline?: string;
+  number?: string;
+  channel?: string;
+  conversationDuration: number;
+  timeOfContact?: Date;
+  taskId?: string;
+  channelSid?: string;
+  serviceSid?: string;
+  csamReports: any[];
+};
+
 // Information about a single contact, as expected from search contacts endpoint (we might want to reuse this type in backend) - (is this a correct placement for this?)
 export type SearchAPIContact = {
   contactId: string;


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand

This PR is related to https://github.com/techmatters/serverless/pull/381.

WIP:
- [x] CI
- [ ] Add tests

## Description
This PR adds support for storing contact id as part of the task attributes, to make it available in Insights.(*)
It also makes available any other properties from the contact as saved in the DB.
This can be referenced in the "one to many" insights configs like
```
{
    "attributeName": "conversation_attribute_10",
    "insightsObject": "conversations",
    "paths": [
      "savedContact.id"
    ]
  }
```
Note that `savedContact.id` is the path to access the saved contact id, since `applyCustomUpdate` (`plugin-hrm-form/src/services/InsightsService.ts`) is now updated like
`const dataSource = { taskAttributes, contactForm, caseForm, savedContact };`.

It also updates the demo form definitions to store the contact id under `conversations_attribute_10`.

(*) To achieve this, we need to have a final "set task attributes" before completing it, but after the contact was saved in HRM. 
On the other hand, since the creation of a contact in HRM depends on us providing a unique task sid, we still have a dependency on a valid Twilio task being available at submission time.
Above constrains implies that:
- For live contacts, the only thing we need to do is "change the order" of the operations. The task was available the whole time, so we just save the contact, update the task attributes, and proceed to complete the task.
- For offline contacts, this required a bit more of adjustments. Previously, we assumed we had everything needed for the "final task attributes" even before saving the contact, so the task could just receive the attributes, be assigned and completed all within the same operation. Now we need to:
  - Create the task, and assign to the corresponding worker.
  - Submit the form in HRM.
  - Generate the final task attributes, update it and then complete it.
  Since some things can go wrong in this process, we also need to account for a cleanup state to prevent the user getting stuck with "stale tasks" that are created but never completed/canceled. For this purpose, in the related PR, we are also adding a short life span for the offline-contact-tasks.

This changes make the offline contact assignment process a bit more time consuming since an extra call to a Serverless function is needed.
I think this implementation suffices for the time given, but is also a good moment to think if our design is correct.
Some questions to think about:
- Do we really want to make the contacts to dependent on a unique task sid being provided?
- Could we use/generate a unique identifier in some other way? 
- Could we inverse the order, and make tasks dependent of the contact id? If so, offline contacts assignment would be back to a single call to Serverless since we could create-assign-complete the task all after the contact is already there.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1498)
- [WIP] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- `npm ci` & `npm start`.
- Make sure that you are using https://github.com/techmatters/serverless/pull/381
  - If you are using remote, confirm that's deployed.
  - If you are using local server, you can `npm start` serverless repo, expose the port via `ngrok http <PORT>` and then point to it in Flex like `Twilio.Flex.Manager.getInstance().serviceConfiguration.attributes.serverless_base_url = 'https://the-url-you-got-from-ngrok'`. Remember to provide `.env` file with at least the following vars (look at the values in Twilio Console -> Serverless -> .env): `TWILIO_WORKSPACE_SID`, `TWILIO_CHAT_TRANSFER_WORKFLOW_SID`, `ACCOUNT_SID`, `AUTH_TOKEN`.
- Submit  contacts (live and offline).
  - Everything should work as expected and with no errors. Contact should be submitted in DB.
  - In Twilio Console -> Taskrouter -> Tasks, find the corresponding task to the contact you just saved and make sure that the id of the submitted contact is properly stored under `conversations.conversations_attribute_10`.