### PR TITLE
CHI-1797: Autpilot -> Lex config conversion script

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -9,3 +9,4 @@ private/
 # Generated files
 new-flex-plugins-workflow.yml
 new-serverless-workflow.yml
+/src/autopilot-migration/json/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@
   - [import-tf](#import-tf)
   - [generate-chatbot-tf](#generate-chatbot-tf)
   - [patch-feature-flags](#patch-feature-flags)
+- [convertAutopilotToLex](#convertAutopilotToLex)
 
 ## generateDeploymentFiles
 
@@ -207,3 +208,20 @@ This sets the same flags as the example above, but uses AWS to look up the Twili
 ```
 
 This sets the same flags as the example above, but uses AWS to look up the Twilio credentials for all the accounts in the development environment and will set the flags for each of them.
+
+
+## convertAutopilotToLex
+
+```bash
+npm run convertAutopilotToLex -- -e {development | staging | production}
+```
+
+Requires AWS creds including region in the environment to run.
+
+This script will convert all the autopilot bots in the specified environment to config files used to generate Lex bots in our helpline Terraform configuration.
+
+It will generate a separate file for each helpline in the environment you specify, and place them all in the ./src/autopilot-migration/json directory.
+
+The configs generated are not 'ready to go', they are a 'best efforts' baseline that will need to be manually curated, deduplicated and tested before they can be used to generate Lex bots, they are intended to be a labour-saving device, not an end to end automation. 
+
+Unfortunately Autopilot and Lex do not fully map, at least not without a much larger investment of engineering time, and since this is a one time migration, this seems like a reasonable compromise.

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,7 +14,8 @@
     "createTwilioApiKeyAndSsmSecret": "node dist/terraformSupplemental/createTwilioApiKeyAndSsmSecret.js",
     "generateNewHelplineFormDefinitions": "node dist/formDefinitions/generateNewHelplineFormDefinitions.js",
     "twilioResources": "tsx src/terraformSupplemental/twilioResources.ts",
-    "updateAllAssetUrls": "tsx src/terraformSupplemental/updateAllAssetUrls.ts"
+    "updateAllAssetUrls": "tsx src/terraformSupplemental/updateAllAssetUrls.ts",
+    "convertAutopilotToLex": "tsx src/autopilot-migration/convertAutopilotToLexTerraformConfigJson.ts"
   },
   "author": "",
   "license": "AGPL",

--- a/scripts/src/autopilot-migration/autopilotReader.ts
+++ b/scripts/src/autopilot-migration/autopilotReader.ts
@@ -1,0 +1,125 @@
+import type { Twilio } from 'twilio';
+import { SampleInstance } from 'twilio/lib/rest/autopilot/v1/assistant/task/sample';
+import { AssistantInstance } from 'twilio/lib/rest/autopilot/v1/assistant';
+import { logInfo, logSuccess } from '../helpers/log';
+
+const getInstanceData = (instance: { data: any }) => instance.data;
+
+export type AssistantDefinition = {
+  uniqueName: string;
+  friendlyName: string;
+  defaults: any;
+  styleSheet: any;
+  logQueries: boolean;
+};
+
+export type FieldTypeResource = {
+  friendlyName: string;
+  uniqueName: string;
+  fieldValues: {
+    language: string;
+    synonymOf: string;
+    value: string;
+  }[];
+};
+
+export type CollectActionDefinition = {
+  collect: {
+    name: string;
+    questions: { type: string; question: string; name: string }[];
+  };
+};
+
+export type TaskDefinition = {
+  friendlyName: string;
+  uniqueName: string;
+  actions: any[];
+  samples: SampleInstance[];
+};
+
+export const isCollectActionDefinition = (action: any): action is CollectActionDefinition =>
+  Boolean(action.collect);
+
+const assistantInstanceToAssistantDefinition = async (
+  assistantInstance: AssistantInstance,
+): Promise<AssistantDefinition> => {
+  const [defaults, styleSheet] = (
+    await Promise.all([
+      assistantInstance.defaults().get().fetch(),
+      assistantInstance.styleSheet().get().fetch(),
+    ])
+  ).map(getInstanceData);
+
+  const { logQueries, friendlyName, uniqueName } = assistantInstance;
+
+  const assistantResource = {
+    uniqueName,
+    friendlyName,
+    defaults,
+    styleSheet,
+    logQueries,
+  };
+
+  logSuccess('Success on: get assistant definition');
+
+  return assistantResource;
+};
+
+export const newAutopilotReader = (client: Twilio) => ({
+  getAssistants: async () => {
+    return client.autopilot.v1.assistants.list();
+  },
+  getAssistantDefinition: async (assistantSid: string): Promise<AssistantDefinition> => {
+    logInfo('Trying to get assistant definition');
+
+    const assistantInstance = await client.autopilot.assistants.get(assistantSid).fetch();
+
+    return assistantInstanceToAssistantDefinition(assistantInstance);
+  },
+
+  getAssistantFieldTypeDefinitions: async (
+    assistantInstance: AssistantInstance,
+  ): Promise<FieldTypeResource[]> => {
+    logInfo('Trying to get assistant field types definitions');
+
+    const fieldTypeInstances = await assistantInstance.fieldTypes().list();
+
+    const fieldTypes = await Promise.all(
+      fieldTypeInstances.map(async (ft) => {
+        const fieldValues = (await ft.fieldValues().list()).map((fv) => {
+          const { language, synonymOf, value } = fv;
+          return { language, synonymOf, value };
+        });
+
+        const { friendlyName, uniqueName } = ft;
+
+        return { friendlyName, uniqueName, fieldValues };
+      }),
+    );
+
+    logSuccess('Success on: get assistant field types definitions');
+
+    return fieldTypes;
+  },
+  getAssistantTaskDefinitions: async (
+    assistantInstance: AssistantInstance,
+  ): Promise<TaskDefinition[]> => {
+    logInfo('Trying to get assistant task definitions');
+    const taskList = await assistantInstance.tasks().list();
+    const tasks = await Promise.all(
+      taskList.map(async (t) => {
+        const { actions } = (await t.taskActions().get().fetch()).data;
+
+        const samples = await t.samples().list();
+
+        const { friendlyName, uniqueName } = t;
+
+        return { friendlyName, uniqueName, actions, samples };
+      }),
+    );
+
+    logSuccess('Success on: get assistant task definitions');
+
+    return tasks;
+  },
+});

--- a/scripts/src/autopilot-migration/autopilotToLexConverters.ts
+++ b/scripts/src/autopilot-migration/autopilotToLexConverters.ts
@@ -1,0 +1,140 @@
+import {
+  CollectActionDefinition,
+  FieldTypeResource,
+  isCollectActionDefinition,
+  TaskDefinition,
+} from './autopilotReader';
+
+const enum SlotValueSelectionStrategy {
+  TopResolution = 'TOP_RESOLUTION',
+}
+
+type SlotValue = {
+  synonyms: string[];
+};
+
+type SlotType = {
+  description: string;
+  value_selection_strategy: string;
+  values: Record<string, SlotValue>;
+};
+
+type Statement = {
+  content: string;
+  content_type: 'PlainText';
+};
+
+type Prompt = Statement & {
+  max_attempts: number;
+};
+
+type Slot = {
+  description: string;
+  slot_type: string;
+  value_elicitation_prompt: Prompt;
+};
+
+type Intent = {
+  description: string;
+  fulfillment_activity: {
+    type: 'ReturnIntent';
+  };
+  conclusion_statement: Statement;
+  rejection_statement: Statement;
+  slots: Record<string, Slot>;
+};
+
+export type LexChatbotConfig = {
+  description: string;
+  locale: string;
+  process_behavior: string;
+  child_directed: boolean;
+  idle_session_ttl_in_seconds: string;
+  abort_statement: Statement;
+  clarification_prompt: Prompt;
+  slot_types: Record<string, SlotType>;
+  intents: Record<string, Intent>;
+};
+
+const DEFAULT_SLOT_TYPES = {
+  YesNo: {
+    description: 'Custom slot for Yes-No kind of questions',
+    value_selection_strategy: 'TOP_RESOLUTION',
+    values: {
+      Yes: {
+        synonyms: ['y', 'yes', 'yep', 'yeah', 'yup', 'ya', 'yah'],
+      },
+      No: {
+        synonyms: ['n', 'no', 'nope', 'nah', 'not'],
+      },
+    },
+  },
+};
+
+export const fieldTypeToSlotType = ({ fieldValues, friendlyName }: FieldTypeResource): SlotType => {
+  const values: SlotType['values'] = {};
+  fieldValues.forEach(({ value, synonymOf }) => {
+    const key = synonymOf || value;
+    values[key] = values[key] || { synonyms: [] };
+    if (synonymOf) {
+      values[key].synonyms.push(value);
+    }
+  });
+
+  return {
+    description: friendlyName,
+    value_selection_strategy: SlotValueSelectionStrategy.TopResolution,
+    values,
+  };
+};
+
+export const fieldTypesToSlotTypes = (
+  fieldTypes: FieldTypeResource[],
+): Record<string, SlotType> => {
+  const slotTypeEntries: [string, SlotType][] = fieldTypes.map((fieldType) => {
+    return [fieldType.uniqueName, fieldTypeToSlotType(fieldType)];
+  });
+  return { ...DEFAULT_SLOT_TYPES, ...Object.fromEntries(slotTypeEntries) };
+};
+
+const collectActionToSlots = ({
+  collect: { questions },
+}: CollectActionDefinition): Record<string, Slot> => {
+  const slotEntries: [string, Slot][] = questions.map(({ type, question, name }, priority) => {
+    return [
+      name,
+      {
+        priority,
+        description: `Imported from question '${name}'`,
+        slot_type: type === 'Twilio.YES_NO' ? 'YesNo' : type,
+        value_elicitation_prompt: {
+          content: question,
+          content_type: 'PlainText',
+          max_attempts: 3,
+        },
+      },
+    ];
+  });
+  return Object.fromEntries(slotEntries);
+};
+
+export const tasksToIntents = (tasks: TaskDefinition[]): Record<string, Intent> => {
+  const allIntentEntries = tasks.flatMap(({ actions, uniqueName, friendlyName }) => {
+    const collectActions: CollectActionDefinition[] = actions.filter((action) =>
+      isCollectActionDefinition(action),
+    );
+    return collectActions.map((action) => {
+      return [
+        uniqueName,
+        {
+          slots: collectActionToSlots(action),
+          description: `${friendlyName ?? uniqueName} intent`,
+          fulfillment_activity: { type: 'ReturnIntent' },
+          conclusion_statement: { content: 'Success', content_type: 'PlainText' },
+          rejection_statement: { content: 'Failure', content_type: 'PlainText' },
+        },
+      ];
+    });
+  });
+  return Object.fromEntries(allIntentEntries);
+};

--- a/scripts/src/autopilot-migration/convertAutopilotToLexTerraformConfigJson.ts
+++ b/scripts/src/autopilot-migration/convertAutopilotToLexTerraformConfigJson.ts
@@ -1,0 +1,102 @@
+import yargs from 'yargs';
+import twilio from 'twilio';
+import { AssistantInstance } from 'twilio/lib/rest/autopilot/v1/assistant';
+import * as fs from 'fs/promises';
+import {
+  Environment,
+  runAgainstAllAccountsForEnvironment,
+  Strategy,
+} from '../terraformSupplemental/runAgainstAllAccountsForEnvironment';
+import { newAutopilotReader } from './autopilotReader';
+import { logDebug, logError, logInfo } from '../helpers/log';
+import {
+  fieldTypesToSlotTypes,
+  LexChatbotConfig,
+  tasksToIntents,
+} from './autopilotToLexConverters';
+
+const EMPTY_LEX_CONFIG: LexChatbotConfig = {
+  description: 'Survey bot',
+  locale: 'en-US',
+  process_behavior: 'BUILD',
+  child_directed: true,
+  idle_session_ttl_in_seconds: '600',
+  abort_statement: {
+    content: 'Sorry, I am not able to assist at this time.',
+    content_type: 'PlainText',
+  },
+  clarification_prompt: {
+    max_attempts: 2,
+    content: "Sorry, I didn't understand that. Please try again.",
+    content_type: 'PlainText',
+  },
+  slot_types: {},
+  intents: {},
+};
+
+async function generateLexTerraformConfig(
+  autopilotReader: ReturnType<typeof newAutopilotReader>,
+  autopilotAssistant: AssistantInstance,
+): Promise<LexChatbotConfig> {
+  const tasks = await autopilotReader.getAssistantTaskDefinitions(autopilotAssistant);
+  const fieldTypes = await autopilotReader.getAssistantFieldTypeDefinitions(autopilotAssistant);
+  const intents = await tasksToIntents(tasks);
+  const slotTypes = fieldTypesToSlotTypes(fieldTypes);
+  return {
+    ...EMPTY_LEX_CONFIG,
+    description: autopilotAssistant.friendlyName,
+    slot_types: slotTypes,
+    intents,
+  };
+}
+
+async function main() {
+  logDebug(`convertAutopilotToLexTerraformConfigJson: ${process.argv.slice(2).join(' ')}`);
+  const { e: environment } = yargs(process.argv.slice(2))
+    .options({
+      e: {
+        alias: 'environment',
+        type: 'string',
+        choices: ['development', 'production', 'staging'],
+        demandOption: true,
+      },
+    })
+    .parseSync();
+
+  logInfo(`Generating starter lex terraform configs for ${environment}`);
+  await runAgainstAllAccountsForEnvironment(
+    environment as Environment,
+    async (accountSid, authToken, shortCode) => {
+      try {
+        logInfo(`Generating lex terraform configs for ${shortCode.toUpperCase()}`);
+        const autopilotReader = newAutopilotReader(twilio(accountSid, authToken));
+        const assistants = await autopilotReader.getAssistants();
+        const fullLexConfig = Object.fromEntries(
+          await Promise.all(
+            assistants.map(async (assistant) => {
+              logDebug(`Generating lex terraform config for ${assistant.uniqueName}`);
+              const lexTerraformConfig = await generateLexTerraformConfig(
+                autopilotReader,
+                assistant,
+              );
+              logInfo(`Generated lex terraform config for ${assistant.uniqueName}`);
+              return [assistant.uniqueName, lexTerraformConfig];
+            }),
+          ),
+        );
+        await fs.writeFile(
+          `./src/autopilot-migration/json/lexTerraformConfig-${environment}-${shortCode.toUpperCase()}.json`,
+          JSON.stringify(fullLexConfig, null, 2),
+        );
+      } catch (e) {
+        logError(`Failed to generate lex terraform configs for ${shortCode.toUpperCase()}`, e);
+      }
+    },
+    Strategy.SEQUENTIAL,
+  );
+}
+
+main().catch((e) => {
+  logError(e);
+  process.exit(1);
+});


### PR DESCRIPTION
# REVIEW AFTER #1477 IS MERGED

## Description

Script to scan all the bots set up for every account in a specified environment and output a lex config file for each helpline based on the format used here: https://github.com/techmatters/flex-plugins/pull/1419/files#diff-da3854ee8bbf216b1029969647f83f11cefceea9adca4ca5a1012305a5f6d2eb

It pulls the field types and turns them into slot types, and the tasks and turns them into intents. See the README.md updates to understand it's usage & limitations

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested locally

### Related Issues
CHI-1797

### Verification steps

* Run the scripts and review the output