### PR TITLE
CHI-2067: Fix scroll 'jitter'

### DIFF
--- a/plugin-hrm-form/src/components/Messaging/MessageList/MessageList.tsx
+++ b/plugin-hrm-form/src/components/Messaging/MessageList/MessageList.tsx
@@ -63,7 +63,6 @@ const MessageList: React.FC<Props> = ({ messages }) => {
     <MessageListContainer ref={ref}>
       <ViewportList viewportRef={ref} items={messagesToRender}>
         {item => {
-          // console.log('MessageList.tsx: rendered message: ', item.sid);
           return isItemDateDivider(item) ? (
             <DateRulerContainer>
               <DateRulerHr />

--- a/plugin-hrm-form/src/components/Messaging/MessageList/MessageList.tsx
+++ b/plugin-hrm-form/src/components/Messaging/MessageList/MessageList.tsx
@@ -27,26 +27,28 @@ type Props = {
   messages: GroupedMessage[];
 };
 
-const renderGroupedMessages = (groupedMessages: GroupedMessagesByDate) =>
+type DateDividerItem = {
+  dateText: string;
+};
+
+const isItemDateDivider = (item: GroupedMessage | DateDividerItem): item is DateDividerItem => {
+  return Boolean((item as DateDividerItem).dateText);
+};
+
+const flattenGroupedMessages = (groupedMessages: GroupedMessagesByDate): (GroupedMessage | DateDividerItem)[] =>
   Object.entries(groupedMessages).flatMap(([dateKey, ms]) => {
-    const dateRuler = (
-      <DateRulerContainer>
-        <DateRulerHr />
-        <DateRulerDateText>{dateKey}</DateRulerDateText>
-        <DateRulerHr />
-      </DateRulerContainer>
-    );
+    const dateRuler = {
+      dateText: dateKey,
+    };
 
-    const messages = ms.map(m => <MessageItem key={m.sid} message={m} />);
-
-    return [dateRuler, ...messages];
+    return [dateRuler, ...ms];
   });
 
 const groupMessagesByDate = (accum: GroupedMessagesByDate, m: GroupedMessage): GroupedMessagesByDate => {
   const dateKey = format(new Date(m.dateCreated), 'yyyy/MM/dd');
 
   if (!accum[dateKey]) {
-    return { ...accum, [dateKey]: [{ ...m }] };
+    return { ...accum, [dateKey]: [m] };
   }
 
   return { ...accum, [dateKey]: [...accum[dateKey], m] };
@@ -55,13 +57,23 @@ const groupMessagesByDate = (accum: GroupedMessagesByDate, m: GroupedMessage): G
 const groupMessages = (messages: GroupedMessage[]): GroupedMessagesByDate => messages.reduce(groupMessagesByDate, {});
 
 const MessageList: React.FC<Props> = ({ messages }) => {
-  const renderedMessages = React.useMemo(() => renderGroupedMessages(groupMessages(messages)), [messages]);
+  const messagesToRender = React.useMemo(() => flattenGroupedMessages(groupMessages(messages)), [messages]);
   const ref = React.useRef(null);
-
   return (
-    <MessageListContainer>
-      <ViewportList ref={ref} items={renderedMessages} scrollThreshold={3} overscan={2}>
-        {item => item}
+    <MessageListContainer ref={ref}>
+      <ViewportList viewportRef={ref} items={messagesToRender}>
+        {item => {
+          // console.log('MessageList.tsx: rendered message: ', item.sid);
+          return isItemDateDivider(item) ? (
+            <DateRulerContainer>
+              <DateRulerHr />
+              <DateRulerDateText>{item.dateText}</DateRulerDateText>
+              <DateRulerHr />
+            </DateRulerContainer>
+          ) : (
+            <MessageItem key={item.sid} message={item} />
+          );
+        }}
       </ViewportList>
     </MessageListContainer>
   );


### PR DESCRIPTION
## Description

* AseloMessageUI message list messages are rendered in the function you pass into the viewport, rather than beforehand - not sure if this is making much difference but it's more in line with the documented guidance on using the ViewportList.
* The viewport ref is set to the container div - this seems to be the important change for fixing the jitter

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-2067

### Verification steps

* Create a long webchat conversation with yourself
* Ensure you create some long messages as well as short ones, to ensure a variety of item heights in the list
* Try scrolling up and tdown the message history using various means (drag the bar, use the arrow, mouse wheel, use the keyboard, any other methods you can think of).
* Ensure behaviour is reasonable. Some jumping of the scroll bar is to be expected as heights get recalculated on the fly, but the content should scroll pretty smoothly