### PR TITLE
 Unsubscribe from audio alerts on transfer WIP

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -197,6 +197,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     setUpComponents(featureFlags, config, translateUI);
     setUpActions(featureFlags, config, getMessage);
     TaskRouterListeners.setTaskWrapupEventListeners(featureFlags);
+    TaskRouterListeners.setTaskCompletedEventListener();
 
     subscribeReservedTaskAlert();
     subscribeNewMessageAlertOnPluginInit();

--- a/plugin-hrm-form/src/utils/setUpTaskRouterListeners.ts
+++ b/plugin-hrm-form/src/utils/setUpTaskRouterListeners.ts
@@ -46,3 +46,8 @@ export const setTaskWrapupEventListeners = (featureFlags: FeatureFlags) => {
     manager.events.addListener('taskWrapup', removeConversationListeners);
   }
 };
+
+export const setTaskCompletedEventListener = () => {
+    const manager = Manager.getInstance();
+    manager.events.addListener('taskCompleted', removeConversationListeners);
+};


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- I am attempting to unsubscribe from audio alerts when a transfer takes place, which removes listeners when task is moved to complete

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->