### PR TITLE
fix: changes for new make/docker tf setup

### DIFF
--- a/twilio-iac/thailand-production/Makefile
+++ b/twilio-iac/thailand-production/Makefile
@@ -1,0 +1,3 @@
+TF_VER = 1.3.6
+
+include ../makefiles/*.make

--- a/twilio-iac/thailand-production/main.tf
+++ b/twilio-iac/thailand-production/main.tf
@@ -23,7 +23,7 @@ provider "aws" {
 }
 
 data "aws_ssm_parameter" "secrets" {
-  name     = "/terraform/twilio-iac/thailand-production/secrets.json"
+  name     = "/terraform/twilio-iac/${basename(abspath(path.module))}secrets.json"
 }
 
 locals {

--- a/twilio-iac/thailand-production/main.tf
+++ b/twilio-iac/thailand-production/main.tf
@@ -23,7 +23,7 @@ provider "aws" {
 }
 
 data "aws_ssm_parameter" "secrets" {
-  name     = "/terraform/twilio-iac/${basename(abspath(path.module))}secrets.json"
+  name     = "/terraform/twilio-iac/${basename(abspath(path.module))}/secrets.json"
 }
 
 locals {

--- a/twilio-iac/thailand-production/variables.tf
+++ b/twilio-iac/thailand-production/variables.tf
@@ -1,9 +1,3 @@
-variable "account_sid" {}
-variable "auth_token" {}
-variable "serverless_url" {}
-variable "datadog_app_id" {}
-variable "datadog_access_token" {}
-
 variable "local_os" {
   description = "The OS running the terraform script. The only value that currently changes behaviour from default is 'Windows'"
   type        = string


### PR DESCRIPTION
I merged master into `bo/alejandro_th_tf_production_updates` before creating this branch and it looks like you mostly had main.tf setup for the new system. 👏 

Before you can run the [Terraform Plan action](https://github.com/techmatters/flex-plugins/actions/workflows/terraform_plan.yml), you will need to run `make manage-ssm-secrets` from your local machine and add the secrets for the helpline. You should then be able to run plan via the action.

Let me know if you run into any issues!