### PR TITLE
Creates Lex Bot development_as_es_CO_pre_survey

### DIFF
--- a/twilio-iac/helplines/as/common.hcl
+++ b/twilio-iac/helplines/as/common.hcl
@@ -19,6 +19,20 @@ locals {
     jsondecode(file("/app/twilio-iac/helplines/configs/lex/en_US/bots/pre_survey.json")),
   )
 
+  es_co_slot_types = merge(
+    jsondecode(file("/app/twilio-iac/helplines/configs/lex/es_CO/slot_types/age.json")),
+    jsondecode(file("/app/twilio-iac/helplines/configs/lex/es_CO/slot_types/gender.json")),
+    jsondecode(file("/app/twilio-iac/helplines/configs/lex/es_CO/slot_types/yes_no.json")),
+  )
+
+  es_co_intents = merge(
+    jsondecode(file("/app/twilio-iac/helplines/configs/lex/es_CO/intents/pre_survey.json")),
+  )
+
+  es_co_bots = merge(
+    jsondecode(file("/app/twilio-iac/helplines/configs/lex/es_CO/bots/pre_survey.json")),
+  )
+
   local_config = {
     helpline           = "Aselo"
     old_dir_prefix     = "aselo-as"
@@ -28,6 +42,12 @@ locals {
         slot_types : local.en_us_slot_types
         intents    : local.en_us_intents
         bots       : local.en_us_bots
+      }
+
+      es_CO : {
+        slot_types : local.es_co_slot_types
+        intents    : local.es_co_intents
+        bots       : local.es_co_bots
       }
     }
   }

--- a/twilio-iac/helplines/configs/lex/en_US/bots/post_survey.json
+++ b/twilio-iac/helplines/configs/lex/en_US/bots/post_survey.json
@@ -5,6 +5,7 @@
     "process_behavior": "BUILD",
     "child_directed": true,
     "idle_session_ttl_in_seconds": "600",
+    "enable_model_improvements": true,
     "abort_statement": {
       "content": "Sorry, I am not able to assist at this time.",
       "content_type": "PlainText"

--- a/twilio-iac/helplines/configs/lex/es_CO/bots/pre_survey.json
+++ b/twilio-iac/helplines/configs/lex/es_CO/bots/pre_survey.json
@@ -1,18 +1,18 @@
 {
   "pre_survey": {
     "description": "Pre Survey bot",
-    "locale": "en-US",
+    "locale": "es-419",
     "process_behavior": "BUILD",
     "child_directed": true,
     "idle_session_ttl_in_seconds": "600",
     "enable_model_improvements": true,
     "abort_statement": {
-      "content": "Sorry, I am not able to assist at this time.",
+      "content": "Lo siento, no puedo ayudar en este momento.",
       "content_type": "PlainText"
     },
     "clarification_prompt": {
       "max_attempts": 2,
-      "content": "Sorry, I didn't understand that. Please try again.",
+      "content": "Lo siento, no entendí eso. Inténtalo de nuevo.",
       "content_type": "PlainText"
     },
     "intents": [

--- a/twilio-iac/helplines/configs/lex/es_CO/intents/pre_survey.json
+++ b/twilio-iac/helplines/configs/lex/es_CO/intents/pre_survey.json
@@ -1,0 +1,66 @@
+{
+  "pre_survey": {
+    "description": "Survey intent",
+    "sample_utterances": [
+      "Hola",
+      "Ayuda",
+      "Necesito ayuda",
+      "Por favor",
+      "Vida",
+      "No seguro",
+      "No segura",
+      "Matar",
+      "Herido",
+      "Herida",
+      "Mí",
+      "Mi",
+      "Incoming webchat contact"
+    ],
+    "fulfillment_activity": {
+      "type": "ReturnIntent"
+    },
+    "conclusion_statement": {
+      "content": "Te transferiremos ahora. Por favor espere para un consejero.",
+      "content_type": "PlainText"
+    },
+    "rejection_statement": {
+      "content": "Lo siento, no puedo ayudar en este momento.",
+      "content_type": "PlainText"
+    },
+    "slots": {
+      "aboutSelf": {
+        "priority": 1,
+        "description": "Caller is calling for self or someone else",
+        "slot_constraint": "Required",
+        "slot_type": "yes_no",
+        "value_elicitation_prompt": {
+          "max_attempts": 2,
+          "content": "¿Estás llamando por ti? Por favor responda Sí o No.",
+          "content_type": "PlainText"
+        }
+      },
+      "age": {
+        "priority": 2,
+        "description": "Age of caller",
+        "slot_constraint": "Required",
+        "slot_type": "age",
+        "value_elicitation_prompt": {
+          "max_attempts": 2,
+          "content": "¿Cuántos años tiene?",
+          "content_type": "PlainText"
+        }
+      },
+      "gender": {
+        "priority": 3,
+        "description": "Caller's gender",
+        "slot_constraint": "Required",
+        "slot_type": "gender",
+        "value_elicitation_prompt": {
+          "max_attempts": 2,
+          "content": "¿Cuál es su género?",
+          "content_type": "PlainText"
+        }
+      }
+    }
+  }
+}

--- a/twilio-iac/helplines/configs/lex/es_CO/slot_types/age.json
+++ b/twilio-iac/helplines/configs/lex/es_CO/slot_types/age.json
@@ -1,0 +1,140 @@
+{
+  "age": {
+    "description": "Age of caller",
+    "value_selection_strategy": "TOP_RESOLUTION",
+    "values": {
+      "0": {
+        "synonyms": [
+          "cero"
+        ]
+      },
+      "1": {
+        "synonyms": [
+          "uno"
+        ]
+      },
+      "2": {
+        "synonyms": [
+          "dos"
+        ]
+      },
+      "3": {
+        "synonyms": [
+          "tres"
+        ]
+      },
+      "4": {
+        "synonyms": [
+          "cuatro"
+        ]
+      },
+      "5": {
+        "synonyms": [
+          "cinco"
+        ]
+      },
+      "6": {
+        "synonyms": [
+          "seis"
+        ]
+      },
+      "7": {
+        "synonyms": [
+          "siete"
+        ]
+      },
+      "8": {
+        "synonyms": [
+          "ocho"
+        ]
+      },
+      "9": {
+        "synonyms": [
+          "nueve"
+        ]
+      },
+      "10": {
+        "synonyms": [
+          "diez"
+        ]
+      },
+      "11": {
+        "synonyms": [
+          "once"
+        ]
+      },
+      "12": {
+        "synonyms": [
+          "doce"
+        ]
+      },
+      "13": {
+        "synonyms": [
+          "trece"
+        ]
+      },
+      "14": {
+        "synonyms": [
+          "catorce"
+        ]
+      },
+      "15": {
+        "synonyms": [
+          "quince"
+        ]
+      },
+      "16": {
+        "synonyms": [
+          "dieciséis",
+          "dieciseis"
+        ]
+      },
+      "17": {
+        "synonyms": [
+          "diecisiete"
+        ]
+      },
+      "18": {
+        "synonyms": [
+          "dieciocho"
+        ]
+      },
+      "19": {
+        "synonyms": [
+          "diecinueve"
+        ]
+      },
+      "20": {
+        "synonyms": [
+          "veinte"
+        ]
+      },
+      "21": {
+        "synonyms": [
+          "veintiuno"
+        ]
+      },
+      "Above 21": {
+        "synonyms": [
+          "22", "23", "24", "25", "26", "27", "28", "29", "30", "31",
+          "32", "33", "34", "35", "36", "37", "38", "39", "40", "41",
+          "42", "43", "44", "45", "46", "47", "48", "49", "50", "51",
+          "52", "53", "54", "55", "56", "57", "58", "59", "60", "61",
+          "62", "63", "64", "65", "66", "67", "68", "69", "70", "71",
+          "72", "73", "74", "75", "76", "77", "78", "79", "80", "81",
+          "82", "83", "84", "85", "86", "87", "88", "89", "90", "91",
+          "92", "93", "94", "95", "96", "97", "98", "99", "100", "101",
+          "102", "103", "104", "105", "106", "107", "108", "109", "110"
+        ]
+      },
+      "X": {
+        "synonyms": [
+          "x"
+        ]
+      },
+      "prefer not to answer": {
+        "synonyms": ["prefiero no", "no responder", "sin responder"]
+      }
+    }
+  }
+}

--- a/twilio-iac/helplines/configs/lex/es_CO/slot_types/gender.json
+++ b/twilio-iac/helplines/configs/lex/es_CO/slot_types/gender.json
@@ -1,0 +1,23 @@
+{
+  "gender": {
+    "description": "Gender of caller",
+    "value_selection_strategy": "TOP_RESOLUTION",
+    "values": {
+      "boy": {
+        "synonyms": ["h", "hombre", "chico", "muchacho", "niño", "chaval", "masculino", "él", "el"]
+      },
+      "girl": {
+        "synonyms": ["m", "mujer",  "chica", "muchacha", "niña", "femenino", "ella"]
+      },
+      "non-binary": {
+        "synonyms": ["ninguno", "ninguna", "No binario", "No binaria"]
+      },
+      "unknown": {
+        "synonyms": ["desconocido", "desconocida", "inseguro", "insegura", "x"]
+      },
+      "prefer not to answer": {
+        "synonyms": ["prefiero no", "no responder", "sin responder"]
+      }
+    }
+  }
+}

--- a/twilio-iac/helplines/configs/lex/es_CO/slot_types/yes_no.json
+++ b/twilio-iac/helplines/configs/lex/es_CO/slot_types/yes_no.json
@@ -1,0 +1,21 @@
+{
+  "yes_no": {
+    "description": "Custom slot for Yes-No kind of questions",
+    "value_selection_strategy": "TOP_RESOLUTION",
+    "values": {
+      "Yes": {
+        "synonyms": [
+          "s",
+          "sí",
+          "si"
+        ]
+      },
+      "No": {
+        "synonyms": [
+          "n",
+          "no"
+        ]
+      }
+    }
+  }
+}

--- a/twilio-iac/terraform-modules/lex/v1/main.tf
+++ b/twilio-iac/terraform-modules/lex/v1/main.tf
@@ -97,6 +97,7 @@ resource "aws_lex_bot" "this" {
   process_behavior            = each.value.process_behavior
   create_version              = false
   idle_session_ttl_in_seconds = each.value.idle_session_ttl_in_seconds
+  enable_model_improvements   = each.value.enable_model_improvements
 
   #   By specifying true to child_directed, you confirm that your use of Amazon Lex is related to a website,
   #   program, or other application that is directed or targeted, in whole or in part, to

--- a/twilio-iac/terraform-modules/lex/v1/variables.tf
+++ b/twilio-iac/terraform-modules/lex/v1/variables.tf
@@ -67,6 +67,7 @@ variable "bots" {
     process_behavior            = optional(string, "BUILD")
     child_directed              = optional(bool, true)
     idle_session_ttl_in_seconds = optional(number, 300)
+    enable_model_improvements   = optional(bool, true)
     abort_statement = object({
       content      = string
       content_type = string

--- a/twilio-iac/terraform-modules/stages/lex/variables.tf
+++ b/twilio-iac/terraform-modules/stages/lex/variables.tf
@@ -63,6 +63,7 @@ variable "lex_bot_languages" {
       process_behavior            = optional(string, "BUILD")
       child_directed              = optional(bool, true)
       idle_session_ttl_in_seconds = optional(number, 600)
+      enable_model_improvements   = optional(bool, true)
       abort_statement = object({
         content      = string
         content_type = string


### PR DESCRIPTION
## Description
This PR creates the bot `development_as_es_CO_pre_survey`.
Lex doesn't support locale `en-CO`, so `es-419` was used (it's the code for Latin American Spanish).
Also, in order to support `es-419`, it was needed to enable `enable_model_improvements`.

### Verification steps
See Lex Bot created at AWS