### PR TITLE
chore: add ignores to license add script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tech-matters/flex-plugins",
   "scripts": {
-    "license:add": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore \"twilio-iac/**\" -ignore \"scripts/**\" -f license-header.tpl .",
-    "license:check": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \"twilio-iac/**\" -ignore \"scripts/**\" -f license-header.tpl ."
+    "license:add": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore \"twilio-iac/**\" -ignore \"scripts/**\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -ignore \"**/build/**\" -f license-header.tpl .",
+    "license:check": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \"twilio-iac/**\" -ignore \"scripts/**\" -ignore \"twilio-iac/**\" -ignore \"scripts/**\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -ignore \"**/build/**\" -f license-header.tpl .",
+    "license:add:windows": "docker run --rm -v %cd%:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -ignore \"**/build/**\" -f license-header.tpl .",
+    "license:check:windows": "docker run --rm -v %cd%:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -ignore \"**/build/**\" -f license-header.tpl .",
+    "license:add:windows:local": "addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -ignore **/build\\\\** -f license-header.tpl .",
+    "license:check:windows:local": "addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -ignore **/build\\\\** -f license-header.tpl ."
   }
 }


### PR DESCRIPTION
Adds ignore patterns (not all but the important ones... hopefully?) to the license add command and windows versions.