### PR TITLE
CHI-1785: Add draft messages to redux

### DIFF
--- a/plugin-hrm-form/src/states/conversations/index.ts
+++ b/plugin-hrm-form/src/states/conversations/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+type ConversationsState = {
+  [conversationSid: string]: {
+    draftMessageText: string;
+  };
+};
+
+const initState = {};
+
+const UPDATE_DRAFT_MESSAGE_TEXT_ACTION = 'UPDATE_DRAFT_MESSAGE_TEXT';
+
+type UpdateDraftMessageTextAction = {
+  type: typeof UPDATE_DRAFT_MESSAGE_TEXT_ACTION;
+  payload: {
+    conversationSid: string;
+    draftMessageText: string;
+  };
+};
+
+export const newUpdateDraftMessageTextAction = (conversationSid: string, draftMessageText: string) => ({
+  type: UPDATE_DRAFT_MESSAGE_TEXT_ACTION,
+  payload: { conversationSid, draftMessageText },
+});
+
+type TextMessagingActionTypes = UpdateDraftMessageTextAction;
+
+export const reduce = (state: ConversationsState = initState, action: TextMessagingActionTypes): ConversationsState => {
+  // eslint-disable-next-line sonarjs/no-small-switch
+  switch (action.type) {
+    case UPDATE_DRAFT_MESSAGE_TEXT_ACTION:
+      return {
+        ...state,
+        [action.payload.conversationSid]: {
+          ...state[action.payload.conversationSid],
+          draftMessageText: action.payload.draftMessageText,
+        },
+      };
+    default:
+      return state;
+  }
+};

--- a/plugin-hrm-form/src/states/index.ts
+++ b/plugin-hrm-form/src/states/index.ts
@@ -27,6 +27,7 @@ import { reduce as RoutingReducer } from './routing/reducer';
 import { reduce as CSAMReportReducer } from './csam-report/reducer';
 import { reduce as DualWriteReducer } from './dualWrite/reducer';
 import { reduce as ReferrableResourcesReducer } from './resources';
+import { reduce as ConversationsReducer } from './conversations';
 import { CaseState } from './case/types';
 
 // Register your redux store under a unique namespace
@@ -37,6 +38,7 @@ export const caseListBase = 'caseList';
 export const connectedCaseBase = 'connectedCase';
 export const queuesStatusBase = 'queuesStatusState';
 export const configurationBase = 'configuration';
+export const conversationsBase = 'conversations';
 export const routingBase = 'routing';
 export const csamReportBase = 'csam-report';
 export const dualWriteBase = 'dualWrite';
@@ -52,6 +54,7 @@ const reducers = {
   [csamReportBase]: CSAMReportReducer,
   [dualWriteBase]: DualWriteReducer,
   [referrableResourcesBase]: ReferrableResourcesReducer,
+  [conversationsBase]: ConversationsReducer,
   /*
    * [csamClcReportBase]: CSAMCLCReportReducer,
    * [connectedCaseBase] - this is going to be combined manually, rather than using 'combineReducers', so isn't in this map


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description

* Adds a 'conversations' redux state, keyed by twilio conversation SID
* Stores partially complete messages under those keys
* Only updates this state when sending a message or unloading the message input component

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added - under a single AseloMessageInput FF
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->