### PR TITLE
CHI-1989: Add support for translation keys in resource attribute display. 

### DIFF
--- a/plugin-hrm-form/src/components/resources/resourceView/ExpandableAttributeContent.tsx
+++ b/plugin-hrm-form/src/components/resources/resourceView/ExpandableAttributeContent.tsx
@@ -52,7 +52,7 @@ const ExpandableAttributeContent: React.FC<ExpandableAttributeContentProps & Par
           maxHeight: isExpanded ? undefined : '120px',
         }}
       >
-        {content}
+        <Template code={content} />
         {isExpanded && (
           <StyledLink
             underline={true}

--- a/plugin-hrm-form/src/components/resources/resourceView/ResourceAttribute.tsx
+++ b/plugin-hrm-form/src/components/resources/resourceView/ResourceAttribute.tsx
@@ -32,8 +32,11 @@ const ResourceAttribute: React.FC<Props> = ({ description, children, isExpandabl
     if (!children) {
       return <Template code="Resources-View-MissingProperty" />;
     }
-    if (typeof children === 'string' && isExpandable === true) {
-      return <ExpandableAttributeContent expandLinkText="ReadMore" collapseLinkText="ReadLess" content={children} />;
+    if (typeof children === 'string') {
+      if (isExpandable === true) {
+        return <ExpandableAttributeContent expandLinkText="ReadMore" collapseLinkText="ReadLess" content={children} />;
+      }
+      return <Template code={children} />;
     }
 
     return children;

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -459,6 +459,7 @@
   "Resources-View-DocumentsRequired": "Documents Required",
   "Resources-View-LanguagesServiced": "Languages Serviced",
   "Resources-View-Coverage": "Coverage",
+  "Resources-View-Coverage-SeeSites": "(see individual sites)",
   "Resources-CopyId": "Copy ID",
   "Resources-IdCopied": "Copied!",
 


### PR DESCRIPTION
## Description

* Add support for translation keys in resource attribute display. 
* Add more helpful coverage placeholder. 
* Fix issue where coverage is 'Canada'

## Steps to verify

* Find a resource with sites, ensure it says '(see individual sites)' under the top level 'Coverage' heading on resource details
* Find a resource without sites (search 'Kids Help Phone'), ensure the top level coverage either has details populated or says 'Not Listed' 
