### PR TITLE
externalRecordings - 3 - CHI-2098 update service configuration attribute when external recordings enabled

### DIFF
--- a/twilio-iac/helplines/as/configs/service-configuration/development.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/development.json
@@ -3,6 +3,7 @@
         "attributeUpdates": {
             "assets_bucket_url": "https://assets-development.tl.techmatters.org"
         },
+        "external_recordings_enabled": "True",
         "feature_flags": {
             "enable_aselo_messaging_ui": true,
             "enable_counselor_toolkits": true,

--- a/twilio-iac/scripts/python_tools/src/service_configuration/config.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/config.py
@@ -19,6 +19,7 @@ ACTIONS = {
     'SYNC_PLAN': 'sync_plan',
     'SYNC_APPLY': 'sync_apply',
     'UNLOCK': 'unlock',
+    'UPDATE_PROP': 'update_prop',
 }
 
 
@@ -72,6 +73,7 @@ ACTION_CONFIGS: dict[str, ActionConfigsDict] = {
         'has_version': True,
         'skip_lock': True,
     },
+    ACTIONS['UPDATE_PROP']: {},
 }
 
 ENVIRONMENTS = [
@@ -108,6 +110,11 @@ ARGS = {
         'required': False,
         'default': None,
         'help': 'Property to update. Example: attributes.hrm_api_version',
+    },
+    '--value': {
+        'required': False,
+        'default': None,
+        'help': 'Value to set for property',
     },
     '--dry_run': {
         'required': False,
@@ -199,12 +206,18 @@ class Config():
         if auth_token:
             self._config['auth_token'] = auth_token
 
-        self._config['sync_action'] = ACTION_CONFIGS[self.action].get('has_sync') or False
-        self._config['skip_local_config'] = ACTION_CONFIGS[self.action].get('skip_local_config') or False
-        self._config['has_version'] = ACTION_CONFIGS[self.action].get('has_version') or False
-        self._config['skip_lock'] = ACTION_CONFIGS[self.action].get('skip_lock') or False
-        self._config['argument'] = ACTION_CONFIGS[self.action].get('argument') or self._config['argument']
-        self._config['json_available'] = ACTION_CONFIGS[self.action].get('json_available') or False
+        self._config['sync_action'] = ACTION_CONFIGS[self.action].get(
+            'has_sync') or False
+        self._config['skip_local_config'] = ACTION_CONFIGS[self.action].get(
+            'skip_local_config') or False
+        self._config['has_version'] = ACTION_CONFIGS[self.action].get(
+            'has_version') or False
+        self._config['skip_lock'] = ACTION_CONFIGS[self.action].get(
+            'skip_lock') or False
+        self._config['argument'] = ACTION_CONFIGS[self.action].get(
+            'argument') or self._config['argument']
+        self._config['json_available'] = ACTION_CONFIGS[self.action].get(
+            'json_available') or False
 
     def init_service_configs(self):
         if (self.helpline_code and self.environment) or self.account_sid:
@@ -260,7 +273,7 @@ class Config():
         environment = environment_arg or self.environment
         account_sid = account_sid_arg or self.account_sid
 
-        if not (helpline_code and environment) and not account_sid :
+        if not (helpline_code and environment) and not account_sid:
             raise Exception(
                 'Could not find helpline code or environment. Please provide helpline code and environment')
 
@@ -320,7 +333,8 @@ class Config():
 
     def validate_json(self):
         if self.json and (not self.json_available):
-            print(f'ERROR: JSON output is not available for the {self.action} action.')
+            print(
+                f'ERROR: JSON output is not available for the {self.action} action.')
             exit(1)
 
     def validate_action_requirements(self):
@@ -331,7 +345,8 @@ class Config():
 
     def validate_no_environment(self):
         if self.environment:
-            print(f'ERROR: The {self.action} action does not accept an environment argument.')
+            print(
+                f'ERROR: The {self.action} action does not accept an environment argument.')
             exit(1)
 
     def validate_all_helplines(self):

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -1,9 +1,9 @@
 import json
 from copy import deepcopy
 from deepdiff import DeepDiff
-from deepmerge import always_merger, Merger
+from deepmerge import always_merger
 from os.path import exists as path_exists
-from typing import List, TypedDict, Unpack
+from typing import TypedDict, Unpack
 from ..aws import SSMClient
 from ..twilio import Twilio
 from .constants import AWS_ROLE_ARN

--- a/twilio-iac/stages/external-recordings/terragrunt.hcl
+++ b/twilio-iac/stages/external-recordings/terragrunt.hcl
@@ -63,4 +63,14 @@ terraform {
     commands = ["apply"]
     execute  = ["/app/twilio-iac/scripts/noop/external-recordings/after.sh"]
   }
+
+  after_hook "update_service_config" {
+    commands = ["apply"]
+    execute  = [
+      "/app/twilio-iac/scripts/python_tools/manageServiceConfig.py",
+      "update_prop",
+      "--prop=attributes.external_recordings_enabled",
+      "--value=True"
+    ]
+  }
 }

--- a/twilio-iac/stages/terragrunt.root.hcl
+++ b/twilio-iac/stages/terragrunt.root.hcl
@@ -36,7 +36,7 @@ locals {
     old_dir_name       = "${local.env_config.old_dir_prefix}-${local.environment}"
     operating_info_key = local.short_helpline
     aws_account_id     = local.aws_account_id
-    role_arn           = local.stage == "external-recording" ? local.admin_role : local.env_role
+    role_arn           = local.stage == "external-recordings" ? local.admin_role : local.env_role
   }
 
   config = merge(local.env_config, local.computed_config)

--- a/twilio-iac/terraform-modules/external-recordings/main.tf
+++ b/twilio-iac/terraform-modules/external-recordings/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "this" {
 }
 
 resource "aws_iam_user" "this" {
-  name = "${var.short_helpline}-${var.short_environment}-twilio-external-recordings"
+  name = "${lower(var.short_helpline)}-${var.environment}-twilio-external-recordings"
 
   tags = {
     environment = var.environment
@@ -39,7 +39,7 @@ resource "aws_iam_user" "this" {
 }
 
 resource "aws_iam_user_policy" "this" {
-  name   = "${var.short_helpline}-${var.short_environment}-twilio-external-recordings"
+  name   = "${var.short_helpline}-${var.environment}-twilio-external-recordings"
   user   = aws_iam_user.this.name
   policy = data.aws_iam_policy_document.this.json
 }


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This adds the ability to update service config values using the serviceConfiguration manager and uses that new system to update the service configuration with an `external_recordings_enabled` in a post apply hook in the external-recordings system.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
run `make apply HL=as HL_ENV=development` for the external-recordings stage