### PR TITLE
Implement email as a previous contact identifier

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -29,7 +29,7 @@ const webChatTask: any = {
   attributes: {
     isContactlessTask: false,
     ip,
-    preEngagementData: { contactType: 'ip', ip },
+    preEngagementData: { contactType: 'ip', contactIdentifier: ip },
   },
 };
 

--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -29,6 +29,7 @@ const webChatTask: any = {
   attributes: {
     isContactlessTask: false,
     ip,
+    preEngagementData: { contactType: 'ip', ip },
   },
 };
 

--- a/plugin-hrm-form/src/___tests__/search/Search.test.js
+++ b/plugin-hrm-form/src/___tests__/search/Search.test.js
@@ -105,7 +105,7 @@ test('<Search> should display <SearchForm />', async () => {
     dateFrom: '2020-03-10',
     dateTo: '2020-03-15',
   };
-  const task = { taskSid: 'WT123' };
+  const task = { taskSid: 'WT123', attributes: { preEngagementData: {} } };
 
   const initialState = createState(task.taskSid, { currentPage, searchFormValues, detailsExpanded });
   const store = mockStore(initialState);
@@ -141,6 +141,7 @@ test('<Search> should display <SearchForm /> with previous contacts checkbox', a
     attributes: {
       isContactlessTask: false,
       ip: 'user-ip',
+      preEngagementData: { contactType: 'ip' },
     },
   };
 

--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -135,7 +135,7 @@ describe('saveContact()', () => {
     queueName: 'queueName',
     channelType: channelTypes.web,
     defaultFrom: 'Anonymous',
-    attributes: { isContactlessTask: false, preEngagementData: { contactType: 'ip' } },
+    attributes: { isContactlessTask: false, preEngagementData: { contactType: 'ip', contactIdentifier: 'ip-address' } },
   };
   const workerSid = 'worker-sid';
   const uniqueIdentifier = 'uniqueIdentifier';
@@ -224,7 +224,7 @@ describe('saveContact() (isContactlessTask)', () => {
       attributes: {
         isContactlessTask: false,
         ip,
-        preEngagementData: { contactType: 'ip', ip },
+        preEngagementData: { contactType: 'ip', contactIdentifier: ip },
       },
     };
     const form = createForm({ callType: callTypes.child, childFirstName: 'Jill' });
@@ -248,7 +248,7 @@ describe('saveContact() (isContactlessTask)', () => {
       attributes: {
         isContactlessTask: false,
         ip: '',
-        preEngagementData: { contactType: 'email', email },
+        preEngagementData: { contactType: 'email', contactIdentifier: email },
       },
     };
     const form = createForm({ callType: callTypes.child, childFirstName: 'Jill' });

--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -135,7 +135,7 @@ describe('saveContact()', () => {
     queueName: 'queueName',
     channelType: channelTypes.web,
     defaultFrom: 'Anonymous',
-    attributes: { isContactlessTask: false },
+    attributes: { isContactlessTask: false, preEngagementData: { contactType: 'ip' } },
   };
   const workerSid = 'worker-sid';
   const uniqueIdentifier = 'uniqueIdentifier';
@@ -224,6 +224,7 @@ describe('saveContact() (isContactlessTask)', () => {
       attributes: {
         isContactlessTask: false,
         ip,
+        preEngagementData: { contactType: 'ip', ip },
       },
     };
     const form = createForm({ callType: callTypes.child, childFirstName: 'Jill' });
@@ -234,6 +235,30 @@ describe('saveContact() (isContactlessTask)', () => {
 
     const numberFromPOST = getNumberFromPOST(mockedFetch);
     expect(numberFromPOST).toEqual(ip);
+
+    mockedFetch.mockClear();
+  });
+
+  test('save email from web calltype', async () => {
+    const email = 'abc@email.com';
+    const webTaskWithIP = {
+      queueName: 'queueName',
+      channelType: channelTypes.web,
+      defaultFrom: 'Anonymous',
+      attributes: {
+        isContactlessTask: false,
+        ip: '',
+        preEngagementData: { contactType: 'email', email },
+      },
+    };
+    const form = createForm({ callType: callTypes.child, childFirstName: 'Jill' });
+
+    const mockedFetch = jest.spyOn(global, 'fetch').mockImplementation(() => fetchSuccess);
+
+    await saveContact(webTaskWithIP, form, workerSid, uniqueIdentifier);
+
+    const numberFromPOST = getNumberFromPOST(mockedFetch);
+    expect(numberFromPOST).toEqual(email);
 
     mockedFetch.mockClear();
   });

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -63,8 +63,8 @@ const PreviousContactsBanner: React.FC<Props> = ({
     changeRoute({ route: 'tabbed-forms', subroute: 'search' });
   };
 
-  let contactIdentifier: string;
   let localizedSourceFromTask: { [channelType in ChannelTypes]: string };
+  let contactIdentifier: string;
   if (isTwilioTask(task)) {
     localizedSourceFromTask = {
       [channelTypes.web]: `${getContactValueTemplate(task)}`,
@@ -77,8 +77,6 @@ const PreviousContactsBanner: React.FC<Props> = ({
       [channelTypes.line]: 'PreviousContacts-LineUser',
     };
     contactIdentifier = getFormattedNumberFromTask(task);
-
-    console.log('>>> task', task.attributes);
   }
 
   return (

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -36,6 +36,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
   changeRoute,
   editContactFormOpen,
 }) => {
+
   const { canView } = getPermissionsForViewingIdentifiers();
   const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -36,7 +36,6 @@ const PreviousContactsBanner: React.FC<Props> = ({
   changeRoute,
   editContactFormOpen,
 }) => {
-
   const { canView } = getPermissionsForViewingIdentifiers();
   const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { Template } from '@twilio/flex-ui';
+import { Template, ITask } from '@twilio/flex-ui';
 
-import { CustomITask, isTwilioTask } from '../types/types';
 import {
   viewPreviousContacts as viewPreviousContactsAction,
   searchContacts as searchContactsAction,
@@ -16,26 +15,15 @@ import { Bold } from '../styles/HrmStyles';
 import { StyledLink } from '../styles/search';
 import { ChannelTypes, channelTypes } from '../states/DomainConstants';
 import { changeRoute as changeRouteAction } from '../states/routing/actions';
-import { getFormattedNumberFromTask, getNumberFromTask } from '../utils/task';
+import { getFormattedNumberFromTask, getNumberFromTask, getContactValueTemplate } from '../utils/task';
 import { getPermissionsForViewingIdentifiers, PermissionActions } from '../permissions';
 
 type OwnProps = {
-  task: CustomITask;
+  task: ITask;
 };
 
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
-
-export const localizedSource: { [channelType in ChannelTypes]: string } = {
-  [channelTypes.web]: 'PreviousContacts-IPAddress',
-  [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
-  [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
-  [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
-  [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
-  [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
-  [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
-  [channelTypes.line]: 'PreviousContacts-LineUser',
-};
 
 const PreviousContactsBanner: React.FC<Props> = ({
   task,
@@ -47,11 +35,22 @@ const PreviousContactsBanner: React.FC<Props> = ({
   changeRoute,
   editContactFormOpen,
 }) => {
+  const localizedSourceFromTask: { [channelType in ChannelTypes]: string } = {
+    [channelTypes.web]: `${getContactValueTemplate(task)}`,
+    [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
+    [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
+    [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
+    [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
+    [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
+    [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
+    [channelTypes.line]: 'PreviousContacts-LineUser',
+  };
+
   const { canView } = getPermissionsForViewingIdentifiers();
   const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
   useEffect(() => {
-    if (isTwilioTask(task) && previousContacts === undefined) {
+    if (previousContacts === undefined) {
       const contactNumber = getNumberFromTask(task);
       const isTraceableNumber = ![null, undefined, '', 'Anonymous'].includes(contactNumber);
 
@@ -75,6 +74,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
   };
 
   const contactIdentifier = getFormattedNumberFromTask(task);
+
   return (
     <div className={editContactFormOpen ? 'editingContact' : ''}>
       <YellowBanner data-testid="PreviousContacts-Container" className="hiddenWhenEditingContact">
@@ -106,7 +106,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
           &nbsp;
           <Template code="PreviousContacts-From" />
           &nbsp;
-          <Template code={localizedSource[task.channelType]} />
+          <Template code={localizedSourceFromTask[task.channelType]} />
           &nbsp;
           {maskIdentifiers ? (
             <Bold>
@@ -115,6 +115,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
           ) : (
             <Bold>{contactIdentifier}</Bold>
           )}
+          .&nbsp;
         </pre>
         <StyledLink underline data-testid="PreviousContacts-ViewRecords" onClick={handleClickViewRecords}>
           <Template code="PreviousContacts-ViewRecords" />

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -150,6 +150,12 @@ const ContactDetailsHome: React.FC<Props> = function ({
 
   const isPhoneContact =
     channel === channelTypes.voice || channel === channelTypes.sms || channel === channelTypes.whatsapp;
+
+  const validEmailPattern = (email): Boolean => {
+    return email.match(/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/);
+  };
+  const isEmailContact = channel === channelTypes.web && validEmailPattern(customerNumber);
+
   const formattedCategories = formatCategories(categories);
 
   const {
@@ -216,13 +222,14 @@ const ContactDetailsHome: React.FC<Props> = function ({
         <SectionEntry descriptionKey="ContactDetails-GeneralDetails-Channel">
           <SectionEntryValue value={formattedChannel} />
         </SectionEntry>
-        {maskIdentifiers ? (
+        {isPhoneContact && (
           <SectionEntry descriptionKey="ContactDetails-GeneralDetails-PhoneNumber">
-            <SectionEntryValue value={strings.MaskIdentifiers} />
+            <SectionEntryValue value={maskIdentifiers ? strings.MaskIdentifiers : customerNumber} />
           </SectionEntry>
-        ) : (
-          <SectionEntry descriptionKey="ContactDetails-GeneralDetails-PhoneNumber">
-            <SectionEntryValue value={isPhoneContact ? customerNumber : ''} />
+        )}
+        {isEmailContact && (
+          <SectionEntry descriptionKey="ContactDetails-GeneralDetails-Email">
+            <SectionEntryValue value={maskIdentifiers ? strings.MaskIdentifiers : customerNumber} />
           </SectionEntry>
         )}
         <SectionEntry descriptionKey="ContactDetails-GeneralDetails-ConversationDuration">

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -151,11 +151,6 @@ const ContactDetailsHome: React.FC<Props> = function ({
   const isPhoneContact =
     channel === channelTypes.voice || channel === channelTypes.sms || channel === channelTypes.whatsapp;
 
-  const validEmailPattern = (email): Boolean => {
-    return email.match(/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/);
-  };
-  const isEmailContact = channel === channelTypes.web && validEmailPattern(customerNumber);
-
   const formattedCategories = formatCategories(categories);
 
   const {
@@ -224,11 +219,6 @@ const ContactDetailsHome: React.FC<Props> = function ({
         </SectionEntry>
         {isPhoneContact && (
           <SectionEntry descriptionKey="ContactDetails-GeneralDetails-PhoneNumber">
-            <SectionEntryValue value={maskIdentifiers ? strings.MaskIdentifiers : customerNumber} />
-          </SectionEntry>
-        )}
-        {isEmailContact && (
-          <SectionEntry descriptionKey="ContactDetails-GeneralDetails-Email">
             <SectionEntryValue value={maskIdentifiers ? strings.MaskIdentifiers : customerNumber} />
           </SectionEntry>
         )}

--- a/plugin-hrm-form/src/components/search/CasePreview/CasePreview.tsx
+++ b/plugin-hrm-form/src/components/search/CasePreview/CasePreview.tsx
@@ -49,6 +49,7 @@ const CasePreview: React.FC<Props> = ({ currentCase, onClickViewCase, counselors
     if (versionId && definitionVersions[versionId]) {
       fetchDefinitionVersions(versionId);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [updateDefinitionVersion, versionId, definitionVersions]);
 
   const statusLabel = definitionVersions[versionId]?.caseStatus[status]?.label ?? status;

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -22,8 +22,8 @@ import { SearchTitle } from '../../../styles/search';
 import { searchFormType, taskType } from '../../../types';
 import { getConfig } from '../../../HrmFormPlugin';
 import { namespace, configurationBase, searchContactsBase, contactFormsBase } from '../../../states';
-import { localizedSource } from '../../PreviousContactsBanner';
-import { getFormattedNumberFromTask, getNumberFromTask } from '../../../utils/task';
+import { channelTypes } from '../../../states/DomainConstants';
+import { getFormattedNumberFromTask, getNumberFromTask, getContactValueTemplate } from '../../../utils/task';
 import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
 
 const getField = value => ({
@@ -146,7 +146,18 @@ class SearchForm extends Component {
       this.props.handleSearchFormChange('contactNumber', value);
     };
 
-    const source = localizedSource[task.channelType];
+    const localizedSourceFromTask = {
+      [channelTypes.web]: `${getContactValueTemplate(task)}`,
+      [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
+      [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
+      [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
+      [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
+      [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
+      [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
+      [channelTypes.line]: 'PreviousContacts-LineUser',
+    };
+    const source = localizedSourceFromTask[task.channelType];
+
     const { canView } = getPermissionsForViewingIdentifiers();
     const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -22,10 +22,9 @@ import { SearchTitle } from '../../../styles/search';
 import { searchFormType, taskType } from '../../../types';
 import { getConfig } from '../../../HrmFormPlugin';
 import { namespace, configurationBase, searchContactsBase, contactFormsBase } from '../../../states';
-// import { channelTypes } from '../../../states/DomainConstants';
-import { getFormattedNumberFromTask, getNumberFromTask } from '../../../utils/task';
+import { getFormattedNumberFromTask, getNumberFromTask, getContactValueTemplate } from '../../../utils/task';
 import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
-// import { isTwilioTask } from '../../../types/types';
+import { channelTypes } from '../../../states/DomainConstants';
 
 const getField = value => ({
   value,
@@ -98,7 +97,6 @@ class SearchForm extends Component {
       dateTo,
       contactNumber,
     } = this.props.values;
-    const localizedSource = this.props.source;
 
     const counselorsOptions = this.props.counselors.map(e => ({
       label: e.fullName,
@@ -147,25 +145,17 @@ class SearchForm extends Component {
       const value = contactNumber === '' ? contactNumberFromTask : '';
       this.props.handleSearchFormChange('contactNumber', value);
     };
-    /*
-     * let localizedSourceFromTask;
-     * if(isTwilioTask(task)){
-     */
-
-    /*
-     *   localizedSourceFromTask = {
-     *    [channelTypes.web]: `${getContactValueTemplate(task)}`,
-     *    [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
-     *    [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
-     *    [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
-     *    [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
-     *    [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
-     *    [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
-     *    [channelTypes.line]: 'PreviousContacts-LineUser',
-     *  };
-     * }
-     * const source = localizedSourceFromTask[task.channelType];
-     */
+    const webChatTemplate = getContactValueTemplate(task);
+    const localizedSource = {
+      [channelTypes.web]: webChatTemplate,
+      [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
+      [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
+      [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
+      [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
+      [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
+      [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
+      [channelTypes.line]: 'PreviousContacts-LineUser',
+    };
 
     const { canView } = getPermissionsForViewingIdentifiers();
     const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
@@ -259,7 +249,7 @@ class SearchForm extends Component {
                       />
                     </Box>
                     <span>
-                      <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={localizedSource} />{' '}
+                      <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={localizedSource[task.channelType]} />{' '}
                       {maskIdentifiers ? (
                         <Bold>
                           <Template code="MaskIdentifiers" />

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -22,9 +22,10 @@ import { SearchTitle } from '../../../styles/search';
 import { searchFormType, taskType } from '../../../types';
 import { getConfig } from '../../../HrmFormPlugin';
 import { namespace, configurationBase, searchContactsBase, contactFormsBase } from '../../../states';
-import { channelTypes } from '../../../states/DomainConstants';
-import { getFormattedNumberFromTask, getNumberFromTask, getContactValueTemplate } from '../../../utils/task';
+// import { channelTypes } from '../../../states/DomainConstants';
+import { getFormattedNumberFromTask, getNumberFromTask } from '../../../utils/task';
 import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
+// import { isTwilioTask } from '../../../types/types';
 
 const getField = value => ({
   value,
@@ -97,6 +98,7 @@ class SearchForm extends Component {
       dateTo,
       contactNumber,
     } = this.props.values;
+    const localizedSource = this.props.source;
 
     const counselorsOptions = this.props.counselors.map(e => ({
       label: e.fullName,
@@ -145,18 +147,25 @@ class SearchForm extends Component {
       const value = contactNumber === '' ? contactNumberFromTask : '';
       this.props.handleSearchFormChange('contactNumber', value);
     };
+    /*
+     * let localizedSourceFromTask;
+     * if(isTwilioTask(task)){
+     */
 
-    const localizedSourceFromTask = {
-      [channelTypes.web]: `${getContactValueTemplate(task)}`,
-      [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
-      [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
-      [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
-      [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
-      [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
-      [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
-      [channelTypes.line]: 'PreviousContacts-LineUser',
-    };
-    const source = localizedSourceFromTask[task.channelType];
+    /*
+     *   localizedSourceFromTask = {
+     *    [channelTypes.web]: `${getContactValueTemplate(task)}`,
+     *    [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
+     *    [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
+     *    [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
+     *    [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
+     *    [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
+     *    [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
+     *    [channelTypes.line]: 'PreviousContacts-LineUser',
+     *  };
+     * }
+     * const source = localizedSourceFromTask[task.channelType];
+     */
 
     const { canView } = getPermissionsForViewingIdentifiers();
     const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
@@ -250,7 +259,7 @@ class SearchForm extends Component {
                       />
                     </Box>
                     <span>
-                      <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={source} />{' '}
+                      <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={localizedSource} />{' '}
                       {maskIdentifiers ? (
                         <Bold>
                           <Template code="MaskIdentifiers" />

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -249,7 +249,8 @@ class SearchForm extends Component {
                       />
                     </Box>
                     <span>
-                      <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={localizedSource[task.channelType]} />{' '}
+                      <Template code="PreviousContacts-OnlyShowRecordsFrom" />{' '}
+                      <Template code={localizedSource[task.channelType]} />{' '}
                       {maskIdentifiers ? (
                         <Bold>
                           <Template code="MaskIdentifiers" />

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -124,26 +124,12 @@ const Search: React.FC<Props> = props => {
   };
   renderMockDialog.displayName = 'MockDialog';
 
-  let localizedSourceFromTask: { [channelType in ChannelTypes]: string };
-  if (isTwilioTask(props.task)) {
-    localizedSourceFromTask = {
-      [channelTypes.web]: `${getContactValueTemplate(props.task)}`,
-      [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
-      [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
-      [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
-      [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
-      [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
-      [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
-      [channelTypes.line]: 'PreviousContacts-LineUser',
-    };
-  }
   const renderSearchPages = (currentPage, currentContact, searchContactsResults, searchCasesResults, form, routing) => {
     switch (currentPage) {
       case SearchPages.form:
         return (
           <SearchForm
             task={props.task}
-            source={localizedSourceFromTask}
             values={form}
             handleSearchFormChange={props.handleSearchFormChange}
             handleSearch={setSearchParamsAndHandleSearch}

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -12,7 +12,7 @@ import SearchResults, { CONTACTS_PER_PAGE, CASES_PER_PAGE } from './SearchResult
 import ContactDetails from './ContactDetails';
 import Case from '../case';
 import { SearchPages } from '../../states/search/types';
-import { CustomITask, SearchAPIContact, standaloneTaskSid } from '../../types/types';
+import { CustomITask, isTwilioTask, SearchAPIContact, standaloneTaskSid } from '../../types/types';
 import SearchResultsBackButton from './SearchResults/SearchResultsBackButton';
 import {
   handleSearchFormChange,
@@ -30,6 +30,8 @@ import {
   contactFormsBase,
 } from '../../states';
 import { Flex } from '../../styles/HrmStyles';
+import { ChannelTypes, channelTypes } from '../../states/DomainConstants';
+import { getContactValueTemplate } from '../../utils';
 
 type OwnProps = {
   task: CustomITask;
@@ -122,12 +124,26 @@ const Search: React.FC<Props> = props => {
   };
   renderMockDialog.displayName = 'MockDialog';
 
+  let localizedSourceFromTask: { [channelType in ChannelTypes]: string };
+  if (isTwilioTask(props.task)) {
+    localizedSourceFromTask = {
+      [channelTypes.web]: `${getContactValueTemplate(props.task)}`,
+      [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
+      [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
+      [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
+      [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
+      [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
+      [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
+      [channelTypes.line]: 'PreviousContacts-LineUser',
+    };
+  }
   const renderSearchPages = (currentPage, currentContact, searchContactsResults, searchCasesResults, form, routing) => {
     switch (currentPage) {
       case SearchPages.form:
         return (
           <SearchForm
             task={props.task}
+            source={localizedSourceFromTask}
             values={form}
             handleSearchFormChange={props.handleSearchFormChange}
             handleSearch={setSearchParamsAndHandleSearch}

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -350,7 +350,7 @@
   "PreviousContacts-And": "and",
   "PreviousContacts-From": "from",
   "PreviousContacts-IPAddress": "IP address",
-  "PreviousContacts-EmailAddress": "Email",
+  "PreviousContacts-EmailAddress": "email",
   "PreviousContacts-PhoneNumber": "phone number",
   "PreviousContacts-WhatsappNumber": "Whatsapp number",
   "PreviousContacts-FacebookUser": "Facebook user",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -282,6 +282,7 @@
   "ContactDetails-GeneralDetails": "General Details",
   "ContactDetails-GeneralDetails-Channel": "Channel",
   "ContactDetails-GeneralDetails-PhoneNumber": "Phone Number",
+  "ContactDetails-GeneralDetails-Email": "Email",
   "ContactDetails-GeneralDetails-ConversationDuration": "Conversation Duration",
   "ContactDetails-GeneralDetails-Counselor": "Counsellor",
   "ContactDetails-GeneralDetails-DateTime": "Date/Time",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -350,6 +350,7 @@
   "PreviousContacts-And": "and",
   "PreviousContacts-From": "from",
   "PreviousContacts-IPAddress": "IP address",
+  "PreviousContacts-EmailAddress": "Email",
   "PreviousContacts-PhoneNumber": "phone number",
   "PreviousContacts-WhatsappNumber": "Whatsapp number",
   "PreviousContacts-FacebookUser": "Facebook user",

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -238,6 +238,7 @@ export type OfflineContactTask = {
     isContactlessTask: true;
     channelType: 'default';
     helplineToSave?: string;
+    // preEngagementData?: any;
   };
   channelType: 'default';
 };
@@ -248,6 +249,7 @@ export type StandaloneITask = {
   taskSid: typeof standaloneTaskSid;
   attributes: {
     isContactlessTask: boolean;
+    // preEngagementData?: any;
   };
 };
 

--- a/plugin-hrm-form/src/utils/task.ts
+++ b/plugin-hrm-form/src/utils/task.ts
@@ -2,21 +2,11 @@ import { ITask } from '@twilio/flex-ui';
 
 import { channelTypes } from '../states/DomainConstants';
 
-export type ContactType = 'ip' | 'email';
-
-export const getContactValueFromWebchat = (task: ITask) => {
-  const taskContactType: ContactType = task.attributes.preEngagementData.contactType;
-  return task.attributes.preEngagementData[taskContactType];
-};
-export const getContactValueTemplate = (task: ITask): string => {
-  const { contactType } = task.attributes.preEngagementData;
-
-  if (contactType === 'ip') {
-    return 'PreviousContacts-IPAddress';
-  } else if (contactType === 'email') {
-    return 'PreviousContacts-EmailAddress';
-  }
-};
+function getContactValueFromWebchat(task) {
+  const { preEngagementData } = task.attributes;
+  if (!preEngagementData) return {};
+  return task.attributes.preEngagementData[preEngagementData.contactType];
+}
 
 export function getNumberFromTask(task: ITask) {
   if (task.channelType === channelTypes.facebook) {
@@ -26,15 +16,25 @@ export function getNumberFromTask(task: ITask) {
   } else if (task.channelType === channelTypes.web) {
     return getContactValueFromWebchat(task);
   }
-
   return task.defaultFrom;
 }
+
 /**
  *
  * @param {ITask | CustomITask} task
  * @param contactNumberFromTask
  */
-
 export const getFormattedNumberFromTask = (task: ITask) => {
   return task.channelType === channelTypes.twitter ? `@${task.attributes.twitterUserHandle}` : getNumberFromTask(task);
 };
+
+// eslint-disable-next-line consistent-return
+export function getContactValueTemplate(task) {
+  const { preEngagementData } = task.attributes;
+  if (!preEngagementData) return '';
+  if (preEngagementData.contactType === 'ip') {
+    return 'PreviousContacts-IPAddress';
+  } else if (preEngagementData.contactType === 'email') {
+    return 'PreviousContacts-EmailAddress';
+  }
+}

--- a/plugin-hrm-form/src/utils/task.ts
+++ b/plugin-hrm-form/src/utils/task.ts
@@ -2,23 +2,39 @@ import { ITask } from '@twilio/flex-ui';
 
 import { channelTypes } from '../states/DomainConstants';
 
+export type ContactType = 'ip' | 'email';
+
+export const getContactValueFromWebchat = (task: ITask) => {
+  const taskContactType: ContactType = task.attributes.preEngagementData.contactType;
+  return task.attributes.preEngagementData[taskContactType];
+};
+export const getContactValueTemplate = (task: ITask): string => {
+  const { contactType } = task.attributes.preEngagementData;
+
+  if (contactType === 'ip') {
+    return 'PreviousContacts-IPAddress';
+  } else if (contactType === 'email') {
+    return 'PreviousContacts-EmailAddress';
+  }
+};
+
 export function getNumberFromTask(task: ITask) {
   if (task.channelType === channelTypes.facebook) {
     return task.defaultFrom.replace('messenger:', '');
   } else if (task.channelType === channelTypes.whatsapp) {
     return task.defaultFrom.replace('whatsapp:', '');
   } else if (task.channelType === channelTypes.web) {
-    return task.attributes.ip;
+    return getContactValueFromWebchat(task);
   }
 
   return task.defaultFrom;
 }
-
 /**
  *
  * @param {ITask | CustomITask} task
  * @param contactNumberFromTask
  */
 
-export const getFormattedNumberFromTask = task =>
-  task.channelType === channelTypes.twitter ? `@${task.attributes.twitterUserHandle}` : getNumberFromTask(task);
+export const getFormattedNumberFromTask = (task: ITask) => {
+  return task.channelType === channelTypes.twitter ? `@${task.attributes.twitterUserHandle}` : getNumberFromTask(task);
+};

--- a/plugin-hrm-form/src/utils/task.ts
+++ b/plugin-hrm-form/src/utils/task.ts
@@ -5,7 +5,7 @@ import { channelTypes } from '../states/DomainConstants';
 const getContactValueFromWebchat = task => {
   const { preEngagementData } = task.attributes;
   if (!preEngagementData) return '';
-  return task.attributes.preEngagementData[preEngagementData.contactType];
+  return preEngagementData.contactIdentifier;
 };
 
 export const getNumberFromTask = (task: ITask) => {

--- a/plugin-hrm-form/src/utils/task.ts
+++ b/plugin-hrm-form/src/utils/task.ts
@@ -2,13 +2,13 @@ import { ITask } from '@twilio/flex-ui';
 
 import { channelTypes } from '../states/DomainConstants';
 
-function getContactValueFromWebchat(task) {
+const getContactValueFromWebchat = task => {
   const { preEngagementData } = task.attributes;
-  if (!preEngagementData) return {};
+  if (!preEngagementData) return '';
   return task.attributes.preEngagementData[preEngagementData.contactType];
-}
+};
 
-export function getNumberFromTask(task: ITask) {
+export const getNumberFromTask = (task: ITask) => {
   if (task.channelType === channelTypes.facebook) {
     return task.defaultFrom.replace('messenger:', '');
   } else if (task.channelType === channelTypes.whatsapp) {
@@ -17,7 +17,7 @@ export function getNumberFromTask(task: ITask) {
     return getContactValueFromWebchat(task);
   }
   return task.defaultFrom;
-}
+};
 
 /**
  *
@@ -29,7 +29,7 @@ export const getFormattedNumberFromTask = (task: ITask) => {
 };
 
 // eslint-disable-next-line consistent-return
-export function getContactValueTemplate(task) {
+export const getContactValueTemplate = task => {
   const { preEngagementData } = task.attributes;
   if (!preEngagementData) return '';
   if (preEngagementData.contactType === 'ip') {
@@ -37,4 +37,4 @@ export function getContactValueTemplate(task) {
   } else if (preEngagementData.contactType === 'email') {
     return 'PreviousContacts-EmailAddress';
   }
-}
+};


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Note: This PR should be reviewed with this webchat's PR https://github.com/techmatters/webchat/pull/168
Primary reviewer: @murilovmachado 

## Description

- This PR supports email address as a Previous Contact Identifier, in addition to ip address. 
- Previous Contacts Banner displays email if webchat config uses 'email' as contactType. Other references to contact(where ip address is shown, now should include email instead). Check Verification steps for checkign the message in conversation and Contact Details

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [n/a] Feature flags added
- [x] Strings are localized - 2 new strings added
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
- #[1354](https://tech-matters.atlassian.net/browse/CHI-1354)

### Verification steps
- This PR should be reviewed alongside https://github.com/techmatters/webchat/pull/168
- Ensure Previous Contacts Banner contains the email address for contact identifier instead of the usual ip address
![Screenshot 2022-12-26 at 11 18 45 AM](https://user-images.githubusercontent.com/102122005/209687041-94f5226f-936d-42c8-973b-68ed4a269f87.png)
- Check the first message in conversation and email is to appear where ip address is shown.
![Screenshot 2022-12-26 at 11 13 24 AM](https://user-images.githubusercontent.com/102122005/209688325-b6c353bd-acb6-4cf3-884b-4bc5a7e7c76d.png)

The following is removed from this PR. 
- Contact Details includes email in if webchat config uses 'email' (But also ensures this is masked when permissions for viewing identifiers is configured to hide)
![Screenshot 2022-12-26 at 11 17 58 AM](https://user-images.githubusercontent.com/102122005/209688334-5b5189fe-c1f2-42b6-ad8e-6048df64be99.png)
