### PR TITLE
fix: use regex to split bucket/key to support multiple regions

### DIFF
--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -209,7 +209,7 @@ export const getFileDownloadUrl = async (fileNameAtAws: string, fileName: string
  * Gets a file download url from S3, using the object url as constructed by AWS
  */
 export const getFileDownloadUrlFromUrl = async (objectUrl: string, fileName: string = undefined) => {
-  let [bucketName, fileNameAtAws] = objectUrl.replace('https://', '').split('.s3.amazonaws.com/');
+  let [bucketName, fileNameAtAws] = objectUrl.replace('https://', '').split(/\.s3\.(.*)?amazonaws.com\//);
 
   // TODO: this allows localstack which uses path style s3 urls, I don't like it being quite so specific, but it works for now.
   if (!bucketName || !fileNameAtAws) {


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

Uses regex to split s3 url for transcripts fetch.

### Checklist
- [ ] Corresponding issue has been opened
- [ n/a ] New tests added
- [ n/a ] Feature flags added
- [ n/a ] Strings are localized
- [ ] Tested for chat contacts
- [ n/a ] Tested for call contacts

### Related Issues
Fixes CHI-1671

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->