### PR TITLE
Address styling diffs between Twilio & Aselo message inputs

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -109,9 +109,12 @@ const setUpComponents = (
   Components.setUpStandaloneSearch();
   setUpReferrableResources();
   setUpCounselorToolkits();
-  if (featureFlags.enable_aselo_messaging_ui) Components.replaceTwilioMessageInput();
-  if (featureFlags.enable_emoji_picker) Components.setupEmojiPicker();
-  if (featureFlags.enable_canned_responses) Components.setupCannedResponses();
+  if (featureFlags.enable_aselo_messaging_ui) {
+    Components.replaceTwilioMessageInput();
+  } else {
+    if (featureFlags.enable_emoji_picker) Components.setupEmojiPicker();
+    if (featureFlags.enable_canned_responses) Components.setupCannedResponses();
+  }
 
   if (maskIdentifiers) {
     // Mask the identifiers in all default channels

--- a/plugin-hrm-form/src/components/AseloMessageInput/AseloMessageInput.tsx
+++ b/plugin-hrm-form/src/components/AseloMessageInput/AseloMessageInput.tsx
@@ -21,16 +21,16 @@ import { useForm } from 'react-hook-form';
 import debounce from 'lodash/debounce';
 import { connect } from 'react-redux';
 
-import CannedResponses from './CannedResponses';
-import { conversationsBase, namespace, RootState } from '../states';
+import CannedResponses from '../CannedResponses';
+import { conversationsBase, namespace, RootState } from '../../states';
 import {
   MessageSendStatus,
   newSendMessageeAsyncAction,
   newUpdateDraftMessageTextAction,
-} from '../states/conversations';
-import asyncDispatch from '../states/asyncDispatch';
-import EmojiPicker from './emojiPicker';
-import { getAseloFeatureFlags } from '../hrmConfig';
+} from '../../states/conversations';
+import asyncDispatch from '../../states/asyncDispatch';
+import EmojiPicker from '../emojiPicker';
+import { getAseloFeatureFlags } from '../../hrmConfig';
 
 /**
  * The following CSS attributtes should be set in here

--- a/plugin-hrm-form/src/components/AseloMessageInput/AseloMessageInput.tsx
+++ b/plugin-hrm-form/src/components/AseloMessageInput/AseloMessageInput.tsx
@@ -16,7 +16,7 @@
 
 import { MessageInputChildrenProps } from '@twilio/flex-ui-core/src/components/channel/MessageInput/MessageInputImpl';
 import React, { Dispatch, useEffect, useState } from 'react';
-import { Button, FlexBox, FlexBoxColumn, Template, withTheme } from '@twilio/flex-ui';
+import { Template, withTheme } from '@twilio/flex-ui';
 import { useForm } from 'react-hook-form';
 import debounce from 'lodash/debounce';
 import { connect } from 'react-redux';
@@ -30,7 +30,17 @@ import {
 } from '../../states/conversations';
 import asyncDispatch from '../../states/asyncDispatch';
 import EmojiPicker from '../emojiPicker';
-import { getAseloFeatureFlags } from '../../hrmConfig';
+import { getAseloFeatureFlags, getTemplateStrings } from '../../hrmConfig';
+import {
+  AseloMessageInputContainer,
+  TextAreaContainer,
+  TextAreaContainerInner,
+  TextArea,
+  MessageInputActions,
+  MessageInputActionsInner,
+  ButtonContainer,
+  SendMessageButton,
+} from './styles';
 
 /**
  * The following CSS attributtes should be set in here
@@ -204,43 +214,44 @@ const AseloMessageInput: React.FC<Props> = ({
   };
 
   const overflow = height < MAX_HEIGHT ? 'hidden' : '';
+  const textAreaPlaceholder = getTemplateStrings()['Type message'] || 'Type message';
 
   return (
-    <div key="textarea">
-      <textarea
-        id="messageInputArea"
-        name="messageInputArea"
-        ref={ref => {
-          register(ref);
-        }}
-        onChange={handleChange}
-        onKeyDown={handleEnterInMessageInput}
-        onBlur={() => updateDraftMessageText(getValues('messageInputArea'))}
-        style={{
-          display: 'block',
-          boxSizing: 'border-box',
-          width: '100%',
-          overflow,
-          height: `${height}px`,
-          lineHeight: `${LINE_HEIGHT}px`,
-          padding: `${PADDING_VERTICAL}px 12px`,
-          fontFamily: '"Open Sans"',
-          fontSize: '13px',
-          marginBottom: '10px',
-          borderColor: '#CACDD8',
-          borderRadius: '4px',
-        }}
-      />
-      <FlexBox>
-        <FlexBoxColumn>{enableEmojiPicker && <EmojiPicker conversationSid={conversationSid} />}</FlexBoxColumn>
-        <FlexBoxColumn>
-          <Button onClick={submitMessageForSending} disabled={isDisabled}>
+    <AseloMessageInputContainer key="textarea">
+      <TextAreaContainer>
+        <TextAreaContainerInner>
+          <TextArea
+            id="messageInputArea"
+            name="messageInputArea"
+            ref={ref => {
+              register(ref);
+            }}
+            onChange={handleChange}
+            onKeyDown={handleEnterInMessageInput}
+            onBlur={() => updateDraftMessageText(getValues('messageInputArea'))}
+            rows={1}
+            placeholder={textAreaPlaceholder}
+            overflow={overflow}
+            height={height}
+            minHeight={MIN_HEIGHT}
+            maxHeight={MAX_HEIGHT}
+            lineHeight={LINE_HEIGHT}
+            paddingVertical={PADDING_VERTICAL}
+          />
+        </TextAreaContainerInner>
+      </TextAreaContainer>
+      <MessageInputActions>
+        <MessageInputActionsInner>
+          {enableEmojiPicker && <EmojiPicker conversationSid={conversationSid} />}
+        </MessageInputActionsInner>
+        <ButtonContainer>
+          <SendMessageButton size="small" onClick={submitMessageForSending} disabled={isDisabled}>
             <Template code="Send" />
-          </Button>
-        </FlexBoxColumn>
-      </FlexBox>
+          </SendMessageButton>
+        </ButtonContainer>
+      </MessageInputActions>
       {enableCannedResponses && <CannedResponses key="canned-responses" conversationSid={conversationSid} />}
-    </div>
+    </AseloMessageInputContainer>
   );
 };
 AseloMessageInput.displayName = 'AseloMessageInput';

--- a/plugin-hrm-form/src/components/AseloMessageInput/index.ts
+++ b/plugin-hrm-form/src/components/AseloMessageInput/index.ts
@@ -1,0 +1,1 @@
+export { default as AseloMessageInput } from './AseloMessageInput';

--- a/plugin-hrm-form/src/components/AseloMessageInput/index.ts
+++ b/plugin-hrm-form/src/components/AseloMessageInput/index.ts
@@ -1,1 +1,17 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 export { default as AseloMessageInput } from './AseloMessageInput';

--- a/plugin-hrm-form/src/components/AseloMessageInput/styles.tsx
+++ b/plugin-hrm-form/src/components/AseloMessageInput/styles.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import { Button, styled } from '@twilio/flex-ui';
+
+const FlexRowNoWrap = styled('div')`
+  display: flex;
+  flex-flow: row nowrap;
+  -webkit-box-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+`;
+FlexRowNoWrap.displayName = 'FlexRowNoWrap';
+
+export const AseloMessageInputContainer = styled(FlexRowNoWrap)`
+  flex-direction: column;
+  overflow-x: visible;
+`;
+AseloMessageInputContainer.displayName = 'AseloMessageInputContainer';
+
+export const TextAreaContainer = styled(FlexRowNoWrap)`
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  align-items: flex-end;
+  background: rgb(255, 255, 255);
+  border: 1.2px solid rgba(202, 205, 216, 1);
+  border-radius: 4px;
+`;
+TextAreaContainer.displayName = 'TextAreaContainer';
+
+export const TextAreaContainerInner = styled('div')`
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  background: transparent;
+  border-radius: 4px;
+
+  &:focus-within {
+    border: 1px solid rgba(2, 99, 224, 0.7);
+    box-shadow: 0px 0px 0px 3px rgba(2, 99, 224, 0.7);
+  }
+`;
+TextAreaContainerInner.displayName = 'TextAreaContainerInner';
+
+type TextAreaProps = {
+  paddingVertical: number;
+  lineHeight: number;
+  height: number;
+  minHeight: number;
+  maxHeight: number;
+  overflow: string;
+};
+export const TextArea = styled('textarea')<TextAreaProps>`
+  display: block;
+  box-sizing: border-box;
+  overflow: ${({ overflow }) => `${overflow}`};
+  width: 100%;
+  height: ${({ height }) => `${height}px`};
+  min-height: ${({ minHeight }) => `${minHeight}px`};
+  max-height: ${({ maxHeight }) => `${maxHeight}px`};
+  padding: ${({ paddingVertical }) => `${paddingVertical}px 12px`};
+  line-height: ${({ lineHeight }) => `${lineHeight}px`};
+  font-size: 0.875rem;
+  font-family: 'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans,
+    Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  resize: none;
+  outline: none;
+  background: transparent;
+  color: rgb(18, 28, 45);
+  border: 0px;
+  border-radius: 4px;
+`;
+TextArea.displayName = 'TextArea';
+
+export const MessageInputActions = styled(FlexRowNoWrap)`
+  overflow: visible;
+  margin-bottom: 16px;
+`;
+MessageInputActions.displayName = 'MessageInputActions';
+
+export const MessageInputActionsInner = styled(MessageInputActions)`
+  width: auto;
+  margin-bottom: 0;
+`;
+MessageInputActionsInner.displayName = 'MessageInputActionsInner';
+
+export const ButtonContainer = styled(MessageInputActions)`
+  -webkit-box-flex: 0;
+  flex-grow: 0;
+  margin-bottom: 0;
+`;
+ButtonContainer.displayName = 'ButtonContainer';
+
+export const SendMessageButton = styled(Button)`
+  background: rgba(216, 27, 96, 0.8);
+  color: #f6f6f6;
+  padding: 4px 8px;
+`;
+SendMessageButton.displayName = 'SendMessageButton';

--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -45,7 +45,7 @@ import { Container } from '../styles/queuesStatus';
 import { FeatureFlags, isInMyBehalfITask } from '../types/types';
 import { colors } from '../channels/colors';
 import { getHrmConfig } from '../hrmConfig';
-import AseloMessageInput from '../components/AseloMessageInput';
+import { AseloMessageInput } from '../components/AseloMessageInput';
 import AseloMessageList from '../components/AseloMessageList';
 
 type SetupObject = ReturnType<typeof getHrmConfig>;


### PR DESCRIPTION
## Description
This PR adds styles to the `AseloMessageInput` (message input replacement) to match those from the default Twilio's one.

![Screenshot from 2023-04-26 12-33-03](https://user-images.githubusercontent.com/15805319/234549563-02876cd7-0eb6-4829-85fc-48b1aad4a646.png)
![Screenshot from 2023-04-26 12-33-10](https://user-images.githubusercontent.com/15805319/234549559-e5a8cd28-f4b9-492f-af01-2bccb2ad8647.png)
![Screenshot from 2023-04-26 12-33-19](https://user-images.githubusercontent.com/15805319/234549552-f3e04a22-f28c-417c-a9b9-0fd01403c41b.png)


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-1892)
- [n/a] New tests added
- [n/a] Feature flags added
- [x] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Enable the feature flag, can be done via `src/hrmConfig.ts` by returning
```
featureFlags: {
  ...featureFlags,
  enable_aselo_messaging_ui: true,
},
```
- `npm run dev`  to start local server.
- Start and accept a new chat based contact.
- Confirm that the styles are looking like those in defauult Flex setup (or in the screenshots). Ideally test this in different monitor sizes to confirm nothing goes crazy.