### PR TITLE
fix download error for non-ascii encodings

### DIFF
--- a/plugin-hrm-form/src/components/common/forms/DownloadFile.tsx
+++ b/plugin-hrm-form/src/components/common/forms/DownloadFile.tsx
@@ -34,6 +34,7 @@ const DownloadFile: React.FC<Props> = ({ fileNameAtAws }) => {
   useEffect(() => {
     if (preSignedUrl) {
       downloadLink.current.click();
+      URL.revokeObjectURL(preSignedUrl);
     }
   }, [preSignedUrl, downloadLink]);
 

--- a/plugin-hrm-form/src/components/common/forms/DownloadFile.tsx
+++ b/plugin-hrm-form/src/components/common/forms/DownloadFile.tsx
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable react/prop-types */
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import DownloadIcon from '@material-ui/icons/GetApp';
 import { Template } from '@twilio/flex-ui';
 
@@ -28,35 +28,39 @@ type Props = {
 };
 
 const DownloadFile: React.FC<Props> = ({ fileNameAtAws }) => {
+  const [preSignedUrl, setPreSignedUrl] = useState('');
+  const downloadLink = useRef<HTMLAnchorElement>();
+
+  useEffect(() => {
+    if (preSignedUrl) {
+      downloadLink.current.click();
+    }
+  }, [preSignedUrl, downloadLink]);
+
   const fileName = formatFileNameAtAws(fileNameAtAws);
 
-  const downloadFile = async (filename: string) => {
-    const encodedFilename = encodeURIComponent(filename);
+  const handleClick = async () => {
+    const encodedFilename = encodeURIComponent(fileName);
     const fileUrl = await getFileDownloadUrl(fileNameAtAws, encodedFilename);
     const response = await fetch(fileUrl.downloadUrl);
 
     const blob = await response.blob();
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-
-    a.style.display = 'none';
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    setPreSignedUrl(url);
   };
-
   return (
     <Flex flexDirection="column" alignItems="flex-start">
       <Box marginBottom="5px">
-        <StyledNextStepButton secondary onClick={() => downloadFile(fileName)}>
+        <StyledNextStepButton secondary onClick={handleClick}>
           <DownloadIcon style={{ fontSize: '20px', marginRight: 5 }} />
           <Template code="DownloadFile-ButtonText" />
         </StyledNextStepButton>
       </Box>
       {fileName}
+      <HiddenText>
+        {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
+        <a aria-hidden="true" href={preSignedUrl} ref={downloadLink} download={fileName} />
+      </HiddenText>
     </Flex>
   );
 };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Bug fix: fix download error when downloading attachment with non-ascii encodings file name
### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Feature flags added
- [N/A] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes C˝HI-1713

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
- Navigate to Cases
- Select a Case that was created by you
- Scroll down to Document
- Add and upload a file  (files that are named both in English and any other language - Thai, for example)
- Go back to Case and click to view a downloaded file
- Download file
