### PR TITLE
Added conference/statusCallback to keep track of in progress call

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/conferencing/conferencing.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/conferencing/conferencing.test.ts
@@ -21,7 +21,7 @@ import { DefinitionVersion, DefinitionVersionId, loadDefinition, useFetchDefinit
 import {
   reduce,
   setIsDialogOpenAction,
-  setIsLoadingAction,
+  setCallStatusAction,
   setPhoneNumberAction,
   ConferencingState,
   newTaskEntry,
@@ -114,18 +114,24 @@ describe('reduce', () => {
     },
   );
 
-  each([{ value: true }, { value: false }]).test(
-    'when setIsLoadingAction is called with $value, set isLoading to $value',
-    async ({ value }) => {
-      const initializedState = reduce(undefined, initializeContactState(mockV1)('WT12345'));
+  each([
+    { value: 'no-call' },
+    { value: 'initiating' },
+    { value: 'initiated' },
+    { value: 'ringing' },
+    { value: 'busy' },
+    { value: 'failed' },
+    { value: 'in-progress' },
+    { value: 'completed' },
+  ]).test('when setCallStatusAction is called with $value, set isLoading to $value', async ({ value }) => {
+    const initializedState = reduce(undefined, initializeContactState(mockV1)('WT12345'));
 
-      const result = reduce(initializedState, setIsLoadingAction('WT12345', value));
+    const result = reduce(initializedState, setCallStatusAction('WT12345', value));
 
-      const expected: ConferencingState = { tasks: { WT12345: { ...newTaskEntry, isLoading: value } } };
+    const expected: ConferencingState = { tasks: { WT12345: { ...newTaskEntry, callStatus: value } } };
 
-      expect(result).toMatchObject(expected);
-    },
-  );
+    expect(result).toMatchObject(expected);
+  });
 
   test('when setPhoneNumberAction is called, set phoneNumber', async () => {
     const initializedState = reduce(undefined, initializeContactState(mockV1)('WT12345'));

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/PhoneInputDialog.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/PhoneInputDialog.tsx
@@ -16,6 +16,7 @@
 import React from 'react';
 import { Template, Button } from '@twilio/flex-ui';
 import { CallEnd as CallEndIcon } from '@material-ui/icons';
+import { CircularProgress } from '@material-ui/core';
 
 import { Row, Bold } from '../../../styles/HrmStyles';
 import { CloseButton } from '../../../styles/callTypeButtons';
@@ -26,6 +27,7 @@ type PhoneDialogProps = {
   setTargetNumber: (targetNumber: string) => void;
   handleClick: () => void;
   setIsDialogOpen: (isDialogOpen: boolean) => void;
+  isLoading: boolean;
 };
 
 const PhoneInputDialog: React.FC<PhoneDialogProps> = ({
@@ -33,6 +35,7 @@ const PhoneInputDialog: React.FC<PhoneDialogProps> = ({
   setTargetNumber,
   handleClick,
   setIsDialogOpen,
+  isLoading,
 }) => {
   const handleNumberChange: React.ChangeEventHandler<HTMLInputElement> = e => {
     setTargetNumber(e.target.value);
@@ -55,15 +58,23 @@ const PhoneInputDialog: React.FC<PhoneDialogProps> = ({
           value={targetNumber}
           onChange={handleNumberChange}
           style={{ width: '60%', padding: '5px' }}
+          disabled={isLoading}
         />
         <Button
           style={{ backgroundColor: '#2762e1', color: '#fff', width: '30%', margin: '0 4px', height: '35px' }}
           autoFocus
           tabIndex={1}
           onClick={handleClick}
+          disabled={isLoading}
         >
-          <CallEndIcon fontSize="medium" /> &nbsp; &nbsp;
-          <Template code="Conference-DialButton" />
+          {isLoading ? (
+            <CircularProgress size={30} style={{ color: '#fff' }} />
+          ) : (
+            <>
+              <CallEndIcon fontSize="medium" /> &nbsp; &nbsp;
+              <Template code="Conference-DialButton" />
+            </>
+          )}
         </Button>
       </Row>
     </PhoneDialogWrapper>

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -251,7 +251,12 @@ export const selfReportToIWF = async (form: ChildCSAMReportForm, caseNumber: str
 
 const validUpdates = ['endConferenceOnExit', 'hold', 'muted'] as const;
 
-type ConferenceAddParticipantParams = { conferenceSid: string; to: string; from: string };
+type ConferenceAddParticipantParams = {
+  conferenceSid: string;
+  to: string;
+  from: string;
+  callStatusSyncDocumentSid: string;
+};
 type ConferenceRemoveParticipantParams = { conferenceSid: string; callSid: string };
 type ConferenceUpdateParticipantParams = {
   conferenceSid: string;
@@ -260,11 +265,12 @@ type ConferenceUpdateParticipantParams = {
 };
 
 export const conferenceApi = {
-  addParticipant: async ({ conferenceSid, to, from }: ConferenceAddParticipantParams) => {
+  addParticipant: async ({ conferenceSid, to, from, callStatusSyncDocumentSid }: ConferenceAddParticipantParams) => {
     const body = {
       conferenceSid,
       to,
       from,
+      callStatusSyncDocumentSid,
     };
 
     const response = await fetchProtectedApi('/conference/addParticipant', body);

--- a/plugin-hrm-form/src/states/conferencing/index.ts
+++ b/plugin-hrm-form/src/states/conferencing/index.ts
@@ -18,12 +18,23 @@ import { omit } from 'lodash';
 
 import { GeneralActionType, INITIALIZE_CONTACT_STATE, RECREATE_CONTACT_STATE } from '../types';
 import { removeContactState } from '../actions';
+import { RootState, conferencingBase, namespace } from '..';
+
+export type CallStatus =
+  | 'no-call'
+  | 'initiating'
+  | 'initiated'
+  | 'ringing'
+  | 'busy'
+  | 'failed'
+  | 'in-progress'
+  | 'completed';
 
 export type ConferencingState = {
   tasks: {
     [taskId: string]: {
       isDialogOpen: boolean;
-      isLoading: boolean;
+      callStatus: CallStatus;
       phoneNumber: string;
     };
   };
@@ -31,7 +42,7 @@ export type ConferencingState = {
 
 export const newTaskEntry = {
   isDialogOpen: false,
-  isLoading: false,
+  callStatus: 'no-call' as CallStatus,
   phoneNumber: '',
 };
 
@@ -42,11 +53,11 @@ export const setIsDialogOpenAction = createAction(SET_IS_DIALOG_OPEN, (taskId: s
   isDialogOpen,
 }));
 
-const SET_IS_LOADING = 'conferencing/set-is-loading';
+const SET_CALL_STATUS = 'conferencing/set-call-status';
 
-export const setIsLoadingAction = createAction(SET_IS_LOADING, (taskId: string, isLoading: boolean) => ({
+export const setCallStatusAction = createAction(SET_CALL_STATUS, (taskId: string, callStatus: CallStatus) => ({
   taskId,
-  isLoading,
+  callStatus,
 }));
 
 const SET_PHONE_NUMBER = 'conferencing/set-phone-number';
@@ -58,7 +69,7 @@ export const setPhoneNumberAction = createAction(SET_PHONE_NUMBER, (taskId: stri
 
 type ConferencingStateAction =
   | ReturnType<typeof setIsDialogOpenAction>
-  | ReturnType<typeof setIsLoadingAction>
+  | ReturnType<typeof setCallStatusAction>
   | ReturnType<typeof setPhoneNumberAction>;
 
 const initialState: ConferencingState = {
@@ -105,13 +116,13 @@ const conferencingReducer = createReducer(initialState, handleAction => [
       },
     },
   })),
-  handleAction(setIsLoadingAction, (state, { payload }) => ({
+  handleAction(setCallStatusAction, (state, { payload }) => ({
     ...state,
     tasks: {
       ...state.tasks,
       [payload.taskId]: {
         ...state.tasks[payload.taskId],
-        isLoading: payload.isLoading,
+        callStatus: payload.callStatus,
       },
     },
   })),
@@ -134,3 +145,6 @@ export const reduce = (
 ): ConferencingState => {
   return conferencingReducer(inputState, action);
 };
+
+export const isCallStatusLoading = (callStatus: CallStatus) =>
+  callStatus === 'initiating' || callStatus === 'initiated' || callStatus === 'ringing';


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/serverless/pull/478.

## Description
This PR 
- Adjust conference add participant service according to linked PR.
- Adds a new service to the shared sync client to create and keep track of call status when adding an external participant.
- Adapts the UI to react accordingly to call status, providing some UI feedback to indicate a counselor that an external call is being made.

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added
- [ ] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Verification steps
- Make sure the linked PR is deployed OR start development server and expose it via ngrok (you first need to edit `functions/conference/addParticipant.ts` function on the serverless side so that `statusCallback` url will point to the ngrok served public url).
- Start development server (and point to the above ngrok url if serving locally).
- Start a new call and accept it in the Flex instance running this code.
- Add external parties and verify that:
  - A loading state is presented to the user when the call starts.
  - Loading state is removed if the call is done to an invalid number (like `1234`), and an error message is displayed.
  - Loading state is removed if the call is done to a valid number as soon as the state of the call is moved past "ringing" (that is, the call is accepted or rejected).