### PR TITLE
Startup optimisation

### DIFF
--- a/plugin-hrm-form/public/appConfig.template.deploy.js
+++ b/plugin-hrm-form/public/appConfig.template.deploy.js
@@ -12,7 +12,7 @@ const appConfig = {
   pluginService: {
     enabled: true,
     url: pluginServiceUrl,
-    // If thisis not set flex waits for 10 seconfs between running plugin init() and rendering components :-/
+    // If this is not set flex waits for 10 seconds between running plugin init() and rendering components :-/
     initializationTimeout: 1,
   },
   sso: {

--- a/plugin-hrm-form/public/appConfig.template.deploy.js
+++ b/plugin-hrm-form/public/appConfig.template.deploy.js
@@ -1,18 +1,22 @@
 // your account sid
-var accountSid = '__TWILIO_ACCOUNT_SID__';
+const accountSid = '__TWILIO_ACCOUNT_SID__';
 
-// set to /plugins.json for local dev
-// set to /plugins.local.build.json for testing your build
-// set to "" for the default live plugin loader
-var pluginServiceUrl = '/plugins.json';
+/*
+ * set to /plugins.json for local dev
+ * set to /plugins.local.build.json for testing your build
+ * set to "" for the default live plugin loader
+ */
+const pluginServiceUrl = '/plugins.json';
 
-var appConfig = {
+const appConfig = {
   pluginService: {
     enabled: true,
     url: pluginServiceUrl,
+    // If thisis not set flex waits for 10 seconfs between running plugin init() and rendering components :-/
+    initializationTimeout: 1,
   },
   sso: {
-    accountSid: accountSid
+    accountSid,
   },
   ytica: false,
   logLevel: 'debug',

--- a/plugin-hrm-form/public/appConfig.template.e2e.js
+++ b/plugin-hrm-form/public/appConfig.template.e2e.js
@@ -12,6 +12,7 @@ const appConfig = {
   pluginService: {
     enabled: true,
     url: pluginServiceUrl,
+    initializationTimeout: 1,
   },
   sso: {
     accountSid,


### PR DESCRIPTION
## Description

By default, Flex waits for 10 seconds (!) between initialising plugins and attempting to render anything. An undocumented setting in the pluginService section of the app.config allows this to be adjusted. 

Since our startup routine should be robust and not require a blanket delay to work around race hazards like that, I tried setting the delay to 1 millisecond and was gratified to see the startup sequence still appears to work fine.

There might be a more elegant way to handle this, a way in the API to inform the plugin loading system that initialization is complete and rendering can commence, but I haven't seen anything - I've asked Twilio: https://console.twilio.com/us1/support/tickets?frameUrl=%2Fconsole%2Fsupport%2Ftickets%2F11040527%3F__override_layout__%3Dembed%26bifrost%3Dtrue%26x-target-region%3Dus1

* Sets 'initializationTimeout' to 1 millisecond in deployment app.config

NOTE: This will only affect deployment configs, to tesst locally you need to add the same attribute to your local `public/app.config`

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps

* Update app.config & start Flex