### PR TITLE
Fix for issue exposed by new KHP data upload.

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ResourcesService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ResourcesService.test.ts
@@ -20,7 +20,6 @@ import { getAseloFeatureFlags } from '../../hrmConfig';
 
 jest.mock('../../services/fetchResourcesApi');
 jest.mock('../../hrmConfig', () => ({
-  getReferrableResourceConfig: () => ({}),
   getAseloFeatureFlags: jest.fn(),
 }));
 

--- a/plugin-hrm-form/src/___tests__/services/ResourcesService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ResourcesService.test.ts
@@ -17,7 +17,6 @@
 import fetchResourcesApi from '../../services/fetchResourcesApi';
 import { getResource, searchResources } from '../../services/ResourceService';
 import { getAseloFeatureFlags } from '../../hrmConfig';
-import { FeatureFlags } from '../../types/types';
 
 jest.mock('../../services/fetchResourcesApi');
 jest.mock('../../hrmConfig', () => ({
@@ -32,7 +31,6 @@ beforeEach(() => {
   mockFetchResourcesApi.mockReset();
   mockGetAseloFeatureFlags.mockReset();
   // eslint-disable-next-line camelcase
-  mockGetAseloFeatureFlags.mockReturnValue({ enable_resources_elastic_search: true } as FeatureFlags);
 });
 
 test('getResource - valid params sends GET /resource/{id} to mockFetchResourcesApi', async () => {

--- a/plugin-hrm-form/src/components/resources/convertKHPResourceAttributes.ts
+++ b/plugin-hrm-form/src/components/resources/convertKHPResourceAttributes.ts
@@ -17,6 +17,8 @@
 import { KhpOperationsDay, KhpUiResource, Language } from './types';
 import { AttributeData, Attributes } from '../../services/ResourceService';
 
+const BLANK_MAIN_CONTACT = { name: '', title: '', email: '', phoneNumber: '', isPrivate: false };
+
 const getAttributeData = (attributes: Attributes | undefined, language: Language, keyName: string): AttributeData => {
   const propDataList = (attributes ?? {})[keyName];
   if (propDataList && Array.isArray(propDataList)) {
@@ -228,22 +230,22 @@ export const convertKHPResourceAttributes = (
   if (!attributes || Array.isArray(attributes)) {
     throw new Error('Invalid attributes to convert to KHP resource');
   }
-  if (!attributes.mainContact || Array.isArray(attributes.mainContact)) {
-    throw new Error('Invalid attributes.mainContact to convert to KHP resource');
-  }
   const sites = attributes.site && !Array.isArray(attributes.site) ? attributes.site : {};
   const operations = attributes.operations && !Array.isArray(attributes.operations) ? attributes.operations : undefined;
   return {
     status: getAttributeValue(attributes, language, 'status'),
     taxonomyCode: getAttributeValue(attributes, language, 'taxonomyCode'),
     description: extractDescriptionInfo(attributes.description, language),
-    mainContact: {
-      name: getAttributeValue(attributes.mainContact, language, 'name'),
-      title: getAttributeValue(attributes.mainContact, language, 'title'),
-      phoneNumber: getAttributeValue(attributes.mainContact, language, 'phoneNumber'),
-      email: getAttributeValue(attributes.mainContact, language, 'email'),
-      isPrivate: getBooleanAttributeValue(attributes.mainContact, 'isPrivate'),
-    },
+    mainContact:
+      attributes.mainContact && !Array.isArray(attributes.mainContact)
+        ? {
+            name: getAttributeValue(attributes.mainContact, language, 'name'),
+            title: getAttributeValue(attributes.mainContact, language, 'title'),
+            phoneNumber: getAttributeValue(attributes.mainContact, language, 'phoneNumber'),
+            email: getAttributeValue(attributes.mainContact, language, 'email'),
+            isPrivate: getBooleanAttributeValue(attributes.mainContact, 'isPrivate'),
+          }
+        : BLANK_MAIN_CONTACT,
     website: getAttributeValue(attributes, language, 'website'),
     operations: extractResourceOperatingHours(operations, language),
     available247: getAttributeValue(attributes, language, 'available247'),

--- a/plugin-hrm-form/src/services/ResourceService.ts
+++ b/plugin-hrm-form/src/services/ResourceService.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import fetchResourceApi from './fetchResourcesApi';
-import { getAseloFeatureFlags, getReferrableResourceConfig } from '../hrmConfig';
+import { getReferrableResourceConfig } from '../hrmConfig';
 
 export type AttributeData<T = any> = {
   language?: string;
@@ -56,19 +56,9 @@ export const searchResources = async (
   start: number,
   limit: number,
 ): Promise<{ totalCount: number; results: ReferrableResource[] }> => {
-  if (getAseloFeatureFlags().enable_resources_elastic_search) {
-    const fromApi = await fetchResourceApi(`search?start=${start}&limit=${limit}`, {
-      method: 'POST',
-      body: JSON.stringify(parameters),
-    });
-    return {
-      ...fromApi,
-      results: fromApi.results,
-    };
-  }
-  const fromApi = await fetchResourceApi(`searchByName?start=${start}&limit=${limit}`, {
+  const fromApi = await fetchResourceApi(`search?start=${start}&limit=${limit}`, {
     method: 'POST',
-    body: JSON.stringify({ nameSubstring: parameters.generalSearchTerm, ids: [] }),
+    body: JSON.stringify(parameters),
   });
   return {
     ...fromApi,

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -260,7 +260,6 @@ export type FeatureFlags = {
   enable_counselor_toolkits: boolean; // Enables Counselor Toolkits
   enable_emoji_picker: boolean; // Enables Emoji Picker
   enable_aselo_messaging_ui: boolean; // Enables Aselo Messaging UI iinstead of the default Twilio one - reduced functionality for low spec clients.
-  enable_resources_elastic_search: boolean; // Use the EasticSearch powered search for resources, rather than the interim name only version.
   enable_conferencing: boolean; // Enables Conferencing UI and replaces default Twilio components and behavior
 };
 /* eslint-enable camelcase */

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -200,10 +200,10 @@ will set the `enable_voice_recordings` to false, and the `enable_transcripts` fl
 This sets the same flags as the example above, but uses AWS to look up the Twilio credentials for the Aselo Development account. Note that the `--helplineShortCode` and the `--helplineEnvironment` arguments are passed in before the `patch-feature-flags` command, not after.
 
 
-3Single account (AWS credentials in environment):
+3. Single account (AWS credentials in environment):
 
 ```
-➜ npm run twilioResources -- --helplineEnvironment development --helplineShortCode AS patch-feature-flags -f enable_voice_recordings:false -f enable_twilio_transcripts:true
+➜ npm run twilioResources -- --helplineEnvironment development patch-feature-flags -f enable_voice_recordings:false -f enable_twilio_transcripts:true
 ```
 
 This sets the same flags as the example above, but uses AWS to look up the Twilio credentials for all the accounts in the development environment and will set the flags for each of them.


### PR DESCRIPTION
## Description

Some resources have no mainContact at all when imported from the latest data upload, so we've added a small piece of defensive code to prevent the dreaded 'white screen' breaking search results

Also removes feature flag to switch from the placeholder SQL based search and elasticsearch, the placeholder search is being removed so we will use ES all the time from now on
