### PR TITLE
Add feature flag to switch resources over to use elastic search

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
@@ -79,7 +79,7 @@ describe('actions', () => {
 
     test('Calls the searchResources service, calculating the start index from the provided page & limit', () => {
       searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 42 }, 1337, true);
-      expect(searchResources).toHaveBeenCalledWith({ nameSubstring: 'hello', ids: [] }, 1337 * 42, 42);
+      expect(searchResources).toHaveBeenCalledWith({ generalSearchTerm: 'hello', ids: [] }, 1337 * 42, 42);
     });
 
     test("'newSearch' flag set - dispatches pending action that resets the result array and sets status to ResultPending", async () => {

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -84,7 +84,7 @@ export const searchResourceAsyncAction = createAsyncAction(
     const { pageSize, generalSearchTerm } = parameters;
     const start = page * pageSize;
     const [nameSubstring, ...ids] = generalSearchTerm.split(';');
-    return { ...(await searchResources({ nameSubstring, ids }, start, pageSize)), start };
+    return { ...(await searchResources({ generalSearchTerm: nameSubstring, ids }, start, pageSize)), start };
   },
   ({ pageSize }: SearchSettings, page: number, newSearch: boolean = true) => ({ newSearch, start: page * pageSize }),
   // { promiseTypeDelimiter: '/' }, // Doesn't work :-(

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -260,6 +260,7 @@ export type FeatureFlags = {
   enable_counselor_toolkits: boolean; // Enables Counselor Toolkits
   enable_emoji_picker: boolean; // Enables Emoji Picker
   enable_aselo_messaging_ui: boolean; // Enables Aselo Messaging UI iinstead of the default Twilio one - reduced functionality for low spec clients.
+  enable_resources_elastic_search: boolean; // Use the EasticSearch powered search for resources, rather than the interim name only version.
 };
 /* eslint-enable camelcase */
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -155,14 +155,51 @@ will create a new file `my_custom_bot.tf` that contains the definition of the bo
 
 This script allows you to safely update the feature flags specified in a Twilio Account's Service Configuration without affecting other settings
 
+#### Providing Twilio Credentials
+
+If you want to update feature flags for a single account and have their credentials handy, you can set them in your environment to use this tool:
+
 You need to have `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` environment variables set (either passed in the command itself or in a `.env` file).
-You also must provide the following parameters to the script:
+
+#### Using AWS credentials to look up accounts
+
+If you have an AWS account with privileges to look up SSM parameters, you can set up your aws creds in the environment.
+
+Then, to select a single account, you pass the `--helplineEnvironment` argument with either `development`, `staging` or `production` and `--helplineShortCode` with the helpline account (upper case, e.g. `AS`, `ZM`).
+
+Alternatively you can just set the `--helplineEnvironment` and omit a `--helplineShortCode` to set the flags for all accounts in a given environment.
+
+NB: **These parameters need to be specified ahead of the `patch-feature-flags` command, not after like the flags you want to set.**
+
+#### Specifying the flags
+
+Using either approach, you also must provide the following parameters to the script:
 
 - `-f / --flag`: Use this to specify a flag and what you wish to set it to. The value must take the form {flag_name}:{flag_set}, e.g. -f my_flag:true. Can be specified multiple times
-  Example:
+
+Examples:
+
+1. Single account (Twilio credentials in environment):
 
 ```
 ➜ npm run twilioResources patch-feature-flags -- -f enable_voice_recordings:false -f enable_twilio_transcripts:true
 ```
 
 will set the `enable_voice_recordings` to false, and the `enable_transcripts` flag to true, creating them if they didn't previously exist, or overwriting their previous setting if they did.
+
+2. Single account (AWS credentials in environment):
+
+```
+➜ npm run twilioResources -- --helplineEnvironment development --helplineShortCode AS patch-feature-flags -f enable_voice_recordings:false -f enable_twilio_transcripts:true
+```
+
+This sets the same flags as the example above, but uses AWS to look up the Twilio credentials for the Aselo Development account. Note that the `--helplineShortCode` and the `--helplineEnvironment` arguments are passed in before the `patch-feature-flags` command, not after.
+
+
+3Single account (AWS credentials in environment):
+
+```
+➜ npm run twilioResources -- --helplineEnvironment development --helplineShortCode AS patch-feature-flags -f enable_voice_recordings:false -f enable_twilio_transcripts:true
+```
+
+This sets the same flags as the example above, but uses AWS to look up the Twilio credentials for all the accounts in the development environment and will set the flags for each of them.

--- a/scripts/src/terraformSupplemental/runAgainstAllAccountsForEnvironment.ts
+++ b/scripts/src/terraformSupplemental/runAgainstAllAccountsForEnvironment.ts
@@ -1,4 +1,4 @@
-import { getSSMParametersByPath } from '../helpers/ssm';
+import { getSSMParameter, getSSMParametersByPath } from '../helpers/ssm';
 import { logDebug } from '../helpers/log';
 
 export const enum Environment {
@@ -15,10 +15,14 @@ export const enum Strategy {
 
 type AccountSID = `AC${string}`;
 
+export const forShortCodes = (helplineCodes: string[] | string) => (shortCode: string) =>
+  (Array.isArray(helplineCodes) ? helplineCodes : [helplineCodes]).includes(shortCode);
+
 export const runAgainstAllAccountsForEnvironment = async (
   environment: Environment,
   action: (accountSid: AccountSID, authToken: string) => Promise<void>,
   strategy: Strategy = Strategy.SEQUENTIAL,
+  filter: (shortCode: string, accountSid: AccountSID) => boolean = () => true,
 ) => {
   const allTwilioTokenParameters = await getSSMParametersByPath(`/${environment}/twilio`);
   logDebug(
@@ -26,17 +30,31 @@ export const runAgainstAllAccountsForEnvironment = async (
     `/${environment}/twilio`,
     allTwilioTokenParameters.length,
   );
-  const allCreds = allTwilioTokenParameters
+  const allAccounts = allTwilioTokenParameters
     .map((parameter) => {
-      logDebug('Testing parameter:', parameter.Name);
-      const match = parameter.Name!.match(/\/[a-z]+\/twilio\/(AC[0-9a-fA-F]+)\/auth_token/);
+      const match = parameter.Name!.match(/\/[a-z]+\/twilio\/([0-9a-zA-Z]+)\/account_sid/);
       if (match) {
-        logDebug('found accountSid:', match[1]);
-        return { accountSid: match[1], authToken: parameter.Value! };
+        logDebug('found accountSid:', match[1], parameter.Value);
+        return { shortCode: match[1], accountSid: parameter.Value! as AccountSID };
       }
+      logDebug('Miss:', parameter.Name);
+
       return null;
     })
-    .filter((p) => p) as { accountSid: AccountSID; authToken: string }[];
+    .filter(
+      (p: { shortCode: string; accountSid: AccountSID } | null) =>
+        p && filter(p.shortCode, p.accountSid),
+    );
+  const allCreds = await Promise.all(
+    allAccounts.map(async (p) => {
+      const { accountSid } = p!;
+      return {
+        accountSid,
+        authToken: (await getSSMParameter(`/${environment}/twilio/${accountSid}/auth_token`, true))!
+          .Parameter!.Value!,
+      };
+    }),
+  );
   logDebug('account cred sets found:', allCreds.length);
   if (strategy === Strategy.SEQUENTIAL) {
     // eslint-disable-next-line no-restricted-syntax

--- a/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
+++ b/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
@@ -20,9 +20,9 @@ async function main() {
     logDebug(`Updating asset urls for ${environment}`);
     // eslint-disable-next-line no-await-in-loop
     await runAgainstAllAccountsForEnvironment(environment, async (accountSid, authToken) => {
-      process.env.TWILIO_ACCOUNT_SID = accountSid;
-      process.env.TWILIO_AUTH_TOKEN = authToken;
       await patchFeatureFlags(
+        accountSid,
+        authToken,
         {},
         { assets_bucket_url: `https://assets-${environment}.tl.techmatters.org` },
         false,


### PR DESCRIPTION
## Description

* Recreates function to allow scripts to be run against multiple accounts - not sure why this was deleted?
* Added option to SSM helper to use account privileges as is
* Allows `patch-feature-flags` to be run by specifying helpline code or against a whole environment
* Added warning to README.md to only use patch-feature-flags on accounts not managed by the new Terraform system


### Related Issues
CHI-1599