### PR TITLE
Gian chi 2046

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -197,73 +197,42 @@ export default class HrmFormPlugin extends FlexPlugin {
     const config = getHrmConfig();
     const featureFlags = getAseloFeatureFlags();
 
-    Flex.Actions.addListener('afterAcceptTask', ({ task }) => {
-      // /// DEBUG
-      const debugEvents = (task: Flex.ITask) => {
-        const conversationState = Flex.StateHelper.getConversationStateForTask(task);
-
-        if (conversationState.isLoadingConversation) {
-          console.log('>>>>>>>> waiting :)');
-          setTimeout(() => debugEvents(task), 1000);
-        } else {
-          console.log('>>>>>>>> conversationState', conversationState);
-          console.log('>>>>>>>> eventNames', conversationState.source.eventNames());
-          conversationState.source.eventNames().forEach(eventName => {
-            conversationState.source.addListener(eventName as any, (data: any) => {
-              console.log('>>>>>>>>', eventName, data);
-            });
-          });
-        }
-      };
-
-      debugEvents(task);
-      // /// DEBUG
-    });
-
     /*
      * localization setup (translates the UI if necessary)
      * WARNING: the way this is done right now is "hacky". More info in initLocalization declaration
      */
-    /*
-     * const { translateUI, getMessage } = setUpLocalization(config);
-     * ActionFunctions.loadCurrentDefinitionVersion();
-     */
+    const { translateUI, getMessage } = setUpLocalization(config);
+    ActionFunctions.loadCurrentDefinitionVersion();
 
-    /*
-     * setUpSharedStateClient();
-     * if (featureFlags.enable_transfers) setUpTransfers();
-     * setUpComponents(featureFlags, config, translateUI);
-     * setUpActions(featureFlags, config, getMessage);
-     */
+    setUpSharedStateClient();
+    if (featureFlags.enable_transfers) setUpTransfers();
+    setUpComponents(featureFlags, config, translateUI);
+    setUpActions(featureFlags, config, getMessage);
 
-    // TaskRouterListeners.setTaskWrapupEventListeners(featureFlags);
+    TaskRouterListeners.setTaskWrapupEventListeners(featureFlags);
 
-    /*
-     * subscribeReservedTaskAlert();
-     * subscribeNewMessageAlertOnPluginInit();
-     */
+    subscribeReservedTaskAlert();
+    subscribeNewMessageAlertOnPluginInit();
 
-    /*
-     * const managerConfiguration: Flex.Config = {
-     *   // colorTheme: HrmTheme,
-     *   theme: {
-     *     componentThemeOverrides: overrides,
-     *     tokens: {
-     *       backgroundColors: {
-     *         colorBackground: HrmTheme.colors.base2,
-     *       },
-     *     },
-     *   },
-     * };
-     * manager.updateConfig(managerConfiguration);
-     */
+    const managerConfiguration: Flex.Config = {
+      // colorTheme: HrmTheme,
+      theme: {
+        componentThemeOverrides: overrides,
+        tokens: {
+          backgroundColors: {
+            colorBackground: HrmTheme.colors.base2,
+          },
+        },
+      },
+    };
+    manager.updateConfig(managerConfiguration);
 
-    // // TODO(nick): Eventually remove this log line or set to debug.  Should we fail hard here?
-    // const { hrmBaseUrl } = config;
-    // console.log(`HRM URL: ${hrmBaseUrl}`);
-    // if (hrmBaseUrl === undefined) {
-    //   console.error('HRM base URL not defined, you must provide this to save program data');
-    // }
+    // TODO(nick): Eventually remove this log line or set to debug.  Should we fail hard here?
+    const { hrmBaseUrl } = config;
+    console.log(`HRM URL: ${hrmBaseUrl}`);
+    if (hrmBaseUrl === undefined) {
+      console.error('HRM base URL not defined, you must provide this to save program data');
+    }
   }
 
   /**

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -197,42 +197,73 @@ export default class HrmFormPlugin extends FlexPlugin {
     const config = getHrmConfig();
     const featureFlags = getAseloFeatureFlags();
 
+    Flex.Actions.addListener('afterAcceptTask', ({ task }) => {
+      // /// DEBUG
+      const debugEvents = (task: Flex.ITask) => {
+        const conversationState = Flex.StateHelper.getConversationStateForTask(task);
+
+        if (conversationState.isLoadingConversation) {
+          console.log('>>>>>>>> waiting :)');
+          setTimeout(() => debugEvents(task), 1000);
+        } else {
+          console.log('>>>>>>>> conversationState', conversationState);
+          console.log('>>>>>>>> eventNames', conversationState.source.eventNames());
+          conversationState.source.eventNames().forEach(eventName => {
+            conversationState.source.addListener(eventName as any, (data: any) => {
+              console.log('>>>>>>>>', eventName, data);
+            });
+          });
+        }
+      };
+
+      debugEvents(task);
+      // /// DEBUG
+    });
+
     /*
      * localization setup (translates the UI if necessary)
      * WARNING: the way this is done right now is "hacky". More info in initLocalization declaration
      */
-    const { translateUI, getMessage } = setUpLocalization(config);
-    ActionFunctions.loadCurrentDefinitionVersion();
+    /*
+     * const { translateUI, getMessage } = setUpLocalization(config);
+     * ActionFunctions.loadCurrentDefinitionVersion();
+     */
 
-    setUpSharedStateClient();
-    if (featureFlags.enable_transfers) setUpTransfers();
-    setUpComponents(featureFlags, config, translateUI);
-    setUpActions(featureFlags, config, getMessage);
+    /*
+     * setUpSharedStateClient();
+     * if (featureFlags.enable_transfers) setUpTransfers();
+     * setUpComponents(featureFlags, config, translateUI);
+     * setUpActions(featureFlags, config, getMessage);
+     */
 
-    TaskRouterListeners.setTaskWrapupEventListeners(featureFlags);
+    // TaskRouterListeners.setTaskWrapupEventListeners(featureFlags);
 
-    subscribeReservedTaskAlert();
-    subscribeNewMessageAlertOnPluginInit();
+    /*
+     * subscribeReservedTaskAlert();
+     * subscribeNewMessageAlertOnPluginInit();
+     */
 
-    const managerConfiguration: Flex.Config = {
-      // colorTheme: HrmTheme,
-      theme: {
-        componentThemeOverrides: overrides,
-        tokens: {
-          backgroundColors: {
-            colorBackground: HrmTheme.colors.base2,
-          },
-        },
-      },
-    };
-    manager.updateConfig(managerConfiguration);
+    /*
+     * const managerConfiguration: Flex.Config = {
+     *   // colorTheme: HrmTheme,
+     *   theme: {
+     *     componentThemeOverrides: overrides,
+     *     tokens: {
+     *       backgroundColors: {
+     *         colorBackground: HrmTheme.colors.base2,
+     *       },
+     *     },
+     *   },
+     * };
+     * manager.updateConfig(managerConfiguration);
+     */
 
-    // TODO(nick): Eventually remove this log line or set to debug.  Should we fail hard here?
-    const { hrmBaseUrl } = config;
-    console.log(`HRM URL: ${hrmBaseUrl}`);
-    if (hrmBaseUrl === undefined) {
-      console.error('HRM base URL not defined, you must provide this to save program data');
-    }
+    // // TODO(nick): Eventually remove this log line or set to debug.  Should we fail hard here?
+    // const { hrmBaseUrl } = config;
+    // console.log(`HRM URL: ${hrmBaseUrl}`);
+    // if (hrmBaseUrl === undefined) {
+    //   console.error('HRM base URL not defined, you must provide this to save program data');
+    // }
   }
 
   /**


### PR DESCRIPTION
## Description
This PR fixes the bug where a webchat chat won't load after it was ended by the service user. See the ticket linked below for more information.

It looks like the cause of this issue is one of the event listeners subscribed to the `participantLeft` event, fired on a conversation (chat channel) when the task is wrapped (due to the Chat Channel Orchestrations). 
A different approach to go about this would be to stop removing the workers from the channel on the wrapup event.

Commit https://github.com/techmatters/flex-plugins/pull/1550/commits/be3a172ca1c5711d75c62edba88fd7cbab2637ce in this branch is just showing that even if we don't add any code to the Flex plugin, this issue is still occurring under the same conditions.
You can also reproduce this bug by, 
- While counselor in the active chat window, end the chat from webchat, then change the counselor ciew (e.g. to an offline contact) and then go back to the webchat chat. 
- While using the development local instance pointing to Aselo Development account, comment out lines 78-83 of `src/utils/setUpTaskRouterListeners.ts`, which means this bug is reproducible in Aselo Development.

In both cases, you'll notice the messages list is gone. This makes me wonder if this isn't actually intended Flex behavior. I tried to setup a clean Flex account with webchat but that ended up being more effort than it deserved. I'm happy to budget some time and do so, just to confirm that this occurs in an entirely blank Flex instance, if that's considered to be worthy.

A support ticket has been open with Twilio to ask about this behavior.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2046)
- [x] New tests added
- [n/a ] Feature flags added
- [n/a ] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
Follow the repro steps in the above ticket and confirm the bug not reproducible anymore (this branch needs to be deployed to the target account where this is intended to be tested, or point to one of those accounts from a local Flex instance).