### PR TITLE
Refactor prepopulateForm method to ensure preEngagamentData populates in the absence of survey

### DIFF
--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -111,9 +111,9 @@ export const getValuesFromPreEngagementData = (
   tabFormDefinition.forEach((field: FormItemDefinition) => {
     if (prepopulateKeys.indexOf(field.name) > -1) {
       if (field.type === 'mixed-checkbox') {
-        if (preEngagementData[field.name] === 'yes' || preEngagementData[field.name] === 'Yes') {
+        if (preEngagementData[field.name]?.toLowerCase() === 'yes') {
           values[field.name] = true;
-        } else if (preEngagementData[field.name] === 'no' || preEngagementData[field.name] === 'No') {
+        } else if (preEngagementData[field.name]?.toLowerCase() === 'no') {
           values[field.name] = false;
         }
         return;
@@ -127,7 +127,7 @@ export const getValuesFromPreEngagementData = (
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export const prepopulateForm = (task: ITask) => {
   const { memory, preEngagementData } = task.attributes;
-
+  if (memory === null && preEngagementData === null) return;
   const { currentDefinitionVersion } = getDefinitionVersions();
   const { tabbedForms, prepopulateKeys } = currentDefinitionVersion;
   const { ChildInformationTab, CallerInformationTab, CaseInformationTab } = tabbedForms;
@@ -156,11 +156,8 @@ export const prepopulateForm = (task: ITask) => {
 
   const { answers } = task.attributes.memory.twilio.collected_data.collect_survey;
 
-  // If can't know if call is child or caller, do nothing here
-  if (!answers.about_self || !['Yes', 'No'].includes(answers.about_self.answer)) return;
-
   const isAboutSelf = answers.about_self.answer === 'Yes';
-  const callType = isAboutSelf ? callTypes.child : callTypes.caller;
+  const callType = isAboutSelf || !answers.about_self ? callTypes.child : callTypes.caller;
   const tabFormDefinition = isAboutSelf ? ChildInformationTab : CallerInformationTab;
   const prepopulateSurveyKeys = isAboutSelf ? survey.ChildInformationTab : survey.CallerInformationTab;
   const subroute = isAboutSelf ? 'childInformation' : 'callerInformation';

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -100,6 +100,7 @@ const getValuesFromAnswers = (
     ...customizableValues,
   };
 };
+
 export const getValuesFromPreEngagementData = (
   preEngagementData: Record<string, string>,
   tabFormDefinition: FormDefinition,
@@ -109,6 +110,14 @@ export const getValuesFromPreEngagementData = (
   const values = {};
   tabFormDefinition.forEach((field: FormItemDefinition) => {
     if (prepopulateKeys.indexOf(field.name) > -1) {
+      if (field.type === 'mixed-checkbox') {
+        if (preEngagementData[field.name] === 'yes' || preEngagementData[field.name] === 'Yes') {
+          values[field.name] = true;
+        } else if (preEngagementData[field.name] === 'no' || preEngagementData[field.name] === 'No') {
+          values[field.name] = false;
+        }
+        return;
+      }
       values[field.name] = preEngagementData[field.name] || '';
     }
   });

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -118,29 +118,62 @@ export const getValuesFromPreEngagementData = (
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export const prepopulateForm = (task: ITask) => {
   const { memory, preEngagementData } = task.attributes;
+
   const { currentDefinitionVersion } = getDefinitionVersions();
   const { tabbedForms, prepopulateKeys } = currentDefinitionVersion;
+  const { ChildInformationTab, CallerInformationTab, CaseInformationTab } = tabbedForms;
+  const { preEngagement, survey } = prepopulateKeys;
 
-  // If this task came from the pre-survey
-  if (memory || preEngagementData) {
-    const { answers } = task.attributes.memory.twilio.collected_data.collect_survey;
+  // PreEngagementData Values
+  const childInfoValues = getValuesFromPreEngagementData(
+    preEngagementData,
+    ChildInformationTab,
+    preEngagement.ChildInformationTab,
+  );
 
-    // If can't know if call is child or caller, do nothing here
-    if (!answers.about_self || !['Yes', 'No'].includes(answers.about_self.answer)) return;
+  // When a helpline has preEnagagement form and no survey
+  if (preEngagementData && memory === null) {
+    Manager.getInstance().store.dispatch(prepopulateFormAction(callTypes.child, childInfoValues, task.taskSid));
 
-    const { CallerInformationTab, ChildInformationTab, CaseInformationTab } = tabbedForms;
-    const isAboutSelf = answers.about_self.answer === 'Yes';
-    const callType = isAboutSelf ? callTypes.child : callTypes.caller;
-    const tabFormDefinition = isAboutSelf ? ChildInformationTab : CallerInformationTab;
-    const prepopulateSurveyKeys = isAboutSelf
-      ? prepopulateKeys.survey.ChildInformationTab
-      : prepopulateKeys.survey.CallerInformationTab;
+    // Open tabbed form to first tab
+    Manager.getInstance().store.dispatch(
+      RoutingActions.changeRoute(
+        { route: 'tabbed-forms', subroute: 'childInformation', autoFocus: true },
+        task.taskSid,
+      ),
+    );
+    return;
+  }
 
-    const surveyValues = getValuesFromAnswers(task, answers, tabFormDefinition, prepopulateSurveyKeys);
+  const { answers } = task.attributes.memory.twilio.collected_data.collect_survey;
 
+  // If can't know if call is child or caller, do nothing here
+  if (!answers.about_self || !['Yes', 'No'].includes(answers.about_self.answer)) return;
+
+  const isAboutSelf = answers.about_self.answer === 'Yes';
+  const callType = isAboutSelf ? callTypes.child : callTypes.caller;
+  const tabFormDefinition = isAboutSelf ? ChildInformationTab : CallerInformationTab;
+  const prepopulateSurveyKeys = isAboutSelf ? survey.ChildInformationTab : survey.CallerInformationTab;
+  const subroute = isAboutSelf ? 'childInformation' : 'callerInformation';
+
+  const surveyValues = getValuesFromAnswers(task, answers, tabFormDefinition, prepopulateSurveyKeys);
+
+  // When a helpline has survey and no preEnagagement form
+  if (memory && !preEngagementData) {
+    Manager.getInstance().store.dispatch(prepopulateFormAction(callType, surveyValues, task.taskSid));
+
+    // Open tabbed form to first tab
+    Manager.getInstance().store.dispatch(
+      RoutingActions.changeRoute({ route: 'tabbed-forms', subroute, autoFocus: true }, task.taskSid),
+    );
+    return;
+  }
+
+  // When a helpline has survey and preEnagagement form to populate
+  if (memory && preEngagementData) {
     const prepopulatePreengagementKeys = isAboutSelf
-      ? prepopulateKeys.preEngagement.ChildInformationTab
-      : prepopulateKeys.preEngagement.CallerInformationTab;
+      ? preEngagement.ChildInformationTab
+      : preEngagement.CallerInformationTab;
     const preEngagementValues = getValuesFromPreEngagementData(
       preEngagementData,
       tabFormDefinition,
@@ -149,17 +182,16 @@ export const prepopulateForm = (task: ITask) => {
     const values = { ...surveyValues, ...preEngagementValues };
     Manager.getInstance().store.dispatch(prepopulateFormAction(callType, values, task.taskSid));
 
-    if (prepopulateKeys.preEngagement.CaseInformationTab.length > 0) {
+    if (preEngagement.CaseInformationTab.length > 0) {
       const caseInfoValues = getValuesFromPreEngagementData(
         preEngagementData,
         CaseInformationTab,
-        prepopulateKeys.preEngagement.CaseInformationTab,
+        preEngagement.CaseInformationTab,
       );
 
       Manager.getInstance().store.dispatch(prepopulateFormAction(callType, caseInfoValues, task.taskSid, true));
     }
     // Open tabbed form to first tab
-    const subroute = isAboutSelf ? 'childInformation' : 'callerInformation';
     Manager.getInstance().store.dispatch(
       RoutingActions.changeRoute({ route: 'tabbed-forms', subroute, autoFocus: true }, task.taskSid),
     );

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -128,6 +128,7 @@ export const getValuesFromPreEngagementData = (
 export const prepopulateForm = (task: ITask) => {
   const { memory, preEngagementData } = task.attributes;
   if (memory === null && preEngagementData === null) return;
+
   const { currentDefinitionVersion } = getDefinitionVersions();
   const { tabbedForms, prepopulateKeys } = currentDefinitionVersion;
   const { ChildInformationTab, CallerInformationTab, CaseInformationTab } = tabbedForms;
@@ -154,7 +155,7 @@ export const prepopulateForm = (task: ITask) => {
     return;
   }
 
-  const { answers } = task.attributes.memory.twilio.collected_data.collect_survey;
+  const { answers } = memory.twilio.collected_data.collect_survey;
 
   const isAboutSelf = answers.about_self.answer === 'Yes';
   const callType = isAboutSelf || !answers.about_self ? callTypes.child : callTypes.caller;


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
- This PR improves on the `prepopulateForm` method to ensure `preEngagamentData` populates in the absence of `survey`. 
- Also, fields with mixed-checkbox as type are parsed to read the value for the checkbox in flex. 

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes # [1071](https://tech-matters.atlassian.net/browse/CHI-1071)

### Verification steps
- Check with webchat and flex configurations for Dev, CL and CA