### PR TITLE
CHI-1569 update deploy-scripts to support terragrunt

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -98,7 +98,7 @@ The script doesn't scan provided terraform variables automatically for its own u
 
 #### Example
 
-`npm run twilioResources -- import-tf -hd=a-helpline-staging ./terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/main.tf --sid var.bot_sid=UAxxx -m chatbots.custom_pre_survey_task[0] -v private.tfvars`
+`npm run twilioResources -- import-tf --helplineDirectory=a-helpline-staging ./terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/main.tf --sid var.bot_sid=UAxxx -m chatbots.custom_pre_survey_task[0] -v private.tfvars`
 
 The above command was used in the following scenario:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,7 @@
 # Scripts
 
 ## Scripts index
+
 - [generateDeploymentFiles](#generateDeploymentFiles)
 - [copyFlow](#copyFlow)
 - [generateNewHelplineFormDefinitions](#generateNewHelplineFormDefinitions)
@@ -11,59 +12,66 @@
   - [patch-feature-flags](#patch-feature-flags)
 
 ## generateDeploymentFiles
+
 This script generates deployment files for `flex-plugins` and `serverless` repos.
 These files file be generated at the root folder:
+
 - `new-flex-plugins-workflow.yml`
 - `new-serverless-workflow.yml`
 
 If the template files (files inside the `template/` folder) are out of sync with Aselo Development deployment workflow files, the script will abort in order to prevent generating old version of workflows (manually disable this check if you are sure that you want the template version).
 
 To run the script:
+
 - Create a `.env` file and fill it with the proper values (see next section).
 - Install dependencies with `npm install`.
 - Run `npm run generateDeploymentFiles` on the root folder.
 
 To run this script we need to provide the following environment
-| Variable               | Description |
+| Variable | Description |
 |------------------------|-------------|
-| HELPLINE               | Helpline's friendly name (e.g. South Africa Helpline) |
-| SHORT_HELPLINE         | Short code for this helpline (e.g. ZA) |
-| ENVIRONMENT            | Target environment, one of Development, Staging or Production |
+| HELPLINE | Helpline's friendly name (e.g. South Africa Helpline) |
+| SHORT_HELPLINE | Short code for this helpline (e.g. ZA) |
+| ENVIRONMENT | Target environment, one of Development, Staging or Production |
 
 ## copyFlow
+
 This script copies over the config of a studio flow from one account to another. Is mainly used to create Messaging Flow when setting up a new helpline, but it can be tweeked to support updating other workflows.
 
 To run the script:
+
 - Create a `.env` file and fill it with the proper values (see next section).
 - Install dependencies with `npm install`.
 - Run `npm run copyFlow` on the root folder.
 
 To run this script we need to provide the following environment
-| Variable               | Description |
+| Variable | Description |
 |------------------------|-------------|
 | TWILIO_ACCOUNT_SID_SOURCE | Twilio account sid of the account that contains the desired Studio Flow |
-| TWILIO_AUTH_TOKEN_SOURCE  | Auth token of the account that contains the desired Studio Flow |
-| FLOW_TO_COPY              | Studio Flow sid to be copied over |
+| TWILIO_AUTH_TOKEN_SOURCE | Auth token of the account that contains the desired Studio Flow |
+| FLOW_TO_COPY | Studio Flow sid to be copied over |
 | TWILIO_ACCOUNT_SID_DESTINATION | Twilio account sid of the account where the Flow should be copied to |
 | TWILIO_AUTH_TOKEN_DESTINATION | Auth token of the account where the Flow should be copied to |
 
-
 ## generateNewHelplineFormDefinitions
+
 This script will generate a new set of form definitions for a helpline with a sensible starting point of default JSON ready to be customised for a specific helpline
 
 To run the script:
+
 ```shell
 npm install
 npm run generateNewHelplineFormDefinitions <helpline> [-f] [-r rootDirectory]
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| helpline  | The helpline code, normally a 2 letter code, a dash and then the version prefixed by a 'v', e.g. `za-v1`. This is the name of the directory that will be created to put all the generated definitions under. |
-| -r, --root | Root directory. If omitted it will put them in `[REPO ROOT]/hrm-form-definitions/form-definitions`, which is where they need to go to be used in the plugin. If you need to generate them elsewhere, for testing for example, specifiy a relative or absolute local path using this option |
+| Parameter   | Description                                                                                                                                                                                                                                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| helpline    | The helpline code, normally a 2 letter code, a dash and then the version prefixed by a 'v', e.g. `za-v1`. This is the name of the directory that will be created to put all the generated definitions under.                                                                                                       |
+| -r, --root  | Root directory. If omitted it will put them in `[REPO ROOT]/hrm-form-definitions/form-definitions`, which is where they need to go to be used in the plugin. If you need to generate them elsewhere, for testing for example, specifiy a relative or absolute local path using this option                         |
 | -f, --force | By default, if the script detects the helpline directory it's about to create already exists, it will warn you and ask permission to continue (because any files with the same name will be overwritten if you proceed). Specifying this option supresses that prompt and overwrites automatically, use with care! |
 
 ## twilioResources
+
 A collection of commands to assist managing twilio resources in Terraform - primarily to assist in ensuring that the Terraform tfstate reflects the real state of the Twilio resources on the account.
 
 Each command has --help docs for specific information about how to use each parameter, the descriptions here provide a more general context & describe typical use cases.
@@ -79,18 +87,18 @@ Using this script as part of setting up a new account is described in /twilio-ia
 
 ### import-tf
 
-Takes a single *.tf Terraform configuration file and scans the resources defined in there. It will then search for those resources in the Twilio account you provide credentials for and if it finds them, imports them into the `tfstate` for this configuration.
+Takes a single \*.tf Terraform configuration file and scans the resources defined in there. It will then search for those resources in the Twilio account you provide credentials for and if it finds them, imports them into the `tfstate` for this configuration.
 
 Its use cases are those which involve trying to import large amounts of resources that are defined in configuration, already exist on the account, but aren't in the `tfstate`.
 Importing existing, non-terraform managed accounts into Terraform is one use case, but also importing significant additions made to staging accounts outside Terraform would be another (I used it to import the SafeSpot 'which district?' autopilot question, which would have been time-consuming otherwise).
 In both of these use cases, the Terraform resources would need to have been configured in the `*.tf` files prior to using this command to update the state, naturally.
 
-*Note:* You STILL need to pass any SIDs that come from variables in using an `--sid` parameter, even if they are defined in the `tfvars` file you pass in with `-v`or as a `TF_VARS_*` environment variable.
+_Note:_ You STILL need to pass any SIDs that come from variables in using an `--sid` parameter, even if they are defined in the `tfvars` file you pass in with `-v`or as a `TF_VARS_*` environment variable.
 The script doesn't scan provided terraform variables automatically for its own use, it just passes the `*.tfvars` file you specify down to the `terraform import` command. It could be enhanced to do this if needed, but doesn't right now.
 
 #### Example
 
-`npm run twilioResources -- import-tf a-helpline-staging ./terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/main.tf --sid var.bot_sid=UAxxx -m chatbots.custom_pre_survey_task[0] -v private.tfvars`
+`npm run twilioResources -- import-tf -hd=a-helpline-staging ./terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/main.tf --sid var.bot_sid=UAxxx -m chatbots.custom_pre_survey_task[0] -v private.tfvars`
 
 The above command was used in the following scenario:
 
@@ -108,14 +116,15 @@ _(these would typically be set anyway if you are running Aselo's Twilio terrafor
 
 Parameters:
 
--------------------------------------------------
-| Parameter                | Meaning            |
-|--------------------------|--------------------|
-| `a-helpline-staging` | The directory, located under `/twilio-iac/` where the helpline's configuration is located |
-| `./terraform-modules/chatbots/terraform-modules/pre-survey-task/a-helpline/main.tf` | The *.tf file we are basing our imports on, relative to `/twilio-iac/`, not the CWD. |
-| `--sid var.bot_sid=UAxxx` | The `--sid` parameter is a way of providing external variables required by the module. In this case, the `pre-survey-task` modules take a variable called `bot_sid` (`./terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/variables.tf`). This needs to be provided in the form `var.<variable_name>=<variable.value>`. The `--sid` parameter can be repeated as often as required, e.g. `--sid var.a=b --sid var.c=d --sid var.e=f ...` |
-| `-m chatbots.custom_pre_survey_task[0]` | This is the path to the module within the configuration structure of the target helpline. Note that `custom_pre_survey_task` specifies index 0. This is because the idiomatic way to conditionally include a module is via the 'count' property of a module being set to 1 or 0 based on conditional logic. This technically turns it into a list of modules with a single element, rather than a single module. As such any modules included conditionally will need the `[0]` qualifier |
-| `-v private.tfvars` | This specifies a tfvars file relative to the configuration directory specified in the first parameter (so this means `/twilio-iac/a-helpline/private.tfvars`). This is currently ONLY used to pass into the `terraform import` commands the script initiates, it is NOT a substitrute for `--sid` parameters. If a variable is used in the .tf file, it still needs an `--sid` parameter to specify if whether it is present in the tfvars file specified here or not |
+---
+
+| Parameter                                                                           | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a-helpline-staging`                                                                | The directory, located under `/twilio-iac/` where the helpline's configuration is located                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `./terraform-modules/chatbots/terraform-modules/pre-survey-task/a-helpline/main.tf` | The \*.tf file we are basing our imports on, relative to `/twilio-iac/`, not the CWD.                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `--sid var.bot_sid=UAxxx`                                                           | The `--sid` parameter is a way of providing external variables required by the module. In this case, the `pre-survey-task` modules take a variable called `bot_sid` (`./terraform-modules/chatbots/terraform-modules/pre-survey-task/safespot/variables.tf`). This needs to be provided in the form `var.<variable_name>=<variable.value>`. The `--sid` parameter can be repeated as often as required, e.g. `--sid var.a=b --sid var.c=d --sid var.e=f ...`                              |
+| `-m chatbots.custom_pre_survey_task[0]`                                             | This is the path to the module within the configuration structure of the target helpline. Note that `custom_pre_survey_task` specifies index 0. This is because the idiomatic way to conditionally include a module is via the 'count' property of a module being set to 1 or 0 based on conditional logic. This technically turns it into a list of modules with a single element, rather than a single module. As such any modules included conditionally will need the `[0]` qualifier |
+| `-v private.tfvars`                                                                 | This specifies a tfvars file relative to the configuration directory specified in the first parameter (so this means `/twilio-iac/a-helpline/private.tfvars`). This is currently ONLY used to pass into the `terraform import` commands the script initiates, it is NOT a substitrute for `--sid` parameters. If a variable is used in the .tf file, it still needs an `--sid` parameter to specify if whether it is present in the tfvars file specified here or not                     |
 
 #### --dryRun / -d
 
@@ -130,13 +139,16 @@ It will create the file locally, so you need to grab it and drop it where it mak
 
 You need to have `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` environment variables set (either passed in the command itself or in a `.env` file).
 You also must provide the following parameters to the script:
-  - `assistantSid`: Target chatbot's assistant sid to generate the .tf from.
-  - `referenceName`: The reference name that will be used as the top level resource (the name of the assistant resource in the .tf file).
-  - `serverlessUrl`: \[optional\] The serverless url of the account. If present, will replace it for the dynamic form in the .tf file.
-Example:
+
+- `assistantSid`: Target chatbot's assistant sid to generate the .tf from.
+- `referenceName`: The reference name that will be used as the top level resource (the name of the assistant resource in the .tf file).
+- `serverlessUrl`: \[optional\] The serverless url of the account. If present, will replace it for the dynamic form in the .tf file.
+  Example:
+
 ```
 ➜ npm run twilioResources -- generate-chatbot-tf --assistantSid=UAxxxxxxxxxxxx --referenceName=my_custom_bot --serverlessUrl=https://serverless-xxxx-production.twil.io
 ```
+
 will create a new file `my_custom_bot.tf` that contains the definition of the bot with the sid `UAxxxxxxxxxxxx`, and will replace all the occurrences of `https://serverless-xxxx-production.twil.io` for the dynamic form we use in the terraform setup (`${var.serverless_url}`).
 
 ### patch-feature-flags
@@ -145,9 +157,12 @@ This script allows you to safely update the feature flags specified in a Twilio 
 
 You need to have `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` environment variables set (either passed in the command itself or in a `.env` file).
 You also must provide the following parameters to the script:
+
 - `-f / --flag`: Use this to specify a flag and what you wish to set it to. The value must take the form {flag_name}:{flag_set}, e.g. -f my_flag:true. Can be specified multiple times
   Example:
+
 ```
 ➜ npm run twilioResources patch-feature-flags -- -f enable_voice_recordings:false -f enable_twilio_transcripts:true
 ```
+
 will set the `enable_voice_recordings` to false, and the `enable_transcripts` flag to true, creating them if they didn't previously exist, or overwriting their previous setting if they did.

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -38,40 +38,7 @@
         "eslint-plugin-prettier": "^3.1.4",
         "prettier": "^2.3.2",
         "ts-node": "^10.1.0",
-        "typescript": "^4.3.5"
-      }
-    },
-    "../hrm-form-definitions": {
-      "version": "1.0.0",
-      "license": "AGPL",
-      "dependencies": {
-        "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
-      },
-      "devDependencies": {
-        "@babel/preset-env": "^7.16.5",
-        "@babel/preset-typescript": "^7.16.5",
-        "@types/jest": "^27.0.3",
-        "@types/lodash": "^4.14.182",
-        "@types/node": "^17.0.8",
-        "@types/react": "^17.0.38",
-        "@typescript-eslint/eslint-plugin": "^4.28.3",
-        "@typescript-eslint/parser": "^4.28.3",
-        "babel-core": "^6.26.3",
-        "eslint": "^7.4.0",
-        "eslint-config-airbnb": "^18.2.0",
-        "eslint-config-airbnb-base": "^14.2.0",
-        "eslint-config-airbnb-typescript": "^12.3.1",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-import-resolver-typescript": "^2.4.0",
-        "eslint-plugin-import": "^2.22.0",
-        "eslint-plugin-prettier": "^3.1.4",
-        "jest": "^27.4.5",
-        "jest-each": "^28.1.1",
-        "prettier": "^2.3.2",
-        "react-hook-form": "^6.11.0",
-        "ts-jest": "^27.1.2",
-        "ts-node": "^10.1.0",
+        "tsx": "^3.12.6",
         "typescript": "^4.3.5"
       }
     },
@@ -182,8 +149,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -199,6 +164,388 @@
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/cjs-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz",
+      "integrity": "sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz",
+      "integrity": "sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.17.6",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
+      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.13.tgz",
+      "integrity": "sha512-5tZZ/hLIfBmt7E8JsE5KbsknoAFmoElkg+A/gjyPtmSQvJjPf+9GsSJihid8VMa08lrsYyaEXOT9RLh3xXQONw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.13.tgz",
+      "integrity": "sha512-F5DgvJMV2ZEpLNpPCO7FEk1wy8O5tg6cikWSB6uvvncsgE1xgbPlm+Boio/4820C2/mj713X83X1h01v0qoeHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.13.tgz",
+      "integrity": "sha512-5m1UUslzpfVrumG3m3Zv2x9VNAcvMOQWJy009y6jt10tcHpzIq2/b0I0k4fz0QYqGSNS1GteRIhVPN4H7OyCXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.13.tgz",
+      "integrity": "sha512-TXbXp/05r7heRsG8yWwbHw9diay+wXIyRNcIHFoNARRIGahYbTW/qwJzE37zkfxLIUPHgR/SyLTUlnTICg14ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.13.tgz",
+      "integrity": "sha512-Ku9Db2sblCxFvQdEO7X9nBaLR/S81uch81e2Q2+Os5z1NcnsFjuqhIYH0Gm6KNNpIKaEbC7gCLbiIPbLLMX4Pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.13.tgz",
+      "integrity": "sha512-t1T5/nIf2j+FdSf1Fa3dcU0cXycr0nK4xJe52qjWa+1I249mM5NBY1ODjiabZxZ0x3CG05y4fd9bxfDLy9kQtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.13.tgz",
+      "integrity": "sha512-/zbkgEO4gY2qGZr9UNAGI38w/FwUY4bx4EC88k9VeiCKNr3ukNgwH/oIgB5Z9/OqpkNLlcS4w9e2d/MIiy5fbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.13.tgz",
+      "integrity": "sha512-RrhjzrCF6aCDH248nUAQoldnRmN7nHMxv85GOj5AH+qkxxYvcig7fnUmgANngntRu4btXhN9WKHMgQ5seERDMw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.13.tgz",
+      "integrity": "sha512-siu3QZrQ7eGrSttvFaRKyjT7kNRbUuHEKzCCyqRh19MbpGokGY13jbIsBEjx6JmH3T50hds325oweS9Ey2ihAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.13.tgz",
+      "integrity": "sha512-ADHA1PqP5gIegehVP0RvxMmNPxpLgetI8QCwYOjUheGXKIKWSdUN8ZS3rusQv3NGZmFCpYdMZzFoI0QtzzGAdw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.13.tgz",
+      "integrity": "sha512-n1JQPxETmR0brkpWlJHeohReEPLH+m00bnJdNnFyHN3zLBt1QypevuZSmnmFWsC+7r7HTwWILj3lBDjtPH3ydg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.13.tgz",
+      "integrity": "sha512-d0pnD/j5KKQ43xtSIvOD+wNIy6D/Vh9GbXVRa3u4zCyiJMYWjxkPkbBzlEgNjdDmUM+5gBFen9k7B8Xscy+Myg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.13.tgz",
+      "integrity": "sha512-C9sMpa/VcGLjVtsT01sXtzZNS7bAZ+icUclkKkiUwBQ9hzT+J+/Xpj+EykI5hB3KgtxQVo4XUahanFoZNxbQ1g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.13.tgz",
+      "integrity": "sha512-jYkc5EpNpvjccAHNYekiAtklusVGWftR0VVLtng7dJzDyy+5adAsf1fOG3LllP0WALxS55/w6boLE/728J/bXw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.13.tgz",
+      "integrity": "sha512-4jAJI5O6E/hATL4lsrG2A+noDjZ377KlATVFKwV3SWaNHj+OvoXe/T84ScQIXEtPI7ndJyLkMYruXj8RR5Ilyw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.13.tgz",
+      "integrity": "sha512-eFLQhJq98qijGRcv9je/9M4Mz1suZ+pOtj62ArsLd0gubNGhhQDz6T30X2X3f1KZ8lkKkr+zN5vtZzx1GAMoFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.13.tgz",
+      "integrity": "sha512-F8PXDeT+3eQpPjf4bmNJapPLu0SKKlWRGPQvBQqVS+YDGoMKnyyYp2UENLFMV8zT7kS39zKxZRZvUL3fMz/7Ww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.13.tgz",
+      "integrity": "sha512-9jWfzbFCnIZdHjNs+00KQHArUbp7kjQDNmiuqkwGOQFs67m4/dKNupBv2DP5hTqVlQY4tW4RG3qpb6Y3zOHJeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.13.tgz",
+      "integrity": "sha512-ALbOMlTIBkAVi6KqYjONa7u2oH95RN7OpetFqMtjufFLBiSaayRuwUzhs2yuR9CfGT4qi0jv6HQDav+EG314TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.13.tgz",
+      "integrity": "sha512-FJBLYL4PkrZGeuHzEqme+0DjNetxkJ+XbB+Aoeow7aQ53JCwsA0/mo8sS5aPkDHgCnMkN4A5GLoFTlDj3BKDrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.13.tgz",
+      "integrity": "sha512-Qrvst9RkLz4qgi3hqswNliYuKW92/HGJnd7xLWkGaGPa8S4qsONf81FW0ebDc5iUHb0I7QJwQATutvghTabnFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.13.tgz",
+      "integrity": "sha512-pZ/NIgz861XaUPlIkPFjP55nJ4PJa0o/CD4zgeRb1Q9FVE+8GvdB6ifJcK05jRhny5hKExhnRFIdgHmmCYH8vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=12"
       }
@@ -1222,6 +1569,12 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1756,6 +2109,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.13.tgz",
+      "integrity": "sha512-4ixMwdErBcQHgTBeoxnowENCPKWFAGxgTyKHMK8gqn9sZaC7ZNWFKtim16g2rzQ2b/FYyy3lIUUJboFtjolhqg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.13",
+        "@esbuild/android-arm64": "0.17.13",
+        "@esbuild/android-x64": "0.17.13",
+        "@esbuild/darwin-arm64": "0.17.13",
+        "@esbuild/darwin-x64": "0.17.13",
+        "@esbuild/freebsd-arm64": "0.17.13",
+        "@esbuild/freebsd-x64": "0.17.13",
+        "@esbuild/linux-arm": "0.17.13",
+        "@esbuild/linux-arm64": "0.17.13",
+        "@esbuild/linux-ia32": "0.17.13",
+        "@esbuild/linux-loong64": "0.17.13",
+        "@esbuild/linux-mips64el": "0.17.13",
+        "@esbuild/linux-ppc64": "0.17.13",
+        "@esbuild/linux-riscv64": "0.17.13",
+        "@esbuild/linux-s390x": "0.17.13",
+        "@esbuild/linux-x64": "0.17.13",
+        "@esbuild/netbsd-x64": "0.17.13",
+        "@esbuild/openbsd-x64": "0.17.13",
+        "@esbuild/sunos-x64": "0.17.13",
+        "@esbuild/win32-arm64": "0.17.13",
+        "@esbuild/win32-ia32": "0.17.13",
+        "@esbuild/win32-x64": "0.17.13"
       }
     },
     "node_modules/escalade": {
@@ -2519,6 +2909,20 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2601,6 +3005,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
+      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -2798,8 +3211,13 @@
       "dev": true
     },
     "node_modules/hrm-form-definitions": {
-      "resolved": "../hrm-form-definitions",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:../hrm-form-definitions",
+      "license": "AGPL",
+      "dependencies": {
+        "@babel/runtime": "^7.16.5",
+        "lodash": "^4.17.21"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -4638,9 +5056,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -4947,6 +5363,25 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/spdx-correct": {
@@ -5487,6 +5922,23 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.6.tgz",
+      "integrity": "sha512-q93WgS3lBdHlPgS0h1i+87Pt6n9K/qULIMNYZo07nSeu2z5QE2CellcAZfofVXBo2tQg9av2ZcRMQ2S2i5oadQ==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/cjs-loader": "^2.4.2",
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "@esbuild-kit/esm-loader": "^2.5.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.js"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/twilio": {
@@ -6065,8 +6517,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
-      "dev": true,
-      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -6079,6 +6529,190 @@
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
+    },
+    "@esbuild-kit/cjs-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz",
+      "integrity": "sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "@esbuild-kit/core-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz",
+      "integrity": "sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==",
+      "dev": true,
+      "requires": {
+        "esbuild": "~0.17.6",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "@esbuild-kit/esm-loader": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
+      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "@esbuild/android-arm": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.13.tgz",
+      "integrity": "sha512-5tZZ/hLIfBmt7E8JsE5KbsknoAFmoElkg+A/gjyPtmSQvJjPf+9GsSJihid8VMa08lrsYyaEXOT9RLh3xXQONw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.13.tgz",
+      "integrity": "sha512-F5DgvJMV2ZEpLNpPCO7FEk1wy8O5tg6cikWSB6uvvncsgE1xgbPlm+Boio/4820C2/mj713X83X1h01v0qoeHg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.13.tgz",
+      "integrity": "sha512-5m1UUslzpfVrumG3m3Zv2x9VNAcvMOQWJy009y6jt10tcHpzIq2/b0I0k4fz0QYqGSNS1GteRIhVPN4H7OyCXg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.13.tgz",
+      "integrity": "sha512-TXbXp/05r7heRsG8yWwbHw9diay+wXIyRNcIHFoNARRIGahYbTW/qwJzE37zkfxLIUPHgR/SyLTUlnTICg14ag==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.13.tgz",
+      "integrity": "sha512-Ku9Db2sblCxFvQdEO7X9nBaLR/S81uch81e2Q2+Os5z1NcnsFjuqhIYH0Gm6KNNpIKaEbC7gCLbiIPbLLMX4Pg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.13.tgz",
+      "integrity": "sha512-t1T5/nIf2j+FdSf1Fa3dcU0cXycr0nK4xJe52qjWa+1I249mM5NBY1ODjiabZxZ0x3CG05y4fd9bxfDLy9kQtA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.13.tgz",
+      "integrity": "sha512-/zbkgEO4gY2qGZr9UNAGI38w/FwUY4bx4EC88k9VeiCKNr3ukNgwH/oIgB5Z9/OqpkNLlcS4w9e2d/MIiy5fbw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.13.tgz",
+      "integrity": "sha512-RrhjzrCF6aCDH248nUAQoldnRmN7nHMxv85GOj5AH+qkxxYvcig7fnUmgANngntRu4btXhN9WKHMgQ5seERDMw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.13.tgz",
+      "integrity": "sha512-siu3QZrQ7eGrSttvFaRKyjT7kNRbUuHEKzCCyqRh19MbpGokGY13jbIsBEjx6JmH3T50hds325oweS9Ey2ihAQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.13.tgz",
+      "integrity": "sha512-ADHA1PqP5gIegehVP0RvxMmNPxpLgetI8QCwYOjUheGXKIKWSdUN8ZS3rusQv3NGZmFCpYdMZzFoI0QtzzGAdw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.13.tgz",
+      "integrity": "sha512-n1JQPxETmR0brkpWlJHeohReEPLH+m00bnJdNnFyHN3zLBt1QypevuZSmnmFWsC+7r7HTwWILj3lBDjtPH3ydg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.13.tgz",
+      "integrity": "sha512-d0pnD/j5KKQ43xtSIvOD+wNIy6D/Vh9GbXVRa3u4zCyiJMYWjxkPkbBzlEgNjdDmUM+5gBFen9k7B8Xscy+Myg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.13.tgz",
+      "integrity": "sha512-C9sMpa/VcGLjVtsT01sXtzZNS7bAZ+icUclkKkiUwBQ9hzT+J+/Xpj+EykI5hB3KgtxQVo4XUahanFoZNxbQ1g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.13.tgz",
+      "integrity": "sha512-jYkc5EpNpvjccAHNYekiAtklusVGWftR0VVLtng7dJzDyy+5adAsf1fOG3LllP0WALxS55/w6boLE/728J/bXw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.13.tgz",
+      "integrity": "sha512-4jAJI5O6E/hATL4lsrG2A+noDjZ377KlATVFKwV3SWaNHj+OvoXe/T84ScQIXEtPI7ndJyLkMYruXj8RR5Ilyw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.13.tgz",
+      "integrity": "sha512-eFLQhJq98qijGRcv9je/9M4Mz1suZ+pOtj62ArsLd0gubNGhhQDz6T30X2X3f1KZ8lkKkr+zN5vtZzx1GAMoFw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.13.tgz",
+      "integrity": "sha512-F8PXDeT+3eQpPjf4bmNJapPLu0SKKlWRGPQvBQqVS+YDGoMKnyyYp2UENLFMV8zT7kS39zKxZRZvUL3fMz/7Ww==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.13.tgz",
+      "integrity": "sha512-9jWfzbFCnIZdHjNs+00KQHArUbp7kjQDNmiuqkwGOQFs67m4/dKNupBv2DP5hTqVlQY4tW4RG3qpb6Y3zOHJeA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.13.tgz",
+      "integrity": "sha512-ALbOMlTIBkAVi6KqYjONa7u2oH95RN7OpetFqMtjufFLBiSaayRuwUzhs2yuR9CfGT4qi0jv6HQDav+EG314TQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.13.tgz",
+      "integrity": "sha512-FJBLYL4PkrZGeuHzEqme+0DjNetxkJ+XbB+Aoeow7aQ53JCwsA0/mo8sS5aPkDHgCnMkN4A5GLoFTlDj3BKDrQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.13.tgz",
+      "integrity": "sha512-Qrvst9RkLz4qgi3hqswNliYuKW92/HGJnd7xLWkGaGPa8S4qsONf81FW0ebDc5iUHb0I7QJwQATutvghTabnFA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.13.tgz",
+      "integrity": "sha512-pZ/NIgz861XaUPlIkPFjP55nJ4PJa0o/CD4zgeRb1Q9FVE+8GvdB6ifJcK05jRhny5hKExhnRFIdgHmmCYH8vg==",
+      "dev": true,
+      "optional": true
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -6832,6 +7466,12 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -7268,6 +7908,36 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "esbuild": {
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.13.tgz",
+      "integrity": "sha512-4ixMwdErBcQHgTBeoxnowENCPKWFAGxgTyKHMK8gqn9sZaC7ZNWFKtim16g2rzQ2b/FYyy3lIUUJboFtjolhqg==",
+      "dev": true,
+      "requires": {
+        "@esbuild/android-arm": "0.17.13",
+        "@esbuild/android-arm64": "0.17.13",
+        "@esbuild/android-x64": "0.17.13",
+        "@esbuild/darwin-arm64": "0.17.13",
+        "@esbuild/darwin-x64": "0.17.13",
+        "@esbuild/freebsd-arm64": "0.17.13",
+        "@esbuild/freebsd-x64": "0.17.13",
+        "@esbuild/linux-arm": "0.17.13",
+        "@esbuild/linux-arm64": "0.17.13",
+        "@esbuild/linux-ia32": "0.17.13",
+        "@esbuild/linux-loong64": "0.17.13",
+        "@esbuild/linux-mips64el": "0.17.13",
+        "@esbuild/linux-ppc64": "0.17.13",
+        "@esbuild/linux-riscv64": "0.17.13",
+        "@esbuild/linux-s390x": "0.17.13",
+        "@esbuild/linux-x64": "0.17.13",
+        "@esbuild/netbsd-x64": "0.17.13",
+        "@esbuild/openbsd-x64": "0.17.13",
+        "@esbuild/sunos-x64": "0.17.13",
+        "@esbuild/win32-arm64": "0.17.13",
+        "@esbuild/win32-ia32": "0.17.13",
+        "@esbuild/win32-x64": "0.17.13"
       }
     },
     "escalade": {
@@ -7846,6 +8516,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7905,6 +8582,12 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "get-tsconfig": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
+      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.7",
@@ -8040,34 +8723,10 @@
       "dev": true
     },
     "hrm-form-definitions": {
-      "version": "file:../hrm-form-definitions",
+      "version": "1.0.0",
       "requires": {
-        "@babel/preset-env": "^7.16.5",
-        "@babel/preset-typescript": "^7.16.5",
         "@babel/runtime": "^7.16.5",
-        "@types/jest": "^27.0.3",
-        "@types/lodash": "^4.14.182",
-        "@types/node": "^17.0.8",
-        "@types/react": "^17.0.38",
-        "@typescript-eslint/eslint-plugin": "^4.28.3",
-        "@typescript-eslint/parser": "^4.28.3",
-        "babel-core": "^6.26.3",
-        "eslint": "^7.4.0",
-        "eslint-config-airbnb": "^18.2.0",
-        "eslint-config-airbnb-base": "^14.2.0",
-        "eslint-config-airbnb-typescript": "^12.3.1",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-import-resolver-typescript": "^2.4.0",
-        "eslint-plugin-import": "^2.22.0",
-        "eslint-plugin-prettier": "^3.1.4",
-        "jest": "^27.4.5",
-        "jest-each": "^28.1.1",
-        "lodash": "^4.17.21",
-        "prettier": "^2.3.2",
-        "react-hook-form": "^6.11.0",
-        "ts-jest": "^27.1.2",
-        "ts-node": "^10.1.0",
-        "typescript": "^4.3.5"
+        "lodash": "^4.17.21"
       }
     },
     "https-proxy-agent": {
@@ -9497,9 +10156,7 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -9703,6 +10360,22 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "spdx-correct": {
@@ -10121,6 +10794,18 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      }
+    },
+    "tsx": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.6.tgz",
+      "integrity": "sha512-q93WgS3lBdHlPgS0h1i+87Pt6n9K/qULIMNYZo07nSeu2z5QE2CellcAZfofVXBo2tQg9av2ZcRMQ2S2i5oadQ==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/cjs-loader": "^2.4.2",
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "fsevents": "~2.3.2"
       }
     },
     "twilio": {

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -41,6 +41,40 @@
         "typescript": "^4.3.5"
       }
     },
+    "../hrm-form-definitions": {
+      "version": "1.0.0",
+      "license": "AGPL",
+      "dependencies": {
+        "@babel/runtime": "^7.16.5",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@babel/preset-env": "^7.16.5",
+        "@babel/preset-typescript": "^7.16.5",
+        "@types/jest": "^27.0.3",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^17.0.8",
+        "@types/react": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
+        "babel-core": "^6.26.3",
+        "eslint": "^7.4.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^27.4.5",
+        "jest-each": "^28.1.1",
+        "prettier": "^2.3.2",
+        "react-hook-form": "^6.11.0",
+        "ts-jest": "^27.1.2",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.3.5"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -148,6 +182,8 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -155,22 +191,13 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
-      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
         "node": ">=12"
@@ -215,6 +242,31 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2746,13 +2798,8 @@
       "dev": true
     },
     "node_modules/hrm-form-definitions": {
-      "version": "1.0.0",
-      "resolved": "file:../hrm-form-definitions",
-      "license": "AGPL",
-      "dependencies": {
-        "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
-      }
+      "resolved": "../hrm-form-definitions",
+      "link": true
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -4591,7 +4638,9 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -5353,12 +5402,12 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/ts-node": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
-      "integrity": "sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-support": "0.6.1",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -5369,17 +5418,16 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
         "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       },
       "peerDependencies": {
         "@swc/core": ">=1.2.50",
@@ -5581,6 +5629,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {
@@ -6011,23 +6065,19 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
     },
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true
-    },
     "@cspotcode/source-map-support": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
-      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@eslint/eslintrc": {
@@ -6063,6 +6113,28 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7968,10 +8040,34 @@
       "dev": true
     },
     "hrm-form-definitions": {
-      "version": "1.0.0",
+      "version": "file:../hrm-form-definitions",
       "requires": {
+        "@babel/preset-env": "^7.16.5",
+        "@babel/preset-typescript": "^7.16.5",
         "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
+        "@types/jest": "^27.0.3",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^17.0.8",
+        "@types/react": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
+        "babel-core": "^6.26.3",
+        "eslint": "^7.4.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^27.4.5",
+        "jest-each": "^28.1.1",
+        "lodash": "^4.17.21",
+        "prettier": "^2.3.2",
+        "react-hook-form": "^6.11.0",
+        "ts-jest": "^27.1.2",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.3.5"
       }
     },
     "https-proxy-agent": {
@@ -9401,7 +9497,9 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "peer": true
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -9970,12 +10068,12 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "ts-node": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
-      "integrity": "sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-support": "0.6.1",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -9986,6 +10084,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -10139,6 +10238,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,20 +13,20 @@
     "copyFlow": "node dist/copyFlow/index.js",
     "createTwilioApiKeyAndSsmSecret": "node dist/terraformSupplemental/createTwilioApiKeyAndSsmSecret.js",
     "generateNewHelplineFormDefinitions": "node dist/formDefinitions/generateNewHelplineFormDefinitions.js",
-    "twilioResources": "ts-node --esm src/terraformSupplemental/twilioResources.ts"
+    "twilioResources": "tsx src/terraformSupplemental/twilioResources.ts"
   },
   "author": "",
   "license": "AGPL",
   "dependencies": {
-    "axios": "^0.25.0",
     "aws-sdk": "^2.947.0",
+    "axios": "^0.25.0",
     "dotenv": "^10.0.0",
+    "hrm-form-definitions": "file:../hrm-form-definitions",
     "node-fetch": "^2.6.4",
     "prompt": "^1.2.0",
     "prompt-confirm": "^2.0.4",
     "twilio": "^3.66.0",
-    "yargs": "17.3.1",
-    "hrm-form-definitions": "file:../hrm-form-definitions"
+    "yargs": "17.3.1"
   },
   "devDependencies": {
     "@tsconfig/node14": "^1.0.1",
@@ -46,6 +46,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "prettier": "^2.3.2",
     "ts-node": "^10.1.0",
+    "tsx": "^3.12.6",
     "typescript": "^4.3.5"
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,10 +11,9 @@
     "compile": "npx tsc",
     "generateDeploymentFiles": "node dist/deploymentFiles/index.js",
     "copyFlow": "node dist/copyFlow/index.js",
-    "importDefaultTwilioResourcesToTerraform": "node dist/terraformSupplemental/importDefaultTwilioResourcesToTerraform.js",
     "createTwilioApiKeyAndSsmSecret": "node dist/terraformSupplemental/createTwilioApiKeyAndSsmSecret.js",
     "generateNewHelplineFormDefinitions": "node dist/formDefinitions/generateNewHelplineFormDefinitions.js",
-    "twilioResources": "node dist/terraformSupplemental/twilioResources.js"
+    "twilioResources": "ts-node --esm src/terraformSupplemental/twilioResources.ts"
   },
   "author": "",
   "license": "AGPL",

--- a/scripts/src/terraformSupplemental/checkArgv.ts
+++ b/scripts/src/terraformSupplemental/checkArgv.ts
@@ -8,7 +8,7 @@ const validateTerraformArgs = (argv: any): void => {
   const isTerraform = TERRAFORM_REQUIRED_ARGS.every((arg) => !!argv[arg]);
   const isTerragrunt = TERRAGRUNT_REQUIRED_ARGS.every((arg) => !!argv[arg]);
 
-  const errorPostfix = `args required for terraform (${TERRAFORM_REQUIRED_ARGS.concat(
+  const errorPostfix = `args required for terraform (${TERRAFORM_REQUIRED_ARGS})`
     ', ',
   )}) for terraform OR args required for terragrunt (${TERRAGRUNT_REQUIRED_ARGS.concat(
     ', ',

--- a/scripts/src/terraformSupplemental/checkArgv.ts
+++ b/scripts/src/terraformSupplemental/checkArgv.ts
@@ -1,26 +1,25 @@
 import { TERRAFORM_REQUIRED_ARGS, TERRAGRUNT_REQUIRED_ARGS } from './execTerraform';
 
 const validateTerraformArgs = (argv: any): void => {
+  // We add a hidden `requireTerraform` arg all commands that depend on terraform,
+  // so if it's not present, we can skip this validation.
   if (!Object.prototype.hasOwnProperty.call(argv, 'requireTerraform')) return;
 
-  const useTerraform = TERRAFORM_REQUIRED_ARGS.every(
-    (arg) => Object.prototype.hasOwnProperty.call(argv, arg) && !!argv[arg],
-  );
+  const isTerraform = TERRAFORM_REQUIRED_ARGS.every((arg) => !!argv[arg]);
+  const isTerragrunt = TERRAGRUNT_REQUIRED_ARGS.every((arg) => !!argv[arg]);
 
-  const useTerragrunt = TERRAGRUNT_REQUIRED_ARGS.every(
-    (arg) => Object.prototype.hasOwnProperty.call(argv, arg) && !!argv[arg],
-  );
+  const errorPostfix = `args required for terraform (${TERRAFORM_REQUIRED_ARGS.concat(
+    ', ',
+  )}) for terraform OR args required for terragrunt (${TERRAGRUNT_REQUIRED_ARGS.concat(
+    ', ',
+  )}) to run this command.`;
 
-  if (useTerraform && useTerragrunt) {
-    throw new Error(
-      'You must provide ONLY a helpline account directory (hl_ad) for terraform OR a helpline, helpline environment, and stage (hl, hl_env, st) for terragrunt to run this command.',
-    );
+  if (isTerraform && isTerragrunt) {
+    throw new Error(`Invalid Terraform Args: You must provide ONLY ${errorPostfix}`);
   }
 
-  if (!useTerraform && !useTerragrunt) {
-    throw new Error(
-      'You must provide either a helpline account directory (hl_ad) for terraform or a helpline, helpline environment, and stage (hl, hl_env, st) for terragrunt to run this command.',
-    );
+  if (!isTerraform && !isTerragrunt) {
+    throw new Error(`Terraform Args Required: You must provide EITHER ${errorPostfix}`);
   }
 };
 

--- a/scripts/src/terraformSupplemental/checkArgv.ts
+++ b/scripts/src/terraformSupplemental/checkArgv.ts
@@ -8,11 +8,7 @@ const validateTerraformArgs = (argv: any): void => {
   const isTerraform = TERRAFORM_REQUIRED_ARGS.every((arg) => !!argv[arg]);
   const isTerragrunt = TERRAGRUNT_REQUIRED_ARGS.every((arg) => !!argv[arg]);
 
-  const errorPostfix = `args required for terraform (${TERRAFORM_REQUIRED_ARGS})`
-    ', ',
-  )}) for terraform OR args required for terragrunt (${TERRAGRUNT_REQUIRED_ARGS.concat(
-    ', ',
-  )}) to run this command.`;
+  const errorPostfix = `args required for terraform (${TERRAFORM_REQUIRED_ARGS}) OR args required for terragrunt (${TERRAGRUNT_REQUIRED_ARGS}) to run this command.`;
 
   if (isTerraform && isTerragrunt) {
     throw new Error(`Invalid Terraform Args: You must provide ONLY ${errorPostfix}`);

--- a/scripts/src/terraformSupplemental/checkArgv.ts
+++ b/scripts/src/terraformSupplemental/checkArgv.ts
@@ -1,0 +1,29 @@
+import { TERRAFORM_REQUIRED_ARGS, TERRAGRUNT_REQUIRED_ARGS } from './execTerraform';
+
+const validateTerraformArgs = (argv: {}) => {
+  if (!Object.prototype.hasOwnProperty.call(argv, 'requireTerraform')) return;
+
+  const useTerraform = TERRAFORM_REQUIRED_ARGS.every((arg) =>
+    Object.prototype.hasOwnProperty.call(argv, arg),
+  );
+
+  const useTerragrunt = TERRAGRUNT_REQUIRED_ARGS.every((arg) =>
+    Object.prototype.hasOwnProperty.call(argv, arg),
+  );
+
+  if (useTerraform && useTerragrunt) {
+    throw new Error(
+      'You must provide either a helpline account directory (hl_ad) or a helpline, helpline environment, and stage (hl, hl_env, st) to run this command.',
+    );
+  }
+
+  if (!useTerraform && !useTerragrunt) {
+    throw new Error(
+      'You must provide either a helpline account directory (hl_ad) or a helpline, helpline environment, and stage (hl, hl_env, st) to run this command.',
+    );
+  }
+};
+
+export const checkArgv = (argv: object): void => {
+  validateTerraformArgs(argv);
+};

--- a/scripts/src/terraformSupplemental/checkArgv.ts
+++ b/scripts/src/terraformSupplemental/checkArgv.ts
@@ -1,29 +1,31 @@
 import { TERRAFORM_REQUIRED_ARGS, TERRAGRUNT_REQUIRED_ARGS } from './execTerraform';
 
-const validateTerraformArgs = (argv: {}) => {
+const validateTerraformArgs = (argv: any): void => {
   if (!Object.prototype.hasOwnProperty.call(argv, 'requireTerraform')) return;
 
-  const useTerraform = TERRAFORM_REQUIRED_ARGS.every((arg) =>
-    Object.prototype.hasOwnProperty.call(argv, arg),
+  const useTerraform = TERRAFORM_REQUIRED_ARGS.every(
+    (arg) => Object.prototype.hasOwnProperty.call(argv, arg) && !!argv[arg],
   );
 
-  const useTerragrunt = TERRAGRUNT_REQUIRED_ARGS.every((arg) =>
-    Object.prototype.hasOwnProperty.call(argv, arg),
+  const useTerragrunt = TERRAGRUNT_REQUIRED_ARGS.every(
+    (arg) => Object.prototype.hasOwnProperty.call(argv, arg) && !!argv[arg],
   );
 
   if (useTerraform && useTerragrunt) {
     throw new Error(
-      'You must provide either a helpline account directory (hl_ad) or a helpline, helpline environment, and stage (hl, hl_env, st) to run this command.',
+      'You must provide ONLY a helpline account directory (hl_ad) for terraform OR a helpline, helpline environment, and stage (hl, hl_env, st) for terragrunt to run this command.',
     );
   }
 
   if (!useTerraform && !useTerragrunt) {
     throw new Error(
-      'You must provide either a helpline account directory (hl_ad) or a helpline, helpline environment, and stage (hl, hl_env, st) to run this command.',
+      'You must provide either a helpline account directory (hl_ad) for terraform or a helpline, helpline environment, and stage (hl, hl_env, st) for terragrunt to run this command.',
     );
   }
 };
 
-export const checkArgv = (argv: object): void => {
+export const checkArgv = (argv: object): boolean => {
   validateTerraformArgs(argv);
+
+  return true;
 };

--- a/scripts/src/terraformSupplemental/execTerraform.ts
+++ b/scripts/src/terraformSupplemental/execTerraform.ts
@@ -6,7 +6,7 @@ const TWILIO_TERRAFORM_ROOT_DIRECTORY = '../twilio-iac';
 
 // TODO: is there a fancy way to do this with typescript based on the UseTerragruntParams and UseTerraformParams types?
 export const TERRAFORM_REQUIRED_ARGS = ['helplineDirectory'];
-export const TERRAGRUNT_REQUIRED_ARGS = ['helpline', 'helplineEnvironment', 'stage'];
+export const TERRAGRUNT_REQUIRED_ARGS = ['helplineShortCode', 'helplineEnvironment', 'stage'];
 
 type TerraformEnvironment = {
   HL: string;
@@ -26,20 +26,20 @@ let terraformVarFile: string;
 let dryRun = false;
 
 export type UseTerragruntParams = {
-  helpline: string;
+  helplineShortCode: string;
   helplineEnvironment: string;
   stage: string;
 };
 
 export const useTerragrunt = ({
-  helpline,
+  helplineShortCode,
   helplineEnvironment,
   stage,
 }: UseTerragruntParams): void => {
   terraformCommand = TerraformCommand.TERRAGRUNT;
 
   env = {
-    HL: helpline,
+    HL: helplineShortCode,
     HL_ENV: helplineEnvironment,
   };
   cwd = `${TWILIO_TERRAFORM_ROOT_DIRECTORY}/stages/${stage}`;

--- a/scripts/src/terraformSupplemental/execTerraform.ts
+++ b/scripts/src/terraformSupplemental/execTerraform.ts
@@ -1,0 +1,84 @@
+import { execSync } from 'child_process';
+import { logDebug, logInfo } from '../helpers/log';
+
+// TODO: use root of repo instead of relative path
+const TWILIO_TERRAFORM_ROOT_DIRECTORY = '../twilio-iac';
+
+// TODO: is there a fancy way to do this with typescript based on the UseTerragruntParams and UseTerraformParams types?
+export const TERRAFORM_REQUIRED_ARGS = ['helplineDirectory'];
+export const TERRAGRUNT_REQUIRED_ARGS = ['helpline', 'helplineEnvironment', 'stage'];
+
+type TerraformEnvironment = {
+  HL: string;
+  HL_ENV?: string;
+};
+
+enum TerraformCommand {
+  TERRAFORM = 'terraform',
+  TERRAGRUNT = 'terragrunt',
+}
+
+let terraformCommand: TerraformCommand;
+let env: TerraformEnvironment;
+let cwd: string;
+let terraformVarFile: string;
+
+let dryRun = false;
+
+export type UseTerragruntParams = {
+  helpline: string;
+  helplineEnvironment: string;
+  stage: string;
+};
+
+export const useTerragrunt = ({
+  helpline,
+  helplineEnvironment,
+  stage,
+}: UseTerragruntParams): void => {
+  terraformCommand = TerraformCommand.TERRAGRUNT;
+
+  env = {
+    HL: helpline,
+    HL_ENV: helplineEnvironment,
+  };
+  cwd = `${TWILIO_TERRAFORM_ROOT_DIRECTORY}/stages/${stage}`;
+};
+
+export type UseTerraformParams = {
+  helplineDirectory: string;
+  varFile?: string;
+};
+
+export const useTerraform = ({ helplineDirectory, varFile }: UseTerraformParams): void => {
+  terraformCommand = TerraformCommand.TERRAFORM;
+  cwd = `${TWILIO_TERRAFORM_ROOT_DIRECTORY}/${helplineDirectory}`;
+  if (varFile) {
+    terraformVarFile = varFile;
+  }
+};
+
+export const isDryRun = (): void => {
+  dryRun = true;
+};
+
+export const execTerraform = async (tfArgs?: string[]): Promise<void> => {
+  if (!terraformCommand) {
+    throw new Error('Terraform command not set, something went wrong with argv checks.');
+  }
+
+  if (terraformVarFile) {
+    tfArgs?.push(`-var-file=${terraformVarFile}`);
+  }
+
+  const command = `${terraformCommand} ${tfArgs?.join(' ')}`;
+
+  if (dryRun) {
+    logDebug(`Would run command (from ${cwd}):`);
+    logInfo(command);
+    return;
+  }
+
+  logDebug(`Running command (from ${cwd}):`, command);
+  execSync(command, { cwd, env });
+};

--- a/scripts/src/terraformSupplemental/handleGlobalArgs.ts
+++ b/scripts/src/terraformSupplemental/handleGlobalArgs.ts
@@ -1,3 +1,0 @@
-export const handleGlobalArgs = (argv: any) => {
-
-}

--- a/scripts/src/terraformSupplemental/handleGlobalArgs.ts
+++ b/scripts/src/terraformSupplemental/handleGlobalArgs.ts
@@ -1,0 +1,3 @@
+export const handleGlobalArgs = (argv: any) => {
+
+}

--- a/scripts/src/terraformSupplemental/handleTerraformArgs.ts
+++ b/scripts/src/terraformSupplemental/handleTerraformArgs.ts
@@ -1,14 +1,23 @@
 import { logInfo } from '../helpers/log';
-import { isDryRun, useTerraform, useTerragrunt } from './execTerraform';
+import { setIsDryRun, useTerraform, useTerragrunt } from './execTerraform';
 import { setEnvFromSsm } from './setEnvFromSsm';
 
+/**
+ * This function sets up the terraformExec system based on global args to support
+ * both terraform and terragrunt commands.
+ *
+ * @param argv
+ * @returns void
+ */
 export const handleTerraformArgs = async (argv: any) => {
+  // We add a hidden `requireTerraform` arg all commands that depend on terraform
+  // so if it's not present, we can skip this setup.
   if (!Object.prototype.hasOwnProperty.call(argv, 'requireTerraform')) return;
 
   if (argv.dryRun) {
     logInfo('================== DRY RUN ==================');
     logInfo('No imports will be performed, command outputs are what would have been run.');
-    isDryRun();
+    setIsDryRun();
   }
 
   // We depend on checkArgv to ensure that if stage is provided, helpline, helplineEnvironment,
@@ -24,6 +33,7 @@ export const handleTerraformArgs = async (argv: any) => {
     return;
   }
 
-  useTerraform(argv.helplineDirectory);
-  await setEnvFromSsm(argv.helplineDirectory);
+  const { helplineDirectory, varFile } = argv;
+  useTerraform({ helplineDirectory, varFile });
+  await setEnvFromSsm(helplineDirectory);
 };

--- a/scripts/src/terraformSupplemental/handleTerraformArgs.ts
+++ b/scripts/src/terraformSupplemental/handleTerraformArgs.ts
@@ -1,0 +1,29 @@
+import { logInfo } from '../helpers/log';
+import { isDryRun, useTerraform, useTerragrunt } from './execTerraform';
+import { setEnvFromSsm } from './setEnvFromSsm';
+
+export const handleTerraformArgs = async (argv: any) => {
+  if (!Object.prototype.hasOwnProperty.call(argv, 'requireTerraform')) return;
+
+  if (argv.dryRun) {
+    logInfo('================== DRY RUN ==================');
+    logInfo('No imports will be performed, command outputs are what would have been run.');
+    isDryRun();
+  }
+
+  // We depend on checkArgv to ensure that if stage is provided, helpline, helplineEnvironment,
+  // and stage are all provided and that this is a terragrunt run.
+  if (argv.stage) {
+    const { helpline, helplineEnvironment, stage } = argv;
+    useTerragrunt({
+      helpline,
+      helplineEnvironment,
+      stage,
+    });
+    await setEnvFromSsm(`${helplineEnvironment}/${helpline}`);
+    return;
+  }
+
+  useTerraform(argv.helplineDirectory);
+  await setEnvFromSsm(argv.helplineDirectory);
+};

--- a/scripts/src/terraformSupplemental/handleTerraformArgs.ts
+++ b/scripts/src/terraformSupplemental/handleTerraformArgs.ts
@@ -14,13 +14,13 @@ export const handleTerraformArgs = async (argv: any) => {
   // We depend on checkArgv to ensure that if stage is provided, helpline, helplineEnvironment,
   // and stage are all provided and that this is a terragrunt run.
   if (argv.stage) {
-    const { helpline, helplineEnvironment, stage } = argv;
+    const { helplineShortCode, helplineEnvironment, stage } = argv;
     useTerragrunt({
-      helpline,
+      helplineShortCode,
       helplineEnvironment,
       stage,
     });
-    await setEnvFromSsm(`${helplineEnvironment}/${helpline}`);
+    await setEnvFromSsm(`${helplineEnvironment}/${helplineShortCode}`);
     return;
   }
 

--- a/scripts/src/terraformSupplemental/importDefaultTwilioResourcesToTerraform.ts
+++ b/scripts/src/terraformSupplemental/importDefaultTwilioResourcesToTerraform.ts
@@ -1,15 +1,9 @@
 import twilio from 'twilio';
-import { execSync } from 'child_process';
+import { execTerraform } from './execTerraform';
 import { logDebug, logInfo, logWarning } from '../helpers/log';
 import { attemptTerraformImport } from './twilioToTerraformImporter';
 
-const TERRAFORM_ROOT_DIRECTORY = '../twilio-iac';
-
-export async function importDefaultResources(
-  account: string,
-  tfvarsFile?: string,
-  dryRun: boolean = false,
-) {
+export async function importDefaultResources(account: string) {
   logDebug(`Importing default resources for '${account}'.`);
 
   const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
@@ -23,11 +17,10 @@ export async function importDefaultResources(
     ).find((tc) => tc.uniqueName === taskChannelUniqueName);
 
     if (taskChannel) {
-      attemptTerraformImport(
+      await attemptTerraformImport(
         `${workspaceSid}/${taskChannel.sid}`,
         `module.taskRouter.twilio_taskrouter_workspaces_task_channels_v1.${taskChannelUniqueName}`,
-        account,
-        { description: `${taskChannelUniqueName} task channel`, tfvarsFile, dryRun },
+        { description: `${taskChannelUniqueName} task channel` },
       );
     } else {
       logWarning(`${taskChannelUniqueName} task channel not found to import`);
@@ -43,37 +36,26 @@ export async function importDefaultResources(
     );
 
     if (flexFlow) {
-      attemptTerraformImport(
+      await attemptTerraformImport(
         `${flexFlow.sid}`,
         `module.flex.twilio_flex_flex_flows_v1.${terraformResourceName}`,
-        account,
-        { description: `${flexFlowFriendlyName} flex flow`, tfvarsFile, dryRun },
+        { description: `${flexFlowFriendlyName} flex flow` },
       );
     } else {
       logWarning(`${flexFlowFriendlyName} flex flow not found to import`);
     }
   }
 
-  if (dryRun) {
-    logInfo('================== DRY RUN ==================');
-    logInfo('No imports will be performed, command outputs are what would have been run.');
-  } else {
-    execSync(`terraform init${tfvarsFile ? ` --var-file ${tfvarsFile}` : ''}`, {
-      cwd: `${TERRAFORM_ROOT_DIRECTORY}/${account}`,
-    });
-  }
+  await execTerraform(['init']);
   const proxy = (await client.proxy.services.list({ limit: 20 })).find(
     (p) => p.uniqueName === 'Flex Proxy Service',
   );
   if (proxy) {
-    attemptTerraformImport(
+    await attemptTerraformImport(
       proxy.sid,
       'module.services.twilio_proxy_services_v1.flex_proxy_service',
-      account,
       {
         description: 'Flex Proxy Service',
-        tfvarsFile,
-        dryRun,
       },
     );
   } else {
@@ -102,14 +84,11 @@ export async function importDefaultResources(
   }
 
   if (chatServiceSid) {
-    attemptTerraformImport(
+    await attemptTerraformImport(
       chatServiceSid,
       'module.services.twilio_chat_services_v2.flex_chat_service',
-      account,
       {
         description: 'Flex Chat Service',
-        tfvarsFile,
-        dryRun,
       },
     );
   } else {
@@ -120,14 +99,11 @@ export async function importDefaultResources(
   );
 
   if (workspace) {
-    attemptTerraformImport(
+    await attemptTerraformImport(
       workspace.sid,
       'module.taskRouter.twilio_taskrouter_workspaces_v1.flex_task_assignment',
-      account,
       {
         description: 'Flex Task Assignment workflow',
-        tfvarsFile,
-        dryRun,
       },
     );
     await locateAndImportDefaultTaskChannel(workspace.sid, 'default');

--- a/scripts/src/terraformSupplemental/setEnvFromSsm.ts
+++ b/scripts/src/terraformSupplemental/setEnvFromSsm.ts
@@ -1,46 +1,48 @@
 import { SSM, STS } from 'aws-sdk';
+import { logWarning } from '../helpers/log';
 
-export const setEnvFromSsm = async (accountDirectory: String): Promise<void> => {
-    const sts = new STS();
+export const setEnvFromSsm = async (keyIdentifier: String): Promise<void> => {
+  const sts = new STS();
 
-    const timestamp = (new Date()).getTime();
-    const params = {
-      RoleArn: 'arn:aws:iam::712893914485:role/tf-twilio-iac-ssm-read-only',
-      RoleSessionName: `tf-supplemental-${timestamp}`
-    };
+  const timestamp = new Date().getTime();
+  const params = {
+    RoleArn: 'arn:aws:iam::712893914485:role/tf-twilio-iac-ssm-read-only',
+    RoleSessionName: `tf-supplemental-${timestamp}`,
+  };
 
-    try {
-        const stsResponse = await sts.assumeRole(params).promise();
+  try {
+    const stsResponse = await sts.assumeRole(params).promise();
 
-        if (!stsResponse.Credentials) {
-            console.error('No credentials found');
-            return;
-        }
-
-        const ssm = new SSM({
-            accessKeyId: stsResponse.Credentials.AccessKeyId,
-            secretAccessKey: stsResponse.Credentials.SecretAccessKey,
-            sessionToken: stsResponse.Credentials.SessionToken,
-          });
-
-        const result = await ssm.getParameter({
-            Name: `/terraform/twilio-iac/${accountDirectory}/secrets.json`,
-            WithDecryption: true,
-        }).promise();
-
-        if (!result.Parameter?.Value) {
-            console.error('No secrets found');
-            return;
-        }
-
-        const secrets = JSON.parse(result.Parameter.Value);
-
-        if (secrets.twilio_account_sid && secrets.twilio_auth_token) {
-            process.env.TWILIO_ACCOUNT_SID = secrets.twilio_account_sid;
-            process.env.TWILIO_AUTH_TOKEN = secrets.twilio_auth_token;
-        }
-    } catch (e) {
-        console.error(e);
-        return;
+    if (!stsResponse.Credentials) {
+      logWarning('No credentials found');
+      return;
     }
-}
+
+    const ssm = new SSM({
+      accessKeyId: stsResponse.Credentials.AccessKeyId,
+      secretAccessKey: stsResponse.Credentials.SecretAccessKey,
+      sessionToken: stsResponse.Credentials.SessionToken,
+    });
+
+    const result = await ssm
+      .getParameter({
+        Name: `/terraform/twilio-iac/${keyIdentifier}/secrets.json`,
+        WithDecryption: true,
+      })
+      .promise();
+
+    if (!result.Parameter?.Value) {
+      logWarning('No secrets found');
+      return;
+    }
+
+    const secrets = JSON.parse(result.Parameter.Value);
+
+    if (secrets.twilio_account_sid && secrets.twilio_auth_token) {
+      process.env.TWILIO_ACCOUNT_SID = secrets.twilio_account_sid;
+      process.env.TWILIO_AUTH_TOKEN = secrets.twilio_auth_token;
+    }
+  } catch (e) {
+    logWarning(e);
+  }
+};

--- a/scripts/src/terraformSupplemental/twilioResources.ts
+++ b/scripts/src/terraformSupplemental/twilioResources.ts
@@ -13,8 +13,11 @@ import {
   patchFeatureFlags,
 } from './updateFlexServiceConfiguration';
 import { generateChatbotResource } from './generateChatbotResource';
+import { handleGlobalArgs } from './handleGlobalArgs';
 
 config();
+
+yargs.middleware(handleGlobalArgs);
 
 async function main() {
   yargs(process.argv.slice(2))
@@ -25,6 +28,30 @@ async function main() {
       global: true,
       describe:
         'Do a dry run, it will log the terraform import commands it would have otherwise run to stdout instead for you to review / copy & run manually',
+    })
+    .option('hl', {
+      type: 'string',
+      default: null,
+      alias: 'helpline',
+      global: true,
+      describe:
+        'Terragrunt Helpline short code - will use terragrunt instead of terraform, e.g. "as", "in", "ct"',
+    })
+    .option('hl_env', {
+      type: 'string',
+      default: null,
+      alias: 'helplineEnv',
+      global: true,
+      describe:
+        'Terragrunt Helpline environment - will use terragrunt instead of terraform, e.g. "dev", "staging", "prod"',
+    })
+    .option('st', {
+      type: 'string',
+      default: null,
+      alias: 'stage',
+      global: true,
+      describe:
+        'Terragrunt stage - will use terragrunt instead of terraform, e.g. "provision", "chatbot", "configure"',
     })
     .option('v', {
       type: 'string',
@@ -51,12 +78,6 @@ async function main() {
           alias: 'type',
           describe:
             "Specify a resource type to scan for by its Terraform name, e.g. 'twilio_autopilot_assistants_field_types_v1'. Can be specified multiple times. Omitting this will scan for all supported resource types.",
-        });
-        argv.option('d', {
-          type: 'boolean',
-          alias: 'dryRun',
-          describe:
-            'Do a dry run, it will log the terraform import commands it would have otherwise run to stdout instead for you to review / copy & run manually',
         });
         argv.option('v', {
           type: 'string',

--- a/scripts/src/terraformSupplemental/twilioResources.ts
+++ b/scripts/src/terraformSupplemental/twilioResources.ts
@@ -141,7 +141,7 @@ async function main() {
       },
       async (argv) => {
         const account = argv.stage
-          ? `${argv.helpline}-${argv.helplineEnvironment}-${argv.stage}`
+          ? `${argv.helplineShortCode}-${argv.helplineEnvironment}-${argv.stage}`
           : (argv.accountDirectory as string);
         await importDefaultResources(account);
       },

--- a/scripts/src/terraformSupplemental/twilioResources.ts
+++ b/scripts/src/terraformSupplemental/twilioResources.ts
@@ -18,14 +18,13 @@ import { handleTerraformArgs } from './handleTerraformArgs';
 
 config();
 
-yargs.middleware(handleTerraformArgs);
-
 async function main() {
   yargs(process.argv.slice(2))
-    .option('hd', {
+    .check((argv) => checkArgv(argv))
+    .middleware((argv) => handleTerraformArgs(argv))
+    .option('helplineDirectory', {
       type: 'string',
       default: null,
-      alias: 'helplineDirectory',
       global: true,
       describe:
         'The directory of the main.tf file for the target account, relative to the twilio-iac directory - only used for terraform based commands',
@@ -38,26 +37,23 @@ async function main() {
       describe:
         'Do a dry run, it will log the terraform import commands it would have otherwise run to stdout instead for you to review / copy & run manually',
     })
-    .option('hl', {
+    .option('helplineShortCode', {
       type: 'string',
       default: null,
-      alias: 'helpline',
       global: true,
       describe:
         'Terragrunt Helpline short code - will use terragrunt instead of terraform, e.g. "as", "in", "ct"',
     })
-    .option('he', {
+    .option('helplineEnvironment', {
       type: 'string',
       default: null,
-      alias: 'helplineEnvironment',
       global: true,
       describe:
         'Terragrunt Helpline environment - will use terragrunt instead of terraform, e.g. "dev", "staging", "prod"',
     })
-    .option('st', {
+    .option('stage', {
       type: 'string',
       default: null,
-      alias: 'stage',
       global: true,
       describe:
         'Terragrunt stage - will use terragrunt instead of terraform, e.g. "provision", "chatbot", "configure"',
@@ -290,7 +286,6 @@ async function main() {
       },
     )
     .demandCommand()
-    .check(checkArgv)
     .help()
     .parse();
 }

--- a/scripts/src/terraformSupplemental/twilioResources.ts
+++ b/scripts/src/terraformSupplemental/twilioResources.ts
@@ -20,8 +20,8 @@ config();
 
 async function main() {
   yargs(process.argv.slice(2))
-    .check((argv) => checkArgv(argv))
-    .middleware((argv) => handleTerraformArgs(argv))
+    .check(checkArgv)
+    .middleware(handleTerraformArgs)
     .option('helplineDirectory', {
       type: 'string',
       default: null,

--- a/scripts/src/terraformSupplemental/twilioToTerraformImporter.ts
+++ b/scripts/src/terraformSupplemental/twilioToTerraformImporter.ts
@@ -1,4 +1,4 @@
-import { execTerraform } from './execTerraform';
+import { execTerraform, isDryRun } from './execTerraform';
 import { logSuccess, logWarning } from '../helpers/log';
 
 type AttemptTerraformImportOptions = {
@@ -29,6 +29,9 @@ export async function attemptTerraformImport(
       logWarning(`${description} already in terraform, moving on.`);
     } else throw error;
   }
+
+  if (isDryRun()) return;
+
   logSuccess(
     `${description}, sid ${twilioResourceSid} successfully imported to terraform as '${terraformResource}'`,
   );

--- a/scripts/src/terraformSupplemental/twilioToTerraformImporter.ts
+++ b/scripts/src/terraformSupplemental/twilioToTerraformImporter.ts
@@ -1,26 +1,17 @@
-import { execSync } from 'child_process';
-import { logDebug, logInfo, logSuccess, logWarning } from '../helpers/log';
-
-const TWILIO_TERRAFORM_ROOT_DIRECTORY = '../twilio-iac';
+import { execTerraform } from './execTerraform';
+import { logSuccess, logWarning } from '../helpers/log';
 
 type AttemptTerraformImportOptions = {
   description: string;
-  tfvarsFile: string;
-  dryRun: boolean;
 };
 
-export function attemptTerraformImport(
+export async function attemptTerraformImport(
   twilioResourceSid: string,
   terraformResource: string,
-  account: string,
   {
     description = `${terraformResource} '${twilioResourceSid}'`,
-    tfvarsFile,
-    dryRun = false,
   }: Partial<AttemptTerraformImportOptions> = {},
-): void {
-  const cwd = `${TWILIO_TERRAFORM_ROOT_DIRECTORY}/${account}`;
-  const tfVarsArg = tfvarsFile ? `-var-file ${tfvarsFile}` : '';
+): Promise<void> {
   let terraformResourceArg = terraformResource
     // .replace(/\s/g, process.platform === 'win32' ? ' ' : '\\ ')
     .replace(/\s/g, ' ')
@@ -31,21 +22,14 @@ export function attemptTerraformImport(
   // if (process.platform === 'win32') {
   terraformResourceArg = `"${terraformResourceArg}"`;
   // }
-  const command = `terraform import ${tfVarsArg} ${terraformResourceArg} ${twilioResourceSid}`;
-  if (dryRun) {
-    logDebug(`Would run command (from ${cwd}):`);
-    logInfo(command);
-  } else {
-    try {
-      logDebug(`Running command (from ${cwd}):`, command);
-      execSync(command, { cwd });
-    } catch (error) {
-      if ((<any>error).stderr?.toString().includes('Resource already managed by Terraform')) {
-        logWarning(`${description} already in terraform, moving on.`);
-      } else throw error;
-    }
-    logSuccess(
-      `${description}, sid ${twilioResourceSid} successfully imported to terraform as '${terraformResource}'`,
-    );
+  try {
+    await execTerraform(['import', terraformResourceArg, twilioResourceSid]);
+  } catch (error) {
+    if ((<any>error).stderr?.toString().includes('Resource already managed by Terraform')) {
+      logWarning(`${description} already in terraform, moving on.`);
+    } else throw error;
   }
+  logSuccess(
+    `${description}, sid ${twilioResourceSid} successfully imported to terraform as '${terraformResource}'`,
+  );
 }

--- a/twilio-iac/docs/terragrunt.md
+++ b/twilio-iac/docs/terragrunt.md
@@ -10,7 +10,7 @@ Terragrunt doesn't do anything fancy in Go to run terraform commands in the modu
 
 ### Working Directory and Cache
 
-Terraform copies files around to build the cache. The cache can come from git or, as in our use case, from the local filesystem. When using local terraform modules as the terraform source, terragrunt copies the dir structure before the `//` in the `source` argument into a local cache. It then uses the directory within that new cache that is defined after the `//` as a working dir for running terraform commands and generating blocks.
+Terragrunt copies files around to build the cache. The cache can come from git or, as in our use case, from the local filesystem. When using local terraform modules as the terraform source, terragrunt copies the dir structure before the `//` in the `source` argument into a local cache. It then uses the directory within that new cache that is defined after the `//` as a working dir for running terraform commands and generating blocks.
 
 For example, If you have a terraform block in your `terragrunt.hcl` like this:
 

--- a/twilio-iac/makefiles/00-setup.make
+++ b/twilio-iac/makefiles/00-setup.make
@@ -8,6 +8,7 @@ TF_ROOT_PATH = $(MOUNT_PATH)/twilio-iac
 ifdef OS
     # We're running Windows, assume powershell
     MY_ENV := $(shell powershell Split-Path -Path (Get-Location) -Leaf)
+    MY_RELATIVE_PATH != powershell (Get-Location).Path.Replace(\"\\\", \"/\").Replace(\"$(MY_PWD)\", \"\")
     DIND_ARG = -v "//var/run/docker.sock:/var/run/docker.sock"
 else
     # We're NOT running windows, assume bash is available

--- a/twilio-iac/makefiles/00-setup.make
+++ b/twilio-iac/makefiles/00-setup.make
@@ -1,5 +1,5 @@
 DOCKER_IMAGE ?= public.ecr.aws/techmatters/terraform
-TF_VER ?= 1.3.7
+TF_VER ?= 1.3.9
 
 MY_PWD ?= $(shell git rev-parse --show-toplevel)
 MOUNT_PATH = /app

--- a/twilio-iac/makefiles/scripts.make
+++ b/twilio-iac/makefiles/scripts.make
@@ -1,7 +1,7 @@
 init-scripts: install-scripts
 
 install-scripts:
-	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/install.sh $(MY_ENV)
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/install.sh
 
 compile-scripts:
-	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/compileScripts.sh $(MY_ENV)
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/compile.sh

--- a/twilio-iac/makefiles/scripts.make
+++ b/twilio-iac/makefiles/scripts.make
@@ -1,15 +1,7 @@
-setup-new-environment: manage-ssm-secrets init twilio-resources-import-account-defaults apply
-
-manage-ssm-secrets:
-	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/secretManager/manageSecrets.py $(MY_ENV)
-
-twilio-resources-import-account-defaults:
-	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/twilioResourceImportAccountDefaults.sh $(MY_ENV)
-
-init-scripts: install-scripts compile-scripts
+init-scripts: install-scripts
 
 install-scripts:
-	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/installScripts.sh $(MY_ENV)
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/install.sh $(MY_ENV)
 
 compile-scripts:
 	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/compileScripts.sh $(MY_ENV)

--- a/twilio-iac/makefiles/terraform/scripts.make
+++ b/twilio-iac/makefiles/terraform/scripts.make
@@ -1,0 +1,7 @@
+setup-new-environment: manage-ssm-secrets init twilio-resources-import-account-defaults apply
+
+manage-ssm-secrets:
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/secretManager/manageSecrets.py $(MY_ENV)
+
+twilio-resources-import-account-defaults:
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh $(MY_ENV)

--- a/twilio-iac/makefiles/terraform/scripts.make
+++ b/twilio-iac/makefiles/terraform/scripts.make
@@ -4,4 +4,4 @@ manage-ssm-secrets:
 	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/secretManager/manageSecrets.py $(MY_ENV)
 
 twilio-resources-import-account-defaults:
-	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh $(MY_ENV)
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh

--- a/twilio-iac/makefiles/terraform/terraform.make
+++ b/twilio-iac/makefiles/terraform/terraform.make
@@ -2,7 +2,7 @@ apply: apply-tf
 
 get: get-tf
 
-init: init-tf
+init: init-scripts init-tf
 
 plan: plan-tf
 

--- a/twilio-iac/makefiles/terragrunt/scripts.make
+++ b/twilio-iac/makefiles/terragrunt/scripts.make
@@ -1,2 +1,10 @@
+setup-new-environment: migrate-state twilio-resources-import-account-defaults
+
+manage-ssm-secrets:
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/secretManager/manageSecrets.py $(MY_ENV)
+
+twilio-resources-import-account-defaults:
+	docker run -it --rm $(DEFAULT_ARGS) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+
 migrate-state:
 	docker run -it --rm $(DEFAULT_ARGS) $(TG_ENV) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/migration/state/main.sh $(HL_ENV) $(HL) $(MY_ENV)

--- a/twilio-iac/makefiles/terragrunt/terragrunt.make
+++ b/twilio-iac/makefiles/terragrunt/terragrunt.make
@@ -38,7 +38,7 @@ apply: apply-tg
 
 apply-all: plan-all-tg apply-all-tg
 
-init: init-tg
+init: init-scripts init-tg
 
 init-all: init-all-tg
 

--- a/twilio-iac/scripts/deploy-scripts/compile.sh
+++ b/twilio-iac/scripts/deploy-scripts/compile.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${script_dir}/setup.sh
+
+npm run compile

--- a/twilio-iac/scripts/deploy-scripts/install.sh
+++ b/twilio-iac/scripts/deploy-scripts/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${script_dir}/setup.sh
+
+npm i

--- a/twilio-iac/scripts/deploy-scripts/setup.sh
+++ b/twilio-iac/scripts/deploy-scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export repo_root=(git rev-parse --show-toplevel)
+export repo_root=$(git rev-parse --show-toplevel)
 
 cd $repo_root/scripts/

--- a/twilio-iac/scripts/deploy-scripts/setup.sh
+++ b/twilio-iac/scripts/deploy-scripts/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export repo_root=(git rev-parse --show-toplevel)
+
+cd $repo_root/scripts/

--- a/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
+# export LOG_LEVEL=DEBUG
+
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
+
 
 npm run twilioResources -- import-account-defaults --helplineDirectory="${MY_ENV}"

--- a/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
@@ -3,6 +3,4 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 
-helplineDir=$1
-
-npm run twilioResources -- import-account-defaults $helplineDir
+npm run twilioResources -- import-account-defaults -hd="${MY_ENV}"

--- a/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
@@ -3,4 +3,4 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 
-npm run twilioResources -- import-account-defaults --helplineDirectory="${MY_ENV}" -d
+npm run twilioResources -- import-account-defaults --helplineDirectory="${MY_ENV}"

--- a/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${script_dir}/../setup.sh
+
+helplineDir=$1
+
+npm run twilioResources -- import-account-defaults $helplineDir

--- a/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terraform/twilioResourceImportAccountDefaults.sh
@@ -3,4 +3,4 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 
-npm run twilioResources -- import-account-defaults -hd="${MY_ENV}"
+npm run twilioResources -- import-account-defaults --helplineDirectory="${MY_ENV}" -d

--- a/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
@@ -3,4 +3,4 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 
-npm run twilioResources -- import-account-defaults --hl=${HL} --hl_env=${HL_ENV} --st=$(MY_ENV) -d
+npm run twilioResources -- import-account-defaults -hl=${HL} -hl_env=${HL_ENV} -st=$(MY_ENV) -d

--- a/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
@@ -3,4 +3,4 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 
-npm run twilioResources -- import-account-defaults -hl=${HL} -hl_env=${HL_ENV} -st=$(MY_ENV) -d
+npm run twilioResources -- import-account-defaults --helplineShortCode=${HL} --helplineEnvironment=${HL_ENV} --stage=${MY_ENV} -d

--- a/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${script_dir}/../setup.sh
+
+npm run twilioResources -- import-account-defaults --hl=${HL} --hl_env=${HL_ENV} --st=$(MY_ENV) -d

--- a/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# export LOG_LEVEL=DEBUG
+
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 

--- a/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
@@ -3,4 +3,4 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 
-npm run twilioResources -- import-account-defaults --helplineShortCode=${HL} --helplineEnvironment=${HL_ENV} --stage=${MY_ENV} -d
+npm run twilioResources -- import-account-defaults --helplineShortCode="${HL}" --helplineEnvironment="${HL_ENV}" --stage="${MY_ENV}"

--- a/twilio-iac/scripts/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/twilioResourceImportAccountDefaults.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-helplineDir=$1
-
-cd ../../scripts/
-
-npm run twilioResources -- import-account-defaults $helplineDir

--- a/twilio-iac/stages/provision/.terraform.lock.hcl
+++ b/twilio-iac/stages/provision/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.26.0"
   constraints = "~> 4.26.0"
   hashes = [
+    "h1:/fzeZBDD+7AIet1b0nXKJA2bnDk0WKEfvE7R2sq8388=",
     "h1:jt8jLpFFhaapdbBqw4WQpDuLN8y7zF8/iLyCzypDxSQ=",
     "zh:0579b105ae471894846fbd740bc9f10b2bd8a48860d8e640b4a9b53fb7d63ffe",
     "zh:0ce445cfbffb6c0eee9e0e2a95850b5749d56aa8211b95a686c24dc2847a36ea",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/external" {
   version = "2.3.1"
   hashes = [
     "h1:bROCw6g5D/3fFnWeJ01L4IrdnJl1ILU8DGDgXCtYzaY=",
+    "h1:uf2KGH9D2vAdfnj8ZAqEwVIpxI82WHsanraXn3dOHzA=",
     "zh:001e2886dc81fc98cf17cf34c0d53cb2dae1e869464792576e11b0f34ee92f54",
     "zh:2eeac58dd75b1abdf91945ac4284c9ccb2bfb17fa9bdb5f5d408148ff553b3ee",
     "zh:2fc39079ba61411a737df2908942e6970cb67ed2f4fb19090cd44ce2082903dd",
@@ -43,6 +45,7 @@ provider "registry.terraform.io/hashicorp/external" {
 provider "registry.terraform.io/hashicorp/github" {
   version = "5.18.3"
   hashes = [
+    "h1:EKpGchrcouicFulbwG00s3NmXWsDDnlhffWqnGANSQQ=",
     "h1:Z/0vjFX80YzM3Oeq0mBbn4XYwb1POggjsu3RVQcbjNc=",
     "zh:050b37d96628cb7451137755929ca8d21ea546bc46d11a715652584070e83ff2",
     "zh:053051061f1b7f7673b0ceffac1f239ba28b0e5b375999206fd39976e85d9f2b",
@@ -65,6 +68,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.1"
   hashes = [
     "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "h1:wqgRvlyVIbkCeCQs+5jj6zVuQL0KDxZZtNofGqqlSdI=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
     "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
@@ -85,6 +89,7 @@ provider "registry.terraform.io/twilio/twilio" {
   constraints = "0.17.0"
   hashes = [
     "h1:6bIJ9HISlNoRo35KeXc1Jp0QKjWo1dOd1YDpRSlUt6s=",
+    "h1:EZONIN61sfhOpVXPtji4gjolORFYL+hT3/bgbV4LX3I=",
     "zh:181fb8392e8f07eac2c265311a00a75167ffbd8bbb518bef470ba4f20069e81d",
     "zh:20cc435ffbadb1c94a8b529d79d119d25481672e176dab31934dcb2efb94ed6e",
     "zh:34c937aba896a017456063849c5c4995b633a0ad6a4cd42ca87e4d272fee56f7",

--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -10,7 +10,7 @@ terraform {
 locals {
   hrm_url           = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
-  cmd_args = var.terragrunt_stage == "" ? "-hd=${basename(abspath(path.root))}" : "-h=${basename(abspath(path.root))} -st=${var.terragrunt_stage} -hl=${var.helpline} -hle=${var.environment}"
+  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : " -st=${var.stage} -hl=${var.helpline} -he=${var.environment}"
   service_configuration_payload = jsonencode({ "ui_attributes" : {
     "warmTransfers" : {
       "enabled" : true

--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -8,95 +8,96 @@ terraform {
 }
 
 locals {
-  hrm_url = var.hrm_url == "" ?  (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
+  hrm_url           = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
-  service_configuration_payload = jsonencode({"ui_attributes":  {
-    "warmTransfers": {
-      "enabled": true
+  cmd_args = var.terragrunt_stage == "" ? "-hd=${basename(abspath(path.root))}" : "-h=${basename(abspath(path.root))} -st=${var.terragrunt_stage} -hl=${var.helpline} -hle=${var.environment}"
+  service_configuration_payload = jsonencode({ "ui_attributes" : {
+    "warmTransfers" : {
+      "enabled" : true
     },
-    "notifications": {
-      "browser": true
+    "notifications" : {
+      "browser" : true
     },
-    "version_compatibility": "yes",
-    "colorTheme": {
-      "light": true,
-      "baseName": "GreyLight",
-      "preset": {
-        "id": "mono-light",
-        "name": "Simple Light"
+    "version_compatibility" : "yes",
+    "colorTheme" : {
+      "light" : true,
+      "baseName" : "GreyLight",
+      "preset" : {
+        "id" : "mono-light",
+        "name" : "Simple Light"
       },
-      "overrides": {
-        "MainHeader": {
-          "Button": {
-            "color": "#000000"
+      "overrides" : {
+        "MainHeader" : {
+          "Button" : {
+            "color" : "#000000"
           },
-          "Container": {
-            "color": "#000000",
-            "background": "#FFFFFF"
+          "Container" : {
+            "color" : "#000000",
+            "background" : "#FFFFFF"
           },
-          "Icon": {
-            "color": "#000000"
+          "Icon" : {
+            "color" : "#000000"
           }
         },
-        "SideNav": {
-          "Button": {
-            "background": "#FFFFFF"
+        "SideNav" : {
+          "Button" : {
+            "background" : "#FFFFFF"
           },
-          "Container": {
-            "background": "#FFFFFF"
+          "Container" : {
+            "background" : "#FFFFFF"
           },
-          "Icon": {
-            "color": "#000000"
+          "Icon" : {
+            "color" : "#000000"
           }
         }
       }
     },
-    "version_message": ""
-  },
-  "account_sid": var.twilio_account_sid,
-  "attributes": {
-    "feature_flags": var.feature_flags,
-    "seenOnboarding": true,
-    "permissionConfig": var.permission_config,
-    "hrm_api_version": "v0",
-    "definitionVersion": var.definition_version,
-    "monitoringEnv": "production",
-    "hrm_base_url": local.hrm_url,
-    "pdfImagesSource": "https://tl-public-chat.s3.amazonaws.com",
-    "logo_url": "https://aselo-logo.s3.amazonaws.com/145+transparent+background+no+TM.png",
-    "multipleOfficeSupport": var.multi_office_support,
-    "serverless_base_url": var.serverless_url,
-    "helplineLanguage": var.helpline_language
-  }})
+    "version_message" : ""
+    },
+    "account_sid" : var.twilio_account_sid,
+    "attributes" : {
+      "feature_flags" : var.feature_flags,
+      "seenOnboarding" : true,
+      "permissionConfig" : var.permission_config,
+      "hrm_api_version" : "v0",
+      "definitionVersion" : var.definition_version,
+      "monitoringEnv" : "production",
+      "hrm_base_url" : local.hrm_url,
+      "pdfImagesSource" : "https://tl-public-chat.s3.amazonaws.com",
+      "logo_url" : "https://aselo-logo.s3.amazonaws.com/145+transparent+background+no+TM.png",
+      "multipleOfficeSupport" : var.multi_office_support,
+      "serverless_base_url" : var.serverless_url,
+      "helplineLanguage" : var.helpline_language
+  } })
 }
 
 resource "twilio_flex_flex_flows_v1" "messaging_flow" {
-  channel_type  = "sms"
-  chat_service_sid = var.flex_chat_service_sid
-  friendly_name = "Flex Messaging Channel Flow"
-  integration_type = "studio"
+  channel_type         = "sms"
+  chat_service_sid     = var.flex_chat_service_sid
+  friendly_name        = "Flex Messaging Channel Flow"
+  integration_type     = "studio"
   integration_flow_sid = var.messaging_studio_flow_sid
-  contact_identity = var.messaging_flow_contact_identity
-  enabled = true
+  contact_identity     = var.messaging_flow_contact_identity
+  enabled              = true
 }
 resource "twilio_flex_flex_flows_v1" "webchat_flow" {
-  channel_type  = "web"
-  chat_service_sid = var.flex_chat_service_sid
-  friendly_name = "Flex Web Channel Flow"
-  integration_type = "studio"
+  channel_type         = "web"
+  chat_service_sid     = var.flex_chat_service_sid
+  friendly_name        = "Flex Web Channel Flow"
+  integration_type     = "studio"
   integration_flow_sid = var.messaging_studio_flow_sid
-  enabled = true
+  enabled              = true
 }
 
 resource "null_resource" "service_configuration" {
   triggers = {
-    configuration: local.service_configuration_payload
+    configuration : local.service_configuration_payload
   }
   provisioner "local-exec" {
     environment = {
       TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD = local.service_configuration_payload
     }
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- update-flex-configuration ${basename(abspath(path.root))}"
+    command = "npm run twilioResources -- update-flex-configuration ${local.cmd_args}"
   }
 }

--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -10,7 +10,9 @@ terraform {
 locals {
   hrm_url           = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
-  cmd_args          = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
+
+  // This cmd_args hackery is temporary until all helplines are migrated to terragrunt or until these scripts are moved to post-apply/after hooks.
+  cmd_args = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
   service_configuration_payload = jsonencode({ "ui_attributes" : {
     "warmTransfers" : {
       "enabled" : true

--- a/twilio-iac/terraform-modules/flex/default/main.tf
+++ b/twilio-iac/terraform-modules/flex/default/main.tf
@@ -10,7 +10,7 @@ terraform {
 locals {
   hrm_url           = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
-  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : " -st=${var.stage} -hl=${var.helpline} -he=${var.environment}"
+  cmd_args          = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
   service_configuration_payload = jsonencode({ "ui_attributes" : {
     "warmTransfers" : {
       "enabled" : true
@@ -98,6 +98,6 @@ resource "null_resource" "service_configuration" {
       TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD = local.service_configuration_payload
     }
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- update-flex-configuration ${local.cmd_args}"
+    command     = "npm run twilioResources -- update-flex-configuration ${local.cmd_args}"
   }
 }

--- a/twilio-iac/terraform-modules/flex/default/variables.tf
+++ b/twilio-iac/terraform-modules/flex/default/variables.tf
@@ -84,3 +84,22 @@ variable "custom_flex_webchat_flow_enabled" {
   type = bool
   default = null
 }
+
+variable "stage" {
+  description = "Set to stage for terragrunt runs"
+  type = string
+  default = ""
+}
+
+// It is a little weird that these are optional, but this entire system may be movoded outside of TF soon anyway
+variable "environment" {
+  description = "Full capitialised environment name, typically 'Production', 'Staging' or 'Development'"
+  type        = string
+  default     = ""
+}
+
+variable "short_helpline" {
+  description = "Short (usually 2 letter) upper case code for helpline"
+  type        = string
+  default     = ""
+}

--- a/twilio-iac/terraform-modules/flex/service-configuration/main.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/main.tf
@@ -10,7 +10,7 @@ terraform {
 locals {
   hrm_url           = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
-  cmd_args          = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-st=${var.stage} -hl=${var.helpline} -he=${var.environment}"
+  cmd_args          = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
 
   service_configuration_payload = jsonencode({ "ui_attributes" : {
     "warmTransfers" : {
@@ -81,6 +81,6 @@ resource "null_resource" "service_configuration" {
       TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD = local.service_configuration_payload
     }
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- update-flex-configuration ${local.cmd_args}"
+    command     = "npm run twilioResources -- update-flex-configuration ${local.cmd_args}"
   }
 }

--- a/twilio-iac/terraform-modules/flex/service-configuration/main.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/main.tf
@@ -8,77 +8,79 @@ terraform {
 }
 
 locals {
-  hrm_url = var.hrm_url == "" ?  (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
+  hrm_url           = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
-  service_configuration_payload = jsonencode({"ui_attributes":  {
-    "warmTransfers": {
-      "enabled": true
+  cmd_args          = var.terragrunt_stage == "" ? "-hd=${basename(abspath(path.root))}" : "-h=${basename(abspath(path.root))} -st=${var.terragrunt_stage} -hl=${var.helpline} -hle=${var.environment}"
+
+  service_configuration_payload = jsonencode({ "ui_attributes" : {
+    "warmTransfers" : {
+      "enabled" : true
     },
-    "notifications": {
-      "browser": true
+    "notifications" : {
+      "browser" : true
     },
-    "version_compatibility": "yes",
-    "colorTheme": {
-      "light": true,
-      "baseName": "GreyLight",
-      "preset": {
-        "id": "mono-light",
-        "name": "Simple Light"
+    "version_compatibility" : "yes",
+    "colorTheme" : {
+      "light" : true,
+      "baseName" : "GreyLight",
+      "preset" : {
+        "id" : "mono-light",
+        "name" : "Simple Light"
       },
-      "overrides": {
-        "MainHeader": {
-          "Button": {
-            "color": "#000000"
+      "overrides" : {
+        "MainHeader" : {
+          "Button" : {
+            "color" : "#000000"
           },
-          "Container": {
-            "color": "#000000",
-            "background": "#FFFFFF"
+          "Container" : {
+            "color" : "#000000",
+            "background" : "#FFFFFF"
           },
-          "Icon": {
-            "color": "#000000"
+          "Icon" : {
+            "color" : "#000000"
           }
         },
-        "SideNav": {
-          "Button": {
-            "background": "#FFFFFF"
+        "SideNav" : {
+          "Button" : {
+            "background" : "#FFFFFF"
           },
-          "Container": {
-            "background": "#FFFFFF"
+          "Container" : {
+            "background" : "#FFFFFF"
           },
-          "Icon": {
-            "color": "#000000"
+          "Icon" : {
+            "color" : "#000000"
           }
         }
       }
     },
-    "version_message": ""
-  },
-  "account_sid": var.twilio_account_sid,
-  "attributes": {
-    "feature_flags": var.feature_flags,
-    "seenOnboarding": true,
-    "permissionConfig": var.permission_config,
-    "hrm_api_version": "v0",
-    "definitionVersion": var.definition_version,
-    "monitoringEnv": "production",
-    "hrm_base_url": local.hrm_url,
-    "pdfImagesSource": "https://tl-public-chat.s3.amazonaws.com",
-    "logo_url": "https://aselo-logo.s3.amazonaws.com/145+transparent+background+no+TM.png",
-    "multipleOfficeSupport": var.multi_office_support,
-    "serverless_base_url": var.serverless_url,
-    "helplineLanguage": var.helpline_language
-  }})
+    "version_message" : ""
+    },
+    "account_sid" : var.twilio_account_sid,
+    "attributes" : {
+      "feature_flags" : var.feature_flags,
+      "seenOnboarding" : true,
+      "permissionConfig" : var.permission_config,
+      "hrm_api_version" : "v0",
+      "definitionVersion" : var.definition_version,
+      "monitoringEnv" : "production",
+      "hrm_base_url" : local.hrm_url,
+      "pdfImagesSource" : "https://tl-public-chat.s3.amazonaws.com",
+      "logo_url" : "https://aselo-logo.s3.amazonaws.com/145+transparent+background+no+TM.png",
+      "multipleOfficeSupport" : var.multi_office_support,
+      "serverless_base_url" : var.serverless_url,
+      "helplineLanguage" : var.helpline_language
+  } })
 }
 
 resource "null_resource" "service_configuration" {
   triggers = {
-    configuration: local.service_configuration_payload
+    configuration : local.service_configuration_payload
   }
   provisioner "local-exec" {
     environment = {
       TWILIO_FLEX_SERVICE_CONFIGURATION_PAYLOAD = local.service_configuration_payload
     }
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- update-flex-configuration ${basename(abspath(path.root))}"
+    command = "npm run twilioResources -- update-flex-configuration ${local.cmd_args}"
   }
 }

--- a/twilio-iac/terraform-modules/flex/service-configuration/main.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/main.tf
@@ -10,7 +10,7 @@ terraform {
 locals {
   hrm_url           = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
-  cmd_args          = var.terragrunt_stage == "" ? "-hd=${basename(abspath(path.root))}" : "-h=${basename(abspath(path.root))} -st=${var.terragrunt_stage} -hl=${var.helpline} -hle=${var.environment}"
+  cmd_args          = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-st=${var.stage} -hl=${var.helpline} -he=${var.environment}"
 
   service_configuration_payload = jsonencode({ "ui_attributes" : {
     "warmTransfers" : {

--- a/twilio-iac/terraform-modules/flex/service-configuration/main.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/main.tf
@@ -10,7 +10,9 @@ terraform {
 locals {
   hrm_url           = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
-  cmd_args          = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
+
+  // This cmd_args hackery is temporary until all helplines are migrated to terragrunt or until these scripts are moved to post-apply/after hooks.
+  cmd_args = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
 
   service_configuration_payload = jsonencode({ "ui_attributes" : {
     "warmTransfers" : {

--- a/twilio-iac/terraform-modules/flex/service-configuration/variables.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/variables.tf
@@ -56,3 +56,22 @@ variable "service_configuration_bump" {
   description = "Used to kick off a service configuration patch. Changes to the configuration will kick off an update automatically, but this can be used to update the config to the configured values anyway - for example if the configuration has been changed outside of terraform and needs to be reset. Simply change this to any value other than the current one to trigger an update next apply."
   default = null
 }
+
+variable "stage" {
+  description = "Set to stage for terragrunt runs"
+  type = string
+  default = ""
+}
+
+// It is a little weird that these are optional, but this entire system may be movoded outside of TF soon anyway
+variable "environment" {
+  description = "Full capitialised environment name, typically 'Production', 'Staging' or 'Development'"
+  type        = string
+  default     = ""
+}
+
+variable "short_helpline" {
+  description = "Short (usually 2 letter) upper case code for helpline"
+  type        = string
+  default     = ""
+}

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
@@ -1,17 +1,19 @@
 locals {
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
+
+  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-h=${basename(abspath(path.root))} -st=${var.stage} -hl=${var.helpline} -hle=${var.environment}"
 }
 
 resource "null_resource" "hrm_static_api_key" {
   triggers = {
-    helpline = var.helpline
-    short_helpline = var.short_helpline
-    environment = var.environment
+    helpline          = var.helpline
+    short_helpline    = var.short_helpline
+    environment       = var.environment
     short_environment = var.short_environment
   }
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- new-key-with-ssm-secret hrm-static-key ${var.short_environment}_TWILIO_${var.short_helpline}_HRM_STATIC_KEY \"${var.helpline}\" ${var.environment} ${basename(abspath(path.root))}"
+    command     = "npm run twilioResources -- new-key-with-ssm-secret ${local.cmd_args} hrm-static-key ${var.short_environment}_TWILIO_${var.short_helpline}_HRM_STATIC_KEY \"${var.helpline}\" ${var.environment}"
     interpreter = local.sync_key_provisioner_interpreter
   }
 }

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
@@ -1,6 +1,7 @@
 locals {
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
 
+  // This cmd_args hackery is temporary until all helplines are migrated to terragrunt or until these scripts are moved to post-apply/after hooks.
   cmd_args = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
 }
 

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
@@ -1,7 +1,7 @@
 locals {
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
 
-  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-st=${var.stage} -hl=${var.helpline} -he=${var.environment}"
+  cmd_args = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
 }
 
 resource "null_resource" "hrm_static_api_key" {

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/main.tf
@@ -1,7 +1,7 @@
 locals {
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
 
-  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-h=${basename(abspath(path.root))} -st=${var.stage} -hl=${var.helpline} -hle=${var.environment}"
+  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-st=${var.stage} -hl=${var.helpline} -he=${var.environment}"
 }
 
 resource "null_resource" "hrm_static_api_key" {

--- a/twilio-iac/terraform-modules/hrmServiceIntegration/default/variables.tf
+++ b/twilio-iac/terraform-modules/hrmServiceIntegration/default/variables.tf
@@ -23,3 +23,9 @@ variable "short_environment" {
   description = "Short upper case environment identifier, typically 'PROD', 'STG' or 'DEV'"
   type        = string
 }
+
+variable "stage" {
+  description = "Set to stage for terragrunt runs"
+  type = string
+  default = ""
+}

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -10,6 +10,7 @@ terraform {
 locals {
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
 
+  // This cmd_args hackery is temporary until all helplines are migrated to terragrunt or until these scripts are moved to post-apply/after hooks.
   cmd_args = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
 }
 

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -9,6 +9,8 @@ terraform {
 
 locals {
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
+
+  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-h=${basename(abspath(path.root))} -st=${var.stage} -hl=${var.helpline} -hle=${var.environment}"
 }
 
 resource "twilio_chat_services_v2" "flex_chat_service" {
@@ -20,19 +22,20 @@ resource "twilio_proxy_services_v1" "flex_proxy_service" {
 }
 
 resource "twilio_sync_services_v1" "shared_state_service" {
-  friendly_name                   = "Shared State Service"
+  friendly_name = "Shared State Service"
 }
 
 resource "null_resource" "sync_api_key" {
   triggers = {
-    helpline = var.helpline
-    short_helpline = var.short_helpline
-    environment = var.environment
+    helpline          = var.helpline
+    short_helpline    = var.short_helpline
+    environment       = var.environment
     short_environment = var.short_environment
   }
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
-    command = "npm run twilioResources -- new-key-with-ssm-secret \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET \"${var.helpline}\" ${var.environment} ${basename(abspath(path.root))} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
+    #TODO: this needs to support terragrunt or terraform
+    command     = "npm run twilioResources -- new-key-with-ssm-secret ${cmd_args} \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET \"${var.helpline}\" ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
     interpreter = local.sync_key_provisioner_interpreter
   }
 }

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -10,7 +10,7 @@ terraform {
 locals {
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
 
-  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-st=${var.stage} -hl=${var.helpline} -he=${var.environment}"
+  cmd_args = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${var.helpline} --helplineEnvironment=${var.environment}"
 }
 
 resource "twilio_chat_services_v2" "flex_chat_service" {

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -35,7 +35,7 @@ resource "null_resource" "sync_api_key" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../../../../scripts"
     #TODO: this needs to support terragrunt or terraform
-    command     = "npm run twilioResources -- new-key-with-ssm-secret ${cmd_args} \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET \"${var.helpline}\" ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
+    command     = "npm run twilioResources -- new-key-with-ssm-secret ${local.cmd_args} \"Shared State Service\" ${var.short_environment}_TWILIO_${var.short_helpline}_SECRET \"${var.helpline}\" ${var.environment} --an=${var.short_environment}_TWILIO_${var.short_helpline}_API_KEY"
     interpreter = local.sync_key_provisioner_interpreter
   }
 }

--- a/twilio-iac/terraform-modules/services/default/main.tf
+++ b/twilio-iac/terraform-modules/services/default/main.tf
@@ -10,7 +10,7 @@ terraform {
 locals {
   sync_key_provisioner_interpreter = var.local_os == "Windows" ? ["PowerShell", "-Command"] : null
 
-  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-h=${basename(abspath(path.root))} -st=${var.stage} -hl=${var.helpline} -hle=${var.environment}"
+  cmd_args = var.stage == "" ? "-hd=${basename(abspath(path.root))}" : "-st=${var.stage} -hl=${var.helpline} -he=${var.environment}"
 }
 
 resource "twilio_chat_services_v2" "flex_chat_service" {

--- a/twilio-iac/terraform-modules/services/default/variables.tf
+++ b/twilio-iac/terraform-modules/services/default/variables.tf
@@ -29,3 +29,9 @@ variable "short_environment" {
   description = "Short upper case environment identifier, typically 'PROD', 'STG' or 'DEV'"
   type        = string
 }
+
+variable "stage" {
+  description = "Set to stage for terragrunt runs"
+  type = string
+  default = ""
+}

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -17,6 +17,24 @@ locals {
 
   chatbot_config = data.terraform_remote_state.chatbot.outputs
   chatbot_sids   = local.chatbot_config.chatbot_sids
+
+  hrm_url_map = {
+    "development" = {
+      "us-east-1" = "https://hrm-development.tl.techmatters.org"
+    }
+    "staging" = {
+      "us-east-1" = "https://hrm-staging.tl.techmatters.org"
+      "us-west-1" = "https://hrm-staging-eu.tl.techmatters.org"
+    }
+    "production" = {
+      "us-east-1" = "https://hrm-production.tl.techmatters.org"
+      "us-west-1" = "https://hrm-staging-eu.tl.techmatters.org"
+    }
+  }
+
+  hrm_url = local.hrm_url_map[var.environment][var.region]
+
+  stage = "configure"
 }
 
 data "terraform_remote_state" "provision" {
@@ -47,6 +65,10 @@ provider "twilio" {
 // TODO: this module should be moved into its own after_hook that can be called individually.
 module "flex" {
   source               = "../../flex/service-configuration"
+  environment          = var.environment
+  short_helpline       = var.short_helpline
+  stage                = local.stage
+
   twilio_account_sid   = local.secrets.twilio_account_sid
   short_environment    = var.short_environment
   operating_info_key   = var.operating_info_key
@@ -55,7 +77,8 @@ module "flex" {
   serverless_url       = local.serverless_url
   multi_office_support = var.multi_office
   feature_flags        = var.feature_flags
-  hrm_url              = "https://hrm-staging-eu.tl.techmatters.org"
+  #tODO: this needs to be a configuration option
+  hrm_url              = local.hrm_url
 }
 
 module "twilioChannel" {

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -28,8 +28,8 @@ locals {
     }
     "production" = {
       "us-east-1" = "https://hrm-production.tl.techmatters.org"
-      "eu-west-1"    = "https://hrm-staging-eu.tl.techmatters.org"
-      "ca-central-1" = "https://hrm-staging-ca.tl.techmatters.org"
+      "eu-west-1"    = "https://hrm-production-eu.tl.techmatters.org"
+      "ca-central-1" = "https://hrm-production-ca.tl.techmatters.org"
     }
   }
 

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -28,7 +28,8 @@ locals {
     }
     "production" = {
       "us-east-1" = "https://hrm-production.tl.techmatters.org"
-      "us-west-1" = "https://hrm-staging-eu.tl.techmatters.org"
+      "eu-west-1"    = "https://hrm-staging-eu.tl.techmatters.org"
+      "ca-central-1" = "https://hrm-staging-ca.tl.techmatters.org"
     }
   }
 

--- a/twilio-iac/terraform-modules/stages/provision/main.tf
+++ b/twilio-iac/terraform-modules/stages/provision/main.tf
@@ -4,6 +4,7 @@ data "aws_ssm_parameter" "secrets" {
 
 locals {
   secrets = jsondecode(data.aws_ssm_parameter.secrets.value)
+  stage   = "provision"
 }
 
 provider "twilio" {
@@ -17,6 +18,7 @@ module "hrmServiceIntegration" {
   short_helpline    = upper(var.short_helpline)
   environment       = title(var.environment)
   short_environment = var.short_environment
+  stage             = local.stage
 }
 
 module "serverless" {


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This is part of the split of #1223 into a PR chain. See description there for some terragrunt overview and planning information. It will probably not run until you get to the catchall at #1317 on the branch CHI-`1569-terraform-refactor-catchall`. But it should help split the review into logical chunks of work.

This updates to the `deploy-scripts` package to support both terragrunt and terraform simultaneously and updates terraform modules with null_resources that make calls to that package to support calling from either system.