### PR TITLE
chore: update prettierrc and eslint so IDE format on save works

### DIFF
--- a/plugin-hrm-form/.eslintrc.json
+++ b/plugin-hrm-form/.eslintrc.json
@@ -1,15 +1,12 @@
 {
-  "extends": [
-    "twilio-react",
-    "plugin:sonarjs/recommended"
-  ],
+  "extends": ["twilio-react", "plugin:sonarjs/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2019,
-    "sourceType": "module", 
-    "ecmaFeatures": { 
-    "jsx": true
-   }
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
   },
   "rules": {
     "no-console": "off",
@@ -29,6 +26,13 @@
     "react/no-multi-comp": "off",
     "react/jsx-no-bind": "off",
     "sonarjs/no-nested-template-literals": "off",
-    "sonar/unused-import": "off"
+    "sonar/unused-import": "off",
+    "prettier/prettier": [
+      "warn",
+      {},
+      {
+        "usePrettierrc": true
+      }
+    ]
   }
 }

--- a/plugin-hrm-form/.prettierrc.js
+++ b/plugin-hrm-form/.prettierrc.js
@@ -1,0 +1,10 @@
+const baseConfig = require('./node_modules/eslint-config-twilio/rules/prettier');
+
+module.exports = {
+  ...baseConfig,
+  ...{
+    arrowParens: 'avoid',
+    singleQuote: true,
+    endOfLine: 'auto',
+  },
+};

--- a/plugin-hrm-form/.prettierrc.js
+++ b/plugin-hrm-form/.prettierrc.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 const baseConfig = require('./node_modules/eslint-config-twilio/rules/prettier');
 
 module.exports = {

--- a/plugin-hrm-form/.prettierrc.json
+++ b/plugin-hrm-form/.prettierrc.json
@@ -1,5 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "singleQuote": true,
-  "endOfLine": "auto"
-}


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This follows the recommended fixes [here](https://github.com/twilio-labs/twilio-style/tree/main/packages/eslint-config-twilio#prettier) to enable IDE auto-formatting to pick up prettier changes from the underlying twilio eslint plugins.

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Make a change (remove a semicolon) and depend on the eslint prettier plugin to fix it on save via the prettier/eslint VS code plugin. Make sure the semicolon is fixed and nothing else in the file changes.

Verify that, if format on save was already working as expected in your IDE, this doesn't break it.