### PR TITLE
[Bug fix]: Audio notifications ring for transferred task

### DIFF
--- a/plugin-hrm-form/src/___tests__/utils/transfer.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/transfer.test.ts
@@ -333,7 +333,7 @@ describe('Kick, close and helpers', () => {
 
   test('setTransferMeta', async () => {
     const coldTask = createTask(
-      {},
+      { channelSid: 'channel1' },
       { sid: 'reservation1', taskSid: 'task1', taskChannelSid: 'channel1', workerSid: 'worker1' },
     );
 
@@ -350,6 +350,7 @@ describe('Kick, close and helpers', () => {
       originalReservation: 'reservation1',
       originalCounselor: 'worker1',
       originalCounselorName: counselorName,
+      originalConversationSid: 'channel1',
       transferStatus: transferStatuses.accepted,
       formDocument: 'some string',
       mode: transferModes.cold,
@@ -370,6 +371,7 @@ describe('Kick, close and helpers', () => {
       originalReservation: 'reservation1',
       originalCounselor: 'WKworker1',
       originalCounselorName: counselorName,
+      originalConversationSid: undefined,
       transferStatus: transferStatuses.transferring,
       formDocument: 'some string',
       mode: transferModes.warm,

--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -57,7 +57,7 @@ const notifyNewMessage = messageInstance => {
     const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
     const isCounsellor = manager.conversationsClient.user.identity === messageInstance.author;
-    if (!isCounsellor && document.visibilityState !== 'visible') {
+    if (!isCounsellor && document.visibilityState === 'hidden') {
       AudioPlayerManager.play(
         {
           url: notificationUrl,
@@ -109,7 +109,7 @@ const notifyReservedTask = reservation => {
     const notificationTone = 'ringtone';
     const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
-    if (document.visibilityState !== 'visible') {
+    if (document.visibilityState === 'hidden') {
       playWhilePending(reservation, notificationUrl);
     }
   } catch (error) {

--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -76,12 +76,34 @@ const notifyNewMessage = messageInstance => {
   }
 };
 
+const reservedTaskMedias: { [reservationSid: string]: string } = {};
+
+const playWhilePending = (reservation: { sid: string; status: string }, notificationUrl: string) => {
+  const checkForPendingReservation = () => {
+    if (reservation.status === 'pending') {
+      const mediaId = AudioPlayerManager.play(
+        {
+          url: notificationUrl,
+          repeatable: false,
+        },
+        (error: AudioPlayerError) => {
+          console.log('AudioPlayerError:', error);
+        },
+      );
+
+      reservedTaskMedias[reservation.sid] = mediaId;
+      setTimeout(checkForPendingReservation, 500);
+    }
+  };
+
+  checkForPendingReservation();
+};
+
 /**
  * notifyReservedTask plays ringtone when an agent has a reserved task in pending state.
- *  The notification stops when the reservation is not longer in pending.
- *  There is a check, checkForPendingReservation, in case, notification does not stop as expected.
- *
- * @param reservation
+ * The notification takes place once ever 500ms, if still pending, the sound is played again.
+ * If multiple tasks are reserved, AudioPlayerManager will stil play one of them
+ * The notification stops when the reservation is not longer in pending.
  */
 const notifyReservedTask = reservation => {
   try {
@@ -90,28 +112,9 @@ const notifyReservedTask = reservation => {
     const notificationTone = 'ringtone';
     const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
-    let media;
-
     if (document.visibilityState === 'visible') {
-      media = AudioPlayerManager.play(
-        {
-          url: notificationUrl,
-          repeatable: true,
-        },
-        (error: AudioPlayerError) => {
-          console.log('AudioPlayerError:', error);
-        },
-      );
+      playWhilePending(reservation, notificationUrl);
     }
-
-    const stopAudio = () => media && AudioPlayerManager.stop(media);
-
-    const reservationStatuses = ['accepted', 'canceled', 'rejected', 'rescinded', 'timeout'];
-    reservationStatuses.forEach(status => reservation.on(status, stopAudio));
-
-    const checkForPendingReservation = () =>
-      reservation.status === 'pending' ? setTimeout(checkForPendingReservation, 5000) : stopAudio();
-    checkForPendingReservation();
   } catch (error) {
     console.error('Error in notifyReservedTask:', error);
   }

--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -56,11 +56,8 @@ const notifyNewMessage = messageInstance => {
     const notificationTone = 'bell';
     const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
-    // normalizeEmail transforms encoded characters with @ and .
-    const normalizeEmail = (identity: string) => identity.replace('_2E', '.').replace('_40', '@');
-
-    const isCounsellor = normalizeEmail(manager.user.identity) === normalizeEmail(messageInstance.author);
-    if (!isCounsellor && document.visibilityState === 'visible') {
+    const isCounsellor = manager.conversationsClient.user.identity === messageInstance.author;
+    if (!isCounsellor && document.visibilityState !== 'visible') {
       AudioPlayerManager.play(
         {
           url: notificationUrl,
@@ -112,7 +109,7 @@ const notifyReservedTask = reservation => {
     const notificationTone = 'ringtone';
     const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
-    if (document.visibilityState === 'visible') {
+    if (document.visibilityState !== 'visible') {
       playWhilePending(reservation, notificationUrl);
     }
   } catch (error) {

--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -79,7 +79,7 @@ const notifyNewMessage = messageInstance => {
 const reservedTaskMedias: { [reservationSid: string]: string } = {};
 
 const playWhilePending = (reservation: { sid: string; status: string }, notificationUrl: string) => {
-  const checkForPendingReservation = () => {
+  const playNotificationIfPending = () => {
     if (reservation.status === 'pending') {
       const mediaId = AudioPlayerManager.play(
         {
@@ -92,11 +92,11 @@ const playWhilePending = (reservation: { sid: string; status: string }, notifica
       );
 
       reservedTaskMedias[reservation.sid] = mediaId;
-      setTimeout(checkForPendingReservation, 500);
+      setTimeout(playNotificationIfPending, 500);
     }
   };
 
-  checkForPendingReservation();
+  playNotificationIfPending();
 };
 
 /**

--- a/plugin-hrm-form/src/utils/setUpTaskRouterListeners.ts
+++ b/plugin-hrm-form/src/utils/setUpTaskRouterListeners.ts
@@ -15,34 +15,67 @@
  */
 
 import { Manager, TaskHelper, StateHelper, ITask } from '@twilio/flex-ui';
+import type { Conversation } from '@twilio/conversations';
 
 import { FeatureFlags } from '../types/types';
+import * as TransferHelpers from './transfer';
 
-const removeConversationListeners = (task: ITask) => {
+const removeConversationListeners = (conversation: Conversation) => {
+  const safelyRemoveListeners = (eventName: string) => {
+    try {
+      if (conversation.listenerCount(eventName)) {
+        conversation.removeAllListeners(eventName);
+      }
+    } catch (err) {
+      console.error(`Failed to safelyRemoveListeners with event ${eventName}`, err);
+    }
+  };
+
+  conversation.eventNames().forEach(safelyRemoveListeners);
+};
+
+const removeConversationListenersForTask = (task: ITask) => {
   if (TaskHelper.isChatBasedTask(task)) {
     const conversationState = StateHelper.getConversationStateForTask(task);
 
-    const safelyRemoveListeners = (eventName: string) => {
-      try {
-        if (conversationState.source?.listenerCount(eventName)) {
-          conversationState.source?.removeAllListeners(eventName);
-        }
-      } catch (err) {
-        console.error(`Failed to safelyRemoveListeners with event ${eventName}`, err);
-      }
-    };
+    removeConversationListeners(conversationState.source);
+  }
+};
 
-    conversationState.source?.eventNames().forEach(safelyRemoveListeners);
+const removeConversationListenersForTransferred = async (task: ITask) => {
+  try {
+    if (
+      TaskHelper.isChatBasedTask(task) &&
+      TransferHelpers.hasTransferStarted(task) &&
+      !TransferHelpers.hasTaskControl(task)
+    ) {
+      const manager = Manager.getInstance();
+
+      const conversation = await manager.conversationsClient.getConversationBySid(
+        task.attributes.transferMeta.originalConversationSid,
+      );
+
+      removeConversationListeners(conversation);
+    }
+  } catch (err) {
+    console.error('Error trying to run taskComplete taskrouter listener', err);
   }
 };
 
 export const setTaskWrapupEventListeners = (featureFlags: FeatureFlags) => {
+  const manager = Manager.getInstance();
   /*
    * If post surveys are on, remove all listeners from the underlying conversation on task wrapup.
    * This is done to hide any further activity between the contact and the post survey chatbot.
    */
   if (featureFlags.enable_post_survey) {
-    const manager = Manager.getInstance();
-    manager.events.addListener('taskWrapup', removeConversationListeners);
+    manager.events.addListener('taskWrapup', removeConversationListenersForTask);
+  }
+
+  /**
+   * If transfers are on, after a task is transferred remove all the conversation listeners to prevent message notifications
+   */
+  if (featureFlags.enable_transfers) {
+    manager.events.addListener('taskCompleted', removeConversationListenersForTransferred);
   }
 };

--- a/plugin-hrm-form/src/utils/transfer.ts
+++ b/plugin-hrm-form/src/utils/transfer.ts
@@ -139,6 +139,7 @@ export const setTransferMeta = async (
       originalReservation: task.sid,
       originalCounselor: task.workerSid,
       originalCounselorName: counselorName,
+      originalConversationSid: task.attributes.channelSid, // save the original conversation sid, so we can cleanup the listeners if transferred succesfully
       sidWithTaskControl: mode === transferModes.warm ? '' : 'WR00000000000000000000000000000000', // if cold, set control to dummy value so Task Janitor completes this one
       transferStatus: mode === transferModes.warm ? transferStatuses.transferring : transferStatuses.accepted,
       formDocument: documentName,

--- a/plugin-hrm-form/src/utils/transfer.ts
+++ b/plugin-hrm-form/src/utils/transfer.ts
@@ -139,7 +139,7 @@ export const setTransferMeta = async (
       originalReservation: task.sid,
       originalCounselor: task.workerSid,
       originalCounselorName: counselorName,
-      originalConversationSid: task.attributes.channelSid, // save the original conversation sid, so we can cleanup the listeners if transferred succesfully
+      originalConversationSid: task.attributes.conversationSid || task.attributes.channelSid, // save the original conversation sid, so we can cleanup the listeners if transferred succesfully
       sidWithTaskControl: mode === transferModes.warm ? '' : 'WR00000000000000000000000000000000', // if cold, set control to dummy value so Task Janitor completes this one
       transferStatus: mode === transferModes.warm ? transferStatuses.transferring : transferStatuses.accepted,
       formDocument: documentName,


### PR DESCRIPTION
## Description
This PR fixes two bugs:
- The one reported in the ticket, where after a task was transferred, the original counselor will still receive message notifications that take place in the underlying conversation.
- Another bug that I spotted while working on this, where a rejected transferred task will sometimes (pretty often) hang on ringing, making **_really_** annoying to keep the tab open. I suspect this was caused because the calls to `AudioPlayerManager.start` and `AudioPlayerManager.stop` were very close to each other, causing the audio to be forever enqueued. To fix this issue I'm changing the approach to the "ring while reserved": instead than using a `repeatable` audio, we'll use a simple one, and every 500ms check if the task is still pending. If it is, just ring again and set a timeout for another 500ms. 

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1676)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Confirm that both issues are occurring in the version deployed to development (or `master`).
- `npm run dev` and confirm that none of the two issues are occurring in this version. Note: you'll need two counselor sessions, but only one of them in local server is enough.