### PR TITLE
Conferencing UI - Increase participant limit to 4 (from 3)

### DIFF
--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/ConferencePanel.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/ConferencePanel.tsx
@@ -59,7 +59,7 @@ const ConferencePanel: React.FC<Props> = ({ task, conference }) => {
           disabled={
             !isLiveCall ||
             isAdding ||
-            (participants && participants.filter(participant => participant.status === 'joined').length >= 3)
+            (participants && participants.filter(participant => participant.status === 'joined').length >= 4)
           }
           onClick={toggleDialog}
         >

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -261,7 +261,7 @@ export type FeatureFlags = {
   enable_emoji_picker: boolean; // Enables Emoji Picker
   enable_aselo_messaging_ui: boolean; // Enables Aselo Messaging UI iinstead of the default Twilio one - reduced functionality for low spec clients.
   enable_resources_elastic_search: boolean; // Use the EasticSearch powered search for resources, rather than the interim name only version.
-  enable_conferencing: boolean; // Enables Conferencing UI and replaces deault Twilio components and behavior
+  enable_conferencing: boolean; // Enables Conferencing UI and replaces default Twilio components and behavior
 };
 /* eslint-enable camelcase */
 


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- Very minor change to accommodate conferencing with 4 participants

### Checklist
- [n/a] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Related Issues
Fixes # see conversation - https://tech-matters.slack.com/archives/CV4QM23UJ/p1686681980315439

### Verification steps
- Check to ensure 4 people can be added to a conference