### PR TITLE
TeamView: Filter Offline workers on load

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -129,6 +129,8 @@ const setUpComponents = (
     strings.TaskInfoPanelContent = strings.TaskInfoPanelContentMasked;
     strings.CallParticipantCustomerName = strings.MaskIdentifiers;
   }
+
+  Components.setupTeamViewFilters();
 };
 
 const setUpActions = (

--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -18,6 +18,7 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import * as Flex from '@twilio/flex-ui';
+import type { FilterDefinitionFactory } from '@twilio/flex-ui/src/components/view/TeamsView';
 
 import { AcceptTransferButton, RejectTransferButton, TransferButton } from '../components/transfer';
 import * as TransferHelpers from './transfer';
@@ -369,4 +370,32 @@ export const setupCannedResponses = () => {
  */
 export const setupEmojiPicker = () => {
   Flex.MessageInputActions.Content.add(<EmojiPicker key="emoji-picker" />);
+};
+
+const activityNoOfflineByDefault: FilterDefinitionFactory = (appState, _teamFiltersPanelProps) => {
+  const activitiesArray = Array.from(appState.flex.worker.activities.values());
+
+  const options = activitiesArray.map(activity => ({
+    value: activity.name,
+    label: activity.name,
+    default: activity.name !== 'Offline',
+  }));
+
+  return {
+    id: 'data.activity_name',
+    fieldName: 'activity',
+    type: Flex.FiltersListItemType.multiValue,
+    title: 'Activities',
+    options,
+  };
+};
+
+export const setupTeamViewFilters = () => {
+  Flex.TeamsView.defaultProps.filters = [
+    activityNoOfflineByDefault,
+    /*
+     * Omit the default since we already include offline in the above
+     * Flex.TeamsView.activitiesFilter
+     */
+  ];
 };


### PR DESCRIPTION
## Description
This PR changes the Team View filter: on page load, the default workers filter is changed to all statuses except “Offline”. Offline is still an option.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1714)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Start local server (`npm run dev`).
- Go to the Team View (supervisor tab) and confirm that on load the offline workers are filtered.
- Select the offline option and confirm that's still working as intended (default workers appear in the Team View too).