### PR TITLE
Add fix to EU hrmBaseUrl

### DIFF
--- a/plugin-hrm-form/src/definitionVersions.ts
+++ b/plugin-hrm-form/src/definitionVersions.ts
@@ -28,7 +28,7 @@ const getEnvironmentFromHrmBaseUrl = (manager: Flex.Manager) => {
   const hrmBaseUrl = `${process.env.REACT_HRM_BASE_URL || manager.serviceConfiguration.attributes.hrm_base_url}`;
   const prefix = 'https://hrm-';
   const suffix = '.tl.techmatters.org';
-  const environment = hrmBaseUrl.substring(prefix.length, hrmBaseUrl.indexOf(suffix));
+  const environment = hrmBaseUrl.substring(prefix.length, hrmBaseUrl.indexOf(suffix)).replace('-eu', '');
 
   /*
    * hrm-test is an alias of hrm-staging that we should deprecate & remove, but some accounts are still configured to point at it


### PR DESCRIPTION
## Description
Adds fix to loading hrm-form-definitions for EU based helplines.

### Verification steps
Verify that EU helplines work fine after deploy