### PR TITLE
CHI-1653: Fix no populate keys

### DIFF
--- a/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -136,7 +136,14 @@ export async function loadDefinition(version: DefinitionVersionId): Promise<Defi
       /* webpackMode: "eager" */ `../../form-definitions/${version}/PrepopulateKeys.json`
     );
   } catch (err) {
-    prepopulateKeys = { ChildInformationTab: [], CallerInformationTab: [] };
+    prepopulateKeys = {
+      survey: { ChildInformationTab: [], CallerInformationTab: [] },
+      preEngagement: {
+        ChildInformationTab: [],
+        CallerInformationTab: [],
+        CaseInformationTab: [],
+      },
+    };
   }
 
   let referenceData;


### PR DESCRIPTION
Primary reviewer:

## Description

* Updates the 'fallback' prepopulateKeys object to match the new layout

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues

CHI-1653

### Verification steps

Ensure the greeting automated message appears when a counsellor picks up a task on helplines with no prepopulateKeys.json defined
