### PR TITLE
CHI-1599: update ff patch script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -155,14 +155,51 @@ will create a new file `my_custom_bot.tf` that contains the definition of the bo
 
 This script allows you to safely update the feature flags specified in a Twilio Account's Service Configuration without affecting other settings
 
+#### Providing Twilio Credentials
+
+If you want to update feature flags for a single account and have their credentials handy, you can set them in your environment to use this tool:
+
 You need to have `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` environment variables set (either passed in the command itself or in a `.env` file).
-You also must provide the following parameters to the script:
+
+#### Using AWS credentials to look up accounts
+
+If you have an AWS account with privileges to look up SSM parameters, you can set up your aws creds in the environment.
+
+Then, to select a single account, you pass the `--helplineEnvironment` argument with either `development`, `staging` or `production` and `--helplineShortCode` with the helpline account (upper case, e.g. `AS`, `ZM`).
+
+Alternatively you can just set the `--helplineEnvironment` and omit a `--helplineShortCode` to set the flags for all accounts in a given environment.
+
+NB: **These parameters need to be specified ahead of the `patch-feature-flags` command, not after like the flags you want to set.**
+
+#### Specifying the flags
+
+Using either approach, you also must provide the following parameters to the script:
 
 - `-f / --flag`: Use this to specify a flag and what you wish to set it to. The value must take the form {flag_name}:{flag_set}, e.g. -f my_flag:true. Can be specified multiple times
-  Example:
+
+Examples:
+
+1. Single account (Twilio credentials in environment):
 
 ```
 ➜ npm run twilioResources patch-feature-flags -- -f enable_voice_recordings:false -f enable_twilio_transcripts:true
 ```
 
 will set the `enable_voice_recordings` to false, and the `enable_transcripts` flag to true, creating them if they didn't previously exist, or overwriting their previous setting if they did.
+
+2. Single account (AWS credentials in environment):
+
+```
+➜ npm run twilioResources -- --helplineEnvironment development --helplineShortCode AS patch-feature-flags -f enable_voice_recordings:false -f enable_twilio_transcripts:true
+```
+
+This sets the same flags as the example above, but uses AWS to look up the Twilio credentials for the Aselo Development account. Note that the `--helplineShortCode` and the `--helplineEnvironment` arguments are passed in before the `patch-feature-flags` command, not after.
+
+
+3Single account (AWS credentials in environment):
+
+```
+➜ npm run twilioResources -- --helplineEnvironment development --helplineShortCode AS patch-feature-flags -f enable_voice_recordings:false -f enable_twilio_transcripts:true
+```
+
+This sets the same flags as the example above, but uses AWS to look up the Twilio credentials for all the accounts in the development environment and will set the flags for each of them.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -153,6 +153,10 @@ will create a new file `my_custom_bot.tf` that contains the definition of the bo
 
 ### patch-feature-flags
 
+**THIS SCRIPT IS ONLY FOR USE IN DEVELOPMENT ACCOUNTS AND OTHER ACCOUNTS NOT MANAGED BY THE NEW TERRAFORM SYSTEM**
+
+For accounts managed under the new terraform system, you should manage feature flags using the 'configuration' stage of that system.
+
 This script allows you to safely update the feature flags specified in a Twilio Account's Service Configuration without affecting other settings
 
 #### Providing Twilio Credentials

--- a/scripts/src/terraformSupplemental/runAgainstAllAccountsForEnvironment.ts
+++ b/scripts/src/terraformSupplemental/runAgainstAllAccountsForEnvironment.ts
@@ -1,4 +1,4 @@
-import { getSSMParametersByPath } from '../helpers/ssm';
+import { getSSMParameter, getSSMParametersByPath } from '../helpers/ssm';
 import { logDebug } from '../helpers/log';
 
 export const enum Environment {
@@ -15,10 +15,14 @@ export const enum Strategy {
 
 type AccountSID = `AC${string}`;
 
+export const forShortCodes = (helplineCodes: string[] | string) => (shortCode: string) =>
+  (Array.isArray(helplineCodes) ? helplineCodes : [helplineCodes]).includes(shortCode);
+
 export const runAgainstAllAccountsForEnvironment = async (
   environment: Environment,
   action: (accountSid: AccountSID, authToken: string) => Promise<void>,
   strategy: Strategy = Strategy.SEQUENTIAL,
+  filter: (shortCode: string, accountSid: AccountSID) => boolean = () => true,
 ) => {
   const allTwilioTokenParameters = await getSSMParametersByPath(`/${environment}/twilio`);
   logDebug(
@@ -26,17 +30,31 @@ export const runAgainstAllAccountsForEnvironment = async (
     `/${environment}/twilio`,
     allTwilioTokenParameters.length,
   );
-  const allCreds = allTwilioTokenParameters
+  const allAccounts = allTwilioTokenParameters
     .map((parameter) => {
-      logDebug('Testing parameter:', parameter.Name);
-      const match = parameter.Name!.match(/\/[a-z]+\/twilio\/(AC[0-9a-fA-F]+)\/auth_token/);
+      const match = parameter.Name!.match(/\/[a-z]+\/twilio\/([0-9a-zA-Z]+)\/account_sid/);
       if (match) {
-        logDebug('found accountSid:', match[1]);
-        return { accountSid: match[1], authToken: parameter.Value! };
+        logDebug('found accountSid:', match[1], parameter.Value);
+        return { shortCode: match[1], accountSid: parameter.Value! as AccountSID };
       }
+      logDebug('Miss:', parameter.Name);
+
       return null;
     })
-    .filter((p) => p) as { accountSid: AccountSID; authToken: string }[];
+    .filter(
+      (p: { shortCode: string; accountSid: AccountSID } | null) =>
+        p && filter(p.shortCode, p.accountSid),
+    );
+  const allCreds = await Promise.all(
+    allAccounts.map(async (p) => {
+      const { accountSid } = p!;
+      return {
+        accountSid,
+        authToken: (await getSSMParameter(`/${environment}/twilio/${accountSid}/auth_token`, true))!
+          .Parameter!.Value!,
+      };
+    }),
+  );
   logDebug('account cred sets found:', allCreds.length);
   if (strategy === Strategy.SEQUENTIAL) {
     // eslint-disable-next-line no-restricted-syntax

--- a/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
+++ b/scripts/src/terraformSupplemental/updateAllAssetUrls.ts
@@ -20,9 +20,9 @@ async function main() {
     logDebug(`Updating asset urls for ${environment}`);
     // eslint-disable-next-line no-await-in-loop
     await runAgainstAllAccountsForEnvironment(environment, async (accountSid, authToken) => {
-      process.env.TWILIO_ACCOUNT_SID = accountSid;
-      process.env.TWILIO_AUTH_TOKEN = authToken;
       await patchFeatureFlags(
+        accountSid,
+        authToken,
         {},
         { assets_bucket_url: `https://assets-${environment}.tl.techmatters.org` },
         false,


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description

* Reverts deletion of 'regular' SSM script functions that run with the base privileges of the user whose AWS creds are provided because these are still used.
* Fix patch-feature-flags and allow feature flags to be patched across all accounts in an environment - not so useful now we do it the TF way but might still come in handy for non TF managed accounts or perhaps in an emergency.


### Related Issues
CHI-1599

### Verification steps

Use the patch-feature flags script the 'classic' way, i.e. with Twilio creds in the environment vars, then for the whole staging env 