### PR TITLE
Remove post-survey support handled in flex

### DIFF
--- a/e2e-tests/ui-tests/aselo-service-mocks/service-configuration.ts
+++ b/e2e-tests/ui-tests/aselo-service-mocks/service-configuration.ts
@@ -41,7 +41,7 @@ export const serviceConfigurationAttributes = () => ({
     enable_csam_report: true,
     post_survey_serverless_handled: true,
     enable_voice_recordings: true,
-    enable_post_survey: true,
+    // enable_post_survey: true,
   },
   seenOnboarding: true,
   permissionConfig: 'dev',

--- a/e2e-tests/ui-tests/aselo-service-mocks/service-configuration.ts
+++ b/e2e-tests/ui-tests/aselo-service-mocks/service-configuration.ts
@@ -41,7 +41,7 @@ export const serviceConfigurationAttributes = () => ({
     enable_csam_report: true,
     post_survey_serverless_handled: true,
     enable_voice_recordings: true,
-    // enable_post_survey: true,
+    enable_post_survey: true,
   },
   seenOnboarding: true,
   permissionConfig: 'dev',

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -149,7 +149,7 @@ const setUpActions = (
   const transferOverride = ActionFunctions.customTransferTask(setupObject);
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject, getMessage);
   const beforeCompleteAction = ActionFunctions.beforeCompleteTask(featureFlags);
-  const afterWrapupAction = ActionFunctions.afterWrapupTask(featureFlags, setupObject);
+  // const afterWrapupAction = ActionFunctions.afterWrapupTask(featureFlags, setupObject);
 
   Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.initializeContactForm);
 
@@ -166,7 +166,7 @@ const setUpActions = (
 
   Flex.Actions.addListener('beforeCompleteTask', beforeCompleteAction);
 
-  Flex.Actions.addListener('afterWrapupTask', afterWrapupAction);
+  // Flex.Actions.addListener('afterWrapupTask', afterWrapupAction);
 
   Flex.Actions.addListener('afterCompleteTask', ActionFunctions.afterCompleteTask);
 

--- a/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
@@ -18,7 +18,6 @@
 import { ITask, ChatOrchestrator } from '@twilio/flex-ui';
 
 import { afterCompleteTask, setUpPostSurvey } from '../../utils/setUpActions';
-
 import { REMOVE_CONTACT_STATE } from '../../states/types';
 import { FeatureFlags } from '../../types/types';
 
@@ -55,3 +54,21 @@ describe('afterCompleteTask', () => {
   });
 });
 
+describe('setUpPostSurvey', () => {
+  test('featureFlags.enable_post_survey === false should not change ChatOrchestrator', async () => {
+    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations');
+    setUpPostSurvey(<FeatureFlags>{ enable_post_survey: false });
+
+    expect(setOrchestrationsSpy).not.toHaveBeenCalled();
+  });
+
+  test('featureFlags.enable_post_survey === true should change ChatOrchestrator', async () => {
+    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
+
+    setUpPostSurvey(<FeatureFlags>{ enable_post_survey: true });
+
+    expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
+    expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));
+    expect(setOrchestrationsSpy).toHaveBeenCalledWith('completed', expect.any(Function));
+  });
+});

--- a/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
@@ -15,14 +15,12 @@
  */
 
 /* eslint-disable camelcase */
-import { ITask, TaskHelper, ChatOrchestrator } from '@twilio/flex-ui';
-import each from 'jest-each';
+import { ITask, ChatOrchestrator } from '@twilio/flex-ui';
 
-import { afterCompleteTask, afterWrapupTask, setUpPostSurvey } from '../../utils/setUpActions';
+import { afterCompleteTask, setUpPostSurvey } from '../../utils/setUpActions';
+
 import { REMOVE_CONTACT_STATE } from '../../states/types';
-import * as ServerlessService from '../../services/ServerlessService';
 import { FeatureFlags } from '../../types/types';
-import { getHrmConfig } from '../../hrmConfig';
 
 const mockFlexManager = {
   store: {
@@ -57,83 +55,3 @@ describe('afterCompleteTask', () => {
   });
 });
 
-describe('afterWrapupTask', () => {
-  each(
-    ['', 'default', 'web', 'voice']
-      .flatMap(channelType => [
-        {
-          channelType,
-          featureFlags: { enable_post_survey: false, post_survey_serverless_handled: false },
-        },
-        {
-          channelType,
-          featureFlags: { enable_post_survey: true, post_survey_serverless_handled: false },
-        },
-        {
-          channelType,
-          featureFlags: { enable_post_survey: false, post_survey_serverless_handled: true },
-        },
-        {
-          channelType,
-          featureFlags: { enable_post_survey: true, post_survey_serverless_handled: true },
-        },
-      ])
-      .map(testCase => {
-        const { channelType, featureFlags } = testCase;
-        const isChatChannel = channelType && channelType !== 'voice' && channelType !== 'default';
-        const shouldCallPostSurveyInit =
-          isChatChannel && featureFlags.enable_post_survey && !featureFlags.post_survey_serverless_handled;
-        const description = `featureFlags.enable_post_survey === ${
-          featureFlags.enable_post_survey
-        } && post_survey_serverless_handled === ${featureFlags.post_survey_serverless_handled} should ${
-          shouldCallPostSurveyInit ? '' : 'not '
-        } trigger post survey for ${isChatChannel ? '' : 'non-'}chat task`;
-
-        return {
-          ...testCase,
-          isChatChannel,
-          shouldCallPostSurveyInit,
-          description,
-        };
-      }),
-  ).test('$description', async ({ channelType, featureFlags, isChatChannel, shouldCallPostSurveyInit }) => {
-    const postSurveyInitSpy = jest.spyOn(ServerlessService, 'postSurveyInit').mockImplementationOnce(async () => ({}));
-
-    const task = ({
-      attributes: { channelSid: 'CHxxxxxx' },
-      taskSid: 'THIS IS THE TASK SID!',
-      channelType,
-      taskChannelUniqueName: isChatChannel ? 'chat' : channelType,
-    } as unknown) as ITask;
-
-    jest.spyOn(TaskHelper, 'isChatBasedTask').mockImplementation(() => isChatChannel);
-    jest.spyOn(TaskHelper, 'getTaskConversationSid').mockImplementationOnce(() => task.attributes.channelSid);
-
-    await afterWrapupTask(featureFlags, <ReturnType<typeof getHrmConfig>>{})({ task });
-
-    if (shouldCallPostSurveyInit) {
-      expect(postSurveyInitSpy).toHaveBeenCalled();
-    } else {
-      expect(postSurveyInitSpy).not.toHaveBeenCalled();
-    }
-  });
-});
-
-describe('setUpPostSurvey', () => {
-  test('featureFlags.enable_post_survey === false should not change ChatOrchestrator', async () => {
-    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations');
-    setUpPostSurvey(<FeatureFlags>{ enable_post_survey: false });
-
-    expect(setOrchestrationsSpy).not.toHaveBeenCalled();
-  });
-
-  test('featureFlags.enable_post_survey === true should change ChatOrchestrator', async () => {
-    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
-
-    setUpPostSurvey(<FeatureFlags>{ enable_post_survey: true });
-
-    expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
-    expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));
-    expect(setOrchestrationsSpy).toHaveBeenCalledWith('completed', expect.any(Function));
-  });
-});

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -179,15 +179,6 @@ export const getWorkerAttributes = async (workerSid: string) => {
   return response;
 };
 
-export const postSurveyInit = async (body: {
-  channelSid: string;
-  taskSid: string;
-  taskLanguage?: string;
-}): Promise<any> => {
-  const response = await fetchProtectedApi('/postSurveyInit', body);
-  return response;
-};
-
 /**
  * Deletes a file from the corresponding S3 bucket
  */

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -330,9 +330,7 @@ const setChatOrchestrationsForPostSurvey = () => {
 };
 
 export const setUpPostSurvey = (featureFlags: FeatureFlags) => {
-  console.log('>>> 1 b setUpPostSurvey')
   if (featureFlags.enable_post_survey) {
-    console.log('>>> 2 b setChatOrchestrationsForPostSurvey')
     setChatOrchestrationsForPostSurvey();
   }
 };

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -33,7 +33,6 @@ import {
   adjustChatCapacity,
   sendSystemMessage,
   getDefinitionVersion,
-  postSurveyInit,
 } from '../services/ServerlessService';
 import { namespace, contactFormsBase, configurationBase, dualWriteBase, conferencingBase } from '../states';
 import * as Actions from '../states/contacts/actions';
@@ -331,39 +330,14 @@ const setChatOrchestrationsForPostSurvey = () => {
 };
 
 export const setUpPostSurvey = (featureFlags: FeatureFlags) => {
+  console.log('>>> 1 b setUpPostSurvey')
   if (featureFlags.enable_post_survey) {
+    console.log('>>> 2 b setChatOrchestrationsForPostSurvey')
     setChatOrchestrationsForPostSurvey();
-  }
-};
-
-const triggerPostSurvey = async (setupObject: SetupObject, payload: ActionPayload): Promise<void> => {
-  const { task } = payload;
-
-  const shouldTriggerPostSurvey =
-    TaskHelper.isChatBasedTask(task) && !isAseloCustomChannelTask(task) && TransferHelpers.hasTaskControl(task);
-
-  if (shouldTriggerPostSurvey) {
-    const { taskSid } = task;
-    const channelSid = TaskHelper.getTaskConversationSid(task);
-
-    const taskLanguage = getTaskLanguage(setupObject)(payload);
-
-    const body = taskLanguage ? { channelSid, taskSid, taskLanguage } : { channelSid, taskSid };
-
-    await postSurveyInit(body);
   }
 };
 
 export const afterCompleteTask = (payload: ActionPayload): void => {
   const manager = Manager.getInstance();
   manager.store.dispatch(GeneralActions.removeContactState(payload.task.taskSid));
-};
-
-export const afterWrapupTask = (featureFlags: FeatureFlags, setupObject: SetupObject) => async (
-  payload: ActionPayload,
-): Promise<void> => {
-  // TODO: Remove this once all accounts are handled by taskrouter
-  if (featureFlags.enable_post_survey && !featureFlags.post_survey_serverless_handled) {
-    await triggerPostSurvey(setupObject, payload);
-  }
 };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
Removing support for post survey logic being handled in Flex

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes # https://tech-matters.atlassian.net/browse/CHI-1969

### Verification steps
- Post survey should work as long as the feature flag for `enable_postsurvey` is true