### PR TITLE
increase message bubble text size

### DIFF
--- a/plugin-hrm-form/src/components/Messaging/MessageItem/styles.tsx
+++ b/plugin-hrm-form/src/components/Messaging/MessageItem/styles.tsx
@@ -116,7 +116,7 @@ export const MessageBubbleBody = styled('div')`
 MessageBubbleBody.displayName = 'MessageBubbleBody';
 
 export const MessageBubbleBodyText = styled(FontOpenSans)<{ isCounselor: boolean }>`
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.54;
   overflow-wrap: break-word;
   color: ${({ isCounselor }) => (isCounselor ? '#FFFFFF' : '#222222')};

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -117,3 +117,8 @@ button.Twilio-TaskCanvasHeader-EndButton:active {
 div.Twilio-ViewCollection{
     background-color: #f6f6f6;
 }
+
+/* The p tag was deeply nested with no Twilio class to reference. So this was the only way to over-ride the CSS  */
+div.Twilio .Twilio-MessageList div div div div div div div p {
+    font-size: 14px;
+}

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -117,8 +117,3 @@ button.Twilio-TaskCanvasHeader-EndButton:active {
 div.Twilio-ViewCollection{
     background-color: #f6f6f6;
 }
-
-/* The p tag was deeply nested with no Twilio class to reference. So this was the only way to over-ride the CSS  */
-div.Twilio .Twilio-MessageList div div div div div div div p {
-    font-size: 14px;
-}


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @GPaoloni  

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Modification - Cleanup styling: message bubble text has a size of 12px. The goal was to increase it to Twilio's default font-size of 14px.

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Feature flags added
- [N/A] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes CHI-1925

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
- Initiate a chat conversation
- Verify that the message bubble text size matches the Twilio default (14px)