### PR TITLE
CHI-1989: Add 'Languages Serviced' and 'Coverage' to the Resource Details

### DIFF
--- a/plugin-hrm-form/src/components/resources/convertKHPResourceAttributes.ts
+++ b/plugin-hrm-form/src/components/resources/convertKHPResourceAttributes.ts
@@ -234,7 +234,7 @@ const extractSiteDetails = (resource: Attributes, sites: Attributes, language: L
       siteId,
       name: getAttributeValue(site, language, 'name') || getAttributeValue(site, language, 'nameDetails'),
       location,
-      email: getAttributeValue(site, '', 'name'),
+      email: getAttributeValue(site, '', 'email'),
       operations: extractSiteOperatingHours(siteId, operationsAttributes, siteOperations, language),
       isActive: getBooleanAttributeValue(site, 'isActive'),
       details: getAttributeData(site, language, 'details')?.info?.details ?? '',

--- a/plugin-hrm-form/src/components/resources/resourceView/SiteDetails.tsx
+++ b/plugin-hrm-form/src/components/resources/resourceView/SiteDetails.tsx
@@ -26,6 +26,7 @@ import {
 import ExpandableSection from './ExpandableSection';
 import OperatingHours from './OperatingHours';
 import ResourceAttributeWithPrivacy from './ResourceAttributeWithPrivacy';
+import ResourceAttribute from './ResourceAttribute';
 
 type Props = {
   sites: KhpUiResource['attributes']['site'];
@@ -35,7 +36,7 @@ const SiteDetails: React.FC<Props> = ({ sites }) => {
   return (
     <div>
       {sites.map(singleSite => {
-        const { siteId, name, location, email, operations, phoneNumbers } = singleSite;
+        const { siteId, name, location, email, operations, phoneNumbers, coverage } = singleSite;
         const { isPrivate, province, city, country, county, postalCode, address1, address2 } = location ?? {};
         return (
           <ExpandableSection key={siteId} title={name}>
@@ -63,6 +64,13 @@ const SiteDetails: React.FC<Props> = ({ sites }) => {
               <ResourceAttributeDescription>Hours</ResourceAttributeDescription>
               <OperatingHours operations={operations} showDescriptionOfHours={true} />
             </ResourceAttributeContent>
+            <ResourceAttribute
+              key="coverage"
+              description="Resources-View-Coverage"
+              data-testid="Resources-View-Coverage"
+            >
+              {coverage}
+            </ResourceAttribute>
           </ExpandableSection>
         );
       })}

--- a/plugin-hrm-form/src/components/resources/resourceView/ViewResource.tsx
+++ b/plugin-hrm-form/src/components/resources/resourceView/ViewResource.tsx
@@ -119,6 +119,10 @@ const ViewResource: React.FC<Props> = ({ resource, error, loadViewedResource, na
                         attributeToDisplay: resourceAttributes.documentsRequired,
                       },
                       { subtitle: 'Resources-View-AgesServed', attributeToDisplay: resourceAttributes.ageRange },
+                      {
+                        subtitle: 'Resources-View-LanguagesServiced',
+                        attributeToDisplay: resourceAttributes.languagesServiced,
+                      },
                     ].map(({ subtitle, attributeToDisplay }) => (
                       <ResourceAttribute key={subtitle} description={subtitle}>
                         {attributeToDisplay}
@@ -150,6 +154,10 @@ const ViewResource: React.FC<Props> = ({ resource, error, loadViewedResource, na
                       {
                         subtitle: 'Resources-View-TranslationServicesAvailable',
                         attributeToDisplay: resourceAttributes.interpretationTranslationServicesAvailable,
+                      },
+                      {
+                        subtitle: 'Resources-View-Coverage',
+                        attributeToDisplay: resourceAttributes.coverage,
                       },
                       // eslint-disable-next-line sonarjs/no-identical-functions
                     ].map(({ subtitle, attributeToDisplay, dataTestId }) => (

--- a/plugin-hrm-form/src/components/resources/types.ts
+++ b/plugin-hrm-form/src/components/resources/types.ts
@@ -41,11 +41,13 @@ export type KhpUiResource = {
     howToAccessSupport: string;
     applicationProcess: string;
     howIsServiceOffered: string;
+    languagesServiced: string;
     accessibility: string;
     documentsRequired: string;
     primaryLocationIsPrivate: boolean;
     primaryLocation: string;
     operations: KhpOperationsDay[];
+    coverage: string;
     site: {
       siteId: string;
       name: string;
@@ -66,6 +68,7 @@ export type KhpUiResource = {
       operations: KhpOperationsDay[];
       isActive: boolean;
       details: string;
+      coverage: string;
     }[];
   };
 };

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -457,6 +457,8 @@
   "Resources-View-ApplicationProcess": "Application Process",
   "Resources-View-HowIsServiceOffered": "How is Service Offered",
   "Resources-View-DocumentsRequired": "Documents Required",
+  "Resources-View-LanguagesServiced": "Languages Serviced",
+  "Resources-View-Coverage": "Coverage",
   "Resources-CopyId": "Copy ID",
   "Resources-IdCopied": "Copied!",
 


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description

Address a couple of issues raised as part of the UI tidy up but needed backend mapping changes

* Coverage is now shown at resource level & per site
* Coverage descriptions should be compatible with the current coverage data and the planned upcoming format
* 'Languages Serviced' is also shown for the resource

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- [X] Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
CHI-1989

### Verification steps

View various resources and look for the 'Languages Serviced' and 'Coverage' entry on the resource. I don't think the old format Coverage puts coverage on the site level, so until we have that data, coverage on each site will always show as 'Not Listed'