### PR TITLE
Mute button for worker participant persists

### DIFF
--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/ToggleMute.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/ToggleMute.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TaskContextProps, TaskHelper, Template, withTaskContext } from '@twilio/flex-ui';
 import MicNoneOutlined from '@material-ui/icons/MicNoneOutlined';
 import MicOffOutlined from '@material-ui/icons/MicOffOutlined';
@@ -26,6 +26,14 @@ type Props = TaskContextProps;
 
 const ToggleMute: React.FC<Props> = ({ call, task, conference }) => {
   const [isMuted, setIsMuted] = useState(false);
+
+  useEffect(() => {
+    const workerParticipant = task?.conference?.participants.find(participant => participant.isCurrentWorker === true);
+
+    if (workerParticipant && workerParticipant.isCurrentWorker && workerParticipant.muted) {
+      setIsMuted(true);
+    }
+  }, [task?.conference?.participants]);
 
   if (!task || !call || !conference) {
     return null;

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/ToggleMute.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/ToggleMute.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { TaskContextProps, TaskHelper, Template, withTaskContext } from '@twilio/flex-ui';
 import MicNoneOutlined from '@material-ui/icons/MicNoneOutlined';
 import MicOffOutlined from '@material-ui/icons/MicOffOutlined';
@@ -25,19 +25,13 @@ import { StyledConferenceButtonWrapper, StyledConferenceButton } from './styles'
 type Props = TaskContextProps;
 
 const ToggleMute: React.FC<Props> = ({ call, task, conference }) => {
-  const [isMuted, setIsMuted] = useState(false);
-
-  useEffect(() => {
-    const workerParticipant = task?.conference?.participants.find(participant => participant.isCurrentWorker === true);
-
-    if (workerParticipant && workerParticipant.isCurrentWorker && workerParticipant.muted) {
-      setIsMuted(true);
-    }
-  }, [task?.conference?.participants]);
-
+  let isMuted = false;
   if (!task || !call || !conference) {
     return null;
   }
+
+  const workerParticipant = task?.conference?.participants.find(participant => participant.isCurrentWorker);
+  isMuted = workerParticipant && workerParticipant.muted;
 
   const handleClick = async () => {
     const { participants } = conference?.source;
@@ -53,7 +47,7 @@ const ToggleMute: React.FC<Props> = ({ call, task, conference }) => {
         updates: { muted: toggleMute },
       });
 
-      setIsMuted(toggleMute);
+      isMuted = toggleMute;
     }
   };
 


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- Mute button persists its state even after reload

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes # [CHI-2050](https://tech-matters.atlassian.net/browse/CHI-2050)

### Verification steps
- Place a call and pick up in Aselo Development
- Click the Mute button for current worker
- Navigate to a different page and come back: The mute button should persist. 

[CHI-2050]: https://tech-matters.atlassian.net/browse/CHI-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ