### PR TITLE
Adding form_definitions_base_url & production plans

### DIFF
--- a/twilio-iac/terraform-modules/flex/service-configuration/main.tf
+++ b/twilio-iac/terraform-modules/flex/service-configuration/main.tf
@@ -8,10 +8,11 @@ terraform {
 }
 
 locals {
-  hrm_url            = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
-  resources_base_url = var.resources_base_url
-  assets_bucket_url  = "https://assets-${lower(var.environment)}.tl.techmatters.org"
-  permission_config  = var.permission_config == "" ? var.operating_info_key : var.permission_config
+  hrm_url                   = var.hrm_url == "" ? (var.short_environment == "PROD" ? "https://hrm-production.tl.techmatters.org" : (var.short_environment == "STG" ? "https://hrm-staging.tl.techmatters.org" : "https://hrm-development.tl.techmatters.org")) : var.hrm_url
+  resources_base_url        = var.resources_base_url
+  assets_bucket_url         = "https://assets-${lower(var.environment)}.tl.techmatters.org"
+  form_definitions_base_url = "${local.assets_bucket_url}/form-definitions/"
+  permission_config         = var.permission_config == "" ? var.operating_info_key : var.permission_config
 
   // This cmd_args hackery is temporary until all helplines are migrated to terragrunt or until these scripts are moved to post-apply/after hooks.
   cmd_args = var.stage == "" ? "--helplineDirectory=${basename(abspath(path.root))}" : "--stage=${var.stage} --helplineShortCode=${lower(var.short_helpline)} --helplineEnvironment=${lower(var.environment)}"
@@ -69,7 +70,8 @@ locals {
       "monitoringEnv" : "production",
       "assets_bucket_url" : local.assets_bucket_url,
       "hrm_base_url" : local.hrm_url,
-      "resources_base_url" : local.resources_base_url
+      "resources_base_url" : local.resources_base_url,
+      "form_definitions_base_url" : local.form_definitions_base_url,
       "pdfImagesSource" : "https://tl-public-chat.s3.amazonaws.com",
       "logo_url" : "https://aselo-logo.s3.amazonaws.com/145+transparent+background+no+TM.png",
       "multipleOfficeSupport" : var.multi_office_support,


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Adding form_definitions_base_url to service configuration. This was breaking CA production so it is needed in order to be able to execute the configure stage without breaking the account. This has been tested on NZ staging.
@stephenhand  I think this is right, right?

@robert-bo-davis  I'm also attaching the production plans for the 2 prod accounts that we have under terragrunt (CL and CA), thank god that there are only 2!
All changes are expected. For CA it will delete the survey resources and update the parameters. The flex configuration changes are also expected, but I can't say for sure if something else is changing for flex configs.  I will keep a backup configuration though when running the applies just to have something to go back to in case something breaks.


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

Files

[chatbot_ca_production.txt](https://github.com/techmatters/flex-plugins/files/11579822/chatbot_ca_production.txt)
[chatbot_cl_production.txt](https://github.com/techmatters/flex-plugins/files/11579823/chatbot_cl_production.txt)
[configure_ca_production.txt](https://github.com/techmatters/flex-plugins/files/11579824/configure_ca_production.txt)
[configure_cl_production.txt](https://github.com/techmatters/flex-plugins/files/11579825/configure_cl_production.txt)
[provision_ca_production.txt](https://github.com/techmatters/flex-plugins/files/11579826/provision_ca_production.txt)
[provision_cl_production.txt](https://github.com/techmatters/flex-plugins/files/11579827/provision_cl_production.txt)

