### PR TITLE
Pin flex-ui to minor version

### DIFF
--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -69,7 +69,7 @@
     "@testing-library/user-event": "^14.1.1",
     "@twilio/flex-plugin": "^6.0.3",
     "@twilio/flex-plugin-scripts": "^6.0.3",
-    "@twilio/flex-ui": "^2.0.0",
+    "@twilio/flex-ui": "2.0.x",
     "@twilio/flex-ui-dev-proxy": "^1.1.2",
     "@types/jest": "^27.5.2",
     "@types/react": "^17.0.47",


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
In #1088 we set the Flex version to be any version >=2.0.0 and <3.0.0. I think we want to be more specific and control the version we use, at least down to the minor version.

Our approach to Flex version change management has generally been:
- A slack reminder every six weeks reminds us to create a ticket to update the version
- As part of that ticket, we update the minor version of Flex
- We also run a full `npm install` to upgrade dependencies and deal with issues that arise
- The upgrades and changes then go through our normal QA process
- Part of the next deployment is to upgrade all accounts to the new version (which happens automatically on deploy)

**Part of reviewing this PR is reviewing that the above process is what is actually done, or editing it to be correct**

Note: `~2.0.0` is equivalent to `2.0.x`. I'm happy with either but thought `2.0.x` was clearer.

### Checklist
N/A to all
I have not built or tested this
