### PR TITLE
Fix: prevent bell ring for offline contact reservations

### DIFF
--- a/plugin-hrm-form/src/utils/audioNotifications.ts
+++ b/plugin-hrm-form/src/utils/audioNotifications.ts
@@ -17,6 +17,7 @@
 import { StateHelper, Manager, AudioPlayerManager, AudioPlayerError } from '@twilio/flex-ui';
 import { Conversation } from '@twilio/conversations';
 
+import { isTwilioTask } from '../types/types';
 import { getHrmConfig } from '../hrmConfig';
 
 export const subscribeAlertOnConversationJoined = task => {
@@ -104,12 +105,14 @@ const playWhilePending = (reservation: { sid: string; status: string }, notifica
  */
 const notifyReservedTask = reservation => {
   try {
-    const { assetsBucketUrl } = getHrmConfig();
+    if (isTwilioTask(reservation.task)) {
+      const { assetsBucketUrl } = getHrmConfig();
 
-    const notificationTone = 'ringtone';
-    const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
+      const notificationTone = 'ringtone';
+      const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
-    playWhilePending(reservation, notificationUrl);
+      playWhilePending(reservation, notificationUrl);
+    }
   } catch (error) {
     console.error('Error in notifyReservedTask:', error);
   }


### PR DESCRIPTION
## Description
This PR fixes the bug where a ring bell will fire for offline contact generated tasks (reservations actually). 

### Verification steps
Save a few offline contacts and confirm the ring is no more :)