### PR TITLE
Chi 1786 write terraform definitions lex bots

### DIFF
--- a/twilio-iac/aws-lex/as-development/bot.tf
+++ b/twilio-iac/aws-lex/as-development/bot.tf
@@ -1,0 +1,37 @@
+resource "aws_lex_bot" "aselo_development_bot" {
+  abort_statement {
+    message {
+      content      = "Sorry, I didn't understand that. Please try again."
+      content_type = "PlainText"
+    }
+  }
+
+#   By specifying true to child_directed, you confirm that your use of Amazon Lex is related to a website, 
+#   program, or other application that is directed or targeted, in whole or in part, to 
+#   children under age 13 and subject to COPPA. 
+#   https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lex_bot#child_directed
+
+  child_directed = true
+
+  clarification_prompt {
+    max_attempts = 2
+
+    message {
+      content      = "Sorry, I didn't understand that. Please try again."
+      content_type = "PlainText"
+    }
+  }
+
+  create_version              = false
+  description                 = "Bot for contacting helplines via webchat"
+  idle_session_ttl_in_seconds = 600
+
+  intent {
+    intent_name    = "Survey"
+    intent_version = "$$LATEST"
+  }
+
+  locale           = "en-US"
+  name             = "Survey"
+  process_behavior = "BUILD"
+}

--- a/twilio-iac/aws-lex/as-development/bot.tf
+++ b/twilio-iac/aws-lex/as-development/bot.tf
@@ -27,8 +27,8 @@ resource "aws_lex_bot" "aselo_development_bot" {
   idle_session_ttl_in_seconds = 600
 
   intent {
-    intent_name    = "Survey"
-    intent_version = "$$LATEST"
+    intent_name    = aws_lex_intent.survey_intent.name
+    intent_version = aws_lex_intent.survey_intent.version
   }
 
   locale           = "en-US"

--- a/twilio-iac/aws-lex/as-development/bot_alias.tf
+++ b/twilio-iac/aws-lex/as-development/bot_alias.tf
@@ -1,0 +1,6 @@
+resource "aws_lex_bot_alias" "aselo_development" {
+  bot_name    = "AseloDevSurvey"
+  bot_version = "1"
+  description = "Aselo Development Version of the Wechat Bot."
+  name        = "AseloDevSurveyBot"
+}

--- a/twilio-iac/aws-lex/as-development/intents.tf
+++ b/twilio-iac/aws-lex/as-development/intents.tf
@@ -20,6 +20,7 @@ resource "aws_lex_intent" "survey_intent" {
     "Incoming webchat contact",
   ]
 
+  # I am not sure this would work. Just added it for completeness sake
   initial_response {
     max_attempts = 2
 
@@ -102,6 +103,7 @@ resource "aws_lex_intent" "survey_intent" {
     }
   }
 
+  # I am not sure this would work. Just added it for completeness sake
   closing_response {
     max_attempts = 2
 

--- a/twilio-iac/aws-lex/as-development/intents.tf
+++ b/twilio-iac/aws-lex/as-development/intents.tf
@@ -1,0 +1,113 @@
+resource "aws_lex_intent" "survey_intent" { 
+
+  name           = "Survey"
+  description    = "Intent for aselo development webchat"
+  version        = "$LATEST"
+
+  sample_utterances = [
+    "H",
+    "Hi",
+    "Hello",
+    "Help",
+    "I need help",
+    "Pls",
+    "Please",
+    "Life",
+    "Not safe",
+    "Kill",
+    "Hurt",
+    "Me",
+    "Incoming webchat contact",
+  ]
+
+  initial_response {
+    max_attempts = 2
+
+    message {
+      content      = "Welcome to the helpline. To help us better serve you, please answer the following three questions."
+      content_type = "PlainText"
+    }
+  }
+
+  fulfillment_activity {
+    type = "ReturnIntent"
+  }
+
+  rejection_statement {
+    message {
+      content      = "Okay, I will not place your order."
+      content_type = "PlainText"
+    }
+  }
+
+  slot {
+    description = "Caller is calling for self or not"
+    name        = "callerType"
+    priority    = 1
+
+    slot_constraint   = "Required"
+    slot_type         = aws_lex_slot_type.caller_types.name
+    slot_type_version = aws_lex_slot_type.caller_types.version
+
+    value_elicitation_prompt {
+      max_attempts = 2
+
+      message {
+        content      = "Are you calling about yourself? Please answer Yes or No."
+        content_type = "PlainText"
+      }
+    }
+  }
+
+  slot {
+    description = "Caller's age"
+    name        = "age"
+    priority    = 2
+
+    slot_constraint   = "Required"
+    slot_type         = aws_lex_slot_type.age.name
+    slot_type_version = aws_lex_slot_type.age.version
+
+    value_elicitation_prompt {
+      max_attempts = 2
+
+      message {
+        content      = "Thank you. You can say ‘prefer not to answer’ (or type X) to any question."
+        content_type = "PlainText"
+      }
+
+      message {
+        content      = "How old are you?"
+        content_type = "PlainText"
+      }
+    }
+  }
+
+  slot {
+    description = "Caller's gender"
+    name        = "gender"
+    priority    = 3
+
+    slot_constraint   = "Required"
+    slot_type         = aws_lex_slot_type.gender.name
+    slot_type_version = aws_lex_slot_type.gender.version
+
+    value_elicitation_prompt {
+      max_attempts = 2
+
+      message {
+        content      = "What is your gender?"
+        content_type = "PlainText"
+      }
+    }
+  }
+
+  closing_response {
+    max_attempts = 2
+
+    message {
+      content      = "We'll transfer you now. Please hold for a counsellor."
+      content_type = "PlainText"
+    }
+  }
+}

--- a/twilio-iac/aws-lex/as-development/slot_types.tf
+++ b/twilio-iac/aws-lex/as-development/slot_types.tf
@@ -32,6 +32,18 @@ resource "aws_lex_slot_type" "age" {
   description    = "Caller's age"
   version        = "$LATEST"
 
+  sample_utterances = [
+    "Yeah",
+    "Yea",
+    "Y",
+    "N",
+    "No",
+    "Na",
+    "Nah",
+    "Nooo",
+    "Yah"
+  ]
+
   enumeration_value {
     synonyms = [
       "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11",

--- a/twilio-iac/aws-lex/as-development/slot_types.tf
+++ b/twilio-iac/aws-lex/as-development/slot_types.tf
@@ -1,0 +1,129 @@
+resource "aws_lex_slot_type" "caller_types" {
+  description   = "Caller is calling for self or not"
+  version       = "$LATEST"
+
+  enumeration_value {
+    synonyms = [
+      "Y",
+      "Ya",
+      "Yah",
+      "Yeah"
+    ]
+
+    value = "Yes"
+  }
+
+  enumeration_value {
+    synonyms = [
+      "N",
+      "Na",
+      "Nah",
+      "Noo"
+    ]
+
+    value = "No"
+  }
+
+  name                     = "CallerTypes"
+  value_selection_strategy = "ORIGINAL_VALUE"
+}
+
+resource "aws_lex_slot_type" "age" {
+  create_version = true
+  description    = "Caller's age"
+
+  enumeration_value {
+    synonyms = [
+      "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11",
+      "12", "13", "14", "15", "16", "17", "18", "19", "20", "21"
+    ]
+
+    value = "21 and Below"
+  }
+
+  enumeration_value {
+    synonyms = [
+      "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", 
+      "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", 
+      "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", 
+      "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", 
+      "62", "63", "64", "65", "66", "67", "68", "69", "70", "71",
+      "72", "73", "74", "75", "76", "77", "78", "79", "80", "81",
+      "82", "83", "84", "85", "86", "87", "88", "89", "90", "91", 
+      "92", "93", "94", "95", "96", "97", "98", "99", "100", "101", 
+      "102", "103", "104", "105", "106", "107", "108", "109", "110"
+    ]
+
+    value = "Above 21"
+  }
+
+  enumeration_value {
+    value = "X"
+  }
+
+  enumeration_value {
+    value = "prefer not to answer"
+  }
+
+  name                     = "Age"
+  value_selection_strategy = "ORIGINAL_VALUE"
+}
+
+resource "aws_lex_slot_type" "gender" {
+  description   = "Caller's gender"
+  version       = "$LATEST"
+
+  enumeration_value {
+    synonyms = [
+      "M",
+      "Dude",
+      "Guy",
+      "Man",
+      "He",
+      "Male"
+    ]
+
+    value = "Boy"
+  }
+
+  enumeration_value {
+    synonyms = [
+      "Woman",
+      "Lady",
+      "Female",
+      "She",
+      "F"
+    ]
+
+    value = "Girl"
+  }
+
+  enumeration_value {
+    synonyms = [
+      "None",
+      "Non binary",
+    ]
+
+    value = "Non-Binary"
+  }
+
+  enumeration_value {
+    synonyms = [
+      "X",
+      "not sure",
+      "Unsure"
+    ]
+
+    value = "Unknown"
+  }
+
+  enumeration_value {
+    value = "prefer not to answer"
+  }
+
+  name                     = "Gender"
+  value_selection_strategy = "ORIGINAL_VALUE"
+}
+
+
+

--- a/twilio-iac/aws-lex/as-development/slot_types.tf
+++ b/twilio-iac/aws-lex/as-development/slot_types.tf
@@ -29,8 +29,8 @@ resource "aws_lex_slot_type" "caller_types" {
 }
 
 resource "aws_lex_slot_type" "age" {
-  create_version = true
   description    = "Caller's age"
+  version        = "$LATEST"
 
   enumeration_value {
     synonyms = [


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @GPaoloni 

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- New feature: writing the terraform definitions for the aws_lex bots for Aselo development. 
- This PR aims to verify that the Terraform module was implemented correctly and the file was adequately structured.
- I have not run `terraform plan` or `terraform apply` yet. Would have to get approval from @robert-bo-davis before doing that.

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Feature flags added
- [N/A] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes [CHI-1786](https://tech-matters.atlassian.net/browse/CHI-1796)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

Task was structured into different folders in twilio-iac:

> /aws_lex
> /as-development
    > bot_alias.tf
    > bot.tf
    > intents.tf
    > slot_types.tf
    