### PR TITLE
Change participant label to use ph no + change input type to text

### DIFF
--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/ConferencePanel.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/ConferencePanel.tsx
@@ -74,9 +74,7 @@ const ConferencePanel: React.FC<Props> = ({ task, conference }) => {
 
       const from = Manager.getInstance().serviceConfiguration.outbound_call_flows.default.caller_id;
       const to = phoneNumber;
-      const label = `Participant ${String(
-        participants.filter(participant => participant.status === 'joined').length + 1,
-      )}`;
+      const label = `External party ${to}`;
 
       await Promise.all(
         conference.source.participants

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/PhoneInputDialog.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/PhoneInputDialog.tsx
@@ -52,7 +52,7 @@ const PhoneInputDialog: React.FC<PhoneDialogProps> = ({
       <Template code="Conference-EnterPhoneNumber" />
       <Row>
         <input
-          type="number"
+          type="text"
           id="number-input"
           placeholder="+1 234-567-8910"
           value={targetNumber}


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- Change `label` to use phone number as part of the phone number 
- Change input type back to text

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
- For testing label change, start a conference, and add a phone number, then remove and add the participant with the same phone number again. This should discontinue errors and able to add participant.