### PR TITLE
Handles EmojiPicker initial state on narrow screens

### DIFF
--- a/plugin-hrm-form/src/components/emojiPicker/index.tsx
+++ b/plugin-hrm-form/src/components/emojiPicker/index.tsx
@@ -52,6 +52,7 @@ const EmojiPicker: React.FC<TaskContextProps & ConnectedProps<typeof connector>>
   const [inputText, setInputText] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [emojisPerLine, setEmojisPerLine] = useState(EMOJIS_PER_LINE_DEFAULT);
+  const [firstTimeOpen, setFirstTimeOpen] = useState(false); // Tracks if the EmojiPicker was opened for the first time
 
   const { blockedEmojis } = definitionVersion ?? { blockedEmojis: [] };
   const conversationSid = getConversationSid(task);
@@ -87,13 +88,28 @@ const EmojiPicker: React.FC<TaskContextProps & ConnectedProps<typeof connector>>
     };
     const manager = Manager.getInstance();
     manager.events.addListener('flexSplitterResize', messagingCanvasResizeListener);
+    window.addEventListener('resize', messagingCanvasResizeListener);
+
+    /**
+     * Call once here to handle the initial state where the
+     * default screen width is small.
+     */
+    messagingCanvasResizeListener();
 
     return () => {
       manager.events.removeListener('flexSplitterResize', messagingCanvasResizeListener);
+      window.removeEventListener('resize', messagingCanvasResizeListener);
     };
-  }, []);
+  }, [firstTimeOpen]);
 
-  const togglePicker = () => setIsOpen(isOpen => !isOpen);
+  const togglePicker = () => {
+    if (!firstTimeOpen) {
+      setFirstTimeOpen(true);
+    }
+
+    setIsOpen(isOpen => !isOpen);
+  };
+
   const handleClickOutside = () => isOpen && setIsOpen(false);
 
   /**


### PR DESCRIPTION
## Description
The EmojiPicker was previously resized when the panel was resized (listener).
But this didn't cover the scenario where the initial state the screen width was small: it needed a resize event until the EmojiPicker width was recalculated.

This PR does 2 things to fix that and make it more robust:
- Triggers the EmojiPicker resize function the first time it's opened
- Also listens to `window.resize` event (not only Twilio's one)

### Related Issues
Fixes https://tech-matters.atlassian.net/browse/CHI-1770

### Verification steps
1) Make the screen very narrow
2) Accept a chat task
3) Open EmojiPicker and check it's not cut/hidden (without resizing the panel or the screen)