### PR TITLE
refactor: move config file parsing into configuration layer of terrarunt

### DIFF
--- a/twilio-iac/helplines/defaults.hcl
+++ b/twilio-iac/helplines/defaults.hcl
@@ -27,6 +27,7 @@ locals {
 
   custom_task_routing_filter_expression = "channelType ==\"web\"  OR isContactlessTask == true OR  twilioNumber IN [${join(", ", formatlist("'%s'", local.twilio_numbers))}]"
 
+  lex_bot_languages = {}
 
   manage_github_secrets = true
 

--- a/twilio-iac/stages/lex/terragrunt.hcl
+++ b/twilio-iac/stages/lex/terragrunt.hcl
@@ -53,52 +53,54 @@ locals {
     language => merge(
       [
         for bot in bots :
-        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/bots/${bot}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/bots/${bot}.json")) :
-        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/bots/${bot}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/bots/${bot}.json")) :
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/bots/${bot}.json"))
-
-
-    ]...)
+          fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/bots/${bot}.json") ?
+          jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/bots/${bot}.json")) :
+          fileexists("/app/twilio-iac/helplines/configs/lex/${language}/bots/${bot}.json") ?
+          jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/bots/${bot}.json")) :
+          jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/bots/${bot}.json"))
+      ]...
+    )
   })
 
   lex_intents = tomap({
     for language, bots in local.lex_bot_languages :
-    language => merge(
-      [
-        for bot in bots :
-        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/intents/${bot}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/intents/${bot}.json")) :
-        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/intents/${bot}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/intents/${bot}.json")) :
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/intents/${bot}.json"))
-
-
-    ]...)
+      language => merge(
+        [
+          for bot in bots :
+            fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/intents/${bot}.json") ?
+            jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/intents/${bot}.json")) :
+            fileexists("/app/twilio-iac/helplines/configs/lex/${language}/intents/${bot}.json") ?
+            jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/intents/${bot}.json")) :
+            jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/intents/${bot}.json"))
+        ]...
+      )
   })
 
   slot_types_names = tomap({
     for language, bots in local.lex_bot_languages :
-    language => distinct(flatten([
-      for obj_key, obj_value in local.lex_intents[language] : [
-        for slot_name, slot_data in obj_value["slots"] :
-        slot_data["slot_type"]
-      ]
-  ])) })
+      language => distinct(
+        flatten([
+          for obj_key, obj_value in local.lex_intents[language] : [
+            for slot_name, slot_data in obj_value["slots"] :
+            slot_data["slot_type"]
+          ]
+        ])
+      )
+  })
 
   lex_slot_types = tomap({
     for language, bots in local.lex_bot_languages :
-    language => merge(
-      [
-        for slot_type in local.slot_types_names[language] :
-        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/slot_types/${slot_type}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/slot_types/${slot_type}.json")) :
-        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/slot_types/${slot_type}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/slot_types/${slot_type}.json")) :
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/slot_types/${slot_type}.json"))
-      ]...
-  ) })
+      language => merge(
+        [
+          for slot_type in local.slot_types_names[language] :
+          fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/slot_types/${slot_type}.json") ?
+          jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/slot_types/${slot_type}.json")) :
+          fileexists("/app/twilio-iac/helplines/configs/lex/${language}/slot_types/${slot_type}.json") ?
+          jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/slot_types/${slot_type}.json")) :
+          jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/slot_types/${slot_type}.json"))
+        ]...
+      )
+  })
 
 
   local_config = {

--- a/twilio-iac/stages/lex/terragrunt.hcl
+++ b/twilio-iac/stages/lex/terragrunt.hcl
@@ -44,7 +44,68 @@ include "root" {
   * We can override the root config with local configuration options if we need to.
   */
 locals {
-  local_config = {}
+  short_helpline = include.root.locals.config.short_helpline
+  environment = include.root.locals.config.environment
+  lex_bot_languages = include.root.locals.config.lex_bot_languages
+
+  lex_bots = tomap({
+    for language, bots in local.lex_bot_languages :
+    language => merge(
+      [
+        for bot in bots :
+        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/bots/${bot}.json") ?
+        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/bots/${bot}.json")) :
+        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/bots/${bot}.json") ?
+        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/bots/${bot}.json")) :
+        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/bots/${bot}.json"))
+
+
+    ]...)
+  })
+
+  lex_intents = tomap({
+    for language, bots in local.lex_bot_languages :
+    language => merge(
+      [
+        for bot in bots :
+        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/intents/${bot}.json") ?
+        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/intents/${bot}.json")) :
+        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/intents/${bot}.json") ?
+        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/intents/${bot}.json")) :
+        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/intents/${bot}.json"))
+
+
+    ]...)
+  })
+
+  slot_types_names = tomap({
+    for language, bots in local.lex_bot_languages :
+    language => distinct(flatten([
+      for obj_key, obj_value in local.lex_intents[language] : [
+        for slot_name, slot_data in obj_value["slots"] :
+        slot_data["slot_type"]
+      ]
+  ])) })
+
+  lex_slot_types = tomap({
+    for language, bots in local.lex_bot_languages :
+    language => merge(
+      [
+        for slot_type in local.slot_types_names[language] :
+        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/slot_types/${slot_type}.json") ?
+        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/slot_types/${slot_type}.json")) :
+        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/slot_types/${slot_type}.json") ?
+        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/slot_types/${slot_type}.json")) :
+        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/slot_types/${slot_type}.json"))
+      ]...
+  ) })
+
+
+  local_config = {
+    lex_bots = local.lex_bots
+    lex_intents = local.lex_intents
+    lex_slot_types = local.lex_slot_types
+  }
 
   config = merge(include.root.locals.config, local.local_config)
 }

--- a/twilio-iac/terraform-modules/stages/lex/main.tf
+++ b/twilio-iac/terraform-modules/stages/lex/main.tf
@@ -2,67 +2,6 @@ provider "awscc" {
   region = var.helpline_region
 }
 
-
-locals {
-  helpline       = var.helpline
-  short_helpline = var.short_helpline
-  environment    = var.environment
-  bots_definitions = tomap({
-    for language, bots in var.lex_bot_languages :
-    language => merge(
-      [
-        for bot in bots :
-        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/bots/${bot}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/bots/${bot}.json")) :
-        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/bots/${bot}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/bots/${bot}.json")) :
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/bots/${bot}.json"))
-
-
-    ]...)
-  })
-
-  intents_definitions = tomap({
-    for language, bots in var.lex_bot_languages :
-    language => merge(
-      [
-        for bot in bots :
-        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/intents/${bot}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/intents/${bot}.json")) :
-        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/intents/${bot}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/intents/${bot}.json")) :
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/intents/${bot}.json"))
-
-
-    ]...)
-  })
-
-  slot_types_names = tomap({
-    for language, bots in var.lex_bot_languages :
-    language => distinct(flatten([
-      for obj_key, obj_value in local.intents_definitions[language] : [
-        for slot_name, slot_data in obj_value["slots"] :
-        slot_data["slot_type"]
-      ]
-  ])) })
-
-  slot_types_definitions = tomap({
-    for language, bots in var.lex_bot_languages :
-    language => merge(
-      [
-        for slot_type in local.slot_types_names[language] :
-        fileexists("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/slot_types/${slot_type}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/${local.short_helpline}/configs/lex/${language}/slot_types/${slot_type}.json")) :
-        fileexists("/app/twilio-iac/helplines/configs/lex/${language}/slot_types/${slot_type}.json") ?
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${language}/slot_types/${slot_type}.json")) :
-        jsondecode(file("/app/twilio-iac/helplines/configs/lex/${substr(language, 0, 2)}/slot_types/${slot_type}.json"))
-      ]...
-  ) })
-
-
-
-}
-
 module "lex" {
   source = "../../lex/v1"
 
@@ -78,12 +17,10 @@ module "lex" {
   environment    = var.environment
   language       = each.key
 
-  bots = local.bots_definitions[each.key]
-  intents = local.intents_definitions[each.key]
-  slot_types = local.slot_types_definitions[each.key]
-
+  bots       = var.lex_bots[each.key]
+  intents    = var.lex_intents[each.key]
+  slot_types = var.lex_slot_types[each.key]
 }
-
 
 module "lexv2" {
   source = "../../lex/v2"

--- a/twilio-iac/terraform-modules/stages/lex/variables.tf
+++ b/twilio-iac/terraform-modules/stages/lex/variables.tf
@@ -19,9 +19,72 @@ variable "helpline" {
 }
 
 variable "lex_bot_languages" {
-  type = map(list(string))
+  type    = map(list(string))
+  default = {}
 }
 
+variable "lex_slot_types" {
+  description = "The slot types for the helpline."
+  type = map(map(object({
+    description              = string
+    value_selection_strategy = string
+    values = map(object({
+      synonyms = optional(list(string), []),
+    }))
+  })))
+}
+
+variable "lex_intents" {
+  description = "The intents for the helpline."
+  type = map(map(object({
+    description       = string
+    sample_utterances = list(string)
+    fulfillment_activity = object({
+      type = string
+    })
+    conclusion_statement = object({
+      content      = string
+      content_type = string
+    })
+    rejection_statement = object({
+      content      = string
+      content_type = string
+    })
+    slots = map(object({
+      priority        = number
+      description     = string
+      slot_constraint = string
+      slot_type       = string
+      value_elicitation_prompt = object({
+        max_attempts = number
+        content      = string
+        content_type = string
+      })
+    }))
+  })))
+}
+
+variable "lex_bots" {
+  description = "The bots for the helpline."
+  type = map(map(object({
+    description                 = string
+    locale                      = optional(string, "en-US")
+    process_behavior            = optional(string, "BUILD")
+    child_directed              = optional(bool, true)
+    idle_session_ttl_in_seconds = optional(number, 300)
+    enable_model_improvements   = optional(bool, true)
+    abort_statement = object({
+      content      = string
+      content_type = string
+    })
+    clarification_prompt = object({
+      max_attempts = number
+      content      = string
+      content_type = string
+    })
+    intents = list(string)
+  })))
+}
 
 // Used for lex v2 via awscc leaving here for now
 variable "lex_v2_config" {


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

This moves lex config file parsing into the configuration layer and make it so lex stage runs don't fail on helplines where lex isn't configured.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->