### PR TITLE
Add ability to save insights custom mappings for non-data conacts

### DIFF
--- a/hrm-form-definitions/form-definitions/demo-v1/insights/oneToManyConfigSpecs.json
+++ b/hrm-form-definitions/form-definitions/demo-v1/insights/oneToManyConfigSpecs.json
@@ -12,6 +12,7 @@
     "insightsObject": "conversations",
     "paths": [
       "savedContact.id"
-    ]
+    ],
+    "saveForNonDataContacts": true
   }
 ]

--- a/hrm-form-definitions/src/formDefinition/insightsConfig.ts
+++ b/hrm-form-definitions/src/formDefinition/insightsConfig.ts
@@ -23,5 +23,6 @@ export type OneToManyConfigSpec = {
   insightsObject: InsightsObject; // In which attributes object this goes
   attributeName: string; // Which name the property receives in above object
   paths: string[]; // Array of paths to grab and concatenate to drop in above property
+  saveForNonDataContacts?: boolean; // Allows the custom mapping to be saved for non-data contacts
 };
 export type OneToManyConfigSpecs = OneToManyConfigSpec[];

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -320,7 +320,8 @@ export const processHelplineConfig = (
 
 const applyCustomUpdate = (customUpdate: OneToManyConfigSpec): InsightsUpdateFunction => {
   return (taskAttributes, contactForm, caseForm, savedContact) => {
-    if (isNonDataCallType(contactForm.callType)) return {};
+    // If it's non data, and specs don't explicitly say to save it, ommit the update
+    if (isNonDataCallType(contactForm.callType) && !customUpdate.saveForNonDataContacts) return {};
 
     const dataSource = { taskAttributes, contactForm, caseForm, savedContact };
     // concatenate the values, taken from dataSource using paths (e.g. 'contactForm.childInformation.province')


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
This PR is a followup of https://github.com/techmatters/flex-plugins/pull/1138.
By Dee's feedback, we'd like to have the ability to save insights custom mappings for non data contacts. This PR adds that option by using a custom flag `saveForNonDataContacts` that can be added to each "one to many specs".
An example of this is added to `demo-v1` definitions, to save contact id for non data contacts.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1498)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- `npm ci` & `npm run dev`.
- Submit a new non-data contact. If it's an offline or a live contact doesn't matter, you just need to pick one of the non data categorization options (Silent, Joke, etc).
- Go to Twilio Console -> Taskrouter -> Tasks, and confirm that the task related to the contact you just submitted contains the appropriate value (contact id) under `attributes.conversations.conversation_attribute_10`.