### PR TITLE
Added participant label, persisted in redux state

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -45,15 +45,12 @@ import { subscribeNewMessageAlertOnPluginInit } from './notifications/newMessage
 import { subscribeReservedTaskAlert } from './notifications/reservedTask';
 import { setUpCounselorToolkits } from './components/toolkits/setUpCounselorToolkits';
 import { setupConferenceComponents, setUpConferenceActions } from './conference';
+import { setUpTransfers } from './transfer';
 
 const PLUGIN_NAME = 'HrmFormPlugin';
 
 // eslint-disable-next-line import/no-unused-modules
 export type SetupObject = ReturnType<typeof getHrmConfig>;
-
-const setUpTransfers = () => {
-  setUpSharedStateClient();
-};
 
 const setUpLocalization = (config: ReturnType<typeof getHrmConfig>) => {
   const manager = Flex.Manager.getInstance();
@@ -207,6 +204,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     const { translateUI, getMessage } = setUpLocalization(config);
     ActionFunctions.loadCurrentDefinitionVersion();
 
+    setUpSharedStateClient();
     if (featureFlags.enable_transfers) setUpTransfers();
     setUpComponents(featureFlags, config, translateUI);
     setUpActions(featureFlags, config, getMessage);

--- a/plugin-hrm-form/src/components/Conference/ParticipantLabel/index.tsx
+++ b/plugin-hrm-form/src/components/Conference/ParticipantLabel/index.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import { Template } from '@twilio/flex-ui';
+import type { ParticipantCanvasChildrenProps } from '@twilio/flex-ui/src/components/canvas/ParticipantCanvas/ParticipantCanvas.definitions';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { conferenceApi } from '../../../services/ServerlessService';
+import { RootState, conferencingBase, namespace } from '../../../states';
+import { addParticipantLabelAction } from '../../../states/conferencing';
+import { ParticipantLabelContainer, ParticipantLabelText } from './styles';
+
+type Props = ParticipantCanvasChildrenProps;
+
+const ParticipantLabel: React.FC<Props> = ({ participant, task, ...props }) => {
+  const participantLabel = useSelector(
+    (state: RootState) =>
+      state[namespace][conferencingBase].tasks[task?.taskSid].participantsLabels[participant?.participantSid],
+  );
+  const dispatch = useDispatch();
+
+  const addParticipantLabel = (participantLabel: string) =>
+    dispatch(addParticipantLabelAction(task.taskSid, participant.participantSid, participantLabel));
+
+  React.useEffect(() => {
+    const getParticipantLabel = async () => {
+      const result = await conferenceApi.getParticipant({
+        callSid: participant?.callSid,
+        conferenceSid: task.conference?.conferenceSid,
+      });
+      addParticipantLabel(result.participant.label);
+    };
+
+    if (!participantLabel) {
+      getParticipantLabel();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <ParticipantLabelContainer>
+      <ParticipantLabelText className="ParticipantCanvas-Name">{participantLabel || '...'}</ParticipantLabelText>
+    </ParticipantLabelContainer>
+  );
+};
+
+export default ParticipantLabel;

--- a/plugin-hrm-form/src/components/Conference/ParticipantLabel/styles.tsx
+++ b/plugin-hrm-form/src/components/Conference/ParticipantLabel/styles.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import { styled } from '@twilio/flex-ui';
+
+import { FontOpenSans } from '../../../styles/HrmStyles';
+
+export const ParticipantLabelText = styled(FontOpenSans)`
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  text-align: center;
+  vertical-align: baseline;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const ParticipantLabelContainer = styled('div')`
+  margin-top: 0.75rem;
+  margin-bottom: 0.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-box-flex: 0;
+  flex-grow: 0;
+  padding: 0.5rem;
+  text-align: center;
+  box-sizing: border-box;
+  width: 100%;
+`;

--- a/plugin-hrm-form/src/conference/setUpConferenceComponents.tsx
+++ b/plugin-hrm-form/src/conference/setUpConferenceComponents.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { CallCanvas, CallCanvasActions, ParticipantCanvas, TaskHelper } from '@twilio/flex-ui';
+import { ParticipantCanvasChildrenProps } from '@twilio/flex-ui/src/components/canvas/ParticipantCanvas/ParticipantCanvas.definitions';
 
 import ConferencePanel from '../components/Conference/ConferenceActions/ConferencePanel';
 import ToggleMute from '../components/Conference/ConferenceActions/ToggleMute';
@@ -24,6 +25,7 @@ import HoldParticipantButton from '../components/Conference/HoldParticipantButto
 import RemoveParticipantButton from '../components/Conference/RemoveParticipantButton';
 import ConferenceMonitor from '../components/Conference/ConferenceMonitor';
 import { getTemplateStrings } from '../hrmConfig';
+import ParticipantLabel from '../components/Conference/ParticipantLabel';
 
 export const setupConferenceComponents = () => {
   const strings = getTemplateStrings();
@@ -70,5 +72,15 @@ export const setupConferenceComponents = () => {
       TaskHelper.isLiveCall(props.task) &&
       props.participant?.connecting &&
       props.participant?.participantType === 'external',
+  });
+  ParticipantCanvas.Content.remove('name', {
+    if: (props: ParticipantCanvasChildrenProps) =>
+      props.participant?.participantType === 'external' || props.participant?.participantType === 'unknown',
+  });
+  // @ts-ignore
+  ParticipantCanvas.Content.add(<ParticipantLabel key="participant-name" />, {
+    if: (props: ParticipantCanvasChildrenProps) =>
+      props.participant?.participantType === 'external' || props.participant?.participantType === 'unknown',
+    sortOrder: 2,
   });
 };

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -258,6 +258,7 @@ type ConferenceAddParticipantParams = {
   callStatusSyncDocumentSid: string;
   label: string;
 };
+type ConferenceGetParticipantParams = { conferenceSid: string; callSid: string };
 type ConferenceRemoveParticipantParams = { conferenceSid: string; callSid: string };
 type ConferenceUpdateParticipantParams = {
   conferenceSid: string;
@@ -282,6 +283,16 @@ export const conferenceApi = {
     };
 
     const response = await fetchProtectedApi('/conference/addParticipant', body);
+    return response;
+  },
+
+  getParticipant: async ({ callSid, conferenceSid }: ConferenceGetParticipantParams): Promise<{ participant: any }> => {
+    const body = {
+      conferenceSid,
+      callSid,
+    };
+
+    const response = await fetchProtectedApi('/conference/getParticipant', body);
     return response;
   },
 

--- a/plugin-hrm-form/src/states/conferencing/index.ts
+++ b/plugin-hrm-form/src/states/conferencing/index.ts
@@ -36,6 +36,7 @@ export type ConferencingState = {
       isDialogOpen: boolean;
       callStatus: CallStatus;
       phoneNumber: string;
+      participantsLabels: { [participantSid: string]: string };
     };
   };
 };
@@ -44,6 +45,7 @@ export const newTaskEntry = {
   isDialogOpen: false,
   callStatus: 'no-call' as CallStatus,
   phoneNumber: '',
+  participantsLabels: {},
 };
 
 const SET_IS_DIALOG_OPEN = 'conferencing/set-is-dialog-open';
@@ -67,10 +69,22 @@ export const setPhoneNumberAction = createAction(SET_PHONE_NUMBER, (taskId: stri
   phoneNumber,
 }));
 
+const ADD_PARTICIPANT_LABEL = 'conferencing/add-participant-label';
+
+export const addParticipantLabelAction = createAction(
+  ADD_PARTICIPANT_LABEL,
+  (taskId: string, participantSid: string, participantLabel: string) => ({
+    taskId,
+    participantSid,
+    participantLabel,
+  }),
+);
+
 type ConferencingStateAction =
   | ReturnType<typeof setIsDialogOpenAction>
   | ReturnType<typeof setCallStatusAction>
-  | ReturnType<typeof setPhoneNumberAction>;
+  | ReturnType<typeof setPhoneNumberAction>
+  | ReturnType<typeof addParticipantLabelAction>;
 
 const initialState: ConferencingState = {
   tasks: {},
@@ -133,6 +147,19 @@ const conferencingReducer = createReducer(initialState, handleAction => [
       [payload.taskId]: {
         ...state.tasks[payload.taskId],
         phoneNumber: payload.phoneNumber,
+      },
+    },
+  })),
+  handleAction(addParticipantLabelAction, (state, { payload }) => ({
+    ...state,
+    tasks: {
+      ...state.tasks,
+      [payload.taskId]: {
+        ...state.tasks[payload.taskId],
+        participantsLabels: {
+          ...state.tasks[payload.taskId].participantsLabels,
+          [payload.participantSid]: payload.participantLabel,
+        },
       },
     },
   })),

--- a/plugin-hrm-form/src/transfer/index.tsx
+++ b/plugin-hrm-form/src/transfer/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { setUpTransferActions } from './setUpTransferActions';
+
+export const setUpTransfers = () => {
+  setUpTransferActions();
+};

--- a/plugin-hrm-form/src/transfer/setUpTransferActions.tsx
+++ b/plugin-hrm-form/src/transfer/setUpTransferActions.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import { NotificationType, Notifications, Template } from '@twilio/flex-ui';
+
+export const TransfersNotifications = {
+  CantHangTransferInProgressNotification: 'TransfersNotifications_CantHangTransferInProgressNotification',
+};
+
+const setUpTransfersNotifications = () => {
+  Notifications.registerNotification({
+    id: TransfersNotifications.CantHangTransferInProgressNotification,
+    type: NotificationType.error,
+    content: <Template code="Can't leave the call until the transfer is accepted or rejected." />,
+  });
+};
+
+export const setUpTransferActions = () => {
+  setUpTransfersNotifications();
+};


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/serverless/pull/485.

## Description
This PR:
- Makes use of the `conference/getParticipant` function added in the above linked PR.
- Adds participants labels into Redux state to persist across navigation.
- When a new external participant is added to a call, we'll retrieve it's label and store it in Redux state to be displayed in the participant canvas.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2024)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Verification steps
- Make sure the above linked PR is deployed, or serve it locally via ngrok.
- Start a new Flex instance.
- Start a new phone call, and add a third participant. Confirm that the external participant label is properly displayed and the styles matches those provided by the default Twilio participant canvas. 