### PR TITLE
Chi 1752 add ability remove referral contact

### DIFF
--- a/plugin-hrm-form/src/components/contact/ResourceReferralList/index.tsx
+++ b/plugin-hrm-form/src/components/contact/ResourceReferralList/index.tsx
@@ -28,6 +28,7 @@ import {
   updateResourceReferralIdToAddForUnsavedContactAction,
   updateResourceReferralLookupStatusForUnsavedContactAction,
   addResourceReferralForUnsavedContactAction,
+  removeResourceReferralForUnsavedContactAction,
 } from '../../../states/contacts/resourceReferral';
 import asyncDispatch from '../../../states/asyncDispatch';
 import { loadResourceAsyncAction, ResourceLoadStatus } from '../../../states/resources';
@@ -41,6 +42,7 @@ import {
   ReferralItem,
   ReferralItemInfo,
   Error,
+  DeleteButton,
 } from './styles';
 
 type OwnProps = {
@@ -72,6 +74,10 @@ const mapDispatchToProps = (dispatch, { taskSid }: OwnProps) => ({
   addResourceReferral: (resource: ReferrableResource) => {
     dispatch(addResourceReferralForUnsavedContactAction(taskSid, resource));
   },
+
+  updateResourceReferralIdToRemove: (value: string) => {
+    dispatch(removeResourceReferralForUnsavedContactAction(taskSid, value));
+  },
 });
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -87,6 +93,7 @@ const ResourceReferralList: React.FC<Props> = ({
   loadResource,
   lookupStatus,
   addResourceReferral,
+  updateResourceReferralIdToRemove,
 }) => {
   // component state 'buffer' to keep the input responsive
   const [resourceReferralToAddText, setResourceReferralToAddText] = useState(resourceReferralIdToAdd);
@@ -101,6 +108,10 @@ const ResourceReferralList: React.FC<Props> = ({
     if (lookupStatus !== ReferralLookupStatus.NOT_STARTED) {
       updateResourceReferralLookupStatus(ReferralLookupStatus.NOT_STARTED);
     }
+  };
+
+  const handleRemoveReferral = (resourceId: string) => {
+    updateResourceReferralIdToRemove(resourceId);
   };
 
   // To retain state if we change the task
@@ -172,11 +183,9 @@ const ResourceReferralList: React.FC<Props> = ({
             <ReferralItemInfo>
               <span>{resourceName}</span>
               <span>ID #{resourceId}</span>
-              <span>
-                <button color="blue" type="submit">
-                  Delete
-                </button>
-              </span>
+              <DeleteButton onClick={() => handleRemoveReferral(resourceId)}>
+                <Template code="Case-DeleteDocument" />
+              </DeleteButton>
             </ReferralItemInfo>
           </ReferralItem>
         ))}

--- a/plugin-hrm-form/src/components/contact/ResourceReferralList/index.tsx
+++ b/plugin-hrm-form/src/components/contact/ResourceReferralList/index.tsx
@@ -172,6 +172,11 @@ const ResourceReferralList: React.FC<Props> = ({
             <ReferralItemInfo>
               <span>{resourceName}</span>
               <span>ID #{resourceId}</span>
+              <span>
+                <button color="blue" type="submit">
+                  Delete
+                </button>
+              </span>
             </ReferralItemInfo>
           </ReferralItem>
         ))}

--- a/plugin-hrm-form/src/components/contact/ResourceReferralList/styles.tsx
+++ b/plugin-hrm-form/src/components/contact/ResourceReferralList/styles.tsx
@@ -73,6 +73,20 @@ export const AddButton = styled('button')<AddButtonProps>`
   }
 `;
 
+// eslint-disable-next-line import/no-unused-modules
+export const DeleteButton = styled('span')`
+  color: #1876d1;
+  font-family: OpenSans;
+  font-size: 13px;
+  line-height: 16px;
+  width: 237px;
+  text-align: left;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-style: normal !important;
+`;
+
 export const Error = styled('p')`
   display: flex;
   color: red;

--- a/plugin-hrm-form/src/states/contacts/resourceReferral.ts
+++ b/plugin-hrm-form/src/states/contacts/resourceReferral.ts
@@ -67,6 +67,13 @@ export const addResourceReferralForUnsavedContactAction = createAction(
   }),
 );
 
+const REMOVE_RESOURCE_REFERRAL_FOR_UNSAVED_CONTACT = 'RemoveResourceReferralForUnsavedContact';
+
+export const removeResourceReferralForUnsavedContactAction = createAction(
+  REMOVE_RESOURCE_REFERRAL_FOR_UNSAVED_CONTACT,
+  (taskId: string, referralId: string) => ({ taskId, referralId }),
+);
+
 const patchUnsavedContactReferralResourceState = (
   state: ContactsState,
   taskId: string,
@@ -139,6 +146,19 @@ export const resourceReferralReducer = (initialState: ContactsState) =>
                 lookupStatus: ReferralLookupStatus.NOT_STARTED,
               },
             },
+          },
+        },
+      };
+    }),
+    handleAction(removeResourceReferralForUnsavedContactAction, (state, { payload: { taskId, referralId } }) => {
+      const referrals = state.tasks[taskId].referrals.filter(referral => referral.resourceId !== referralId);
+      return {
+        ...state,
+        tasks: {
+          ...state.tasks,
+          [taskId]: {
+            ...state.tasks[taskId],
+            referrals,
           },
         },
       };

--- a/plugin-hrm-form/src/translations/en-CA/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-CA/flexUI.json
@@ -20,6 +20,7 @@
   "BottomBar-SaveAndAddAnotherNote": "Save and Add Another",
   "Case-AddIncident": "Add Incident",
   "Case-AddDocument": "Add",
+  "Case-DeleteDocument": "Delete",
   "Case-EditNote": "Edit Note",
   "Case-EditReferral": "Edit Referral Contact",
   "Case-Referral": "Referral Contact",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -165,6 +165,7 @@
   "Case-AddIncident": "Add Incident",
   "Case-AddDocument": "Add Document",
   "Case-EditNote": "Edit Note",
+  "Case-DeleteDocument": "Delete",
   "Case-EditReferral": "Edit Referral",
   "Case-EditHousehold": "Edit Household Member",
   "Case-EditPerpetrator": "Edit Perpetrator",


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @stephenhand 

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- New feature: Add the ability to remove referrals from a contact

**Goal**: Enable counsellors to delete a referral that they previously added to a contact.

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Feature flags added
- [x] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

### Related Issues
Fixes [CHI-1752](https://tech-matters.atlassian.net/browse/CHI-1752)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
- Add offline contact
- Navigate to Contact Summary
- Add a Shared Resource
- Verify that there is a Delete button attached to every added shared resource
- Click on the Delete button to remove a referral from the contact

[CHI-1752]: https://tech-matters.atlassian.net/browse/CHI-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ