### PR TITLE
Hangup call before dropping rejected transfer

### DIFF
--- a/plugin-hrm-form/src/utils/transfer.ts
+++ b/plugin-hrm-form/src/utils/transfer.ts
@@ -15,7 +15,7 @@
  */
 
 // eslint-disable-next-line no-unused-vars
-import { Actions, ITask, TaskHelper, StateHelper } from '@twilio/flex-ui';
+import { Actions, ITask, TaskHelper } from '@twilio/flex-ui';
 
 import { transferStatuses, transferModes } from '../states/DomainConstants';
 import { CustomITask, isOfflineContactTask, isTwilioTask } from '../types/types';
@@ -177,8 +177,9 @@ export const closeCallOriginal = async (task: ITask) => {
  * @param {ITask} task
  * @returns {Promise<void>}
  */
-export const closeCallSelf = async (task: ITask) => {
+export const closeCallSelf = async (task: ITask): Promise<void> => {
   await setTransferRejected(task);
   await returnTaskControl(task);
+  await Actions.invokeAction('HangupCall', { sid: task.sid });
   await Actions.invokeAction('CompleteTask', { sid: task.sid });
 };


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/serverless/pull/426

## Description
This PR fixes the bug where warm transfers are unable to reject transfer (see ticket below). This issue does not occurs when the transfer-target worker rejects the initial reservation, but when joins the call and then hits the "Reject Transfer" button. The fix is pretty simple: before completing the task that links the conference, invoke a "Hangup" action.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1729)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Verification steps
Follow the reproduction steps in the ticket and confirm that the behavior is now the expected one.