### PR TITLE
QA feedback for styling on resources pages

### DIFF
--- a/plugin-hrm-form/src/components/resources/ResourceIdCopyButton/index.tsx
+++ b/plugin-hrm-form/src/components/resources/ResourceIdCopyButton/index.tsx
@@ -21,6 +21,7 @@ import { useState } from 'react';
 import { Template } from '@twilio/flex-ui';
 
 import { Button } from './styles';
+import { getTemplateStrings } from '../../../hrmConfig';
 
 type OwnProps = {
   resourceId: string;
@@ -28,6 +29,7 @@ type OwnProps = {
 };
 
 const ResourceIdCopyButton: React.FC<OwnProps> = ({ resourceId, height = '36px' }) => {
+  const strings = getTemplateStrings();
   const [justCopied, setJustCopied] = useState(false);
 
   const copyClicked = async () => {
@@ -37,7 +39,7 @@ const ResourceIdCopyButton: React.FC<OwnProps> = ({ resourceId, height = '36px' 
   };
 
   return justCopied ? (
-    <Button type="button" title={`#${resourceId}`} style={{ height }}>
+    <Button type="button" title={`${strings['Resources-IdCopied']} #${resourceId}`} style={{ height }}>
       <CheckIcon style={{ marginRight: '8px' }} />
       &nbsp;
       <Template code="Resources-IdCopied" />
@@ -46,7 +48,7 @@ const ResourceIdCopyButton: React.FC<OwnProps> = ({ resourceId, height = '36px' 
     <Button
       type="button"
       onClick={copyClicked}
-      title={`#${resourceId}`}
+      title={`${strings['Resources-CopyId']} #${resourceId}`}
       style={{ height }}
       data-testid="copy-id-button"
     >

--- a/plugin-hrm-form/src/components/resources/resourceView/OperatingHours.tsx
+++ b/plugin-hrm-form/src/components/resources/resourceView/OperatingHours.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { Template } from '@twilio/flex-ui';
 
 import { KhpUiResource } from '../types';
 import { ResourcePreviewAttributeContent, ResourceSubtitle } from '../../../styles/ReferrableResources';
@@ -28,6 +29,16 @@ const OperatingHours: React.FC<Props> = ({ operations, showDescriptionOfHours })
   return (
     <table>
       <tbody>
+        {!operations ||
+          (operations.length === 0 && (
+            <tr>
+              <td>
+                <ResourcePreviewAttributeContent>
+                  <Template code="Resources-View-MissingProperty" />
+                </ResourcePreviewAttributeContent>
+              </td>
+            </tr>
+          ))}
         {operations.map(day => {
           if (day.hoursOfOperation) {
             return (

--- a/plugin-hrm-form/src/components/resources/resourceView/ViewResource.tsx
+++ b/plugin-hrm-form/src/components/resources/resourceView/ViewResource.tsx
@@ -96,7 +96,7 @@ const ViewResource: React.FC<Props> = ({ resource, error, loadViewedResource, na
               {attributes && (
                 <ResourceAttributesContainer>
                   {/* FIRST COLUMN */}
-                  <ResourceAttributesColumn style={{ flexGrow: 3 }}>
+                  <ResourceAttributesColumn style={{ flexGrow: 3, paddingLeft: 0, marginLeft: '1px' }}>
                     {[
                       {
                         subtitle: 'Resources-View-Details',

--- a/plugin-hrm-form/src/components/resources/search/ResourcePreview.tsx
+++ b/plugin-hrm-form/src/components/resources/search/ResourcePreview.tsx
@@ -73,7 +73,7 @@ const ResourcePreview: React.FC<Props> = ({ resourceResult, onClickViewResource 
           </PreviewRow>
         </div>
         <PreviewRow>
-          <ResourceAttributesColumn style={{ alignSelf: 'baseline' }}>
+          <ResourceAttributesColumn style={{ paddingLeft: 0, marginLeft: 0, alignSelf: 'baseline' }}>
             <Box marginTop="8px" marginBottom="8px">
               <Column>
                 <Box marginBottom="6px">

--- a/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
@@ -55,7 +55,7 @@ import {
 import SearchInput from '../../caseList/filters/SearchInput';
 import { getTemplateStrings } from '../../../hrmConfig';
 import asyncDispatch from '../../../states/asyncDispatch';
-import { FiltersCheckbox, MultiSelectCheckboxLabel } from '../../../styles/caseList/filters';
+import { FiltersCheckbox } from '../../../styles/caseList/filters';
 import SearchAutoComplete from './SearchAutoComplete';
 
 const NO_AGE_SELECTED = -1;
@@ -205,7 +205,7 @@ const SearchResourcesForm: React.FC<Props> = ({
                     );
                   }}
                 />
-                {label ?? value}
+                &nbsp;&nbsp;{label ?? value}
               </FormLabel>
             </Grid>
           ))}
@@ -334,6 +334,7 @@ const SearchResourcesForm: React.FC<Props> = ({
                         updateFilterSelection('interpretationTranslationServicesAvailable', checked || undefined);
                       }}
                     />
+                    &nbsp;&nbsp;
                     <Template code="Resources-Search-InterpretationTranslationServicesAvailable-Checkbox" />
                   </FormLabel>
                 </Column>

--- a/plugin-hrm-form/src/styles/ReferrableResources.tsx
+++ b/plugin-hrm-form/src/styles/ReferrableResources.tsx
@@ -17,7 +17,7 @@
 import { styled } from '@twilio/flex-ui';
 import { ButtonBase } from '@material-ui/core';
 
-import { Box, Column, Flex, Absolute, Row, FontOpenSans, StyledNextStepButton } from './HrmStyles';
+import { Box, Column, Flex, Row, FontOpenSans, StyledNextStepButton } from './HrmStyles';
 import HrmTheme from './HrmTheme';
 
 export const ResourcePreviewWrapper = styled('div')`
@@ -60,7 +60,7 @@ export const ResourcePreviewAttributeContent = styled(FontOpenSans)`
 ResourcePreviewAttributeContent.displayName = 'ResourcePreviewAttributeContent';
 
 export const ReferrableResourcesContainer = styled(Flex)`
-  padding: 20px;
+  padding: 10px 20px 20px 25px;
   max-width: 1230px;
   width: 100%;
   background-color: #f6f6f6;


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description

* Fixed left alignment on resource search result item and details
* Updated 'Copy ID' button tooltip
* Ensured 'Not Listed' appears for empty Hours of Operation
* Increased padding between filter checkboxes and their labels
* Lined up the 'back' buttons for the resource view and search results

### Checklist
- [X] Corresponding issue has been opened


### Related Issues
CHI-2001

### Verification steps

See ticket