### PR TITLE
CHI-1653: fix greeting

### DIFF
--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -127,22 +127,21 @@ export const getValuesFromPreEngagementData = (
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export const prepopulateForm = (task: ITask) => {
   const { memory, preEngagementData } = task.attributes;
-  if (memory === null && preEngagementData === null) return;
+  if (!memory && !preEngagementData) return;
 
   const { currentDefinitionVersion } = getDefinitionVersions();
   const { tabbedForms, prepopulateKeys } = currentDefinitionVersion;
   const { ChildInformationTab, CallerInformationTab, CaseInformationTab } = tabbedForms;
   const { preEngagement, survey } = prepopulateKeys;
 
-  // PreEngagementData Values
-  const childInfoValues = getValuesFromPreEngagementData(
-    preEngagementData,
-    ChildInformationTab,
-    preEngagement.ChildInformationTab,
-  );
-
   // When a helpline has preEnagagement form and no survey
-  if (preEngagementData && memory === null) {
+  if (preEngagementData && !memory) {
+    // PreEngagementData Values
+    const childInfoValues = getValuesFromPreEngagementData(
+      preEngagementData,
+      ChildInformationTab,
+      preEngagement.ChildInformationTab,
+    );
     Manager.getInstance().store.dispatch(prepopulateFormAction(callTypes.child, childInfoValues, task.taskSid));
 
     // Open tabbed form to first tab


### PR DESCRIPTION
## Description

* Fixes CHI-1653
* Makes the prepopulateForm function handle no preengagement data

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1653

### Verification steps

See ticket - ensure greeting appears for channels with no preengagement