### PR TITLE
CHI-1599 Add feature flag to switch resources over to use elastic search

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
@@ -79,7 +79,7 @@ describe('actions', () => {
 
     test('Calls the searchResources service, calculating the start index from the provided page & limit', () => {
       searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 42 }, 1337, true);
-      expect(searchResources).toHaveBeenCalledWith({ nameSubstring: 'hello', ids: [] }, 1337 * 42, 42);
+      expect(searchResources).toHaveBeenCalledWith({ generalSearchTerm: 'hello', ids: [] }, 1337 * 42, 42);
     });
 
     test("'newSearch' flag set - dispatches pending action that resets the result array and sets status to ResultPending", async () => {

--- a/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
@@ -79,7 +79,7 @@ describe('actions', () => {
 
     test('Calls the searchResources service, calculating the start index from the provided page & limit', () => {
       searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 42 }, 1337, true);
-      expect(searchResources).toHaveBeenCalledWith({ generalSearchTerm: 'hello', ids: [] }, 1337 * 42, 42);
+      expect(searchResources).toHaveBeenCalledWith({ generalSearchTerm: 'hello', filters: {} }, 1337 * 42, 42);
     });
 
     test("'newSearch' flag set - dispatches pending action that resets the result array and sets status to ResultPending", async () => {

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -84,7 +84,7 @@ export const searchResourceAsyncAction = createAsyncAction(
     const { pageSize, generalSearchTerm } = parameters;
     const start = page * pageSize;
     const [nameSubstring, ...ids] = generalSearchTerm.split(';');
-    return { ...(await searchResources({ generalSearchTerm: nameSubstring, ids }, start, pageSize)), start };
+    return { ...(await searchResources({ generalSearchTerm: nameSubstring, filters: {} }, start, pageSize)), start };
   },
   ({ pageSize }: SearchSettings, page: number, newSearch: boolean = true) => ({ newSearch, start: page * pageSize }),
   // { promiseTypeDelimiter: '/' }, // Doesn't work :-(

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -84,7 +84,7 @@ export const searchResourceAsyncAction = createAsyncAction(
     const { pageSize, generalSearchTerm } = parameters;
     const start = page * pageSize;
     const [nameSubstring, ...ids] = generalSearchTerm.split(';');
-    return { ...(await searchResources({ nameSubstring, ids }, start, pageSize)), start };
+    return { ...(await searchResources({ generalSearchTerm: nameSubstring, ids }, start, pageSize)), start };
   },
   ({ pageSize }: SearchSettings, page: number, newSearch: boolean = true) => ({ newSearch, start: page * pageSize }),
   // { promiseTypeDelimiter: '/' }, // Doesn't work :-(

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -83,8 +83,7 @@ export const searchResourceAsyncAction = createAsyncAction(
   async (parameters: SearchSettings, page: number) => {
     const { pageSize, generalSearchTerm } = parameters;
     const start = page * pageSize;
-    const [nameSubstring, ...ids] = generalSearchTerm.split(';');
-    return { ...(await searchResources({ generalSearchTerm: nameSubstring, filters: {} }, start, pageSize)), start };
+    return { ...(await searchResources({ generalSearchTerm, filters: {} }, start, pageSize)), start };
   },
   ({ pageSize }: SearchSettings, page: number, newSearch: boolean = true) => ({ newSearch, start: page * pageSize }),
   // { promiseTypeDelimiter: '/' }, // Doesn't work :-(

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -260,6 +260,7 @@ export type FeatureFlags = {
   enable_counselor_toolkits: boolean; // Enables Counselor Toolkits
   enable_emoji_picker: boolean; // Enables Emoji Picker
   enable_aselo_messaging_ui: boolean; // Enables Aselo Messaging UI iinstead of the default Twilio one - reduced functionality for low spec clients.
+  enable_resources_elastic_search: boolean; // Use the EasticSearch powered search for resources, rather than the interim name only version.
 };
 /* eslint-enable camelcase */
 


### PR DESCRIPTION
## Description

* Adds feature flag to switch between placeholder and elastic search for resources: `enable_resources_elastic_search`
* Requires https://github.com/techmatters/hrm/pull/380 to be merged & deployed in the environment the account is using for elastic search mode to work

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- [X] Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-1599

### Verification steps
1. Deploy https://github.com/techmatters/hrm/pull/380 to the HRM enviornment and ensure `enable_resources_elastic_search` is not set.
2. Search for a word in the name of a resource & verify that the resource appears in the results
3. Search for a word that appears in the attributes of the resource but not the name (i.e. the description) & verify the resource does not appear in the results
4. Set the  `enable_resources_elastic_search` flag
5. Search for a word in the name of a resource & verify that the resource appears in the results.
6. Search for a word that appears in the attributes of the resource but not the name (i.e. the description) & verify the resource does appear in the results