### PR TITLE
Address styling diffs between Twilio & Aselo message inputs

### DIFF
--- a/plugin-hrm-form/src/components/AseloMessageInput.tsx
+++ b/plugin-hrm-form/src/components/AseloMessageInput.tsx
@@ -16,7 +16,7 @@
 
 import { MessageInputChildrenProps } from '@twilio/flex-ui-core/src/components/channel/MessageInput/MessageInputImpl';
 import React, { Dispatch, useEffect, useState } from 'react';
-import { Button, Template, withTheme } from '@twilio/flex-ui';
+import { Button, Template, withTheme, styled } from '@twilio/flex-ui';
 import { useForm } from 'react-hook-form';
 import debounce from 'lodash/debounce';
 import { connect } from 'react-redux';
@@ -29,6 +29,7 @@ import {
   newUpdateDraftMessageTextAction,
 } from '../states/conversations';
 import asyncDispatch from '../states/asyncDispatch';
+import { getTemplateStrings } from '../hrmConfig';
 
 type MessageProps = Partial<MessageInputChildrenProps>;
 
@@ -117,24 +118,119 @@ const AseloMessageInput: React.FC<Props> = ({
     }
   };
 
+  const textAreaPlaceholder = getTemplateStrings()['Type message'] || 'Type message';
+
   return (
-    <div key="textarea">
-      <textarea
-        id="messageInputArea"
-        name="messageInputArea"
-        ref={ref => {
-          register(ref);
-        }}
-        onChange={handleChange}
-        onKeyDown={handleEnterInMessageInput}
-      />
-      <Button onClick={submitMessageForSending} disabled={isDisabled}>
-        <Template code="Send" />
-      </Button>
+    <AseloMessageInputContainer key="textarea">
+      <TextAreaContainer>
+        <TextAreaContainerInner>
+          <TextArea
+            id="messageInputArea"
+            name="messageInputArea"
+            ref={ref => {
+              register(ref);
+            }}
+            onChange={handleChange}
+            onKeyDown={handleEnterInMessageInput}
+            rows={1}
+            placeholder={textAreaPlaceholder}
+          />
+        </TextAreaContainerInner>
+      </TextAreaContainer>
+      <MessageInputActions>
+        <MessageInputActionsInner>
+          {
+            // Emoji picker goes in here
+            ':)'
+          }
+        </MessageInputActionsInner>
+        <ButtonContainer>
+          <SendMessageButton size="small" onClick={submitMessageForSending} disabled={isDisabled}>
+            <Template code="Send" />
+          </SendMessageButton>
+        </ButtonContainer>
+      </MessageInputActions>
       <CannedResponses key="canned-responses" conversationSid={conversationSid} />
-    </div>
+    </AseloMessageInputContainer>
   );
 };
 AseloMessageInput.displayName = 'AseloMessageInput';
 
 export default withTheme(connector(AseloMessageInput));
+
+const FlexRowNoWrap = styled('div')`
+  display: flex;
+  flex-flow: row nowrap;
+  -webkit-box-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+`;
+
+const AseloMessageInputContainer = styled(FlexRowNoWrap)`
+  flex-direction: column;
+  overflow-x: visible;
+`;
+
+const TextAreaContainer = styled(FlexRowNoWrap)`
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  align-items: flex-end;
+  background: rgb(255, 255, 255);
+  border: 1.2px solid rgba(202, 205, 216, 1);
+  border-radius: 4px;
+`;
+
+const TextAreaContainerInner = styled('div')`
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  background: transparent;
+  border-radius: 4px;
+
+  &:focus-within {
+    border: 1px solid rgba(2, 99, 224, 0.7);
+    box-shadow: 0px 0px 0px 3px rgba(2, 99, 224, 0.7);
+  }
+`;
+
+const TextArea = styled('textarea')`
+  min-height: 2.25rem;
+  max-height: 120px;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  padding: 0.5rem 12px;
+  display: block;
+  border: 0px;
+  font-family: 'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans,
+    Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  width: 100%;
+  resize: none;
+  outline: none;
+  box-sizing: border-box;
+  overflow: hidden auto;
+  background: transparent;
+  color: rgb(18, 28, 45);
+  border-radius: 4px;
+`;
+
+const MessageInputActions = styled(FlexRowNoWrap)`
+  overflow: visible;
+  margin-bottom: 16px;
+`;
+
+const MessageInputActionsInner = styled(MessageInputActions)`
+  width: auto;
+  margin-bottom: 0;
+`;
+
+const ButtonContainer = styled(MessageInputActions)`
+  -webkit-box-flex: 0;
+  flex-grow: 0;
+  margin-bottom: 0;
+`;
+
+const SendMessageButton = styled(Button)`
+  background: rgba(216, 27, 96, 0.8);
+  color: #f6f6f6;
+  padding: 4px 8px;
+`;

--- a/plugin-hrm-form/src/components/AseloMessageInput/AseloMessageInput.tsx
+++ b/plugin-hrm-form/src/components/AseloMessageInput/AseloMessageInput.tsx
@@ -16,20 +16,30 @@
 
 import { MessageInputChildrenProps } from '@twilio/flex-ui-core/src/components/channel/MessageInput/MessageInputImpl';
 import React, { Dispatch, useEffect, useState } from 'react';
-import { Button, Template, withTheme, styled } from '@twilio/flex-ui';
+import { Template, withTheme } from '@twilio/flex-ui';
 import { useForm } from 'react-hook-form';
 import debounce from 'lodash/debounce';
 import { connect } from 'react-redux';
 
-import CannedResponses from './CannedResponses';
-import { conversationsBase, namespace, RootState } from '../states';
+import CannedResponses from '../CannedResponses';
+import { conversationsBase, namespace, RootState } from '../../states';
 import {
   MessageSendStatus,
   newSendMessageeAsyncAction,
   newUpdateDraftMessageTextAction,
-} from '../states/conversations';
-import asyncDispatch from '../states/asyncDispatch';
-import { getTemplateStrings } from '../hrmConfig';
+} from '../../states/conversations';
+import asyncDispatch from '../../states/asyncDispatch';
+import { getTemplateStrings } from '../../hrmConfig';
+import {
+  AseloMessageInputContainer,
+  TextAreaContainer,
+  TextAreaContainerInner,
+  TextArea,
+  MessageInputActions,
+  MessageInputActionsInner,
+  ButtonContainer,
+  SendMessageButton,
+} from './styles';
 
 type MessageProps = Partial<MessageInputChildrenProps>;
 
@@ -157,80 +167,3 @@ const AseloMessageInput: React.FC<Props> = ({
 AseloMessageInput.displayName = 'AseloMessageInput';
 
 export default withTheme(connector(AseloMessageInput));
-
-const FlexRowNoWrap = styled('div')`
-  display: flex;
-  flex-flow: row nowrap;
-  -webkit-box-flex: 1;
-  flex-grow: 1;
-  flex-shrink: 1;
-`;
-
-const AseloMessageInputContainer = styled(FlexRowNoWrap)`
-  flex-direction: column;
-  overflow-x: visible;
-`;
-
-const TextAreaContainer = styled(FlexRowNoWrap)`
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-  align-items: flex-end;
-  background: rgb(255, 255, 255);
-  border: 1.2px solid rgba(202, 205, 216, 1);
-  border-radius: 4px;
-`;
-
-const TextAreaContainerInner = styled('div')`
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  background: transparent;
-  border-radius: 4px;
-
-  &:focus-within {
-    border: 1px solid rgba(2, 99, 224, 0.7);
-    box-shadow: 0px 0px 0px 3px rgba(2, 99, 224, 0.7);
-  }
-`;
-
-const TextArea = styled('textarea')`
-  min-height: 2.25rem;
-  max-height: 120px;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  padding: 0.5rem 12px;
-  display: block;
-  border: 0px;
-  font-family: 'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans,
-    Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
-  width: 100%;
-  resize: none;
-  outline: none;
-  box-sizing: border-box;
-  overflow: hidden auto;
-  background: transparent;
-  color: rgb(18, 28, 45);
-  border-radius: 4px;
-`;
-
-const MessageInputActions = styled(FlexRowNoWrap)`
-  overflow: visible;
-  margin-bottom: 16px;
-`;
-
-const MessageInputActionsInner = styled(MessageInputActions)`
-  width: auto;
-  margin-bottom: 0;
-`;
-
-const ButtonContainer = styled(MessageInputActions)`
-  -webkit-box-flex: 0;
-  flex-grow: 0;
-  margin-bottom: 0;
-`;
-
-const SendMessageButton = styled(Button)`
-  background: rgba(216, 27, 96, 0.8);
-  color: #f6f6f6;
-  padding: 4px 8px;
-`;

--- a/plugin-hrm-form/src/components/AseloMessageInput/index.ts
+++ b/plugin-hrm-form/src/components/AseloMessageInput/index.ts
@@ -1,0 +1,3 @@
+import { default as AseloMessageInput } from './AseloMessageInput';
+
+export default AseloMessageInput;

--- a/plugin-hrm-form/src/components/AseloMessageInput/styles.tsx
+++ b/plugin-hrm-form/src/components/AseloMessageInput/styles.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Button, styled } from '@twilio/flex-ui';
+
+export const FlexRowNoWrap = styled('div')`
+  display: flex;
+  flex-flow: row nowrap;
+  -webkit-box-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+`;
+FlexRowNoWrap.displayName = 'FlexRowNoWrap';
+
+export const AseloMessageInputContainer = styled(FlexRowNoWrap)`
+  flex-direction: column;
+  overflow-x: visible;
+`;
+AseloMessageInputContainer.displayName = 'AseloMessageInputContainer';
+
+export const TextAreaContainer = styled(FlexRowNoWrap)`
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  align-items: flex-end;
+  background: rgb(255, 255, 255);
+  border: 1.2px solid rgba(202, 205, 216, 1);
+  border-radius: 4px;
+`;
+TextAreaContainer.displayName = 'TextAreaContainer';
+
+export const TextAreaContainerInner = styled('div')`
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  background: transparent;
+  border-radius: 4px;
+
+  &:focus-within {
+    border: 1px solid rgba(2, 99, 224, 0.7);
+    box-shadow: 0px 0px 0px 3px rgba(2, 99, 224, 0.7);
+  }
+`;
+TextAreaContainerInner.displayName = 'TextAreaContainerInner';
+
+export const TextArea = styled('textarea')`
+  min-height: 2.25rem;
+  max-height: 120px;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  padding: 0.5rem 12px;
+  display: block;
+  border: 0px;
+  font-family: 'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans,
+    Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  width: 100%;
+  resize: none;
+  outline: none;
+  box-sizing: border-box;
+  overflow: hidden auto;
+  background: transparent;
+  color: rgb(18, 28, 45);
+  border-radius: 4px;
+`;
+TextArea.displayName = 'TextArea';
+
+export const MessageInputActions = styled(FlexRowNoWrap)`
+  overflow: visible;
+  margin-bottom: 16px;
+`;
+MessageInputActions.displayName = 'MessageInputActions';
+
+export const MessageInputActionsInner = styled(MessageInputActions)`
+  width: auto;
+  margin-bottom: 0;
+`;
+MessageInputActionsInner.displayName = 'MessageInputActionsInner';
+
+export const ButtonContainer = styled(MessageInputActions)`
+  -webkit-box-flex: 0;
+  flex-grow: 0;
+  margin-bottom: 0;
+`;
+ButtonContainer.displayName = 'ButtonContainer';
+
+export const SendMessageButton = styled(Button)`
+  background: rgba(216, 27, 96, 0.8);
+  color: #f6f6f6;
+  padding: 4px 8px;
+`;
+SendMessageButton.displayName = 'SendMessageButton';


### PR DESCRIPTION
## Description
This PR adds styles to the `AseloMessageInput` (message input replacement) to match those from the default Twilio's one.

Notes:
- Emoji picker is not included here, it will occupy the spot of the smiley face :p.

![Screenshot from 2023-04-25 16-51-21](https://user-images.githubusercontent.com/15805319/234320571-ffd87451-19e0-4888-b9be-9cd81ba3e0a1.png)
![Screenshot from 2023-04-25 16-51-28](https://user-images.githubusercontent.com/15805319/234320566-576ddb8e-32a8-4b9b-b958-99017804e8cc.png)
![Screenshot from 2023-04-25 16-51-32](https://user-images.githubusercontent.com/15805319/234320558-2cf8a15c-98c2-4ec7-951e-1f4acf06e7dd.png)

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1892)
- [n/a] New tests added
- [n/a] Feature flags added
- [x] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- `npm run dev` t ostart local server.
- Start and accept a new chat based contact.
- Confirm that the styles are looking like those in defauult Flex setup (or in the screenshots).