### PR TITLE
Chat Input Dynamic Resizing

### DIFF
--- a/plugin-hrm-form/src/components/AseloMessageInput.tsx
+++ b/plugin-hrm-form/src/components/AseloMessageInput.tsx
@@ -11,7 +11,15 @@ type Props = Partial<MessageInputChildrenProps>;
 
 type Conversation = Awaited<ReturnType<Manager['conversationsClient']['getConversationBySid']>>;
 
+const PADDING = 2;
+const VERTICAL_PADDING = PADDING * 2;
+const LINE_HEIGHT = 16;
+const MIN_LINES = 2;
+const MAX_LINES = 5;
+
 const AseloMessageInput: React.FC<Props> = props => {
+  const initialHeight = MIN_LINES * LINE_HEIGHT + VERTICAL_PADDING;
+  const [height, setHeight] = useState(initialHeight);
   const [conversation, setConversation] = useState<Conversation>();
   const { register, handleSubmit, setValue, getValues } = useForm();
   const { conversationSid } = props;
@@ -31,12 +39,34 @@ const AseloMessageInput: React.FC<Props> = props => {
     }
   };
 
-  const handleChange = debounce(triggerTyping, 500, {
-    leading: true,
-    trailing: true,
-  });
+  const handleChange = (e: React.ChangeEvent) => {
+    debounce(triggerTyping, 500, {
+      leading: true,
+      trailing: true,
+    });
+
+    const { scrollHeight } = e.target;
+
+    console.log({ height, scrollHeight });
+
+    let nextHeight: number;
+
+    if (height && scrollHeight && height !== scrollHeight) {
+      if (scrollHeight > height) {
+        const maxHeight = MAX_LINES * LINE_HEIGHT + VERTICAL_PADDING;
+        nextHeight = Math.min(height + LINE_HEIGHT, maxHeight);
+      } else {
+        const minHeight = MIN_LINES * LINE_HEIGHT + VERTICAL_PADDING;
+        nextHeight = Math.max(height - LINE_HEIGHT, minHeight);
+      }
+
+      setHeight(nextHeight);
+    }
+  };
 
   useTraceUpdate(props, 'AseloMessageInput');
+
+  const heightInPixels = height ? `${height}px` : 'auto';
 
   return (
     <div key="textarea">
@@ -47,6 +77,7 @@ const AseloMessageInput: React.FC<Props> = props => {
           register(ref);
         }}
         onChange={handleChange}
+        style={{ height: heightInPixels, lineHeight: `${LINE_HEIGHT}px`, padding: `${PADDING}px` }}
       />
       <Button
         onClick={handleSubmit(async () => {

--- a/plugin-hrm-form/src/components/AseloMessageInput.tsx
+++ b/plugin-hrm-form/src/components/AseloMessageInput.tsx
@@ -11,16 +11,16 @@ type Props = Partial<MessageInputChildrenProps>;
 
 type Conversation = Awaited<ReturnType<Manager['conversationsClient']['getConversationBySid']>>;
 
-const PADDING = 2;
+const PADDING_VERTICAL = 8;
 const BORDER_WIDTH = 1;
-const LINE_HEIGHT = 16;
+const LINE_HEIGHT = 20;
 const MIN_LINES = 1;
 const MAX_LINES = 5;
-const MIN_HEIGHT = MIN_LINES * LINE_HEIGHT + PADDING * 2 + BORDER_WIDTH * 2;
-const MAX_HEIGHT = MAX_LINES * LINE_HEIGHT + PADDING * 2 + BORDER_WIDTH * 2;
+const MIN_HEIGHT = MIN_LINES * LINE_HEIGHT + PADDING_VERTICAL * 2 + BORDER_WIDTH * 2;
+const MAX_HEIGHT = MAX_LINES * LINE_HEIGHT + PADDING_VERTICAL * 2 + BORDER_WIDTH * 2;
 
 const AseloMessageInput: React.FC<Props> = props => {
-  const initialHeight = MIN_LINES * LINE_HEIGHT + PADDING * 2 + BORDER_WIDTH * 2;
+  const initialHeight = MIN_LINES * LINE_HEIGHT + PADDING_VERTICAL * 2 + BORDER_WIDTH * 2;
   const [height, setHeight] = useState<number>(initialHeight);
   const [prevScrollHeight, setPrevScrollHeight] = useState<number>();
   const [conversation, setConversation] = useState<Conversation>();
@@ -90,6 +90,8 @@ const AseloMessageInput: React.FC<Props> = props => {
 
   useTraceUpdate(props, 'AseloMessageInput');
 
+  const overflow = height < MAX_HEIGHT ? 'hidden' : '';
+
   return (
     <div key="textarea">
       <textarea
@@ -100,10 +102,18 @@ const AseloMessageInput: React.FC<Props> = props => {
         }}
         onChange={handleChange}
         style={{
+          display: 'block',
+          boxSizing: 'border-box',
+          width: '100%',
+          overflow,
           height: `${height}px`,
           lineHeight: `${LINE_HEIGHT}px`,
-          padding: `${PADDING}px`,
-          boxSizing: 'border-box',
+          padding: `${PADDING_VERTICAL}px 12px`,
+          fontFamily: '"Open Sans"',
+          fontSize: '13px',
+          marginBottom: '10px',
+          borderColor: '#CACDD8',
+          borderRadius: '4px',
         }}
       />
       <Button


### PR DESCRIPTION
## Description
Handles dynamic resizing of the text area.
It starts with showing **1 line** of text and grows to **5 lines**. After that, a scrollbar is displayed.
When erasing text, it shrinks appropriately, also handling whether the scrollbar is shown or not.

![text-area](https://user-images.githubusercontent.com/1504544/233464444-4322cd5a-3b12-4261-b32f-9354a1f86a03.gif)


### Verification steps
Play with writing and erasing text and check that the text area dynamic resizing works according to the specs.