### PR TITLE
Fix scrollbar on message bubbles for long non-spaced strings

### DIFF
--- a/plugin-hrm-form/src/components/Messaging/MessageItem/styles.tsx
+++ b/plugin-hrm-form/src/components/Messaging/MessageItem/styles.tsx
@@ -118,7 +118,7 @@ MessageBubbleBody.displayName = 'MessageBubbleBody';
 export const MessageBubbleBodyText = styled(FontOpenSans)<{ isCounselor: boolean }>`
   font-size: 12px;
   line-height: 1.54;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   color: ${({ isCounselor }) => (isCounselor ? '#FFFFFF' : '#222222')};
 `;
 MessageBubbleBodyText.displayName = 'MessageBubbleBodyText';


### PR DESCRIPTION
## Description
Visual fix for displaying long non-spaced word at the message bubble.
Previously, it was not breaking this long word into multiple lines and showing a horizontal scrollbar, instead.
Now, It breaks the word as expected and does not show a scroll bar anymore.

### Related Issues
Fixes [CHI-1923](https://tech-matters.atlassian.net/browse/CHI-1923)

### Verification steps
Send a message that's a really long word, without spaces, and check that now scrollbar is displayed.