### PR TITLE
Refactor reserved task notification logic

### DIFF
--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -104,9 +104,7 @@ const notifyReservedTask = reservation => {
       reservation.on(status, stopAudio);
     });
 
-    setTimeout(() => {
-      stopAudio();
-    }, 120000);
+    setTimeout(stopAudio, 120000);
 
     const checkForReservedTask = () => {
       if (reservation.task.status === 'reserved') {

--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -76,11 +76,12 @@ const notifyNewMessage = messageInstance => {
   }
 };
 
-/** notifyReservedTask plays ringtone when an agent has a reserved task in pending state.
- *  The notification stops when the reservation is not longer in pending. 
+/**
+ * notifyReservedTask plays ringtone when an agent has a reserved task in pending state.
+ *  The notification stops when the reservation is not longer in pending.
  *  There is a check, checkForPendingReservation, in case, notification does not stop as expected.
- * 
- * @param reservation 
+ *
+ * @param reservation
  */
 const notifyReservedTask = reservation => {
   try {

--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -110,9 +110,8 @@ const notifyReservedTask = reservation => {
     reservationStatuses.forEach(status => reservation.on(status, stopAudio));
 
     const checkForPendingReservation = () =>
-      reservation.status === 'pending' ? setTimeout(checkForPendingReservation, 5000) : stopAudio;
+      reservation.status === 'pending' ? setTimeout(checkForPendingReservation, 5000) : stopAudio();
     checkForPendingReservation();
-
   } catch (error) {
     console.error('Error in notifyReservedTask:', error);
   }

--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -14,24 +14,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { StateHelper, Manager, AudioPlayerManager } from '@twilio/flex-ui';
+import { StateHelper, Manager, AudioPlayerManager, AudioPlayerError } from '@twilio/flex-ui';
 import { Conversation } from '@twilio/conversations';
 
 import { getHrmConfig } from '../hrmConfig';
-
-const trySubscribeAudioAlerts = (task, ms: number, retries: number) => {
-  setTimeout(() => {
-    const convoState = StateHelper.getConversationStateForTask(task);
-
-    // if channel is not ready, wait 200ms and retry
-    if (convoState.isLoadingConversation) {
-      if (retries < 10) trySubscribeAudioAlerts(task, 200, retries + 1);
-      else console.error('Failed to subscribe audio alerts: max retries reached.');
-    } else {
-      subscribeAlertOnNewMessage(convoState.source);
-    }
-  }, ms);
-};
 
 export const subscribeAlertOnConversationJoined = task => {
   const manager = Manager.getInstance();
@@ -39,7 +25,8 @@ export const subscribeAlertOnConversationJoined = task => {
 };
 
 export const subscribeNewMessageAlertOnPluginInit = () => {
-  const { tasks } = Manager.getInstance().store.getState().flex.worker;
+  const manager = Manager.getInstance();
+  const { tasks } = manager.store.getState().flex.worker;
   tasks.forEach(task => trySubscribeAudioAlerts(task, 0, 0));
 };
 
@@ -47,48 +34,92 @@ const subscribeAlertOnNewMessage = (conversation: Conversation) => {
   conversation.on('messageAdded', notifyNewMessage);
 };
 
+const trySubscribeAudioAlerts = (task, ms: number, retries: number) => {
+  setTimeout(() => {
+    const convoState = StateHelper.getConversationStateForTask(task);
+
+    // if channel is not ready, wait 200ms and retry
+    if (convoState?.isLoadingConversation) {
+      if (retries < 10) trySubscribeAudioAlerts(task, 200, retries + 1);
+      else console.error('Failed to subscribe audio alerts: max retries reached.');
+    } else {
+      subscribeAlertOnNewMessage(convoState?.source);
+    }
+  }, ms);
+};
+
 const notifyNewMessage = messageInstance => {
-  const manager = Manager.getInstance();
-  const { assetsBucketUrl } = getHrmConfig();
+  try {
+    const manager = Manager.getInstance();
+    const { assetsBucketUrl } = getHrmConfig();
 
-  const notificationTone = 'bell';
-  const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
+    const notificationTone = 'bell';
+    const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
-  // normalizeEmail transforms an encoded characters with @ and .
-  const normalizeEmail = (identity: string) => identity.replace('_2E', '.').replace('_40', '@');
+    // normalizeEmail transforms encoded characters with @ and .
+    const normalizeEmail = (identity: string) => identity.replace('_2E', '.').replace('_40', '@');
 
-  const isCounsellor = normalizeEmail(manager.user.identity) === normalizeEmail(messageInstance.author);
-  if (!isCounsellor && document.visibilityState === 'visible') {
-    AudioPlayerManager.play({
-      url: notificationUrl,
-      repeatable: false,
-    });
+    const isCounsellor = normalizeEmail(manager.user.identity) === normalizeEmail(messageInstance.author);
+    if (!isCounsellor && document.visibilityState === 'visible') {
+      AudioPlayerManager.play(
+        {
+          url: notificationUrl,
+          repeatable: false,
+        },
+        (error: AudioPlayerError) => {
+          console.log('AudioPlayerError:', error);
+        },
+      );
+    }
+  } catch (error) {
+    console.error('Error in notifyNewMessage:', error);
   }
 };
 
 const notifyReservedTask = reservation => {
-  const { assetsBucketUrl } = getHrmConfig();
+  try {
+    const { assetsBucketUrl } = getHrmConfig();
 
-  const notificationTone = 'ringtone';
-  const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
+    const notificationTone = 'ringtone';
+    const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
-  let media;
+    let media;
 
-  if (document.visibilityState === 'visible') {
-    media = AudioPlayerManager.play({
-      url: notificationUrl,
-      repeatable: true,
+    if (document.visibilityState === 'visible') {
+      media = AudioPlayerManager.play(
+        {
+          url: notificationUrl,
+          repeatable: true,
+        },
+        (error: AudioPlayerError) => {
+          console.log('AudioPlayerError:', error);
+        },
+      );
+    }
+
+    const stopAudio = () => AudioPlayerManager.stop(media);
+
+    const taskStatuses = ['accepted', 'canceled', 'rejected', 'rescinded', 'timeout'];
+    taskStatuses.forEach(status => {
+      reservation.on(status, stopAudio);
     });
+
+    setTimeout(() => {
+      stopAudio();
+    }, 120000);
+
+    const checkForReservedTask = () => {
+      if (reservation.task.status === 'reserved') {
+        setTimeout(checkForReservedTask, 5000);
+      } else {
+        stopAudio();
+      }
+    };
+
+    checkForReservedTask();
+  } catch (error) {
+    console.error('Error in notifyReservedTask:', error);
   }
-  const taskStatuses = ['accepted', 'canceled', 'rejected', 'rescinded', 'timeout'];
-  taskStatuses.forEach(status => {
-    reservation.on(status, () => {
-      AudioPlayerManager.stop(media);
-    });
-  });
-  setTimeout(() => {
-    AudioPlayerManager.stop(media);
-  }, 15000);
 };
 
 export const subscribeReservedTaskAlert = () => {

--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -106,14 +106,13 @@ const notifyReservedTask = reservation => {
 
     const stopAudio = () => media && AudioPlayerManager.stop(media);
 
-    const taskStatuses = ['accepted', 'canceled', 'rejected', 'rescinded', 'timeout'];
-    taskStatuses.forEach(status => {
-      reservation.on(status, stopAudio);
-    });
+    const reservationStatuses = ['accepted', 'canceled', 'rejected', 'rescinded', 'timeout'];
+    reservationStatuses.forEach(status => reservation.on(status, stopAudio));
 
     const checkForPendingReservation = () =>
       reservation.status === 'pending' ? setTimeout(checkForPendingReservation, 5000) : stopAudio;
     checkForPendingReservation();
+
   } catch (error) {
     console.error('Error in notifyReservedTask:', error);
   }


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
- Checking reservation status on an interval to ensure clean up if notification clean up is missed. 
- ~~Change setTimeout to 2 minutes(from 15 seconds)~~  Not anymore. Removing this

### Checklist
- [n/a] Corresponding issue has been opened
- [x] New tests added ( in a different PR)
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes [remove 15 second timer ](https://tech-matters.slack.com/archives/CV4QM23UJ/p1675437711969629?thread_ts=1675198539.557809&cid=CV4QM23UJ)

### Verification steps
- Check for behavior around stopping media on a reserved task. 