### PR TITLE
bg: Fix Household Member/Perpetrator Duplication

### DIFF
--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -43,7 +43,7 @@ import { transformValues } from '../../services/ContactService';
 import { updateCase } from '../../services/CaseService';
 import { createStateItem, CustomHandlers, disperseInputs, splitAt, splitInHalf } from '../common/forms/formGenerators';
 import { useCreateFormFromDefinition } from '../forms';
-import type { CaseInfo, CaseItemEntry, CaseItemFormValues, CustomITask, StandaloneITask } from '../../types/types';
+import type { CaseInfo, CaseItemEntry, CustomITask, StandaloneITask } from '../../types/types';
 import {
   AddCaseSectionRoute,
   AppRoutes,

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -191,8 +191,23 @@ const AddEditCaseItem: React.FC<Props> = ({
       };
       newInfo = sectionApi.upsertCaseSectionItemFromForm(info, newItem);
       formDefinition.forEach(fd => {
+        /*
+         * In the first instance when fd.type === 'copy-to', rawForm[fd.name] returns a boolean.
+         * Then subsequently rawForm[fd.name] returns an array
+         * First, we check when rawForm[fd.name] is a boolean and assign the value validateCopyTo.
+         * Next, we check when rawForm[fd.name] is array,
+         * validates if its length is greater than zero and assign the value to validateCopyTo
+         */
+
+        let validateCopyTo = rawForm[fd.name];
+        const isArray = Array.isArray(rawForm[fd.name]);
+
+        if (isArray) {
+          validateCopyTo = (rawForm[fd.name] as string).length > 0;
+        }
+
         // A preceding 'filter' call looks nicer but TS type narrowing isn't smart enough to work with that.
-        if (fd.type === 'copy-to' && rawForm[fd.name]) {
+        if (fd.type === 'copy-to' && validateCopyTo) {
           newInfo = copyCaseSectionItem({
             definition: definitionVersion,
             original: newInfo,

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -43,7 +43,7 @@ import { transformValues } from '../../services/ContactService';
 import { updateCase } from '../../services/CaseService';
 import { createStateItem, CustomHandlers, disperseInputs, splitAt, splitInHalf } from '../common/forms/formGenerators';
 import { useCreateFormFromDefinition } from '../forms';
-import type { CaseInfo, CaseItemEntry, CustomITask, StandaloneITask } from '../../types/types';
+import type { CaseInfo, CaseItemEntry, CaseItemFormValues, CustomITask, StandaloneITask } from '../../types/types';
 import {
   AddCaseSectionRoute,
   AppRoutes,
@@ -191,23 +191,8 @@ const AddEditCaseItem: React.FC<Props> = ({
       };
       newInfo = sectionApi.upsertCaseSectionItemFromForm(info, newItem);
       formDefinition.forEach(fd => {
-        /*
-         * In the first instance when fd.type === 'copy-to', rawForm[fd.name] returns a boolean.
-         * Then subsequently rawForm[fd.name] returns an array
-         * First, we check when rawForm[fd.name] is a boolean and assign the value validateCopyTo.
-         * Next, we check when rawForm[fd.name] is array,
-         * validates if its length is greater than zero and assign the value to validateCopyTo
-         */
-
-        let validateCopyTo = rawForm[fd.name];
-        const isArray = Array.isArray(rawForm[fd.name]);
-
-        if (isArray) {
-          validateCopyTo = (rawForm[fd.name] as string).length > 0;
-        }
-
         // A preceding 'filter' call looks nicer but TS type narrowing isn't smart enough to work with that.
-        if (fd.type === 'copy-to' && validateCopyTo) {
+        if (fd.type === 'copy-to' && rawForm[fd.name]) {
           newInfo = copyCaseSectionItem({
             definition: definitionVersion,
             original: newInfo,
@@ -228,6 +213,9 @@ const AddEditCaseItem: React.FC<Props> = ({
   async function saveAndStay() {
     await save();
     closeActions({ ...routing, action: CaseItemAction.Add });
+
+    // Reset the entire form state, fields reference, and subscriptions.
+    methods.reset();
   }
 
   async function saveAndLeave() {


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Bug fix: Household Member/Perpetrator Duplication

**The Problem:** In the Case forms, while adding household members or perpetrators, when we add two or more households or perpetrators consecutively (Save and add Another…), it gets duplicated (even though the checkbox to add them to the perpetrator/household is not selected). When we add just one household or perpetrator and exit, it doesn’t happen. This only happens when we add two or more households or perpetrators consecutively.

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Feature flags added
- [N/A] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes [CHI-1963](https://tech-matters.atlassian.net/browse/CHI-1963)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
- Navigate to case-list and select a case you created
- Click on the `Perpetrator` or `Household Member` button
- Input data, but don't select the checkbox. Click on the `Save and add Another…` button
- Repeat step 3
-  Repeat step 3 again, but this time, select the checkbox
- Navigate back to case-list (click on the `Cancel` button)
- Verify that the added household member/perpetrator is only duplicated where the checkbox was selected.