### PR TITLE
[Bug] Hide PreviousContactsCheckbox in Standalone Search

### DIFF
--- a/hrm-form-definitions/form-definitions/mt/v1/tabbedForms/IssueCategorizationTab.json
+++ b/hrm-form-definitions/form-definitions/mt/v1/tabbedForms/IssueCategorizationTab.json
@@ -7,7 +7,7 @@
         {"label": "Exposure to online child pornography"},
         {"label": "Online extortion or blackmail"},
         {"label": "Online grooming for sexual purposes"},
-        {"label": "Unspecified / Other"},
+        {"label": "(A&T) Unspecified / Other"},
         {"label": "Unwanted sexting"},
         {"label": "Victim of online child pornography"},
         {"label": "Victim of online sexual exploitation"}
@@ -24,9 +24,9 @@
         {"label": "Physical abuse"},
         {"label": "Economic abuse"},
         {"label": "Psychological abuse"},
-        {"label": "Sexual abuse"},
+        {"label": "(AV) Sexual abuse"},
         {"label": "Witness to violence"},
-        {"label": "Unspecified / Other"}
+        {"label": "(AV) Unspecified / Other"}
       ]
     },
     "Addiction": {
@@ -42,7 +42,7 @@
         {"label": "Gaming addiction"},
         {"label": "Smoking addiction"},
         {"label": "Spiritual obsession"},
-        {"label": "Unspecified / Other"}
+        {"label": "(A) Unspecified / Other"}
       ]
     },
     "Adult Related Issues": {
@@ -65,7 +65,7 @@
         {"label": "Employment Opportunities"},
         {"label": "Poor Living Conditions"},
         {"label": "Resources and financial aid"},
-        {"label": "Unspecified / Other"}
+        {"label": "(BN) Unspecified / Other"}
       ]
     },
     "Bullying": {
@@ -77,19 +77,19 @@
         {"label": "Sexual"},
         {"label": "Theft"},
         {"label": "Stalking"},
-        {"label": "Unspecified"}
+        {"label": "(B) Unspecified"}
       ]
     },
     "Child Migration / Children on the Move": {
       "color": "#bbfff5",
       "subcategories": [
-        {"label": "Child trafficking"},
+        {"label": "(CM) Child trafficking"},
         {"label": "Child without status / Undocumented"},
         {"label": "Internally displaced child (domestic)"},
         {"label": "Problems with adjusting to a new environment"},
         {"label": "Refugee child (cross-border)"},
         {"label": "Seeking job opportunities"},
-        {"label": "Unspecified / Other"},
+        {"label": "(CM) Unspecified / Other"},
         {"label": "Voluntary child migration"}
       ]
     },
@@ -98,16 +98,16 @@
       "subcategories": [
         {"label": "Bonded child labour"},
         {"label": "Child kidnapping"},
-        {"label": "Child marriage"},
+        {"label": "(CE) Child marriage"},
         {"label": "Child sexual exploitation/prostitution"},
-        {"label": "Child trafficking"},
+        {"label": "(CE) Child trafficking"},
         {"label": "Children used for begging"},
         {"label": "Children used for criminal activity"},
         {"label": "Domestic child labour"},
         {"label": "Organ harvesting"},
         {"label": "Other child labour"},
         {"label": "Sexual exploitation in the context of travel/tourism"},
-        {"label": "Unspecified / Other"}
+        {"label": "(CE) Unspecified / Other"}
       ]
     },
     "Cyberbullying": {
@@ -119,9 +119,9 @@
         {"label": "Harassment"},
         {"label": "Inappropriate content"},
         {"label": "Online flaming/fighting"},
-        {"label": "Revenge porn"},
+        {"label": "(CB) Revenge porn"},
         {"label": "Sexual extortion"},
-        {"label": "Unspecified / Other"},
+        {"label": "(CB) Unspecified / Other"},
         {"label": "Unwanted 'sexting'"},
         {"label": "Victim of cyberstalking"},
         {"label": "Victim of impersonation"},
@@ -141,7 +141,7 @@
     "Discrimination": {
       "color": "#ffbbe3",
       "subcategories": [
-        {"label": "Access to education"},
+        {"label": "(D) Access to education"},
         {"label": "Age-related"},
         {"label": "Criminal record / Ex-prisoner related"},
         {"label": "Denial of opportunities/services"},
@@ -153,14 +153,14 @@
         {"label": "Mental and physical health / Disability"},
         {"label": "Racism related"},
         {"label": "Sexual orientation related"},
-        {"label": "Unspecified / Other"}
+        {"label": "(D) Unspecified / Other"}
       ]
     },
     "Family Relationships": {
       "color": "#ffbbbb",
       "subcategories": [
         {"label": "Adoption / Fostering issues"},
-        {"label": "Bereavement"},
+        {"label": "(FR) Bereavement"},
         {"label": "Child custody and access"},
         {"label": "Divorced / Separated parents / Parents in conflict"},
         {"label": "Maintenance and child support"},
@@ -169,7 +169,7 @@
         {"label": "Parental pressure"},
         {"label": "Parents with addiction and/or mental health problems"},
         {"label": "Sibling relationship"},
-        {"label": "Unspecified / Other"}
+        {"label": "(FR) Unspecified / Other"}
       ]
     },
     "Gender, Sexuality, Sexual Awareness": {
@@ -185,7 +185,7 @@
         {"label": "Sexual fantasy"},
         {"label": "Sexual identity"},
         {"label": "Social Exclusion / Ostracism based on sexual Orientation"},
-        {"label": "Unspecified / Other"}
+        {"label": "(GSSA) Unspecified / Other"}
       ]
     },
     "General/Other": {
@@ -203,7 +203,7 @@
         {"label": "Amputations"},
         {"label": "Breast ironing"},
         {"label": "Burning and branding"},
-        {"label": "Child marriage"},
+        {"label": "(HTP) Child marriage"},
         {"label": "Cutting"},
         {"label": "Dowry related issues"},
         {"label": "Female genital mutilation (FMG)"},
@@ -212,14 +212,14 @@
         {"label": "Honour killing"},
         {"label": "Sex-Selective infanticide"},
         {"label": "Virginity tests"},
-        {"label": "Unspecified / Other"}
+        {"label": "(HTP) Unspecified / Other"}
       ]
     },
     "HIV/AIDS infected/affected children": {
       "color": "#14ffd6",
       "subcategories": [
         {"label": "Access to medication"},
-        {"label": "Bereavement"},
+        {"label": "(HIV) Bereavement"},
         {"label": "Children living with HIV/AIDS"},
         {"label": "Children orphaned due to HIV/AIDS"},
         {"label": "HIV/AIDS prevention"},
@@ -228,7 +228,7 @@
         {"label": "Parents (or family) with HIV/AIDS"},
         {"label": "Pregnancy and HIV"},
         {"label": "Sexual abuse / Rape in relation to HIV"},
-        {"label": "Unspecified / Other"}
+        {"label": "(HIV) Unspecified / Other"}
       ]
     },
     "Homelessness": {
@@ -241,7 +241,7 @@
         {"label": "Orphaned"},
         {"label": "Repatriation"},
         {"label": "Seeking shelter"},
-        {"label": "Unspecified / Other"}
+        {"label": "(H) Unspecified / Other"}
       ]
     },
     "Information Requested": {
@@ -265,7 +265,7 @@
         {"label": "Children in conflict with law"},
         {"label": "Children in need of legal representation"},
         {"label": "Law in conflict with children’s rights"},
-        {"label": "Unspecified / Other"}
+        {"label": "(LM&JJ) Unspecified / Other"}
       ]
     },
     "Parenting and Child Rearing": {
@@ -284,13 +284,13 @@
         {"label": "Parenting"},
         {"label": "Pre-natal care"},
         {"label": "Unmanageable children"},
-        {"label": "Unspecified / Other"}
+        {"label": "(P&CR) Unspecified / Other"}
       ]
     },
     "Peer Relationships": {
       "color": "#9f9f9f",
       "subcategories": [
-        {"label": "Bereavement"},
+        {"label": "(PR) Bereavement"},
         {"label": "Bystander / Third-party concern"},
         {"label": "Making friends"},
         {"label": "Missing friends"},
@@ -300,7 +300,7 @@
         {"label": "Problems with friends"},
         {"label": "Relationship difficulties"},
         {"label": "Sexual pressure from partner"},
-        {"label": "Unspecified / Other"}
+        {"label": "(PR) Unspecified / Other"}
       ]
     },
     "Physical Abuse": {
@@ -326,7 +326,7 @@
         {"label": "Hospitalisation"},
         {"label": "Nutrition"},
         {"label": "In need of medical assistance"},
-        {"label": "Unspecified / Other"}
+        {"label": "(PH&H) Unspecified / Other"}
       ]
     },
     "Psycho-social, Mental Health": {
@@ -349,21 +349,21 @@
         {"label": "Self harm"},
         {"label": "Stress"},
         {"label": "Suicide"},
-        {"label": "Unspecified / Other"}
+        {"label": "(PS&MH) Unspecified / Other"}
       ]
     },
     "School-Related and Education": {
       "color": "#e0ab4f",
       "subcategories": [
         {"label": "Academic problems"},
-        {"label": "Access to education"},
+        {"label": "(SR&E) Access to education"},
         {"label": "Homework"},
         {"label": "Learning disorders"},
         {"label": "Performance anxiety"},
         {"label": "Problems with teachers and school authorities"},
         {"label": "School drop-outs"},
         {"label": "Teacher problems"},
-        {"label": "Unspecified / Other"}
+        {"label": "(SR&E) Unspecified / Other"}
       ]
     },
     "Sexual Abuse": {
@@ -377,12 +377,12 @@
         {"label": "Incest"},
         {"label": "Marital rape"},
         {"label": "Rape"},
-        {"label": "Revenge porn"},
-        {"label": "Sexual abuse"},
+        {"label": "(SA) Revenge porn"},
+        {"label": "(SA) Sexual abuse"},
         {"label": "Sexual exploitation"},
         {"label": "Sexual harassment"},
         {"label": "Sexual violence"},
-        {"label": "Unspecified / Other"}
+        {"label": "(SA) Unspecified / Other"}
       ]
     }
   }

--- a/plugin-hrm-form/src/components/search/SearchForm/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.tsx
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable no-empty-function */
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { ITask, Template } from '@twilio/flex-ui';
 
@@ -82,12 +82,15 @@ const SearchForm: React.FC<Props> = ({
     handleFocus: () => {},
   });
 
-  const showPreviousContactsCheckbox = () => {
+  const [showPreviousContactsCheckbox, setShowPreviousContactsCheckbox] = useState(false);
+  useEffect(() => {
     const contactsCount = previousContacts?.contacts?.count || 0;
     const casesCount = previousContacts?.cases?.count || 0;
-
-    return contactsCount > 0 || casesCount > 0;
-  };
+    if (contactsCount > 0 || casesCount > 0) {
+      setShowPreviousContactsCheckbox(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showPreviousContactsCheckbox]);
 
   const { firstName, lastName, counselor, helpline, phoneNumber, dateFrom, dateTo, contactNumber } = values;
 

--- a/plugin-hrm-form/src/components/search/SearchForm/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.tsx
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable no-empty-function */
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { ITask, Template } from '@twilio/flex-ui';
 
@@ -82,15 +82,11 @@ const SearchForm: React.FC<Props> = ({
     handleFocus: () => {},
   });
 
-  const [showPreviousContactsCheckbox, setShowPreviousContactsCheckbox] = useState(false);
-  useEffect(() => {
+  const showPreviousContactsCheckbox = () => {
     const contactsCount = previousContacts?.contacts?.count || 0;
     const casesCount = previousContacts?.cases?.count || 0;
-    if (contactsCount > 0 || casesCount > 0) {
-      setShowPreviousContactsCheckbox(true);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showPreviousContactsCheckbox]);
+    return contactsCount > 0 || casesCount > 0;
+  };
 
   const { firstName, lastName, counselor, helpline, phoneNumber, dateFrom, dateTo, contactNumber } = values;
 
@@ -229,7 +225,7 @@ const SearchForm: React.FC<Props> = ({
             />
           )}
         </Row>
-        {showPreviousContactsCheckbox && (
+        {showPreviousContactsCheckbox() && (
           <Row>
             <Box marginTop="20px">
               <FormLabel htmlFor="Search_PreviousContacts">

--- a/plugin-hrm-form/src/translations/th-TH/messages.json
+++ b/plugin-hrm-form/src/translations/th-TH/messages.json
@@ -1,6 +1,6 @@
 {
   "WelcomeMsg": "สวัสดีค่ะ มูลนิธิสายเด็ก1387 ยินดีให้บริการค่ะ กรุณาบอกอายุและจังหวัดที่น้องอยู่ค่ะ",
-  "GoodbyeMsg": "The counsellor has left the chat. Thank you for reaching out. Please contact us again if you need more help."
+  "GoodbyeMsg": "พี่ๆ สายเด็กขอบคุณนะคะที่มาใช้บริการ หากมีเรื่องไม่สบายใจ อยากปรึกษา อยากระบาย ทักมาหากันได้เลยนะคะ ตั้งแต่เวลา 06:00-24:00"
 
 
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
- This PR corrects this bug: `showPreviousContactsCheckbox` in its recent change is computing correctly, but not updating when the page loads, showing the Previous Contacts checkbox

### Checklist
- [n/a] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Related Issues
Fixes # https://tech-matters.slack.com/archives/CV4QM23UJ/p1676489031550779

### Verification steps
![Screenshot 2023-02-15 at 3 25 36 PM](https://user-images.githubusercontent.com/102122005/219148754-b92f88fb-aeb2-4ee7-acf6-1161dab3ca59.png)
![Screenshot 2023-02-15 at 3 26 19 PM](https://user-images.githubusercontent.com/102122005/219149709-93e8f1c0-7935-406c-9dd2-7d22c5ed9756.png)
