### PR TITLE
[PoC] addWrapper with virtualized list on MessageList

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -22620,6 +22620,11 @@
         "@reach/observe-rect": "^1.1.0"
       }
     },
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.14.tgz",
+      "integrity": "sha512-UW9AiHYF2uo/8YgPYEtWHtwssFpHt/oQxs+uroTUcNI3W9/dP/+DVwQ47d2Xp3v2jVWlBuiOT+NBV2z6jam9XQ=="
+    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -55,6 +55,7 @@
     "react-keyboard-event-handler": "^1.5.4",
     "react-redux": "^7.2.6",
     "react-router-dom": "^5.3.0",
+    "react-virtualized-auto-sizer": "^1.0.14",
     "redux": "^4.1.2",
     "redux-promise-middleware-actions": "^3.1.0",
     "rollbar": "^2.25.0",

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -132,6 +132,8 @@ const setUpComponents = (
 
   Components.setupTeamViewFilters();
   Components.setupWorkerDirectoryFilters();
+
+  Components.test();
 };
 
 const setUpActions = (

--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import * as Flex from '@twilio/flex-ui';
 import type { FilterDefinitionFactory } from '@twilio/flex-ui/src/components/view/TeamsView';
+import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { AcceptTransferButton, RejectTransferButton, TransferButton } from '../components/transfer';
 import * as TransferHelpers from './transfer';
@@ -407,4 +408,17 @@ export const setupWorkerDirectoryFilters = () => {
   const hiddenWorkerFilter = `data.activity_name IN ${JSON.stringify(availableActivities)}`;
 
   Flex.WorkerDirectoryTabs.defaultProps.hiddenWorkerFilter = hiddenWorkerFilter;
+};
+
+const AutoSizerWrapper: React.FC<{}> = ({ children }) => (
+  <div style={{ height: '100%', width: '100%' }}>{children}</div>
+);
+AutoSizerWrapper.displayName = 'AutoSizerWrapper';
+
+export const test = () => {
+  Flex.MessageList.Content.addWrapper(OriginalComponent => originalProps => (
+    <AutoSizerWrapper>
+      <AutoSizer>{() => <OriginalComponent {...originalProps} />}</AutoSizer>
+    </AutoSizerWrapper>
+  ));
 };


### PR DESCRIPTION
## Description
This would be an ideal solution to https://github.com/techmatters/flex-plugins/pull/1335, using a [virtualized list wrapper](https://github.com/bvaughn/react-virtualized-auto-sizer). Unfortunately, this method appears in the code but is not supported at the time of writing. Message from Twilio support:
>Unfortunately, at this time, the list you found in the docs is the full list of components that are able to utilize the addWrapper() API.  I just double-checked with MessageList and TaskCanvas (also not supported, but has the addWrapper() method), and neither yielded any changes.  Engineering is working to expand the list of components that can utilize the API, but I don't have any sort of timetable on when those changes will be put into effect.

Leaving around in case this ever arrives :)

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->