### PR TITLE
fix: e2e lambda fail on list lambda error

### DIFF
--- a/.github/workflows/e2e_lambda_deploy.yml
+++ b/.github/workflows/e2e_lambda_deploy.yml
@@ -114,6 +114,10 @@ jobs:
         run: |
           DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.region }}/g')
           FUNCTION_NAMES=$(aws lambda list-functions --region ${{ matrix.region }} | jq -r '.Functions[] | select(.FunctionName | test("${{ inputs.environment }}-.*-e2e")) .FunctionName')
+          if [ $? -ne 0 ]; then
+            echo "Error listing functions"
+            exit 1
+          fi
           for FUNCTION_NAME in $FUNCTION_NAMES; do
             aws lambda update-function-code --function-name $FUNCTION_NAME --image-uri "$DOCKER_IMAGE" --publish
           done


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Adds a block so e2e lambda deploy action correctly errors if the lambda list function fails.