### PR TITLE
fix: need to override region on session client as well

### DIFF
--- a/twilio-iac/scripts/python_tools/src/aws/sts_client.py
+++ b/twilio-iac/scripts/python_tools/src/aws/sts_client.py
@@ -40,4 +40,4 @@ class STSClient():
         )
 
     def get_session_client(self, service_name: str):
-        return self.session.client(service_name)
+        return self.session.client(service_name, config=self._config)


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
I discovered a but when testing where the region isn't being properly set on sts sessions in the service configuration system.
This fixes that issue.