### PR TITLE
Split post survey bot into two intents

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -42,6 +42,40 @@
         "typescript": "^4.3.5"
       }
     },
+    "../hrm-form-definitions": {
+      "version": "1.0.0",
+      "license": "AGPL",
+      "dependencies": {
+        "@babel/runtime": "^7.16.5",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@babel/preset-env": "^7.16.5",
+        "@babel/preset-typescript": "^7.16.5",
+        "@types/jest": "^27.0.3",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^17.0.8",
+        "@types/react": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
+        "babel-core": "^6.26.3",
+        "eslint": "^7.4.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^27.4.5",
+        "jest-each": "^28.1.1",
+        "prettier": "^2.3.2",
+        "react-hook-form": "^6.11.0",
+        "ts-jest": "^27.1.2",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.3.5"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -149,6 +183,8 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -3202,13 +3238,8 @@
       "dev": true
     },
     "node_modules/hrm-form-definitions": {
-      "version": "1.0.0",
-      "resolved": "file:../hrm-form-definitions",
-      "license": "AGPL",
-      "dependencies": {
-        "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
-      }
+      "resolved": "../hrm-form-definitions",
+      "link": true
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -4991,7 +5022,9 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -6450,6 +6483,8 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
       "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -8648,10 +8683,34 @@
       "dev": true
     },
     "hrm-form-definitions": {
-      "version": "1.0.0",
+      "version": "file:../hrm-form-definitions",
       "requires": {
+        "@babel/preset-env": "^7.16.5",
+        "@babel/preset-typescript": "^7.16.5",
         "@babel/runtime": "^7.16.5",
-        "lodash": "^4.17.21"
+        "@types/jest": "^27.0.3",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^17.0.8",
+        "@types/react": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
+        "babel-core": "^6.26.3",
+        "eslint": "^7.4.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^27.4.5",
+        "jest-each": "^28.1.1",
+        "lodash": "^4.17.21",
+        "prettier": "^2.3.2",
+        "react-hook-form": "^6.11.0",
+        "ts-jest": "^27.1.2",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.3.5"
       }
     },
     "https-proxy-agent": {
@@ -10020,7 +10079,9 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "peer": true
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",

--- a/twilio-iac/helplines/configs/lex/en_US/bots/post_survey.json
+++ b/twilio-iac/helplines/configs/lex/en_US/bots/post_survey.json
@@ -16,7 +16,8 @@
       "content_type": "PlainText"
     },
     "intents": [
-      "post_survey"
+      "post_survey_yes",
+      "post_survey_no"
     ]
   }
 }

--- a/twilio-iac/helplines/configs/lex/en_US/intents/post_survey.json
+++ b/twilio-iac/helplines/configs/lex/en_US/intents/post_survey.json
@@ -1,11 +1,14 @@
 {
-  "post_survey":{
-    "description": "Post Survey Intent",
+  "post_survey_yes":{
+    "description": "Post Survey Intent - Yes",
     "sample_utterances": [
-      "survey ended",
-      "survey closed",
-      "counselor ended survey",
-      "caller exited call"
+      "y",
+      "yes",
+      "yep",
+      "yeah",
+      "yup",
+      "ya",
+      "yah"
     ],
     "fulfillment_activity": {
       "type": "ReturnIntent"
@@ -19,17 +22,6 @@
       "content_type": "PlainText"
     },
     "slots": {
-      "answerQuestions": {
-        "priority": 1,
-        "description": "answerQuestions",
-        "slot_constraint": "Required",
-        "slot_type": "yes_no",
-        "value_elicitation_prompt": {
-          "max_attempts": 2,
-          "content": "The counsellor has left the chat. Thank you for reaching out. Please contact us again if you need more help. \nBefore you leave, would you be willing to answer a few questions about the service you received today? Please answer Yes or No.",
-          "content_type": "PlainText"
-        }
-      },
       "wasHelpful": {
         "priority": 1,
         "description": "wasHelpful",
@@ -53,5 +45,27 @@
         }
       }
     }
+  },
+  "post_survey_no":{
+    "description": "Post Survey Intent - Yes",
+    "sample_utterances": [
+      "n",
+      "no",
+      "nope",
+      "nah",
+      "not"
+    ],
+    "fulfillment_activity": {
+      "type": "ReturnIntent"
+    },
+    "conclusion_statement": {
+      "content": "Thank you for reaching out. Please contact us again if you need more help.",
+      "content_type": "PlainText"
+    },
+    "rejection_statement": {
+      "content": "Sorry, I didn't understand that.",
+      "content_type": "PlainText"
+    },
+    "slots": {}
   }
 }


### PR DESCRIPTION
## Description
This PR does a small refactor to adjust the post survey bot to it's actual expected behavior, splitting it into two different intents that are triggered based on the user's response: one to perform the survey, the other to just abort it.

### Verification steps
Try some dialogs from the AWS Lex console, or start a webchat contact. The expected behavior is as described above.