### PR TITLE
CHI-1602: Migrate resources UI to call CloudSearch endpoint

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ResourcesService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ResourcesService.test.ts
@@ -31,10 +31,10 @@ test('getResource - GET /resource/{id}', () => {
 
 test('searchResources - POST /search?start={start}&limit={limit}', () => {
   mockFetchResourcesApi.mockResolvedValue({});
-  const params = { nameSubstring: 'bob', ids: ['anna'] };
+  const params = { generalSearchTerm: 'bob' };
   searchResources(params, 1337, 42);
   expect(mockFetchResourcesApi).toHaveBeenCalledWith('search?start=1337&limit=42', {
     method: 'POST',
-    body: JSON.stringify(params),
+    body: JSON.stringify({ ...params, filters: {} }),
   });
 });

--- a/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
@@ -55,7 +55,7 @@ const nonInitialState: ReferrableResourceSearchState = {
   currentPage: 2,
   status: ResourceSearchStatus.ResultPending,
   parameters: {
-    omniSearchTerm: 'something else',
+    generalSearchTerm: 'something else',
     filters: { some: 'other filter' },
     pageSize: 2,
   },
@@ -77,32 +77,14 @@ describe('actions', () => {
     });
 
     test('Calls the searchResources service, calculating the start index from the provided page & limit', () => {
-      searchResourceAsyncAction({ omniSearchTerm: 'hello', pageSize: 42 }, 1337, true);
-      expect(searchResources).toHaveBeenCalledWith({ nameSubstring: 'hello', ids: [] }, 1337 * 42, 42);
-    });
-
-    test('Semicolons in omniSearch term - splits on semicolon, first term is name, subsequent are IDs', () => {
-      searchResourceAsyncAction({ omniSearchTerm: 'hello;how;are;you;today', pageSize: 42 }, 1337, true);
-      expect(searchResources).toHaveBeenCalledWith(
-        { nameSubstring: 'hello', ids: ['how', 'are', 'you', 'today'] },
-        1337 * 42,
-        42,
-      );
-    });
-
-    test('Starts with semicolon in omniSearch term - splits on semicolon, all terms are IDs', () => {
-      searchResourceAsyncAction({ omniSearchTerm: ';hello;how;are;you;today', pageSize: 42 }, 1337, true);
-      expect(searchResources).toHaveBeenCalledWith(
-        { nameSubstring: '', ids: ['hello', 'how', 'are', 'you', 'today'] },
-        1337 * 42,
-        42,
-      );
+      searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 42 }, 1337, true);
+      expect(searchResources).toHaveBeenCalledWith({ generalSearchTerm: 'hello' }, 1337 * 42, 42);
     });
 
     test("'newSearch' flag set - dispatches pending action that resets the result array and sets status to ResultPending", async () => {
       const { dispatch, getState } = testStore({ results: [null, null, null] });
       const startingState = getState();
-      dispatch(searchResourceAsyncAction({ omniSearchTerm: 'hello', pageSize: 42 }, 1337, true));
+      dispatch(searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 42 }, 1337, true));
       const state = getState();
       expect(state).toStrictEqual({ ...startingState, status: ResourceSearchStatus.ResultPending, results: [] });
     });
@@ -110,7 +92,7 @@ describe('actions', () => {
     test("'newSearch' flag not set - dispatches pending action that sets status to ResultPending but leaves results array as is", async () => {
       const { dispatch, getState } = testStore({ results: [null, null, null] });
       const startingState = getState();
-      dispatch(searchResourceAsyncAction({ omniSearchTerm: 'hello', pageSize: 42 }, 1337, false));
+      dispatch(searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 42 }, 1337, false));
       const state = getState();
       expect(state).toStrictEqual({ ...startingState, status: ResourceSearchStatus.ResultPending });
     });
@@ -126,7 +108,7 @@ describe('actions', () => {
         const { dispatch, getState } = testStore({ results: [null, null, null] });
         const startingState = getState();
         const dispatchPromise = (dispatch(
-          searchResourceAsyncAction({ omniSearchTerm: 'hello', pageSize: 2 }, 0),
+          searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 2 }, 0),
         ) as unknown) as PromiseLike<unknown>;
         const pendingState = getState();
         expect(pendingState).toStrictEqual({
@@ -248,7 +230,7 @@ describe('actions', () => {
         });
         const startingState = getState();
         await ((dispatch(
-          searchResourceAsyncAction({ omniSearchTerm: 'hello', pageSize: 2 }, 1, newSearch),
+          searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 2 }, 1, newSearch),
         ) as unknown) as PromiseLike<unknown>);
         const fulfilledState = getState();
         expect(fulfilledState).toStrictEqual({
@@ -268,7 +250,7 @@ describe('actions', () => {
         });
         const { dispatch, getState } = testStore({ results: [] });
         await ((dispatch(
-          searchResourceAsyncAction({ omniSearchTerm: 'hello', pageSize: 2 }, 0),
+          searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 2 }, 0),
         ) as unknown) as PromiseLike<unknown>);
         const fulfilledState = getState();
         expect(fulfilledState.results.length).toBeLessThan(50000);
@@ -289,7 +271,7 @@ describe('actions', () => {
         const startingState = getState();
         try {
           await ((dispatch(
-            searchResourceAsyncAction({ omniSearchTerm: 'hello', pageSize: 2 }, 0),
+            searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 2 }, 0),
           ) as unknown) as PromiseLike<unknown>);
         } catch {
           // Error still bubbles up so need to swallow it
@@ -316,7 +298,7 @@ describe('actions', () => {
         const startingState = getState();
         try {
           await ((dispatch(
-            searchResourceAsyncAction({ omniSearchTerm: 'hello', pageSize: 2 }, 0, false),
+            searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 2 }, 0, false),
           ) as unknown) as PromiseLike<unknown>);
         } catch {
           // Error still bubbles up so need to swallow it
@@ -334,7 +316,7 @@ describe('actions', () => {
   describe('updateSearchFormAction', () => {
     test('Updates search form parameters with those specified in the action payload, leaving the rest of the search state as was', () => {
       const updatedParameters: SearchSettings = {
-        omniSearchTerm: 'something else',
+        generalSearchTerm: 'something else',
         filters: { some: 'other filter' },
         pageSize: 10,
       };
@@ -352,12 +334,12 @@ describe('actions', () => {
 
       const { dispatch, getState } = testStore({
         ...nonInitialState,
-        parameters: { omniSearchTerm: 'something', filters: { some: 'filter' }, pageSize: 5 },
+        parameters: { generalSearchTerm: 'something', filters: { some: 'filter' }, pageSize: 5 },
       });
       dispatch(updateSearchFormAction(updatedParameters));
       expect(getState()).toStrictEqual({
         ...nonInitialState,
-        parameters: { omniSearchTerm: 'something', filters: { some: 'filter' }, pageSize: 10 },
+        parameters: { generalSearchTerm: 'something', filters: { some: 'filter' }, pageSize: 10 },
       });
     });
     test('Fully replaces filters, removes all existing ones', () => {
@@ -365,12 +347,15 @@ describe('actions', () => {
         filters: { other: 'setting' },
       };
       const newState = resourceSearchReducer(
-        { ...nonInitialState, parameters: { omniSearchTerm: 'something', filters: { some: 'filter' }, pageSize: 5 } },
+        {
+          ...nonInitialState,
+          parameters: { generalSearchTerm: 'something', filters: { some: 'filter' }, pageSize: 5 },
+        },
         updateSearchFormAction(updatedParameters),
       );
       expect(newState).toStrictEqual({
         ...nonInitialState,
-        parameters: { omniSearchTerm: 'something', filters: { other: 'setting' }, pageSize: 5 },
+        parameters: { generalSearchTerm: 'something', filters: { other: 'setting' }, pageSize: 5 },
       });
     });
   });

--- a/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
@@ -38,9 +38,9 @@ import asyncDispatch from '../../../states/asyncDispatch';
 type OwnProps = {};
 
 const mapStateToProps = (state: RootState) => {
-  const { omniSearchTerm, pageSize } = state[namespace][referrableResourcesBase].search.parameters;
+  const { generalSearchTerm, pageSize } = state[namespace][referrableResourcesBase].search.parameters;
   return {
-    omniSearchTerm,
+    generalSearchTerm,
     pageSize,
   };
 };
@@ -48,9 +48,10 @@ const mapStateToProps = (state: RootState) => {
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
   const searchAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
   return {
-    updateOmiSearchTerm: (omniSearchTerm: string) => dispatch(updateSearchFormAction({ omniSearchTerm })),
+    updateOmiSearchTerm: (omniSearchTerm: string) =>
+      dispatch(updateSearchFormAction({ generalSearchTerm: omniSearchTerm })),
     submitSearch: (omniSearchTerm: string, pageSize: number) =>
-      searchAsyncDispatch(searchResourceAsyncAction({ omniSearchTerm, pageSize }, 0)),
+      searchAsyncDispatch(searchResourceAsyncAction({ generalSearchTerm: omniSearchTerm, pageSize }, 0)),
     resetSearch: () => dispatch(resetSearchFormAction()),
   };
 };

--- a/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
@@ -48,10 +48,9 @@ const mapStateToProps = (state: RootState) => {
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
   const searchAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
   return {
-    updateOmiSearchTerm: (omniSearchTerm: string) =>
-      dispatch(updateSearchFormAction({ generalSearchTerm: omniSearchTerm })),
-    submitSearch: (omniSearchTerm: string, pageSize: number) =>
-      searchAsyncDispatch(searchResourceAsyncAction({ generalSearchTerm: omniSearchTerm, pageSize }, 0)),
+    updateGeneralSearchTerm: (generalSearchTerm: string) => dispatch(updateSearchFormAction({ generalSearchTerm })),
+    submitSearch: (generalSearchTerm: string, pageSize: number) =>
+      searchAsyncDispatch(searchResourceAsyncAction({ generalSearchTerm, pageSize }, 0)),
     resetSearch: () => dispatch(resetSearchFormAction()),
   };
 };
@@ -61,9 +60,9 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const SearchResourcesForm: React.FC<Props> = ({
-  omniSearchTerm,
+  generalSearchTerm,
   pageSize,
-  updateOmiSearchTerm,
+  updateGeneralSearchTerm,
   submitSearch,
   resetSearch,
 }) => {
@@ -80,11 +79,11 @@ const SearchResourcesForm: React.FC<Props> = ({
           </Box>
           <SearchInput
             label={strings['Resources-SearchForm-OmniSearchLabel']}
-            searchTerm={omniSearchTerm}
+            searchTerm={generalSearchTerm}
             innerRef={firstElement}
-            onChangeSearch={event => updateOmiSearchTerm(event.target.value)}
+            onChangeSearch={event => updateGeneralSearchTerm(event.target.value)}
             clearSearchTerm={() => {
-              updateOmiSearchTerm('');
+              updateGeneralSearchTerm('');
             }}
             onShiftTab={() => {
               /**/
@@ -102,7 +101,11 @@ const SearchResourcesForm: React.FC<Props> = ({
         >
           <Template code="Resources-Search-ClearFormButton" />
         </StyledNextStepButton>
-        <StyledNextStepButton type="button" roundCorners={true} onClick={() => submitSearch(omniSearchTerm, pageSize)}>
+        <StyledNextStepButton
+          type="button"
+          roundCorners={true}
+          onClick={() => submitSearch(generalSearchTerm, pageSize)}
+        >
           <Template code="SearchForm-Button" />
         </StyledNextStepButton>
       </BottomButtonBar>

--- a/plugin-hrm-form/src/services/ResourceService.ts
+++ b/plugin-hrm-form/src/services/ResourceService.ts
@@ -59,18 +59,17 @@ export const getResource = async (resourceId: string): Promise<ReferrableResourc
 };
 
 type SearchParameters = {
-  nameSubstring: string;
-  ids: string[];
+  generalSearchTerm: string;
 };
 
 export const searchResources = async (
-  parameters: SearchParameters,
+  { generalSearchTerm }: SearchParameters,
   start: number,
   limit: number,
 ): Promise<{ totalCount: number; results: ReferrableResource[] }> => {
   const fromApi = await fetchResourceApi(`search?start=${start}&limit=${limit}`, {
     method: 'POST',
-    body: JSON.stringify(parameters),
+    body: JSON.stringify({ generalSearchTerm, filters: {} }),
   });
   return {
     ...fromApi,

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -32,7 +32,7 @@ export enum ResourceSearchStatus {
 export type ReferrableResourceSearchState = {
   // eslint-disable-next-line prettier/prettier
   parameters: {
-    omniSearchTerm: string;
+    generalSearchTerm: string;
     filters: Record<string, any>;
     pageSize: number;
   };
@@ -46,7 +46,7 @@ export type ReferrableResourceSearchState = {
 export const initialState: ReferrableResourceSearchState = {
   parameters: {
     filters: {},
-    omniSearchTerm: '',
+    generalSearchTerm: '',
     pageSize: 5,
   },
   currentPage: 0,
@@ -81,10 +81,9 @@ const SEARCH_ACTION = 'resource-action/search';
 export const searchResourceAsyncAction = createAsyncAction(
   SEARCH_ACTION,
   async (parameters: SearchSettings, page: number) => {
-    const { pageSize, omniSearchTerm } = parameters;
-    const [nameSubstring, ...ids] = omniSearchTerm.split(';');
+    const { pageSize, generalSearchTerm } = parameters;
     const start = page * pageSize;
-    return { ...(await searchResources({ nameSubstring, ids }, start, pageSize)), start };
+    return { ...(await searchResources({ generalSearchTerm }, start, pageSize)), start };
   },
   ({ pageSize }: SearchSettings, page: number, newSearch: boolean = true) => ({ newSearch, start: page * pageSize }),
   // { promiseTypeDelimiter: '/' }, // Doesn't work :-(

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -410,7 +410,7 @@
   "Resources-LoadResourceError": "Something went wrong trying to load this resource.",
   "Resources-Search-FormTitle": "Search for Resources",
   "Resources-Search-ResultsTitle": "Search Results",
-  "Resources-Search-ResultsDescription": "Showing {{count}} results for <span style=\"font-weight:800\">\"{{omniSearchTerm}}\"</span>",
+  "Resources-Search-ResultsDescription": "Showing {{count}} results for <span style=\"font-weight:800\">\"{{generalSearchTerm}}\"</span>",
   "Resources-Search-ClearFormButton": "Clear Form",
   "Resources-ResourceSearchError": "Something went wrong trying to search for resources."
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description

* Migrates the flex resources client to use the payload expected by the new CloudSearch powered resource search endpoint
* Renames internal variables that include 'omnisearch' to use the term 'general search' instead 

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A (all behind an overall resource feature flag prior to v1) Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-1602

### Verification steps

Regression test search endpoint (it should be able to search on resource information as well as name now)