### PR TITLE
CHI-2001: Remove ID text from resource ID copy buttons + styling tweaks

### DIFF
--- a/plugin-hrm-form/src/components/resources/ResourceIdCopyButton/index.tsx
+++ b/plugin-hrm-form/src/components/resources/ResourceIdCopyButton/index.tsx
@@ -18,14 +18,16 @@ import * as React from 'react';
 import CopyIcon from '@material-ui/icons/FileCopyOutlined';
 import CheckIcon from '@material-ui/icons/CheckCircle';
 import { useState } from 'react';
+import { Template } from '@twilio/flex-ui';
 
 import { Button } from './styles';
 
 type OwnProps = {
   resourceId: string;
+  height?: string;
 };
 
-const ResourceIdCopyButton: React.FC<OwnProps> = ({ resourceId }) => {
+const ResourceIdCopyButton: React.FC<OwnProps> = ({ resourceId, height }) => {
   const [justCopied, setJustCopied] = useState(false);
 
   const copyClicked = () => {
@@ -35,12 +37,16 @@ const ResourceIdCopyButton: React.FC<OwnProps> = ({ resourceId }) => {
   };
 
   return justCopied ? (
-    <Button type="button">
-      <CheckIcon style={{ marginRight: '8px' }} /> Copied!
+    <Button type="button" title={`#${resourceId}`} style={{ ...{ height } }}>
+      <CheckIcon style={{ marginRight: '8px' }} />
+      &nbsp;
+      <Template code="Resources-IdCopied" />
     </Button>
   ) : (
-    <Button type="button" onClick={copyClicked}>
-      <CopyIcon style={{ marginRight: '8px' }} /> Copy ID #{resourceId}
+    <Button type="button" onClick={copyClicked} title={`#${resourceId}`} style={{ ...{ height } }}>
+      <CopyIcon style={{ marginRight: '8px' }} />
+      &nbsp;
+      <Template code="Resources-CopyId" />
     </Button>
   );
 };

--- a/plugin-hrm-form/src/components/resources/search/resourceView/ViewResource.tsx
+++ b/plugin-hrm-form/src/components/resources/search/resourceView/ViewResource.tsx
@@ -160,7 +160,7 @@ const ViewResource: React.FC<Props> = ({ resource, error, loadViewedResource, na
                   {/* THIRD COLUMN */}
                   <ResourceAttributesColumn>
                     <span style={{ padding: '2px', width: '75%' }}>
-                      <ResourceIdCopyButton resourceId={id} />
+                      <ResourceIdCopyButton resourceId={id} height="44px" />
                     </span>
                     <FieldSelect
                       id="select_language"

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -436,6 +436,8 @@
   "Resources-Search-howServiceIsOffered": "How is this service offered?",
   "Resources-Search-feeStructure": "Fee Structure",
   "Resources-Search-targetPopulations": "Target Populations",
+  "Resources-CopyId": "Copy ID",
+  "Resources-IdCopied": "Copied!",
 
   "Conference-AddConferenceCallParticipant": "Add Conference Call Participant",
   "Conference-EnterPhoneNumber": "Enter phone number",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -42,6 +42,40 @@
         "typescript": "^4.3.5"
       }
     },
+    "../hrm-form-definitions": {
+      "version": "1.0.0",
+      "license": "AGPL",
+      "dependencies": {
+        "@babel/runtime": "^7.16.5",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@babel/preset-env": "^7.16.5",
+        "@babel/preset-typescript": "^7.16.5",
+        "@types/jest": "^27.0.3",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^17.0.8",
+        "@types/react": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
+        "babel-core": "^6.26.3",
+        "eslint": "^7.4.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^27.4.5",
+        "jest-each": "^28.1.1",
+        "prettier": "^2.3.2",
+        "react-hook-form": "^6.11.0",
+        "ts-jest": "^27.1.2",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.3.5"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -149,6 +183,8 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -3202,13 +3238,8 @@
       "dev": true
     },
     "node_modules/hrm-form-definitions": {
-      "version": "1.0.0",
-      "resolved": "file:../hrm-form-definitions",
-      "license": "AGPL",
-      "dependencies": {
-        "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
-      }
+      "resolved": "../hrm-form-definitions",
+      "link": true
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -4991,7 +5022,9 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -6450,6 +6483,8 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -8648,10 +8683,34 @@
       "dev": true
     },
     "hrm-form-definitions": {
-      "version": "1.0.0",
+      "version": "file:../hrm-form-definitions",
       "requires": {
+        "@babel/preset-env": "^7.16.5",
+        "@babel/preset-typescript": "^7.16.5",
         "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
+        "@types/jest": "^27.0.3",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^17.0.8",
+        "@types/react": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
+        "babel-core": "^6.26.3",
+        "eslint": "^7.4.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^27.4.5",
+        "jest-each": "^28.1.1",
+        "lodash": "^4.17.21",
+        "prettier": "^2.3.2",
+        "react-hook-form": "^6.11.0",
+        "ts-jest": "^27.1.2",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.3.5"
       }
     },
     "https-proxy-agent": {
@@ -10020,7 +10079,9 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "peer": true
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",


### PR DESCRIPTION
## Description

* The ID on the 'Copy ID' button is moved to a tooltip
* The button is slightly taller on the 'View Resource' page
* The text for the buttons is now translatable strings

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- [X] Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-2006

### Verification steps

See ticket