### PR TITLE
adding preEngagementData to webchat attributes

### DIFF
--- a/twilio-iac/terraform-modules/channels/twilio-channel/channel-attributes-mt/webchat-attributes.tftpl
+++ b/twilio-iac/terraform-modules/channels/twilio-channel/channel-attributes-mt/webchat-attributes.tftpl
@@ -6,5 +6,6 @@
   "language":"{{trigger.message.ChannelAttributes.pre_engagement_data.language}}",
   "ignoreAgent": "",
   "transferTargetType": "",
-  "memory": {{ widgets.${chatbot_language}.memory  | to_json}}
+  "memory": {{ widgets.${chatbot_language}.memory  | to_json}},
+  "preEngagementData": {{trigger.message.ChannelAttributes.pre_engagement_data | to_json}}
 }

--- a/twilio-iac/terraform-modules/channels/twilio-channel/channel-attributes/webchat-attributes.tftpl
+++ b/twilio-iac/terraform-modules/channels/twilio-channel/channel-attributes/webchat-attributes.tftpl
@@ -7,5 +7,6 @@
   "language":"${task_language}",
   "ignoreAgent": "",
   "transferTargetType": "",
-  "memory": {{widgets.ChatBot.memory | to_json}}
+  "memory": {{widgets.ChatBot.memory | to_json}},
+  "preEngagementData": {{trigger.message.ChannelAttributes.pre_engagement_data | to_json}}
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:
@murilovmachado 

Adding the preEngagementData attribute to the webchat widget. Now this will be part as the default attributes.

@murilovmachado  If I'm not around feel free to merge this if you approve.
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->