### PR TITLE
CHI-2043: Ensure search term is updated in the state when a search is initially submitted

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
@@ -88,7 +88,15 @@ describe('actions', () => {
       const startingState = getState();
       dispatch(searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 42 }, 1337, true));
       const state = getState();
-      expect(state).toStrictEqual({ ...startingState, status: ResourceSearchStatus.ResultPending, results: [] });
+      expect(state).toStrictEqual({
+        ...startingState,
+        parameters: {
+          ...startingState.parameters,
+          generalSearchTerm: 'hello',
+        },
+        status: ResourceSearchStatus.ResultPending,
+        results: [],
+      });
     });
 
     test("'newSearch' flag not set - dispatches pending action that sets status to ResultPending but leaves results array as is", async () => {
@@ -96,7 +104,14 @@ describe('actions', () => {
       const startingState = getState();
       dispatch(searchResourceAsyncAction({ generalSearchTerm: 'hello', pageSize: 42 }, 1337, false));
       const state = getState();
-      expect(state).toStrictEqual({ ...startingState, status: ResourceSearchStatus.ResultPending });
+      expect(state).toStrictEqual({
+        ...startingState,
+        parameters: {
+          ...startingState.parameters,
+          generalSearchTerm: 'hello',
+        },
+        status: ResourceSearchStatus.ResultPending,
+      });
     });
 
     describe('resourceSearch completes', () => {
@@ -116,6 +131,10 @@ describe('actions', () => {
         const pendingState = getState();
         expect(pendingState).toStrictEqual({
           ...startingState,
+          parameters: {
+            ...startingState.parameters,
+            generalSearchTerm: 'hello',
+          },
           status: ResourceSearchStatus.ResultPending,
           results: [],
         });
@@ -123,6 +142,10 @@ describe('actions', () => {
         const fulfilledState = getState();
         expect(fulfilledState).toStrictEqual({
           ...startingState,
+          parameters: {
+            ...startingState.parameters,
+            generalSearchTerm: 'hello',
+          },
           status: ResourceSearchStatus.ResultReceived,
           results: [
             { id: 'RESULT_1', name: 'Result 1', attributes: {} },
@@ -238,6 +261,10 @@ describe('actions', () => {
         const fulfilledState = getState();
         expect(fulfilledState).toStrictEqual({
           ...startingState,
+          parameters: {
+            ...startingState.parameters,
+            generalSearchTerm: 'hello',
+          },
           status: ResourceSearchStatus.ResultReceived,
           results: expectedResults,
         });
@@ -282,6 +309,10 @@ describe('actions', () => {
         const rejectedState = getState();
         expect(rejectedState).toStrictEqual({
           ...startingState,
+          parameters: {
+            ...startingState.parameters,
+            generalSearchTerm: 'hello',
+          },
           status: ResourceSearchStatus.Error,
           error,
           results: [],
@@ -309,6 +340,10 @@ describe('actions', () => {
         const rejectedState = getState();
         expect(rejectedState).toStrictEqual({
           ...startingState,
+          parameters: {
+            ...startingState.parameters,
+            generalSearchTerm: 'hello',
+          },
           status: ResourceSearchStatus.Error,
           error,
         });

--- a/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
@@ -136,6 +136,7 @@ const SearchResourcesForm: React.FC<Props> = ({
     Object.values(filterSelections).some(value => value !== undefined && value !== '');
 
   const submitSearchIfValid = () => {
+    updateGeneralSearchTerm(generalSearchTermBoxText);
     if (hasValidSearchSettings()) {
       submitSearch(generalSearchTermBoxText, filterSelections, pageSize);
     }
@@ -144,6 +145,10 @@ const SearchResourcesForm: React.FC<Props> = ({
   useEffect(() => {
     updateSuggestSearch(generalSearchTermBoxText);
   }, [generalSearchTermBoxText, updateSuggestSearch]);
+
+  useEffect(() => {
+    setGeneralSearchTermBoxText(generalSearchTerm);
+  }, [generalSearchTerm, setGeneralSearchTermBoxText]);
 
   const ageRangeDropDown = (dropdown: 'Min' | 'Max', optionList: FilterOption<number>[]) => {
     const currentSelection =
@@ -239,7 +244,7 @@ const SearchResourcesForm: React.FC<Props> = ({
                   submitSearchIfValid();
                 }}
                 clearSearchTerm={() => {
-                  setGeneralSearchTermBoxText('');
+                  updateGeneralSearchTerm('');
                 }}
                 onShiftTab={() => {
                   /**/
@@ -250,7 +255,9 @@ const SearchResourcesForm: React.FC<Props> = ({
           <SearchAutoComplete
             generalSearchTermBoxText={generalSearchTermBoxText}
             suggestSearch={suggestSearch}
-            setGeneralSearchTermBoxText={setGeneralSearchTermBoxText}
+            setGeneralSearchTermBoxText={term => {
+              updateGeneralSearchTerm(term);
+            }}
           />
           <ResourcesSearchFormSectionHeader data-testid="Resources-Search-FilterHeader">
             <Template code="Resources-Search-FilterHeader" />

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -159,7 +159,11 @@ export const searchResourceAsyncAction = createAsyncAction(
       start,
     };
   },
-  ({ pageSize }: SearchSettings, page: number, newSearch: boolean = true) => ({ newSearch, start: page * pageSize }),
+  ({ pageSize, generalSearchTerm }: SearchSettings, page: number, newSearch: boolean = true) => ({
+    generalSearchTerm,
+    newSearch,
+    start: page * pageSize,
+  }),
   // { promiseTypeDelimiter: '/' }, // Doesn't work :-(
 );
 
@@ -249,6 +253,10 @@ export const resourceSearchReducer = createReducer(initialState, handleAction =>
   handleAction(searchResourceAsyncAction.pending as typeof searchResourceAsyncAction, (state, action) => {
     return {
       ...state,
+      parameters: {
+        ...state.parameters,
+        generalSearchTerm: action.meta.generalSearchTerm,
+      },
       results: action.meta.newSearch ? [] : state.results,
       status: ResourceSearchStatus.ResultPending,
     };


### PR DESCRIPTION
## Description

A couple of cases were occurring where the contents of the search box were going out of sync , so I added a couple of fixes to ensure the 2 were 'resynced' more reliably:

* A new effect will reset the contents of the box to the redux value when the redux value changes.
* Things that change the box contents other than typing / pasting (using the 'clear' cross, clear button or selecting an autocomplete suggestion) now update the redux value rather than the box text state - the box text is then updated via the new effect above
* Submitting a search updates the current search parameter in redux to the value submitted as a search. This ensures the 2 are in sync after the user submits a search by hitting 'Enter' (this doesn't blur the text box like clicking the 'Search' button does, so they weren't being synced in this case previously)

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-1989

### Verification steps

* Use the search UI in lots of different ways, setting filters and search terms in different orders, using the mouse & keyboard, the clear button on the search input box, the clear form button at the bottom, autocomplete suggestions etc.
* When searches are submitted, ensure these 3 things are correct - The search results look to be for the last submitted search (rather than a previous one), the search result description matches the submitted search, and the search form is in the expected search when you return to it from the results
* Try several searches with and without resetting the search form, try paginating etc. and ensure the 3 things outlined above are preserved