### PR TITLE
Translations and strings updated for conference call to show left call

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -138,7 +138,12 @@ const setUpComponents = (
   Components.setupTeamViewFilters();
   Components.setupWorkerDirectoryFilters();
 
-  if (featureFlags.enable_conferencing) setupConferenceComponents();
+  const strings = getTemplateStrings();
+  if (featureFlags.enable_conferencing) {
+    setupConferenceComponents();
+    strings.TaskLineCallEndedTitle = strings.TaskLineCallLeaveTitle;
+    strings.HangupCallTooltip = strings.HangupCallLeaveTooltip;
+  }
 };
 
 const setUpActions = (

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/Hangup.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/Hangup.tsx
@@ -22,8 +22,10 @@ import { StyledConferenceButtonWrapper, StyledHangUpButton } from './styles';
 
 type Props = TaskContextProps;
 
-const Hangup: React.FC<Props> = ({ call, task }) => {
-  if (!task || !call) {
+const Hangup: React.FC<Props> = ({ call, task, conference }) => {
+  const participants = conference?.source?.participants || [];
+
+  if (!task || !call || !participants) {
     return null;
   }
 
@@ -39,7 +41,11 @@ const Hangup: React.FC<Props> = ({ call, task }) => {
         <CallEndIcon />
       </StyledHangUpButton>
       <span>
-        <Template code="Hang Up" />
+        {participants && participants.filter(participant => participant.status === 'joined').length > 2 ? (
+          <Template code="Leave Call" />
+        ) : (
+          <Template code="Hang Up" />
+        )}
       </span>
     </StyledConferenceButtonWrapper>
   );

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/PhoneInputDialog.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/PhoneInputDialog.tsx
@@ -59,7 +59,6 @@ const PhoneInputDialog: React.FC<PhoneDialogProps> = ({
         <Button
           style={{ backgroundColor: '#192b33', color: '#fff', width: '30%', margin: '0 4px', height: '35px' }}
           autoFocus
-          tabIndex={1}
           onClick={handleClick}
         >
           <CallEndIcon fontSize="medium" /> &nbsp; &nbsp;

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/styles.ts
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/styles.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { styled, Button } from '@twilio/flex-ui';
+import { styled } from '@twilio/flex-ui';
 
 import { Flex } from '../../../styles/HrmStyles';
 

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -437,5 +437,7 @@
 
   "Conference-AddConferenceCallParticipant": "Add Conference Call Participant",
   "Conference-EnterPhoneNumber": "Enter phone number",
-  "Conference-DialButton": "Dial"
+  "Conference-DialButton": "Dial",
+  "TaskLineCallLeaveTitle": "YOU HAVE LEFT THE CALL",
+  "HangupCallLeaveTooltip": "Leave Call"
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description

- Change “Hang Up” to “Leave Call” in Conference Actions bar at bottom
- Change tooltip in leftmost menu to say "Leave Call"
- Changes the end state text “CALL ENDED” to “YOU HAVE LEFT THE CALL”
- Fix tab order with in phone input dialog

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
![Screenshot 2023-06-22 at 5 28 32 PM](https://github.com/techmatters/flex-plugins/assets/102122005/d25bf78a-6d77-48df-8950-bd0de81f3114)
![Screenshot 2023-06-22 at 5 27 32 PM](https://github.com/techmatters/flex-plugins/assets/102122005/a3c88297-4f86-4a0e-81cb-58937d41b918)
