### PR TITLE
chore: use ssm to pull in webhook url based on environment POC

### DIFF
--- a/twilio-iac/helplines/cl/production.hcl
+++ b/twilio-iac/helplines/cl/production.hcl
@@ -4,7 +4,7 @@ locals {
   config            = merge(local.common_config, local.local_config)
 
   local_config = {
-    slack_webhook_url = "https://hooks.slack.com/example"
+
     #Studio flow
     flow_vars = {
       service_sid                  = "ZSe84c8040f76f6e331310f132b88c25d8"

--- a/twilio-iac/helplines/cl/staging.hcl
+++ b/twilio-iac/helplines/cl/staging.hcl
@@ -4,7 +4,7 @@ locals {
   config            = merge(local.common_config, local.local_config)
 
   local_config = {
-    slack_webhook_url = "https://hooks.slack.com/example"
+ 
     #Studio flow
     flow_vars = {
       service_sid                  = "ZSeed7070ce3f2974cb12a0382a2c93340"

--- a/twilio-iac/helplines/templates/studio-flows/messaging-no-chatbot-operating-hours.tftpl
+++ b/twilio-iac/helplines/templates/studio-flows/messaging-no-chatbot-operating-hours.tftpl
@@ -40,7 +40,7 @@ ${
             "event": "success"
           },
           {
-            "next": "slack_notify_error",
+            "next": "webhook_notify_error",
             "event": "fail"
           }
         ],
@@ -74,7 +74,7 @@ ${
         "type": "split-based-on",
         "transitions": [
           {
-            "next": "slack_notify_error",
+            "next": "webhook_notify_error",
             "event": "noMatch"
           },
           {
@@ -115,7 +115,7 @@ ${
         }
       },
       {
-        "name": "slack_notify_error",
+        "name": "webhook_notify_error",
         "type": "make-http-request",
         "transitions": [
           {
@@ -133,7 +133,7 @@ ${
           "method": "POST",
           "content_type": "application/json;charset=utf-8",
           "body": "{ \"text\": \"Issue detected on ${short_helpline} ${short_environment} Flow SID: {{flow.flow_sid}} Execution SID: {{flow.sid}}  \" }",
-          "url": slack_webhook_url
+          "url": webhook_url_studio_errors
         }
       },
       {
@@ -145,7 +145,7 @@ ${
             "event": "sent"
           },
           {
-            "next": "slack_notify_error",
+            "next": "webhook_notify_error",
             "event": "failed"
           }
         ],
@@ -169,7 +169,7 @@ ${
             "event": "sent"
           },
           {
-            "next": "slack_notify_error",
+            "next": "webhook_notify_error",
             "event": "failed"
           }
         ],

--- a/twilio-iac/helplines/templates/studio-flows/voice-no-chatbot-operating-hours.tftpl
+++ b/twilio-iac/helplines/templates/studio-flows/voice-no-chatbot-operating-hours.tftpl
@@ -39,11 +39,11 @@ ${
             "event": "callComplete"
           },
           {
-            "next": "slack_notify_error",
+            "next": "webhook_notify_error",
             "event": "failedToEnqueue"
           },
           {
-            "next": "slack_notify_error",
+            "next": "webhook_notify_error",
             "event": "callFailure"
           }
         ],
@@ -86,7 +86,7 @@ ${
             "event": "success"
           },
           {
-            "next": "slack_notify_error",
+            "next": "webhook_notify_error",
             "event": "fail"
           }
         ],
@@ -120,7 +120,7 @@ ${
         "type": "split-based-on",
         "transitions": [
           {
-            "next": "slack_notify_error",
+            "next": "webhook_notify_error",
             "event": "noMatch"
           },
           {
@@ -161,7 +161,7 @@ ${
         }
       },
       {
-        "name": "slack_notify_error",
+        "name": "webhook_notify_error",
         "type": "make-http-request",
         "transitions": [
           {
@@ -179,7 +179,7 @@ ${
           "method": "POST",
           "content_type": "application/json;charset=utf-8",
           "body": "{ \"text\": \"Issue detected on ${short_helpline} ${short_environment} Flow SID: {{flow.flow_sid}} Execution SID: {{flow.sid}}  \" }",
-          "url": slack_webhook_url
+          "url": webhook_url_studio_errors
         }
       },
       {

--- a/twilio-iac/linealibre-cl-production/main.tf
+++ b/twilio-iac/linealibre-cl-production/main.tf
@@ -75,9 +75,6 @@ locals {
     "webchat" = { "contact_identity" = "", "channel_type" = "web" }
   }
 
-
-  slack_webhook_url = "https://hooks.slack.com/example"
-
   //serverless
   ui_editable = true
 

--- a/twilio-iac/linealibre-cl-staging/main.tf
+++ b/twilio-iac/linealibre-cl-staging/main.tf
@@ -75,8 +75,7 @@ locals {
   }
   custom_channels    = []
   strings            = jsondecode(file("${path.module}/../translations/${local.helpline_language}/strings.json"))
-  slack_webhook_url            = "https://hooks.slack.com/example"
- 
+
   //serverless
   ui_editable = true
 

--- a/twilio-iac/stages/aws-provider.tftpl
+++ b/twilio-iac/stages/aws-provider.tftpl
@@ -4,6 +4,8 @@ provider "aws" {
     session_name = "tf-${environment}-${short_helpline}-${stage}"
   }
 
+  region = "us-east-1"
+
   # Make it faster by skipping some things
   skip_metadata_api_check     = true
   skip_region_validation      = true

--- a/twilio-iac/terraform-modules/channels/v1/main.tf
+++ b/twilio-iac/terraform-modules/channels/v1/main.tf
@@ -12,7 +12,8 @@ data "aws_ssm_parameter" "webhook_url_studio_errors" {
 }
 
 locals {
-  webhook_url_studio_errors = data.aws_ssm_parameter.webhook_url_studio_errors.value
+  #Marking this as non sensitive since we need to see the studio flow definition when running a plan to validate changes.
+  webhook_url_studio_errors = nonsensitive(data.aws_ssm_parameter.webhook_url_studio_errors.value)
 }
 
 #I'm not sure about this resource, the idea is to have 1 studio flow json template and also as few as possible
@@ -47,7 +48,7 @@ resource "twilio_studio_flows_v2" "channel_studio_flow" {
       }
       workflow_sids     = var.workflow_sids,
       task_channel_sids = var.task_channel_sids
-      slack_webhook_url = local.webhook_url_studio_errors
+      webhook_url_studio_errors = local.webhook_url_studio_errors
       short_helpline    = var.short_helpline
       short_environment = var.short_environment
       channel_attributes = merge(

--- a/twilio-iac/terraform-modules/channels/v1/main.tf
+++ b/twilio-iac/terraform-modules/channels/v1/main.tf
@@ -7,20 +7,26 @@ terraform {
   }
 }
 
-#I'm not sure about this resource, the idea is to have 1 studio flow json template and also as few as possible 
-#channel attribute templates. 
+data "aws_ssm_parameter" "webhook_url_studio_errors" {
+  name = "/${var.environment}/slack/webhook_url_studio_errors"
+}
 
-#var.flow_vars would be a dynamic map with all variables needed that are set in the configuration layer and common to every channel 
+locals {
+  webhook_url_studio_errors = data.aws_ssm_parameter.webhook_url_studio_errors.value
+}
+
+#I'm not sure about this resource, the idea is to have 1 studio flow json template and also as few as possible
+#channel attribute templates.
+
+#var.flow_vars would be a dynamic map with all variables needed that are set in the configuration layer and common to every channel
 #(channel_flow_vars would be specific to the channel), like function sids (created outside terraform)
 #or other variables specific to the helpline or template being used.
 
-#var.chatbots should be a map with all the chatbots objects (not just the sid, for amazon lex we might need a webhook or something), this should be the ouput of the chatbot module, 
+#var.chatbots should be a map with all the chatbots objects (not just the sid, for amazon lex we might need a webhook or something), this should be the ouput of the chatbot module,
 #so this module should be called after the creation of chatbots. The studio flow template will usually need the chatbot sids or identifier to call them.
 
 #I'm not sure about the "channel_attributes =" section, channel_attributes will be different depending on the channel and chatbots used.
 #The chatbots are needed to save their memory inside the channel attributes. A default channel attribute with no chatbots will usually require only the task_language
-
-
 
 
 resource "twilio_studio_flows_v2" "channel_studio_flow" {
@@ -41,7 +47,7 @@ resource "twilio_studio_flows_v2" "channel_studio_flow" {
       }
       workflow_sids     = var.workflow_sids,
       task_channel_sids = var.task_channel_sids
-      slack_webhook_url = var.slack_webhook_url
+      slack_webhook_url = local.webhook_url_studio_errors
       short_helpline    = var.short_helpline
       short_environment = var.short_environment
       channel_attributes = merge(

--- a/twilio-iac/terraform-modules/channels/v1/variables.tf
+++ b/twilio-iac/terraform-modules/channels/v1/variables.tf
@@ -18,12 +18,6 @@ variable "task_language" {
   description = "Override the default language by setting this"
 }
 
-variable "slack_webhook_url" {
-  type        = string
-  default     = ""
-  description = "Slack income webhook"
-}
-
 variable "channels" {
   type = map(object({
     templatefile         = string,

--- a/twilio-iac/terraform-modules/channels/v1/variables.tf
+++ b/twilio-iac/terraform-modules/channels/v1/variables.tf
@@ -1,3 +1,8 @@
+variable "environment" {
+  description = "Environment identifier, typically 'production', 'staging' or 'development'"
+  type        = string
+}
+
 variable "short_environment" {
   description = "Short upper case environment identifier, typically 'PROD', 'STG' or 'DEV'"
   type        = string

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -93,6 +93,7 @@ module "channel" {
   channels              = var.channels
   chatbots              = local.chatbots
   enable_post_survey    = var.enable_post_survey
+  environment           = var.environment
   flow_vars             = var.flow_vars
   short_environment     = var.short_environment
   task_language         = var.task_language

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -98,7 +98,6 @@ module "channel" {
   short_environment     = var.short_environment
   task_language         = var.task_language
   short_helpline        = upper(var.short_helpline)
-  slack_webhook_url     = var.slack_webhook_url
 }
 
 

--- a/twilio-iac/terraform-modules/stages/configure/variables.tf
+++ b/twilio-iac/terraform-modules/stages/configure/variables.tf
@@ -181,8 +181,3 @@ variable "enable_post_survey" {
   type    = bool
   default = false
 }
-
-variable "slack_webhook_url" {
-  type        = string
-  description = "Slack income webhook"
-}


### PR DESCRIPTION
…into alejandro/cl/tf_migration_2<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This sets up the channels module to pull the correct secret for webhook url out of SSM. The ssm params have been manually created.

I did *not* cleanup all of the unneeded variables/config settings. I'll leave that to you @janorivera 