### PR TITLE
[PoC] Demonstrate redux-promise-middleware

### DIFF
--- a/plugin-hrm-form/src/hooks/useLoadDefinitionVersions.ts
+++ b/plugin-hrm-form/src/hooks/useLoadDefinitionVersions.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { DefinitionVersionId } from 'hrm-form-definitions';
+
+import { updateDefinitionVersion } from '../states/configuration/actions';
+import { getMissingDefinitionVersions } from '../utils/definitionVersions';
+
+const dedup = <T>(arr: T[]) => Array.from(new Set(arr));
+
+// eslint-disable-next-line import/no-unused-modules
+export const useLoadDefinitionVersions = <T>(
+  withVersion: T | T[],
+  extractVersionFromObject: (t: T) => DefinitionVersionId,
+) => {
+  const [isLoadingDefinitionVersions, setIsLoadingDefinitionVersion] = React.useState(false);
+  const dispatch = useDispatch();
+
+  const extractVersionFromObjectRef = React.useRef(extractVersionFromObject);
+
+  React.useEffect(() => {
+    extractVersionFromObjectRef.current = extractVersionFromObject;
+  }, [extractVersionFromObject]);
+
+  React.useEffect(() => {
+    const fetchMissingDefinitionVersions = async () => {
+      setIsLoadingDefinitionVersion(true);
+
+      const definitionsVersions = Array.isArray(withVersion)
+        ? dedup(withVersion.map(extractVersionFromObjectRef.current))
+        : [extractVersionFromObjectRef.current(withVersion)];
+
+      const loadedDefinitions = await getMissingDefinitionVersions(definitionsVersions);
+
+      loadedDefinitions.forEach(d => dispatch(updateDefinitionVersion(d.version, d.definition)));
+      setIsLoadingDefinitionVersion(false);
+    };
+
+    fetchMissingDefinitionVersions();
+  }, [dispatch, withVersion]);
+
+  return { isLoadingDefinitionVersions };
+};

--- a/plugin-hrm-form/src/states/caseList/listContent.ts
+++ b/plugin-hrm-form/src/states/caseList/listContent.ts
@@ -36,7 +36,6 @@ export const FETCH_CASE_LIST_STARTED = `${FETCH_CASE_LIST}_PENDING` as const;
 
 type FetchCaseListStartAction = { type: typeof FETCH_CASE_LIST_STARTED };
 
-
 export const fetchCaseListStartReducer = (
   state: CaseListContentState,
   action: FetchCaseListStartAction,

--- a/plugin-hrm-form/src/states/caseList/listContent.ts
+++ b/plugin-hrm-form/src/states/caseList/listContent.ts
@@ -1,6 +1,6 @@
 // State
-
-import { Case as CaseType, Case } from '../../types/types';
+import { Case, ListCasesQueryParams } from '../../types/types';
+import { listCases } from '../../services/CaseService';
 
 export type CaseListContentState = {
   listLoading: boolean;
@@ -18,51 +18,52 @@ export const caseListContentInitialState = (): CaseListContentState => ({
   caseDetailsOpen: false,
 });
 
-export const FETCH_CASE_LIST_STARTED = 'FETCH_CASE_LIST_STARTED';
+const FETCH_CASE_LIST = 'FETCH_CASE_LIST';
+export const fetchCaseList = (
+  queryParams: ListCasesQueryParams,
+  listCasesPayload: {
+    filters: any;
+    helpline: any;
+  },
+) => {
+  return {
+    type: FETCH_CASE_LIST,
+    payload: listCases(queryParams, listCasesPayload),
+  };
+};
+
+export const FETCH_CASE_LIST_STARTED = `${FETCH_CASE_LIST}_PENDING` as const;
 
 type FetchCaseListStartAction = { type: typeof FETCH_CASE_LIST_STARTED };
 
-export const fetchCaseListStarted = (): FetchCaseListStartAction => ({
-  type: FETCH_CASE_LIST_STARTED,
-});
 
 export const fetchCaseListStartReducer = (
   state: CaseListContentState,
   action: FetchCaseListStartAction,
 ): CaseListContentState => ({ ...state, listLoading: true });
 
-export const FETCH_CASE_LIST_SUCCESS = 'FETCH_CASE_LIST_SUCCESS';
+export const FETCH_CASE_LIST_SUCCESS = `${FETCH_CASE_LIST}_FULFILLED` as const;
 
 type FetchCaseListSuccessAction = {
   type: typeof FETCH_CASE_LIST_SUCCESS;
-  payload: { caseList: CaseType[]; caseCount: number };
+  payload: Awaited<ReturnType<typeof listCases>>;
 };
-
-export const fetchCaseListSuccess = (caseList: CaseType[], caseCount: number): FetchCaseListSuccessAction => ({
-  type: FETCH_CASE_LIST_SUCCESS,
-  payload: { caseList, caseCount },
-});
 
 export const fetchCaseListSuccessReducer = (
   state: CaseListContentState,
   action: FetchCaseListSuccessAction,
 ): CaseListContentState => {
-  const { caseList, caseCount } = action.payload;
+  const { cases: caseList, count: caseCount } = action.payload;
   return { ...state, caseList, caseCount, listLoading: false, fetchError: undefined };
 };
 
-export const FETCH_CASE_LIST_ERROR = 'FETCH_CASE_LIST_ERROR';
-type CaseListFetchErrorAction = { type: typeof FETCH_CASE_LIST_ERROR; payload: { error: any } };
-
-export const fetchCaseListError = (error: any): CaseListFetchErrorAction => ({
-  type: FETCH_CASE_LIST_ERROR,
-  payload: { error },
-});
+export const FETCH_CASE_LIST_ERROR = `${FETCH_CASE_LIST}_REJECTED` as const;
+type CaseListFetchErrorAction = { type: typeof FETCH_CASE_LIST_ERROR; payload: any };
 
 export const fetchCaseListErrorReducer = (
   state: CaseListContentState,
   action: CaseListFetchErrorAction,
-): CaseListContentState => ({ ...state, listLoading: false, fetchError: action.payload.error });
+): CaseListContentState => ({ ...state, listLoading: false, fetchError: action.payload });
 
 export const OPEN_CASE_DETAILS = 'OPEN_CASE_DETAILS';
 

--- a/plugin-hrm-form/src/utils/definitionVersions.ts
+++ b/plugin-hrm-form/src/utils/definitionVersions.ts
@@ -4,13 +4,11 @@ import { Case, SearchAPIContact } from '../types/types';
 import { getDefinitionVersionsList } from '../services/ServerlessService';
 import { getDefinitionVersions } from '../HrmFormPlugin';
 
-// eslint-disable-next-line import/no-unused-modules
-const getMissingDefinitionVersions = async (versions: DefinitionVersionId[]) => {
+export const getMissingDefinitionVersions = async (versions: DefinitionVersionId[]) => {
   const { definitionVersions } = getDefinitionVersions();
   const missingDefinitionVersions: DefinitionVersionId[] = versions.filter(
     v => Object.values(DefinitionVersionId).includes(v) && !definitionVersions[v],
   );
-
   // eslint-disable-next-line sonarjs/prefer-immediate-return
   const definitions = await getDefinitionVersionsList(missingDefinitionVersions);
   return definitions;


### PR DESCRIPTION
Note: since this is a PoC, I'm not fixing the CI unless we decide is worth the effort :stuck_out_tongue_closed_eyes: 

## Description
This PR is (kinda) part of investigating different options for async behavior in our Redux actions.
After doing some reading, it looks like we can't use Redux middleware yet (Sagas and Thunks are still out :disappointed:)
- [Twilio documentation](https://www.twilio.com/docs/flex/developer/ui/redux#:~:text=You%20might%20be%20wondering%20why,this%20is%20not%20yet%20supported)
- [Github issue referencing this exact same thing](https://github.com/twilio/flex-plugin-builder/issues/171)

However, we can use [redux-promise-middleware](https://github.com/pburtchaell/redux-promise-middleware) ([as it is bundled with Flex](https://www.twilio.com/docs/flex/developer/ui/redux#write-asynchronous-actions)).
The idea of this middleware is that we provide a single action creator of the shape of 
```
const asyncAction = () => ({
  type: 'ACTION_TYPE',
  payload: new Promise(...),    // or asyncFunction()
})
```
and the middleware will capture the action, and since it's `payload` is a `Promise`, it will decompose it into three different actions: 
- `ACTION_TYPE_PENDING`: dispatched when `asyncAction` is called.
- `ACTION_TYPE_FULFILLED`: dispatched when the promise resolves successfully. The `payload` of this second action will be the value to which the promise resolved.
- `ACTION_TYPE_REJECTED`: dispatched when the promise is rejected. The `payload` of this second action will be the value to which the promise was rejected.

The pros:
- We don't need to manually write actions creators to express the different actions involved in an async action.
- Easy to use.

The cons:
- Does not really adds much value, since we still need to express the reducer logic and the action types. The second can be somewhat mitigated if we use [createAsyncAction](https://github.com/pburtchaell/redux-promise-middleware/tree/main/examples/using-promise-actions#using-promise-middleware-with-redux-promise-middleware-actions) helper.
- Forces us to separate the complex logic that involves multiple dispatches (e.g. fetch missing definition versions after loading the case list). Since this is the main use case to advocate for thunks/sagas, I'm not fully convinced of refactoring our current code like in this PoC, but happy to change my mind if the team thinks it's a good idea.

This PR have two different commits to review:
- 56badcb0fdf3b5ac860c7c61f8aff6499601c9ce, where I'm demonstrating how we could use this middleware to express our async actions.
- 19b3e489761b956db8a357605f237640ca19ed8f, where I've introduced a custom hook to handle the "fetch missing definition versions" logic. The idea of this is to show how we could share this behavior between our components, if we migrate to redux pomise and don't want to repeat ourselves.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/jira/software/c/projects/CHI/boards/7?modal=detail&selectedIssue=CHI-1237)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Checking out to both commits should work as usual, specially around the case list view. Note that I've introduced a case with version `co-v1`, to include different definition versions.
- Changing `fetchCaseList` (`src/states/caseList/listContent.ts`) to return `payload: Promise.reject(new Error('Booom!')),` should trigger the error page for this view.