### PR TITLE
chore: add ssm param for transcript retention override

### DIFF
--- a/twilio-iac/helplines/ca/production.hcl
+++ b/twilio-iac/helplines/ca/production.hcl
@@ -40,7 +40,7 @@ locals {
       g2t : ["????"],
     }
 
-    hrm_transcript_retention_override = 90
+    hrm_transcript_retention_days_override = 90
 
      // THIS SHOULD BE REMOVED Serverless
     ui_editable = true

--- a/twilio-iac/helplines/ca/production.hcl
+++ b/twilio-iac/helplines/ca/production.hcl
@@ -39,8 +39,10 @@ locals {
       khp : ["????"],
       g2t : ["????"],
     }
-    
-     // THIS SHOULD BE REMOVED Serverless 
+
+    hrm_transcript_retention_override = 90
+
+     // THIS SHOULD BE REMOVED Serverless
     ui_editable = true
 
      #Chatbots

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -193,3 +193,11 @@ moved {
   from = module.voiceChannel
   to   = module.voiceChannel[0]
 }
+
+resource "aws_ssm_parameter" "transcript_retention_override" {
+  count = var.hrm_transcript_retention_override >= 0 ? 1 : 0
+
+  name  = "/${var.environment}/hrm/${local.secrets.twilio_account_sid}/transcript_retention_days"
+  type  = "String"
+  value = var.hrm_transcript_retention_override
+}

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -195,9 +195,9 @@ moved {
 }
 
 resource "aws_ssm_parameter" "transcript_retention_override" {
-  count = var.hrm_transcript_retention_override >= 0 ? 1 : 0
+  count = var.hrm_transcript_retention_days_override >= 0 ? 1 : 0
 
   name  = "/${var.environment}/hrm/${local.secrets.twilio_account_sid}/transcript_retention_days"
   type  = "String"
-  value = var.hrm_transcript_retention_override
+  value = var.hrm_transcript_retention_days_override
 }

--- a/twilio-iac/terraform-modules/stages/configure/variables.tf
+++ b/twilio-iac/terraform-modules/stages/configure/variables.tf
@@ -187,3 +187,9 @@ variable "resources_base_url" {
   type        = string
   default     = ""
 }
+
+variable "hrm_transcript_retention_override" {
+  description = "Number of days to retain HRM Contact Job Cleanup logs"
+  type        = number
+  default     = -1
+}

--- a/twilio-iac/terraform-modules/stages/configure/variables.tf
+++ b/twilio-iac/terraform-modules/stages/configure/variables.tf
@@ -188,7 +188,7 @@ variable "resources_base_url" {
   default     = ""
 }
 
-variable "hrm_transcript_retention_override" {
+variable "hrm_transcript_retention_days_override" {
   description = "Number of days to retain HRM Contact Job Cleanup logs"
   type        = number
   default     = -1


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This adds an SSM parameter to set the CA Production ssm param for 90 days of transcript retention. It has been targeted applied.

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Verify ssm param exists
