### PR TITLE
fixing assets url and ff for mt prod

### DIFF
--- a/twilio-iac/mt-kellimni-production/main.tf
+++ b/twilio-iac/mt-kellimni-production/main.tf
@@ -51,7 +51,7 @@ locals {
     "enable_filter_cases": true,
     "enable_sort_cases": true,
     "enable_transfers": true,
-    "enable_manual_pulling": true,
+    "enable_manual_pulling": false,
     "enable_csam_report": false,
     "enable_canned_responses": true,
     "enable_dual_write": false,
@@ -163,6 +163,7 @@ module flex {
   source = "../terraform-modules/flex/service-configuration"
   twilio_account_sid = local.secrets.twilio_account_sid
   short_environment = local.short_environment
+  environment = local.environment
   operating_info_key = local.operating_info_key
   permission_config = local.permission_config
   definition_version = local.definition_version

--- a/twilio-iac/terraform-modules/flex/service-configuration/main.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 locals {
   hrm_url = var.hrm_url == "" ?  (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
-  assets_bucket_url = "https://assets-${lower(var.environment)}.tl.techmatters.org"
+  assets_bucket_url = "https://s3.amazonaws.com/assets-${lower(var.environment)}.tl.techmatters.org"
   permission_config = var.permission_config == "" ? var.operating_info_key : var.permission_config
 
   // This cmd_args hackery is temporary until all helplines are migrated to terragrunt or until these scripts are moved to post-apply/after hooks.

--- a/twilio-iac/terraform-modules/flex/service-configuration/variables.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/variables.tf
@@ -79,7 +79,6 @@ variable "region" {
 variable "environment" {
   description = "Full capitialised environment name, typically 'Production', 'Staging' or 'Development'"
   type        = string
-  default     = ""
 }
 
 variable "short_helpline" {


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:
@mythilytm  I didn't catch that the the "environment" variable was optional and with a default value of empty string, so the url set for assets-url  was wrong after a terraform apply. So this will fix that.
I'm also modifying a feature flag that was overwritten by the terraform apply. 


## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->