### PR TITLE
Update `fetchApi` to handle plaintext responses

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -178,7 +178,7 @@ describe('saveContact()', () => {
   };
   const workerSid = 'worker-sid';
   const uniqueIdentifier = 'uniqueIdentifier';
-  const fetchSuccess = Promise.resolve(<any>{ ok: true, json: jest.fn() });
+  const fetchSuccess = Promise.resolve(<any>{ ok: true, json: jest.fn(), text: jest.fn() });
 
   test('data calltype saves form data', async () => {
     const form = createForm({ callType: callTypes.child, childFirstName: 'Jill' });
@@ -216,7 +216,7 @@ describe('saveContact() (isContactlessTask)', () => {
   };
   const workerSid = 'worker-sid';
   const uniqueIdentifier = 'uniqueIdentifier';
-  const fetchSuccess = Promise.resolve(<any>{ ok: true, json: jest.fn() });
+  const fetchSuccess = Promise.resolve(<any>{ ok: true, json: jest.fn(), text: jest.fn() });
   let mockedFetch;
 
   beforeEach(() => {
@@ -363,9 +363,11 @@ describe('transformValues', () => {
 
 test('updateContactInHrm - calls a PATCH HRM endpoint using the supplied contact ID in the route', async () => {
   const responseBody = { from: 'HRM' };
-  const mockedFetch = jest
-    .spyOn(global, 'fetch')
-    .mockResolvedValue(<Response>{ ok: true, json: () => Promise.resolve(responseBody) });
+  const mockedFetch = jest.spyOn(global, 'fetch').mockResolvedValue(<Response>{
+    ok: true,
+    json: () => Promise.resolve(responseBody),
+    text: () => Promise.resolve(responseBody),
+  });
   try {
     const inputPatch = { rawJson: { caseInformation: { categories: {} } } };
     const ret = await updateContactInHrm('1234', inputPatch);

--- a/plugin-hrm-form/src/___tests__/services/fetchApi.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/fetchApi.test.ts
@@ -37,6 +37,9 @@ describe('fetchProtectedApi', () => {
         json(): Promise<any> {
           return Promise.resolve(responseBody);
         },
+        text(): Promise<any> {
+          return Promise.resolve(responseBody);
+        },
         ok: true,
         status: 200,
         statusText: 'OK',

--- a/plugin-hrm-form/src/___tests__/services/fetchHrmApi.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/fetchHrmApi.test.ts
@@ -43,6 +43,9 @@ describe('fetchHrmApi', () => {
         json(): Promise<any> {
           return Promise.resolve(responseBody);
         },
+        text(): Promise<any> {
+          return Promise.resolve(responseBody);
+        },
         ok: true,
         status: 200,
         statusText: 'OK',

--- a/plugin-hrm-form/src/___tests__/services/fetchProtectedApi.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/fetchProtectedApi.test.ts
@@ -42,6 +42,9 @@ describe('fetchProtectedApi', () => {
         json(): Promise<any> {
           return Promise.resolve(responseBody);
         },
+        text(): Promise<any> {
+          return Promise.resolve(responseBody);
+        },
         ok: true,
         status: 200,
         statusText: 'OK',

--- a/plugin-hrm-form/src/___tests__/services/fetchResourcesApi.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/fetchResourcesApi.test.ts
@@ -48,6 +48,9 @@ describe('fetchHrmApi', () => {
         json(): Promise<any> {
           return Promise.resolve(responseBody);
         },
+        text(): Promise<any> {
+          return Promise.resolve(responseBody);
+        },
         ok: true,
         status: 200,
         statusText: 'OK',

--- a/plugin-hrm-form/src/services/fetchApi.ts
+++ b/plugin-hrm-form/src/services/fetchApi.ts
@@ -75,10 +75,7 @@ export const fetchApi = async (baseUrl: URL, endpointPath: string, options: Requ
     }
     throw new ApiError(`Error response: ${response.status} (${response.statusText})`, { response, body });
   }
-  let result;
-  try {
-    result = (await response.json()) as Promise<any>;
-  } finally {
-    return result;
-  }
+
+  const contentType = response.headers?.get('Content-Type');
+  return contentType && contentType.includes('json') ? response.json() : response.text();
 };

--- a/plugin-hrm-form/src/services/fetchApi.ts
+++ b/plugin-hrm-form/src/services/fetchApi.ts
@@ -76,6 +76,8 @@ export const fetchApi = async (baseUrl: URL, endpointPath: string, options: Requ
     throw new ApiError(`Error response: ${response.status} (${response.statusText})`, { response, body });
   }
 
-  const contentType = response.headers?.get('Content-Type');
-  return contentType && contentType.includes('json') ? response.json() : response.text();
+  if ((response.headers?.get('Content-Type') ?? '').toLowerCase().includes('json')) {
+    return response.json();
+  }
+  return response.text();
 };

--- a/plugin-hrm-form/src/services/fetchApi.ts
+++ b/plugin-hrm-form/src/services/fetchApi.ts
@@ -75,6 +75,10 @@ export const fetchApi = async (baseUrl: URL, endpointPath: string, options: Requ
     }
     throw new ApiError(`Error response: ${response.status} (${response.statusText})`, { response, body });
   }
-
-  return response.json() as Promise<any>;
+  let result;
+  try {
+    result = (await response.json()) as Promise<any>;
+  } finally {
+    return result;
+  }
 };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
- This PR ensures fall back to parsing the response as plaintext to ensure `fetchApi` handles plaintext response

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Related Issues
Fixes # [1719](https://tech-matters.atlassian.net/browse/CHI-1719)

### Verification steps
1. Receive a contact and fill out all required fields
2. Click on `Add Contact to New Case`
3. Click on `Cancel Contact and Return to Case`
4. Ensure you can see 'Case' view 