### PR TITLE
Add support for simple checkbox when populating select options in webchat preengagement

### DIFF
--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -128,10 +128,11 @@ export const getValuesFromPreEngagementData = (
   const values = {};
   tabFormDefinition.forEach((field: FormItemDefinition) => {
     if (prepopulateKeys.indexOf(field.name) > -1) {
-      if (field.type === 'mixed-checkbox') {
-        if (preEngagementData[field.name]?.toLowerCase() === 'yes') {
+      if (['mixed-checkbox', 'checkbox'].includes(field.type)) {
+        const fieldValue = preEngagementData[field.name]?.toLowerCase();
+        if (fieldValue === 'yes') {
           values[field.name] = true;
-        } else if (preEngagementData[field.name]?.toLowerCase() === 'no') {
+        } else if (fieldValue === 'no' || field.type === 'checkbox') {
           values[field.name] = false;
         }
         return;


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: 

## Description
- There is a bug in the KHP form population for a simple checkbox. Previously, only the 'mixed-checkbox' field type was supported, but not a simple 'checkbox' field type
- This PR ensure simple checkbox works when populating select options in webchat pre-engagement form 

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes # no jira ticket -

### Verification steps
- Run flex with ca-staging account locally with its form definitions populated. 
- From ca-staging webchat instance, 
  1. In webchat, select 'Prefer not to answer' for  `Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee? *` 
  2. In flex, Newcomer field should populate as empty checkbox, not filled in flex
![Screenshot 2023-05-05 at 4 49 49 PM 1](https://user-images.githubusercontent.com/102122005/236566441-7454da5b-6c0c-43cc-ad74-6b62778bb530.png)
