### PR TITLE
Update E2E chat scripts and flex environment for CA 

### DIFF
--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -55,7 +55,13 @@ export const webchatScripts = {
       counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
     ],
   },
-  staging: {},
+  staging: {
+    ca: [
+      counselorAutoStatement(
+        'You are number 1 in line. To keep your chat active, please do not leave/refresh this window or hit the back button.',
+      ),
+    ],
+  },
   production: {},
 };
 

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  ChatStatement,
   botStatement,
   callerStatement,
   counselorAutoStatement,
@@ -57,9 +58,10 @@ export const webchatScripts = {
   },
   staging: {
     ca: [
-      counselorAutoStatement(
+      botStatement(
         'You are number 1 in line. To keep your chat active, please do not leave/refresh this window or hit the back button.',
       ),
+      counselorAutoStatement("Hi, you've reached a counsellor. What would you like to talk about?"),
     ],
   },
   production: {},

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -33,7 +33,7 @@ export const webchatScripts = {
     botStatement("Thank you. You can say 'prefer not to answer' (or type X) to any question."),
     botStatement('How old are you?'),
     callerStatement('10'),
-    botStatement('What is your gender?'), // Step required in Aselo Dev, not in E2E
+    botStatement('What is your gender?'),
     callerStatement('girl'),
     botStatement("We'll transfer you now. Please hold for a counsellor."),
     counselorAutoStatement('Hi, this is the counsellor. How can I help you?'),
@@ -66,7 +66,16 @@ export const webchatScripts = {
       counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
     ],
   },
-  production: {},
+  production: {
+    ca: [
+      botStatement(
+        'You are number 1 in line. To keep your chat active, please do not leave/refresh this window or hit the back button.',
+      ),
+      counselorAutoStatement("Hi, you've reached a counsellor. What would you like to talk about?"),
+      callerStatement('CALLER TEST CHAT MESSAGE'),
+      counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
+    ],
+  },
 };
 
 export const getWebchatScript = (): ChatStatement[] => {

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -62,6 +62,8 @@ export const webchatScripts = {
         'You are number 1 in line. To keep your chat active, please do not leave/refresh this window or hit the back button.',
       ),
       counselorAutoStatement("Hi, you've reached a counsellor. What would you like to talk about?"),
+      callerStatement('CALLER TEST CHAT MESSAGE'),
+      counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),
     ],
   },
   production: {},

--- a/e2e-tests/tests/webchat.spec.ts
+++ b/e2e-tests/tests/webchat.spec.ts
@@ -67,7 +67,6 @@ test.describe.serial('Web chat caller', () => {
     const flexChatProgress: AsyncIterator<ChatStatement> = flexChat(pluginPage).chat(chatScript);
 
     const helplineShortCode = getConfigValue('helplineShortCode') as string;
-    const helplineEnv = getConfigValue('helplineEnv') as string;
 
     // Currently this loop handles the handing back and forth of control between the caller & counselor sides of the chat.
     // Each time round the loop it allows the webchat to process statements until it yields control back to this loop
@@ -91,75 +90,46 @@ test.describe.serial('Web chat caller', () => {
             await flexChatProgress.next();
             break;
         }
-      } else {
       }
-    }
-    console.log('Starting filling form');
-    const form = contactForm(pluginPage);
-    if (helplineEnv === 'development') {
-      await form.fill([
-        <ContactFormTab>{
-          id: 'childInformation',
-          label: 'Child',
-          fill: form.fillStandardTab,
-          items: {
-            firstName: 'E2E',
-            lastName: 'TEST',
-            phone1: '1234512345',
-            province: 'Northern',
-            district: 'District A',
-          },
-        },
-        <ContactFormTab<Categories>>{
-          id: 'categories',
-          label: 'Categories',
-          fill: form.fillCategoriesTab,
-          items: {
-            Accessibility: ['Education'],
-          },
-        },
-        <ContactFormTab>{
-          id: 'caseInformation',
-          label: 'Summary',
-          fill: form.fillStandardTab,
-          items: {
-            callSummary: 'E2E TEST CALL',
-          },
-        },
-      ]);
-    } else if (
-      helplineShortCode === 'ca' &&
-      (helplineEnv === 'staging' || helplineEnv === 'production')
-    ) {
-      await form.fill([
-        <ContactFormTab>{
-          id: 'person',
-          label: 'Person',
-          fill: form.fillStandardTab,
-        },
-        <ContactFormTab<Categories>>{
-          id: 'categories',
-          label: 'Issue Tags',
-          fill: form.fillCategoriesTab,
-          items: {
-            Parenting: ['Parenting'],
-          },
-        },
-        <ContactFormTab>{
-          id: 'caseInformation',
-          label: 'Summary',
-          fill: form.fillStandardTab,
-          items: {
-            callSummary: 'E2E TEST CALL',
-          },
-        },
-      ]);
     }
 
     if (getConfigValue('skipDataUpdate') as boolean) {
       console.log('Skipping saving form');
       return;
     }
+
+    console.log('Starting filling form');
+    const form = contactForm(pluginPage);
+    await form.fill([
+      <ContactFormTab>{
+        id: 'childInformation',
+        label: 'Child',
+        fill: form.fillStandardTab,
+        items: {
+          firstName: 'E2E',
+          lastName: 'TEST',
+          phone1: '1234512345',
+          province: 'Northern',
+          district: 'District A',
+        },
+      },
+      <ContactFormTab<Categories>>{
+        id: 'categories',
+        label: 'Categories',
+        fill: form.fillCategoriesTab,
+        items: {
+          Accessibility: ['Education'],
+        },
+      },
+      <ContactFormTab>{
+        id: 'caseInformation',
+        label: 'Summary',
+        fill: form.fillStandardTab,
+        items: {
+          callSummary: 'E2E TEST CALL',
+        },
+      },
+    ]);
 
     console.log('Saving form');
     await form.save();

--- a/e2e-tests/workerStatus.ts
+++ b/e2e-tests/workerStatus.ts
@@ -21,6 +21,7 @@ export enum WorkerStatus {
   UNKNOWN,
   AVAILABLE = 'Available',
   OFFLINE = 'Offline',
+  READY = 'Ready',
 }
 
 export function statusIndicator(page: Page) {


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- Update E2E chat script for CA and update to use CA's use of worker status, i.e., 'Ready' instead of 'Available.


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes # https://tech-matters.atlassian.net/browse/CHI-2114

### Verification steps
- Run E2E for CA staging locally and ensure `webchat.spec.ts` passes
TODO: Test on CA production.