### PR TITLE
chore: console log save contact form errors

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -85,10 +85,11 @@ const BottomBar: React.FC<
       await submitContactForm(task, contactForm, caseForm);
       await completeTask(task);
     } catch (error) {
-      console.error('submitContactForm Error', error);
       if (window.confirm(strings['Error-ContinueWithoutRecording'])) {
-        console.error('submitContactForm COMPLETING TASK WITHOUT RECORDING', error);
+        recordBackendError('Submit Contact Form TASK COMPLETED WITHOUT RECORDING', error);
         await completeTask(task);
+      } else {
+        recordBackendError('Submit Contact Form', error);
       }
     } finally {
       setSubmitting(false);

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -85,7 +85,9 @@ const BottomBar: React.FC<
       await submitContactForm(task, contactForm, caseForm);
       await completeTask(task);
     } catch (error) {
+      console.error('submitContactForm Error', error);
       if (window.confirm(strings['Error-ContinueWithoutRecording'])) {
+        console.error('submitContactForm COMPLETING TASK WITHOUT RECORDING', error);
         await completeTask(task);
       }
     } finally {

--- a/plugin-hrm-form/src/fullStory/index.ts
+++ b/plugin-hrm-form/src/fullStory/index.ts
@@ -125,6 +125,7 @@ export function recordingErrorHandler(
  * @param backendError - The error object produced by the back end interaction
  */
 export function recordBackendError(action: string, backendError: Error): void {
+  console.error(`Backend Error: ${action}`, backendError);
   recordEvent('Backend Error', {
     // eslint-disable-next-line camelcase
     action_str: action,


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This adds some console errors on hrm form save failure that we can search for in datadog.