### PR TITLE
CHI-1884: Added 30 day expiry to HRM export JSON in helpline docs buckets.

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -42,40 +42,6 @@
         "typescript": "^4.3.5"
       }
     },
-    "../hrm-form-definitions": {
-      "version": "1.0.0",
-      "license": "AGPL",
-      "dependencies": {
-        "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
-      },
-      "devDependencies": {
-        "@babel/preset-env": "^7.16.5",
-        "@babel/preset-typescript": "^7.16.5",
-        "@types/jest": "^27.0.3",
-        "@types/lodash": "^4.14.182",
-        "@types/node": "^17.0.8",
-        "@types/react": "^17.0.38",
-        "@typescript-eslint/eslint-plugin": "^4.28.3",
-        "@typescript-eslint/parser": "^4.28.3",
-        "babel-core": "^6.26.3",
-        "eslint": "^7.4.0",
-        "eslint-config-airbnb": "^18.2.0",
-        "eslint-config-airbnb-base": "^14.2.0",
-        "eslint-config-airbnb-typescript": "^12.3.1",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-import-resolver-typescript": "^2.4.0",
-        "eslint-plugin-import": "^2.22.0",
-        "eslint-plugin-prettier": "^3.1.4",
-        "jest": "^27.4.5",
-        "jest-each": "^28.1.1",
-        "prettier": "^2.3.2",
-        "react-hook-form": "^6.11.0",
-        "ts-jest": "^27.1.2",
-        "ts-node": "^10.1.0",
-        "typescript": "^4.3.5"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -183,8 +149,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -3238,8 +3202,13 @@
       "dev": true
     },
     "node_modules/hrm-form-definitions": {
-      "resolved": "../hrm-form-definitions",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:../hrm-form-definitions",
+      "license": "AGPL",
+      "dependencies": {
+        "@babel/runtime": "^7.16.5",
+        "lodash": "^4.17.21"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -5022,9 +4991,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -6483,8 +6450,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
-      "dev": true,
-      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -8683,34 +8648,10 @@
       "dev": true
     },
     "hrm-form-definitions": {
-      "version": "file:../hrm-form-definitions",
+      "version": "1.0.0",
       "requires": {
-        "@babel/preset-env": "^7.16.5",
-        "@babel/preset-typescript": "^7.16.5",
         "@babel/runtime": "^7.16.5",
-        "@types/jest": "^27.0.3",
-        "@types/lodash": "^4.14.182",
-        "@types/node": "^17.0.8",
-        "@types/react": "^17.0.38",
-        "@typescript-eslint/eslint-plugin": "^4.28.3",
-        "@typescript-eslint/parser": "^4.28.3",
-        "babel-core": "^6.26.3",
-        "eslint": "^7.4.0",
-        "eslint-config-airbnb": "^18.2.0",
-        "eslint-config-airbnb-base": "^14.2.0",
-        "eslint-config-airbnb-typescript": "^12.3.1",
-        "eslint-config-prettier": "^6.11.0",
-        "eslint-import-resolver-typescript": "^2.4.0",
-        "eslint-plugin-import": "^2.22.0",
-        "eslint-plugin-prettier": "^3.1.4",
-        "jest": "^27.4.5",
-        "jest-each": "^28.1.1",
-        "lodash": "^4.17.21",
-        "prettier": "^2.3.2",
-        "react-hook-form": "^6.11.0",
-        "ts-jest": "^27.1.2",
-        "ts-node": "^10.1.0",
-        "typescript": "^4.3.5"
+        "lodash": "^4.17.21"
       }
     },
     "https-proxy-agent": {
@@ -10079,9 +10020,7 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",

--- a/twilio-iac/terraform-modules/aws/default/main.tf
+++ b/twilio-iac/terraform-modules/aws/default/main.tf
@@ -68,6 +68,22 @@ resource "aws_s3_bucket_ownership_controls" "docs" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "hrm_export_expiry" {
+  bucket = aws_s3_bucket.docs.arn
+
+  rule {
+    expiration {
+      days = 30
+    }
+    filter {
+      prefix = "hrm-data/"
+    }
+    id = "HRM Exported Data Expiration Policy"
+    status = "Enabled"
+  }
+
+}
+
 resource "aws_s3_bucket" "chat" {
   bucket   = local.chat_s3_location
   provider = aws.bucket

--- a/twilio-iac/terraform-modules/aws/default/main.tf
+++ b/twilio-iac/terraform-modules/aws/default/main.tf
@@ -69,7 +69,7 @@ resource "aws_s3_bucket_ownership_controls" "docs" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "hrm_export_expiry" {
-  bucket = aws_s3_bucket.docs.arn
+  bucket = aws_s3_bucket.docs.bucket
 
   rule {
     expiration {


### PR DESCRIPTION
## Description

Currently all objects in the helpline's docs bucket under the `hrm-data/` key will expire and be removed after 30 days

We can make it more configurable later should the need arise.

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- N/A Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
Fixes #....

### Verification steps

* Run a targeted apply on a helpline, e.g.: 
```
make HL=ca HL_ENV=staging plan -- tf_args="-target=module.aws.aws_s3_bucket_lifecycle_configuration.hrm_export_expiry"
```

* Check the S3 settings for the bucket in the console to ensure they are as expected
* Review in 40 days to ensure old stuff is being removed

Or alternatively you can temporarily apply a much shorter expiry as part of the same config to verify it works as expected

A plan for KHP staging has been reviewed but not applied anywhere yet.