### PR TITLE
CHI-2049 hide vertical line that was introduced in flex-ui upgrade

### DIFF
--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -117,3 +117,7 @@ button.Twilio-TaskCanvasHeader-EndButton:active {
 div.Twilio-ViewCollection{
     background-color: #f6f6f6;
 }
+
+div.Twilio-Splitter div.Twilio-AgentDesktopView\.Panel2 {
+    border-left-width: 0px;
+}


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This overrides the new setting in flex-ui that caused a vertical line to appear between the split panes.

### Checklist
- [ ] Corresponding issue has been opened

### Related Issues
Fixes CHI-2049

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
View main flex-plugin page and there is no longer a vertical line through the page.