### PR TITLE
Show new lines at message bubble

### DIFF
--- a/plugin-hrm-form/src/components/Messaging/MessageItem/styles.tsx
+++ b/plugin-hrm-form/src/components/Messaging/MessageItem/styles.tsx
@@ -118,7 +118,6 @@ MessageBubbleBody.displayName = 'MessageBubbleBody';
 export const MessageBubbleBodyText = styled(FontOpenSans)<{ isCounselor: boolean }>`
   font-size: 12px;
   line-height: 1.54;
-  overflow-wrap: break-word;
   white-space: break-spaces;
   overflow-wrap: anywhere;
   color: ${({ isCounselor }) => (isCounselor ? '#FFFFFF' : '#222222')};

--- a/plugin-hrm-form/src/components/Messaging/MessageItem/styles.tsx
+++ b/plugin-hrm-form/src/components/Messaging/MessageItem/styles.tsx
@@ -119,6 +119,7 @@ export const MessageBubbleBodyText = styled(FontOpenSans)<{ isCounselor: boolean
   font-size: 12px;
   line-height: 1.54;
   overflow-wrap: break-word;
+  white-space: break-spaces;
   color: ${({ isCounselor }) => (isCounselor ? '#FFFFFF' : '#222222')};
 `;
 MessageBubbleBodyText.displayName = 'MessageBubbleBodyText';


### PR DESCRIPTION
## Description
New lines should show up at the message bubble.

Before:
<img width="228" alt="image" src="https://user-images.githubusercontent.com/1504544/235961520-6489530b-7504-4149-bfb7-f9919d8774f4.png">

After:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/1504544/235961682-149c3320-3340-43a5-8be1-beef15edc60e.png">


### Related Issues
Fixes [CHI-1924](https://tech-matters.atlassian.net/browse/CHI-1924)

### Verification steps
Type a message with new lines.
See that those new lines appear at the message bubbles.