### PR TITLE
JM MT CL Prod Plans and last edits

### DIFF
--- a/twilio-iac/helplines/cl/common.hcl
+++ b/twilio-iac/helplines/cl/common.hcl
@@ -9,7 +9,6 @@ locals {
     default_autopilot_chatbot_enabled = false
     task_language                     = "es-CL"
     voice_ivr_language                = "es-MX"
-    contacts_waiting_channels         = ["voice", "web"]
     enable_post_survey                = true
 
     workflows = {

--- a/twilio-iac/helplines/cl/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/common.json
@@ -8,9 +8,10 @@
         "feature_flags": {
             "enable_aselo_messaging_ui": true,
             "enable_conferencing": false,
-            "enable_fullstory_monitoring": true,
+            "enable_fullstory_monitoring": false,
             "enable_manual_pulling": false,
             "enable_resources": false,
+            "enable_lex": true,
             "enable_voice_recordings": true
         },
         "helplineLanguage": "es-CL",

--- a/twilio-iac/helplines/cl/configs/service-configuration/production.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/production.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_lex": false,
             "enable_save_insights": true,
             "enable_transcripts": false
         },

--- a/twilio-iac/helplines/cl/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/staging.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_lex": true
         },
         "helpline_code": "cl"
     }

--- a/twilio-iac/helplines/jm/common.hcl
+++ b/twilio-iac/helplines/jm/common.hcl
@@ -12,7 +12,6 @@ locals {
     task_language                     = "en-US"
     helpline_language                 = "en-US"
     voice_ivr_language                = ""
-    contacts_waiting_channels         = ["web","whatsapp","facebook","instagram"]
     enable_post_survey                = false
     
    

--- a/twilio-iac/helplines/jm/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/jm/configs/service-configuration/common.json
@@ -2,6 +2,7 @@
     "attributes": {
         "definitionVersion": "jm-v1",
         "feature_flags": {
+            "enable_lex": true,
             "enable_conferencing": false,
             "enable_counselor_toolkits": false,
             "enable_csam_clc_report": false,

--- a/twilio-iac/helplines/jm/configs/service-configuration/production.json
+++ b/twilio-iac/helplines/jm/configs/service-configuration/production.json
@@ -3,7 +3,6 @@
         "feature_flags": {
             "enable_aselo_messaging_ui": false,
             "enable_fullstory_monitoring": true,
-            "enable_lex": false,
             "enable_transcripts": false,
             "enable_voice_recordings": false
         },

--- a/twilio-iac/helplines/jm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/jm/configs/service-configuration/staging.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_lex": true,
             "enable_manual_pulling": false,
             "enable_transcripts": true,
             "enable_twilio_transcripts": false,

--- a/twilio-iac/helplines/jm/production.hcl
+++ b/twilio-iac/helplines/jm/production.hcl
@@ -14,34 +14,8 @@ locals {
     }
 
 
-    #Chatbots
+   
 
-    #Feature flags
-    feature_flags = {
-      "enable_fullstory_monitoring" : true,
-      "enable_upload_documents" : true,
-      "enable_post_survey" : true,
-      "enable_contact_editing" : true,
-      "enable_case_management" : true,
-      "enable_offline_contact" : true,
-      "enable_filter_cases" : true,
-      "enable_sort_cases" : true,
-      "enable_transfers" : true,
-      "enable_manual_pulling" : false,
-      "enable_csam_report" : false,
-      "enable_canned_responses" : true,
-      "enable_dual_write" : false,
-      "enable_save_insights" : true,
-      "enable_previous_contacts" : true,
-      "enable_voice_recordings" : true,
-      "enable_twilio_transcripts" : true,
-      "enable_external_transcripts" : true,
-      "post_survey_serverless_handled" : true,
-      "enable_csam_clc_report" : false,
-      "enable_counselor_toolkits" : false,
-      "enable_resources" : false,
-      "enable_emoji_picker" : true,
-      "enable_aselo_messaging_ui" : true
-    }
+ 
   }
 }

--- a/twilio-iac/helplines/jm/staging.hcl
+++ b/twilio-iac/helplines/jm/staging.hcl
@@ -17,32 +17,6 @@ locals {
     ui_editable = true
     #Chatbots
 
-    #Feature flags
-    feature_flags = {
-      "enable_fullstory_monitoring" : true,
-      "enable_upload_documents" : true,
-      "enable_post_survey" : true,
-      "enable_contact_editing" : true,
-      "enable_case_management" : true,
-      "enable_offline_contact" : true,
-      "enable_filter_cases" : true,
-      "enable_sort_cases" : true,
-      "enable_transfers" : true,
-      "enable_manual_pulling" : false,
-      "enable_csam_report" : false,
-      "enable_canned_responses" : true,
-      "enable_dual_write" : false,
-      "enable_save_insights" : false,
-      "enable_previous_contacts" : true,
-      "enable_voice_recordings" : true,
-      "enable_twilio_transcripts" : true,
-      "enable_external_transcripts" : true,
-      "post_survey_serverless_handled" : true,
-      "enable_csam_clc_report" : false,
-      "enable_counselor_toolkits" : false,
-      "enable_resources" : false,
-      "enable_emoji_picker" : true,
-      "enable_aselo_messaging_ui" : true
-    }
+    
   }
 }

--- a/twilio-iac/helplines/mt/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/mt/configs/service-configuration/common.json
@@ -16,7 +16,7 @@
             "enable_counselor_toolkits": false,
             "enable_csam_clc_report": false,
             "enable_fullstory_monitoring": true,
-            "enable_lex": false,
+            "enable_lex": true,
             "enable_post_survey": false,
             "enable_save_insights": true,
             "enable_transcripts": false,

--- a/twilio-iac/helplines/mt/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mt/configs/service-configuration/staging.json
@@ -1,8 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_emoji_picker": false,
-            "enable_lex": true
+            "enable_emoji_picker": false
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
         "helplineLanguage": ""

--- a/twilio-iac/mt-kellimni-production/main.tf
+++ b/twilio-iac/mt-kellimni-production/main.tf
@@ -98,21 +98,16 @@ module "twilioChannel" {
   channel_contact_identity = each.value.contact_identity
   channel_type             = each.value.channel_type
   custom_flow_definition = templatefile(
-    "../terraform-modules/channels/flow-templates/language-mt/with-chatbot.tftpl",
+    "../terraform-modules/channels/flow-templates/language-mt/messaging-lex.tftpl",
     {
       channel_name                  = "${each.key}"
       serverless_url                = module.serverless.serverless_environment_production_url
       serverless_service_sid        = module.serverless.serverless_service_sid
       serverless_environment_sid    = module.serverless.serverless_environment_production_sid
+      capture_channel_with_bot_sid = "ZH95285b8e20b443a167ada3db38b1ff99"
+      send_message_janitor_sid     = "ZH91ec531cde681192daf63e306db90d88"
       master_workflow_sid           = module.taskRouter.master_workflow_sid
       chat_task_channel_sid         = module.taskRouter.chat_task_channel_sid
-      chatbot_en_sid                = twilio_autopilot_assistants_v1.chatbot_en.sid
-      chatbot_mt_sid                = twilio_autopilot_assistants_v1.chatbot_mt.sid
-      chatbot_ukr_sid               = twilio_autopilot_assistants_v1.chatbot_ukr.sid
-      chatbot_language_selector_sid = twilio_autopilot_assistants_v1.chatbot_language_selector.sid
-      channel_attributes_EN         = templatefile("../terraform-modules/channels/twilio-channel/channel-attributes-mt/${each.key}-attributes.tftpl", { chatbot_language = "chatbot_EN" })
-      channel_attributes_MT         = templatefile("../terraform-modules/channels/twilio-channel/channel-attributes-mt/${each.key}-attributes.tftpl", { chatbot_language = "chatbot_MT" })
-      channel_attributes_UKR        = templatefile("../terraform-modules/channels/twilio-channel/channel-attributes-mt/${each.key}-attributes.tftpl", { chatbot_language = "chatbot_UKR" })
       flow_description              = "${title(each.key)} Messaging Flow"
   })
   target_task_name      = local.target_task_name
@@ -128,12 +123,24 @@ module "customChannel" {
   source                = "../terraform-modules/channels/custom-channel"
   channel_name          = each.key
   janitor_enabled       = true
+    custom_flow_definition = templatefile(
+    "../terraform-modules/channels/flow-templates/language-mt/messaging-lex.tftpl",
+    {
+      channel_name                 = "${each.key}"
+      serverless_url               = module.serverless.serverless_environment_production_url
+      serverless_service_sid       = module.serverless.serverless_service_sid
+      serverless_environment_sid   = module.serverless.serverless_environment_production_sid
+      capture_channel_with_bot_sid = "ZH95285b8e20b443a167ada3db38b1ff99"
+      send_message_janitor_sid     = "ZH91ec531cde681192daf63e306db90d88"
+      master_workflow_sid          = module.taskRouter.master_workflow_sid
+      chat_task_channel_sid        = module.taskRouter.chat_task_channel_sid
+      flow_description             = "${title(each.key)} Messaging Flow"
+  })
   master_workflow_sid   = module.taskRouter.master_workflow_sid
   chat_task_channel_sid = module.taskRouter.chat_task_channel_sid
   flex_chat_service_sid = module.services.flex_chat_service_sid
   short_helpline        = local.short_helpline
   short_environment     = local.short_environment
-  task_language         = "en-MT"
 }
 
 module "survey" {

--- a/twilio-iac/stages/provision/.terraform.lock.hcl
+++ b/twilio-iac/stages/provision/.terraform.lock.hcl
@@ -22,30 +22,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/awscc" {
-  version     = "0.52.0"
-  constraints = "0.52.0"
-  hashes = [
-    "h1:GoRBFL28LM+/vweFOCN/IHYLvzQBnHbN4cMyJSnhIZM=",
-    "h1:H1UuZGS+HWiyNmzB/3lk4eVNybAqQzhwGPqiKufvW3g=",
-    "zh:0a2e0f27e61c51a23117a8307fbff720913c2b418933fab9539ce3c3cdbed45a",
-    "zh:19eadcc1d1f40a2960ea639a8f285f6fd6d81e7ecef96b69126caeea9e429b99",
-    "zh:3189890803b5c67573593d4105a714e5c1a8bba66892abcebb41ab745733b284",
-    "zh:35ef6779eb97538e92d9aa57fb1864fca02cf8447d57004d62ca7d6476244b22",
-    "zh:56b0ac8310b31bff97e843e88496e6c60aa8b3abaaa01de6ac3018d3fcb52745",
-    "zh:67ad698e004acdbe3f8530aa81019a478d2f9e540e06255c61cd35dea4b9274a",
-    "zh:6c7512b4e502446d5005ea76f469d3ac4c91a4eda6789a10a92d79714fd57581",
-    "zh:737f45080d9d944c5ce2a6736fd728a11a4c976722ace2bf1ecdafa69583f12c",
-    "zh:7ed53d97c2b5a09a03444e569bb23826179dc3a111f1c69f9439c133b16da7ff",
-    "zh:980c9179d5768f74eb307922730486e682fac62670ecac5099152ad2db27da4a",
-    "zh:b6574e592509d28de4bc493f5bcfd758b512fd7b8768cc2e357728d0117f303e",
-    "zh:b7bdcfa2c3f299bd76491ecdbc855077d62fd23c1ce5f2889f6be07d3adc572f",
-    "zh:cc2de9689dc85ca9c6f6f99d887aaea0b66e1064404e36566146c5af949f2529",
-    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
-    "zh:fa07e029fd48a19245f6955c6bac89ec883755836125889c35634cb897bb1e35",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/external" {
   version = "2.3.1"
   hashes = [

--- a/twilio-iac/terraform-modules/survey/default/main.tf
+++ b/twilio-iac/terraform-modules/survey/default/main.tf
@@ -19,27 +19,17 @@ resource "twilio_taskrouter_workspaces_workflows_v1" "survey_workflow" {
   friendly_name = "Survey"
   workspace_sid = var.flex_task_assignment_workspace_sid
   configuration = jsonencode({
-    "task_routing": {
-      "filters": [
+    "task_routing" : {
+      "filters" : [
         {
-          "filter_friendly_name": "Survey Filter",
-          "expression": var.custom_task_routing_filter_expression != "" ? var.custom_task_routing_filter_expression : "isSurveyTask==true",
-          "targets": [
+          "filter_friendly_name" : "CaptureChannel",
+          "expression" : "isChatCaptureControl==true",
+          "targets" : [
             {
-              "expression": var.custom_task_routing_survey_queue_target_filter_expression,
-              "queue": twilio_taskrouter_workspaces_task_queues_v1.survey_queue.sid
+              "queue" : twilio_taskrouter_workspaces_task_queues_v1.survey_queue.sid
             }
           ]
-        },
-      {
-        "filter_friendly_name": "CaptureChannel",
-        "expression": "isChatCaptureControl==true",
-        "targets": [
-          {
-            "queue": twilio_taskrouter_workspaces_task_queues_v1.survey_queue.sid
-          }
-        ]
-      }
+        }
       ]
     }
   })
@@ -50,5 +40,5 @@ resource "twilio_taskrouter_workspaces_workflows_v1" "survey_workflow" {
 resource "twilio_taskrouter_workspaces_task_channels_v1" "survey" {
   workspace_sid = var.flex_task_assignment_workspace_sid
   friendly_name = "Survey"
-  unique_name = "survey"
+  unique_name   = "survey"
 }


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

Final edits and plans for JM, MT and CL PROD.

### Checklist
- [x] JM: Prod studio flow created manually. No need to apply main.tf
- [x] JM: Survey resources created manually
- [x] JM: Messaging Studio flow backed up
- [x] MT: Studio flows backed up
- [x] Enable_lex = true on all prod config files.


## Migration Process 

### JM
(Pre survey bot)

- [x] 1. Lex stage apply (creation of bots) 
- [x] 2. Manually assign flex channels to lex studio flow 
- [x] 3. Service configuration apply (turning on Lex)

### MT
(Pre survey bots)

- [x] 1. Lex stage apply (creation of bots) 
- [x] 2. MT main.tf apply (updating survey workflow filter, updating studio flows and removing FFs)
- [x] 3. Service configuration apply (turning on Lex)

### CL
(CL has only a post survey bot)

- [x] 1. Lex stage apply (creation of bots) 
- [x] 2. Provision stage apply  (updating survey workflow filter)
- [x] 3. Service configuration apply (turning on Lex)

