### PR TITLE
Removed fallback on about self condition

### DIFF
--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -242,7 +242,7 @@ export function reduce(
           ...state.tasks,
           [action.taskId]: {
             ...currentTask,
-            callType,
+            callType: callType ? callType : state.tasks[action.taskId].callType,
             [formName]: {
               ...currentTask[formName],
               ...values,

--- a/plugin-hrm-form/src/states/contacts/types.ts
+++ b/plugin-hrm-form/src/states/contacts/types.ts
@@ -101,7 +101,7 @@ type HandleExpandCategoryAction = {
 
 type PrePopulateFormAction = {
   type: typeof PREPOPULATE_FORM;
-  callType: DataCallTypes;
+  callType: DataCallTypes | null;
   values: { [property: string]: string };
   taskId: string;
   isCaseInfo: Boolean;

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -211,7 +211,7 @@ export const prepopulateForm = (task: ITask, featureFlags: FeatureFlags) => {
   const answers = getAnswers(featureFlags.enable_lex, memory);
 
   const isAboutSelf = answers.aboutSelf === 'Yes';
-  const callType = isAboutSelf || !answers.aboutSelf ? callTypes.child : callTypes.caller;
+  const callType = isAboutSelf ? callTypes.child : callTypes.caller;
   const tabFormDefinition = isAboutSelf ? ChildInformationTab : CallerInformationTab;
   const prepopulateSurveyKeys = isAboutSelf ? survey.ChildInformationTab : survey.CallerInformationTab;
   const subroute = isAboutSelf ? 'childInformation' : 'callerInformation';

--- a/plugin-hrm-form/src/utils/prepopulateForm.ts
+++ b/plugin-hrm-form/src/utils/prepopulateForm.ts
@@ -246,20 +246,20 @@ export const prepopulateForm = (task: ITask, featureFlags: FeatureFlags) => {
       );
       const values = { ...surveyValues, ...preEngagementValues };
       Manager.getInstance().store.dispatch(prepopulateFormAction(callType, values, task.taskSid));
-    }
 
-    if (preEngagement.CaseInformationTab.length > 0) {
-      const caseInfoValues = getValuesFromPreEngagementData(
-        preEngagementData,
-        CaseInformationTab,
-        preEngagement.CaseInformationTab,
+      if (preEngagement.CaseInformationTab.length > 0) {
+        const caseInfoValues = getValuesFromPreEngagementData(
+          preEngagementData,
+          CaseInformationTab,
+          preEngagement.CaseInformationTab,
+        );
+
+        Manager.getInstance().store.dispatch(prepopulateFormAction(callType, caseInfoValues, task.taskSid, true));
+      }
+      // Open tabbed form to first tab
+      Manager.getInstance().store.dispatch(
+        RoutingActions.changeRoute({ route: 'tabbed-forms', subroute, autoFocus: true }, task.taskSid),
       );
-
-      Manager.getInstance().store.dispatch(prepopulateFormAction(callType, caseInfoValues, task.taskSid, true));
     }
-    // Open tabbed form to first tab
-    Manager.getInstance().store.dispatch(
-      RoutingActions.changeRoute({ route: 'tabbed-forms', subroute, autoFocus: true }, task.taskSid),
-    );
   }
 };


### PR DESCRIPTION
## Description
This PR removes a default on "is about self" question that cuases a bug when the chatbot about self question is `null`, causing a blank form screen as shown in the bug ticket. A new condition is added before populating the forms: if there is no "about self" answer, we can't call `prepopulateFormAction` since it requires for a call type (which is based on "about self"). The previous statement is true for caller and child info, but we'll still allow partial case summary updates.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2149)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Start Flex development server on this branch.
- Start a new chat contact, answering an invalid value to the "about self" question (like "x").
- Confirm that the form is initialized correctly and left in the "categorize contact" screen.
