### PR TITLE
CHI-2062: webchat test updates to prevent writing data to hrm

### DIFF
--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -1,0 +1,39 @@
+import {
+  botStatement,
+  callerStatement,
+  counselorAutoStatement,
+  counselorStatement,
+} from './chatModel';
+
+export const webchatScripts = {
+  e2e: [
+    botStatement(
+      'Welcome to the helpline. To help us better serve you, please answer the following three questions.',
+    ),
+    botStatement('Are you calling about yourself? Please answer Yes or No.'),
+    callerStatement('yes'),
+    botStatement("Thank you. You can say 'prefer not to answer' (or type X) to any question."),
+    botStatement('How old are you?'),
+    callerStatement('10'),
+    botStatement('What is your gender?'), // Step required in Aselo Dev, not in E2E
+    callerStatement('girl'),
+    botStatement("We'll transfer you now. Please hold for a counsellor."),
+    counselorAutoStatement('Hi, this is the counsellor. How can I help you?'),
+    callerStatement('CALLER TEST CHAT MESSAGE'),
+    counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
+  ],
+  as: [
+    botStatement("Sorry, I didn't understand that. Please try again."),
+    callerStatement('hi'),
+    botStatement('Are you calling about yourself? Please answer Yes or No.'),
+    callerStatement('yes'),
+    botStatement('How old are you?'),
+    callerStatement('10'),
+    botStatement('What is your gender?'), // Step required in Aselo Dev, not in E2E
+    callerStatement('girl'),
+    botStatement("We'll transfer you now. Please hold for a counsellor."),
+    counselorAutoStatement('Hi, this is the counsellor. How can I help you?'),
+    callerStatement('CALLER TEST CHAT MESSAGE'),
+    counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
+  ],
+};

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  ChatStatement,
   botStatement,
   callerStatement,
   counselorAutoStatement,
@@ -32,7 +33,7 @@ export const webchatScripts = {
     botStatement("Thank you. You can say 'prefer not to answer' (or type X) to any question."),
     botStatement('How old are you?'),
     callerStatement('10'),
-    botStatement('What is your gender?'), // Step required in Aselo Dev, not in E2E
+    botStatement('What is your gender?'),
     callerStatement('girl'),
     botStatement("We'll transfer you now. Please hold for a counsellor."),
     counselorAutoStatement('Hi, this is the counsellor. How can I help you?'),
@@ -55,8 +56,26 @@ export const webchatScripts = {
       counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
     ],
   },
-  staging: {},
-  production: {},
+  staging: {
+    ca: [
+      botStatement(
+        'You are number 1 in line. To keep your chat active, please do not leave/refresh this window or hit the back button.',
+      ),
+      counselorAutoStatement("Hi, you've reached a counsellor. What would you like to talk about?"),
+      callerStatement('CALLER TEST CHAT MESSAGE'),
+      counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
+    ],
+  },
+  production: {
+    ca: [
+      botStatement(
+        'You are number 1 in line. To keep your chat active, please do not leave/refresh this window or hit the back button.',
+      ),
+      counselorAutoStatement("Hi, you've reached a counsellor. What would you like to talk about?"),
+      callerStatement('CALLER TEST CHAT MESSAGE'),
+      counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
+    ],
+  },
 };
 
 export const getWebchatScript = (): ChatStatement[] => {

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -4,9 +4,10 @@ import {
   counselorAutoStatement,
   counselorStatement,
 } from './chatModel';
+import { getConfigValue } from './config';
 
 export const webchatScripts = {
-  e2e: [
+  default: [
     botStatement(
       'Welcome to the helpline. To help us better serve you, please answer the following three questions.',
     ),
@@ -22,18 +23,29 @@ export const webchatScripts = {
     callerStatement('CALLER TEST CHAT MESSAGE'),
     counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
   ],
-  as: [
-    botStatement("Sorry, I didn't understand that. Please try again."),
-    callerStatement('hi'),
-    botStatement('Are you calling about yourself? Please answer Yes or No.'),
-    callerStatement('yes'),
-    botStatement('How old are you?'),
-    callerStatement('10'),
-    botStatement('What is your gender?'), // Step required in Aselo Dev, not in E2E
-    callerStatement('girl'),
-    botStatement("We'll transfer you now. Please hold for a counsellor."),
-    counselorAutoStatement('Hi, this is the counsellor. How can I help you?'),
-    callerStatement('CALLER TEST CHAT MESSAGE'),
-    counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
-  ],
+  development: {
+    as: [
+      botStatement("Sorry, I didn't understand that. Please try again."),
+      callerStatement('hi'),
+      botStatement('Are you calling about yourself? Please answer Yes or No.'),
+      callerStatement('yes'),
+      botStatement('How old are you?'),
+      callerStatement('10'),
+      botStatement('What is your gender?'), // Step required in Aselo Dev, not in E2E
+      callerStatement('girl'),
+      botStatement("We'll transfer you now. Please hold for a counsellor."),
+      counselorAutoStatement('Hi, this is the counsellor. How can I help you?'),
+      callerStatement('CALLER TEST CHAT MESSAGE'),
+      counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
+    ],
+  },
+  staging: {},
+  production: {},
+};
+
+export const getWebchatScript = (): ChatStatement[] => {
+  const helplineShortCode = getConfigValue('helplineShortCode') as string;
+  const helplineEnv = getConfigValue('helplineEnv') as string;
+
+  return webchatScripts[helplineEnv][helplineShortCode] || webchatScripts.default;
 };

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 import {
   botStatement,
   callerStatement,

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -63,5 +63,5 @@ export const getWebchatScript = (): ChatStatement[] => {
   const helplineShortCode = getConfigValue('helplineShortCode') as string;
   const helplineEnv = getConfigValue('helplineEnv') as string;
 
-  return webchatScripts[helplineEnv][helplineShortCode] || webchatScripts.default;
+  return webchatScripts[helplineEnv]?.[helplineShortCode] || webchatScripts.default;
 };

--- a/e2e-tests/flexChat.ts
+++ b/e2e-tests/flexChat.ts
@@ -38,7 +38,7 @@ export function flexChat(page: Page) {
     messageWithText: (type: string, text: string) =>
       type == 'twilio'
         ? taskCanvas.locator(`div.Twilio-MessageBubble-Body :text-is("${text}")`)
-        : taskCanvas.locator(`div[role="listitem"] p:text-is("${text}")`),
+        : taskCanvas.locator(`p:text-is("${text}")`),
   };
 
   return {
@@ -74,14 +74,17 @@ export function flexChat(page: Page) {
             try {
               await selectors
                 .messageWithText(type, text)
-                .waitFor({ timeout: 3000, state: 'attached' });
+                .waitFor({ timeout: 2000, state: 'attached' });
+              continue;
             } catch (err) {
               console.log(
-                `Caller statement '${text}' not found after 3 seconds. Assuming action is required to send it so the flex chat processor is yielding control.`,
+                `Caller statement '${text}' not found after 2 seconds. Assuming action is required to send it so the flex chat processor is yielding control.`,
               );
               yield statementItem;
             }
-            await selectors.messageWithText(type, text).waitFor({ timeout: 60000 });
+            await selectors
+              .messageWithText(type, text)
+              .waitFor({ timeout: 60000, state: 'attached' });
             break;
         }
       }

--- a/e2e-tests/flexChat.ts
+++ b/e2e-tests/flexChat.ts
@@ -91,4 +91,3 @@ export function flexChat(page: Page) {
     },
   };
 }
-2;

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -8,6 +8,7 @@
     "test": "npx playwright test --workers 1",
     "test:ui": "npx playwright test --config ui-tests/playwright.ui-test.config.ts",
     "test:local": "DEBUG=pw:api LOAD_SSM_CONFIG=true npm run test",
+    "test:development:as": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=as SKIP_DATA_UPDATE=true npm run test",
     "test:development:e2e": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=e2e npm run test",
     "test:staging:ca": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=staging HL=ca npm run test",
     "test:production:ca": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=production HL=ca npm run test",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -11,6 +11,7 @@
     "test:development:as": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=as SKIP_DATA_UPDATE=true npm run test",
     "test:development:e2e": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=e2e npm run test",
     "test:staging:ca": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=staging HL=ca npm run test",
+    "test:staging:ca:headed": "LOAD_SSM_CONFIG=true HL_ENV=staging HL=ca SKIP_DATA_UPDATE=true PLAYWRIGHT_BROWSER_TELEMETRY_LEVEL=none npm test -- --headed",
     "test:production:ca": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=production HL=ca npm run test",
     "lint": "eslint --ext ts .",
     "lint:fix": "npm run lint -- --fix .",

--- a/e2e-tests/tests/offlineContact.spec.ts
+++ b/e2e-tests/tests/offlineContact.spec.ts
@@ -18,13 +18,13 @@ import { expect, Page, test } from '@playwright/test';
 import { Categories, contactForm, ContactFormTab } from '../contactForm';
 import { caseHome } from '../case';
 import { agentDesktop, navigateToAgentDesktop } from '../agent-desktop';
-import { skipTestIfNotTargeted, skipTestIfDataUpdateDisabled } from '../skipTest';
+import { getConfigValue } from '../config';
+import { skipTestIfNotTargeted } from '../skipTest';
 import { notificationBar } from '../notificationBar';
 import { setupContextAndPage, closePage } from '../browser';
 
 test.describe.serial('Offline Contact (with Case)', () => {
   skipTestIfNotTargeted();
-  skipTestIfDataUpdateDisabled();
 
   let pluginPage: Page;
 
@@ -97,6 +97,11 @@ test.describe.serial('Offline Contact (with Case)', () => {
     ]);
 
     const beforeDate = new Date(); // Capture date here since we'll create case inmediately after saving contact
+
+    if (getConfigValue('skipDataUpdate') as boolean) {
+      console.log('Skipping saving form');
+      return;
+    }
 
     console.log('Saving form');
     await form.save({ saveAndAddToCase: true });

--- a/e2e-tests/tests/offlineContact.spec.ts
+++ b/e2e-tests/tests/offlineContact.spec.ts
@@ -18,13 +18,13 @@ import { expect, Page, test } from '@playwright/test';
 import { Categories, contactForm, ContactFormTab } from '../contactForm';
 import { caseHome } from '../case';
 import { agentDesktop, navigateToAgentDesktop } from '../agent-desktop';
-import { getConfigValue } from '../config';
-import { skipTestIfNotTargeted } from '../skipTest';
+import { skipTestIfNotTargeted, skipTestIfDataUpdateDisabled } from '../skipTest';
 import { notificationBar } from '../notificationBar';
 import { setupContextAndPage, closePage } from '../browser';
 
 test.describe.serial('Offline Contact (with Case)', () => {
   skipTestIfNotTargeted();
+  skipTestIfDataUpdateDisabled();
 
   let pluginPage: Page;
 
@@ -98,10 +98,10 @@ test.describe.serial('Offline Contact (with Case)', () => {
 
     const beforeDate = new Date(); // Capture date here since we'll create case inmediately after saving contact
 
-    if (getConfigValue('skipDataUpdate') as boolean) {
-      console.log('Skipping saving form');
-      return;
-    }
+    // if (getConfigValue('skipDataUpdate') as boolean) {
+    //   console.log('Skipping saving form');
+    //   return;
+    // }
 
     console.log('Saving form');
     await form.save({ saveAndAddToCase: true });

--- a/e2e-tests/tests/webchat.spec.ts
+++ b/e2e-tests/tests/webchat.spec.ts
@@ -18,11 +18,8 @@ import { BrowserContext, Page, test } from '@playwright/test';
 import * as webchat from '../webchat';
 import { WebChatPage } from '../webchat';
 import { statusIndicator, WorkerStatus } from '../workerStatus';
-import {
-  ChatStatement,
-  ChatStatementOrigin,
-} from '../chatModel';
-import { webchatScripts } from '../chatScripts';
+import { ChatStatement, ChatStatementOrigin } from '../chatModel';
+import { getWebchatScript } from '../chatScripts';
 import { flexChat } from '../flexChat';
 import { getConfigValue } from '../config';
 import { skipTestIfNotTargeted } from '../skipTest';
@@ -51,7 +48,11 @@ test.describe.serial('Web chat caller', () => {
       await notificationBar(pluginPage).dismissAllNotifications();
     }
     await closePage(pluginPage);
-    await deleteAllTasksInQueue('Flex Task Assignment', 'Master Workflow', 'Childline');
+    await deleteAllTasksInQueue();
+  });
+
+  test.afterEach(async () => {
+    await deleteAllTasksInQueue();
   });
 
   test('Chat ', async () => {
@@ -60,8 +61,7 @@ test.describe.serial('Web chat caller', () => {
     await chatPage.fillPreEngagementForm();
     // await chatPage.selectHelpline('Fake Helpline'); // Step required in Aselo Dev, not in E2E
 
-    const helplineShortCode = getConfigValue('helplineShortCode') as string;
-    const chatScript = webchatScripts[helplineShortCode];
+    const chatScript = getWebchatScript();
 
     const webchatProgress = chatPage.chat(chatScript);
     const flexChatProgress: AsyncIterator<ChatStatement> = flexChat(pluginPage).chat(chatScript);

--- a/e2e-tests/webchat.ts
+++ b/e2e-tests/webchat.ts
@@ -22,6 +22,7 @@ import { getConfigValue } from './config';
 const E2E_CHAT_URL = getConfigValue('webchatUrl') as string;
 
 export type WebChatPage = {
+  fillPreEngagementForm: () => Promise<void>;
   openChat: () => Promise<void>;
   selectHelpline: (helpline: string) => Promise<void>;
   chat: (statements: ChatStatement[]) => AsyncIterable<ChatStatement>;
@@ -40,6 +41,8 @@ export async function open(browser: Browser | BrowserContext): Promise<WebChatPa
     helplineDropdown: page.locator('div#select-helpline'),
     helplineOptions: page.locator('div#menu-helpline ul'),
     startChatButton: page.locator('div.Twilio-PreEngagementCanvas button[type="submit"]'),
+    nameInput: page.locator('input#name'),
+    termsAndConditionsCheckbox: page.locator('input#termsAndConditions'),
 
     //Chatting
     chatMessageArea: page.locator('div.Twilio-MessagingCanvas'),
@@ -56,6 +59,16 @@ export async function open(browser: Browser | BrowserContext): Promise<WebChatPa
   console.log('Found start chat button.');
 
   return {
+    fillPreEngagementForm: async () => {
+      await selectors.preEngagementWindow.waitFor();
+      if (await selectors.nameInput.isVisible()) {
+        await selectors.nameInput.fill('name');
+      }
+      if (await selectors.termsAndConditionsCheckbox.isVisible()) {
+        await selectors.termsAndConditionsCheckbox.check();
+      }
+    },
+
     openChat: async () => {
       await expect(selectors.chatPanelWindow).toHaveCount(0, { timeout: 500 });
       await selectors.toggleChatOpenButton.click();

--- a/e2e-tests/webchat.ts
+++ b/e2e-tests/webchat.ts
@@ -41,7 +41,7 @@ export async function open(browser: Browser | BrowserContext): Promise<WebChatPa
     helplineDropdown: page.locator('div#select-helpline'),
     helplineOptions: page.locator('div#menu-helpline ul'),
     startChatButton: page.locator('div.Twilio-PreEngagementCanvas button[type="submit"]'),
-    nameInput: page.locator('input#name'),
+    nameInput: page.locator("//input[@id='name' or @id='nickname']"),
     termsAndConditionsCheckbox: page.locator('input#termsAndConditions'),
 
     //Chatting

--- a/e2e-tests/workerStatus.ts
+++ b/e2e-tests/workerStatus.ts
@@ -21,6 +21,7 @@ export enum WorkerStatus {
   UNKNOWN,
   AVAILABLE = 'Available',
   OFFLINE = 'Offline',
+  READY = 'Ready',
 }
 
 export function statusIndicator(page: Page) {


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This expands the webchat scripts to be customizable per helpline/environment. This system will likely be a bit more of a cascading config before we are done with it. 

It configures the flexchat system to work with the default twilio chat system our our custom implementation.

It also fixes the webchat cleanup to cleanup all tasks with the e2eTestMode flag set to true instead of specifying info about the task that could change between helplines.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->