### PR TITLE
CHI-1868: Fix transfer listeners

### DIFF
--- a/plugin-hrm-form/src/conversationListeners.ts
+++ b/plugin-hrm-form/src/conversationListeners.ts
@@ -1,20 +1,20 @@
 import { Conversation } from '@twilio/conversations';
 
-type ConversationListener = Parameters<Conversation['on']>;
+type ConversationListenerParams = Parameters<Conversation['on']>;
 
-const aseloListeners: Record<string, ConversationListener[]> = {};
+const aseloListeners: Record<string, ConversationListenerParams[]> = {};
 
-export const addAseloListener = (conversation: Conversation, ...[event, listener]: ConversationListener) => {
-  conversation.on(event, listener);
-  aseloListeners[conversation.sid] = [...(aseloListeners[conversation.sid] || []), [event, listener]];
+export const addAseloListener = (conversation: Conversation, ...listenerArgs: ConversationListenerParams) => {
+  conversation.on(...listenerArgs);
+  aseloListeners[conversation.sid] = [...(aseloListeners[conversation.sid] || []), listenerArgs];
 };
 
 export const deactivateAseloListeners = (conversation: Conversation) => {
   const listeners = aseloListeners[conversation.sid] || [];
-  listeners.forEach(([event, listener]) => conversation.off(event, listener as any));
+  listeners.forEach(listenerArgs => conversation.off(...listenerArgs));
 };
 
 export const reactivateAseloListeners = (conversation: Conversation) => {
   const listeners = aseloListeners[conversation.sid] || [];
-  listeners.forEach(([event, listener]) => conversation.on(event, listener as any));
+  listeners.forEach(listenerArgs => conversation.on(...listenerArgs));
 };

--- a/plugin-hrm-form/src/conversationListeners.ts
+++ b/plugin-hrm-form/src/conversationListeners.ts
@@ -1,0 +1,20 @@
+import { Conversation } from '@twilio/conversations';
+
+type ConversationListener = Parameters<Conversation['on']>;
+
+const aseloListeners: Record<string, ConversationListener[]> = {};
+
+export const addAseloListener = (conversation: Conversation, ...[event, listener]: ConversationListener) => {
+  conversation.on(event, listener);
+  aseloListeners[conversation.sid] = [...(aseloListeners[conversation.sid] || []), [event, listener]];
+};
+
+export const deactivateAseloListeners = (conversation: Conversation) => {
+  const listeners = aseloListeners[conversation.sid] || [];
+  listeners.forEach(([event, listener]) => conversation.off(event, listener as any));
+};
+
+export const reactivateAseloListeners = (conversation: Conversation) => {
+  const listeners = aseloListeners[conversation.sid] || [];
+  listeners.forEach(([event, listener]) => conversation.on(event, listener as any));
+};

--- a/plugin-hrm-form/src/conversationListeners.ts
+++ b/plugin-hrm-form/src/conversationListeners.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 import { Conversation } from '@twilio/conversations';
 
 type ConversationListenerParams = Parameters<Conversation['on']>;

--- a/plugin-hrm-form/src/notifications/newMessage.ts
+++ b/plugin-hrm-form/src/notifications/newMessage.ts
@@ -17,6 +17,7 @@
 import { Manager, StateHelper, AudioPlayerManager, AudioPlayerError } from '@twilio/flex-ui';
 
 import { getHrmConfig } from '../hrmConfig';
+import { addAseloListener } from '../conversationListeners';
 
 export const subscribeAlertOnConversationJoined = task => {
   const manager = Manager.getInstance();
@@ -37,7 +38,7 @@ const trySubscribeAudioAlerts = (task, ms: number, retries: number) => {
       if (retries < 10) trySubscribeAudioAlerts(task, 200, retries + 1);
       else console.error('Failed to subscribe audio alerts: max retries reached.');
     } else {
-      convoState?.source.on('messageAdded', notifyNewMessage);
+      addAseloListener(convoState.source, 'messageAdded', notifyNewMessage);
     }
   }, ms);
 };

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -49,6 +49,7 @@ import { recordEvent } from '../fullStory';
 import { CustomITask, FeatureFlags } from '../types/types';
 import { getAseloFeatureFlags, getHrmConfig } from '../hrmConfig';
 import { subscribeAlertOnConversationJoined } from '../notifications/newMessage';
+import { reactivateAseloListeners } from '../conversationListeners';
 
 type SetupObject = ReturnType<typeof getHrmConfig>;
 type GetMessage = (key: string) => (key: string) => Promise<string>;
@@ -125,6 +126,10 @@ const takeControlIfTransfer = async (task: ITask) => {
 
 const handleTransferredTask = async (task: ITask) => {
   await takeControlIfTransfer(task);
+  const convo = StateHelper.getConversationStateForTask(task);
+  if (convo?.source) {
+    reactivateAseloListeners(convo.source);
+  }
   await restoreFormIfTransfer(task);
 };
 

--- a/plugin-hrm-form/src/utils/setUpTaskRouterListeners.ts
+++ b/plugin-hrm-form/src/utils/setUpTaskRouterListeners.ts
@@ -19,6 +19,7 @@ import type { Conversation } from '@twilio/conversations';
 
 import { FeatureFlags } from '../types/types';
 import * as TransferHelpers from './transfer';
+import { deactivateAseloListeners } from '../conversationListeners';
 
 const removeConversationListeners = (conversation: Conversation) => {
   const safelyRemoveListeners = (eventName: string) => {
@@ -42,7 +43,7 @@ const removeConversationListenersForTask = (task: ITask) => {
   }
 };
 
-const removeConversationListenersForTransferred = async (task: ITask) => {
+const deactivateConversationListenersForTransferred = async (task: ITask) => {
   try {
     if (
       TaskHelper.isChatBasedTask(task) &&
@@ -55,7 +56,7 @@ const removeConversationListenersForTransferred = async (task: ITask) => {
         task.attributes.transferMeta.originalConversationSid,
       );
 
-      removeConversationListeners(conversation);
+      deactivateAseloListeners(conversation);
     }
   } catch (err) {
     console.error('Error trying to run taskComplete taskrouter listener', err);
@@ -76,6 +77,6 @@ export const setTaskWrapupEventListeners = (featureFlags: FeatureFlags) => {
    * If transfers are on, after a task is transferred remove all the conversation listeners to prevent message notifications
    */
   if (featureFlags.enable_transfers) {
-    manager.events.addListener('taskCompleted', removeConversationListenersForTransferred);
+    manager.events.addListener('taskCompleted', deactivateConversationListenersForTransferred);
   }
 };

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -41,6 +41,40 @@
         "typescript": "^4.3.5"
       }
     },
+    "../hrm-form-definitions": {
+      "version": "1.0.0",
+      "license": "AGPL",
+      "dependencies": {
+        "@babel/runtime": "^7.16.5",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@babel/preset-env": "^7.16.5",
+        "@babel/preset-typescript": "^7.16.5",
+        "@types/jest": "^27.0.3",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^17.0.8",
+        "@types/react": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
+        "babel-core": "^6.26.3",
+        "eslint": "^7.4.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^27.4.5",
+        "jest-each": "^28.1.1",
+        "prettier": "^2.3.2",
+        "react-hook-form": "^6.11.0",
+        "ts-jest": "^27.1.2",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.3.5"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -148,6 +182,8 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -2746,13 +2782,8 @@
       "dev": true
     },
     "node_modules/hrm-form-definitions": {
-      "version": "1.0.0",
-      "resolved": "file:../hrm-form-definitions",
-      "license": "AGPL",
-      "dependencies": {
-        "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
-      }
+      "resolved": "../hrm-form-definitions",
+      "link": true
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -4591,7 +4622,9 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -6011,6 +6044,8 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -7968,10 +8003,34 @@
       "dev": true
     },
     "hrm-form-definitions": {
-      "version": "1.0.0",
+      "version": "file:../hrm-form-definitions",
       "requires": {
+        "@babel/preset-env": "^7.16.5",
+        "@babel/preset-typescript": "^7.16.5",
         "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
+        "@types/jest": "^27.0.3",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^17.0.8",
+        "@types/react": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
+        "babel-core": "^6.26.3",
+        "eslint": "^7.4.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^27.4.5",
+        "jest-each": "^28.1.1",
+        "lodash": "^4.17.21",
+        "prettier": "^2.3.2",
+        "react-hook-form": "^6.11.0",
+        "ts-jest": "^27.1.2",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.3.5"
       }
     },
     "https-proxy-agent": {
@@ -9401,7 +9460,9 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "peer": true
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",


### PR DESCRIPTION
## Description

Fixes CHI-1868

* No longer strips all listeners from a text conversation when it is transferred away.
* Adds our custom listeners to a registry when we add them to a conversation
* 'Deactivates' those listeners when a conversation is transferred, i.e. removes them from the conversation but leaves them in the registry
* 'Reactivates' them if the conversation is ever transferred back, i.e. looks them up from the registry and adds them back to the convo

Other ideas I tried:

* @GPaoloni suggested changing the User Notification level for the conversation to 'muted'. From the API docs this appeared to be what we needed, but in reality it appeared to have no effect, even when muted the audio notifications for the conversation still came through
* Leaving the convo when transferring away then rejoining when transferred back - didn't work at all, the counsellor still wasn't considered a participant until the caller sent a message, messages from the conversation with the other counselor were still absent, new messages didn't appear in the counselors message view, all sorts of issues

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
CHI-1868

### Verification steps

See ticket