### PR TITLE
CHI-1899: All account runner helper function for scripts

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,7 +13,8 @@
     "copyFlow": "node dist/copyFlow/index.js",
     "createTwilioApiKeyAndSsmSecret": "node dist/terraformSupplemental/createTwilioApiKeyAndSsmSecret.js",
     "generateNewHelplineFormDefinitions": "node dist/formDefinitions/generateNewHelplineFormDefinitions.js",
-    "twilioResources": "tsx src/terraformSupplemental/twilioResources.ts"
+    "twilioResources": "tsx src/terraformSupplemental/twilioResources.ts",
+    "updateAllAssetUrls": "tsx src/terraformSupplemental/updateAllAssetUrls.ts"
   },
   "author": "",
   "license": "AGPL",

--- a/scripts/src/terraformSupplemental/runAgainstAllAccountsForEnvironment.ts
+++ b/scripts/src/terraformSupplemental/runAgainstAllAccountsForEnvironment.ts
@@ -1,0 +1,50 @@
+import { getSSMParametersByPath } from '../helpers/ssm';
+import { logDebug } from '../helpers/log';
+
+export const enum Environment {
+  DEVELOPMENT = 'development',
+  STAGING = 'staging',
+  PRODUCTION = 'production',
+  LOCAL = 'local',
+}
+
+export const enum Strategy {
+  SEQUENTIAL = 'sequential',
+  CONCURRENT = 'concurrent',
+}
+
+type AccountSID = `AC${string}`;
+
+export const runAgainstAllAccountsForEnvironment = async (
+  environment: Environment,
+  action: (accountSid: AccountSID, authToken: string) => Promise<void>,
+  strategy: Strategy = Strategy.SEQUENTIAL,
+) => {
+  const allTwilioTokenParameters = await getSSMParametersByPath(`/${environment}/twilio`);
+  logDebug(
+    'allTwilioTokenParameters found for:',
+    `/${environment}/twilio`,
+    allTwilioTokenParameters.length,
+  );
+  const allCreds = allTwilioTokenParameters
+    .map((parameter) => {
+      logDebug('Testing parameter:', parameter.Name);
+      const match = parameter.Name!.match(/\/[a-z]+\/twilio\/(AC[0-9a-fA-F]+)\/auth_token/);
+      if (match) {
+        logDebug('found accountSid:', match[1]);
+        return { accountSid: match[1], authToken: parameter.Value! };
+      }
+      return null;
+    })
+    .filter((p) => p) as { accountSid: AccountSID; authToken: string }[];
+  logDebug('account cred sets found:', allCreds.length);
+  if (strategy === Strategy.SEQUENTIAL) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const { accountSid, authToken } of allCreds) {
+      // eslint-disable-next-line no-await-in-loop
+      await action(accountSid, authToken);
+    }
+  } else {
+    await Promise.all(allCreds.map(({ accountSid, authToken }) => action(accountSid, authToken)));
+  }
+};

--- a/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
+++ b/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
@@ -1,0 +1,31 @@
+import {
+  Environment,
+  runAgainstAllAccountsForEnvironment,
+} from './runAgainstAllAccountsForEnvironment';
+import { patchFeatureFlags } from './updateFlexServiceConfiguration';
+import { logDebug } from '../helpers/log';
+
+async function main() {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const environment of [
+    // Environment.DEVELOPMENT,
+    Environment.STAGING,
+    // Environment.PRODUCTION,
+  ]) {
+    logDebug(`Updating asset urls for ${environment}`);
+    // eslint-disable-next-line no-await-in-loop
+    await runAgainstAllAccountsForEnvironment(environment, async (accountSid, authToken) => {
+      process.env.TWILIO_ACCOUNT_SID = accountSid;
+      process.env.TWILIO_AUTH_TOKEN = authToken;
+      await patchFeatureFlags(
+        {},
+        { assets_bucket_url: `https://assets-${environment}.tl.techmatters.org` },
+        true,
+      );
+    });
+  }
+}
+
+main().catch((err) => {
+  throw err;
+});

--- a/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
+++ b/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
@@ -5,6 +5,11 @@ import {
 import { patchFeatureFlags } from './updateFlexServiceConfiguration';
 import { logDebug } from '../helpers/log';
 
+/**
+ * This script was used to update the asset urls for all environments in a one off operation.
+ * It is left here as an example of how to combine the runAgainstAllAccountsForEnvironment and patchFeatureFlags
+ * scripts to update the configurations for all accounts in an environment.
+ */
 async function main() {
   // eslint-disable-next-line no-restricted-syntax
   for (const environment of [

--- a/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
+++ b/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
@@ -8,9 +8,9 @@ import { logDebug } from '../helpers/log';
 async function main() {
   // eslint-disable-next-line no-restricted-syntax
   for (const environment of [
-    // Environment.DEVELOPMENT,
+    Environment.DEVELOPMENT,
     Environment.STAGING,
-    // Environment.PRODUCTION,
+    Environment.PRODUCTION,
   ]) {
     logDebug(`Updating asset urls for ${environment}`);
     // eslint-disable-next-line no-await-in-loop
@@ -20,7 +20,7 @@ async function main() {
       await patchFeatureFlags(
         {},
         { assets_bucket_url: `https://assets-${environment}.tl.techmatters.org` },
-        true,
+        false,
       );
     });
   }


### PR DESCRIPTION
## Description

* A function in scripts that will scrape the SSM parameters for all the account creds in an environment and allow you to pass in an action to run against all of them
* An example script that uses this function to patch the service configuration of every account

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- N/A Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
CHI-1899

### Verification steps

Verified by patching asset bucket urls in all accounts