### PR TITLE
Terraform linting and security tools

### DIFF
--- a/twilio-iac/.tflint.hcl
+++ b/twilio-iac/.tflint.hcl
@@ -1,0 +1,6 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" { enabled = true }

--- a/twilio-iac/makefiles/terraform.make
+++ b/twilio-iac/makefiles/terraform.make
@@ -20,5 +20,5 @@ destroy:
 validate:
 	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) terraform validate $(tf_args)
 
-lint:
-	docker run -it --rm -v $(MY_PWD):/data -e TFLINT_LOG=warn --entrypoint '' -w /data/$(MY_ENV) wata727/tflint tflint --module .
+fmt:
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) terraform fmt $(tf_args)

--- a/twilio-iac/makefiles/test.make
+++ b/twilio-iac/makefiles/test.make
@@ -1,0 +1,7 @@
+lint: fmt tflint tfsec
+
+tflint:
+	docker run -it --rm -v $(MY_PWD)/twilio-iac:/data -e TFLINT_LOG=warn ghcr.io/terraform-linters/tflint-bundle --recursive
+
+tfsec:
+	docker run -it --rm -v $(MY_PWD)/twilio-iac:/src aquasec/tfsec /src

--- a/twilio-iac/makefiles/test.make
+++ b/twilio-iac/makefiles/test.make
@@ -1,4 +1,10 @@
-lint: fmt tflint tfsec
+lint: fmt-check tflint tfsec
+
+fmt-check:
+	docker run -it --rm -v $(MY_PWD)/twilio-iac:/app $(DOCKER_IMAGE):$(TF_VER) terraform fmt -recursive -write=false -diff $(tf_args)
+
+fmt-fix:
+	docker run -it --rm -v $(MY_PWD)/twilio-iac:/app $(DOCKER_IMAGE):$(TF_VER) terraform fmt -recursive $(tf_args)
 
 tflint:
 	docker run -it --rm -v $(MY_PWD)/twilio-iac:/data -e TFLINT_LOG=warn ghcr.io/terraform-linters/tflint-bundle --recursive

--- a/twilio-iac/terraform-poc-account/main.tf
+++ b/twilio-iac/terraform-poc-account/main.tf
@@ -87,7 +87,6 @@ module flex {
   operating_info_key = var.operating_info_key
   permission_config = "zm"
   definition_version = var.definition_version
-  serverless_url = module.serverless.serverless_environment_production_url
   hrm_url = "https://hrm-development-eu.tl.techmatters.org"
   multi_office_support = var.multi_office
   feature_flags = var.feature_flags


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

This adds some common terraform linting and security tools to the makefile configuration. They generate a *lot* of output right now and it will be a massive change set to fix everything they find. I'm adding this for team insight. We should probably plan to slowly introduce each of these tools into our CI/CD process and do the code cleanup at some point during future lulls in active TF development.

The suggested order of rollout:

1. fmt-check/fmt-fix since this will fix issues automatically.
2. tflint will require manual changes
3. tfsec will require manual changes.

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

From any terraform helpline directory run the following (these run global checks even though you are in a specific start directory):

```
make fmt-check
make tflint
make tfsec
```
