### PR TITLE
CHI-1989: Trim & remove double quotes from suggestions

### DIFF
--- a/plugin-hrm-form/src/components/resources/search/SearchAutoComplete.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchAutoComplete.tsx
@@ -18,7 +18,7 @@
 import React from 'react';
 
 import { AutoCompleteDropdown, AutoCompleteDropdownRow } from '../../../styles/ReferrableResources';
-import { TaxonomyLevelNameCompletion } from '../../../states/resources/search';
+import { sanitizeInputForSuggestions, TaxonomyLevelNameCompletion } from '../../../states/resources/search';
 
 type OwnProps = {
   generalSearchTermBoxText: string;
@@ -33,7 +33,7 @@ const SearchAutoComplete: React.FC<Props> = ({
   suggestSearch,
   setGeneralSearchTermBoxText,
 }) => {
-  const searchTerm = generalSearchTermBoxText.toLocaleLowerCase();
+  const searchTerm = sanitizeInputForSuggestions(generalSearchTermBoxText);
   const searchTermLength = searchTerm.length >= 3;
 
   const onSearch = (searchTerm: string) => {

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -168,9 +168,12 @@ export const searchResourceAsyncAction = createAsyncAction(
   // { promiseTypeDelimiter: '/' }, // Doesn't work :-(
 );
 
+export const sanitizeInputForSuggestions = (input: string): string =>
+  input.trim().replaceAll(/"/g, '').toLocaleLowerCase();
+
 // eslint-disable-next-line import/no-unused-modules
 export const suggestSearchAsyncAction = createAsyncAction(SUGGEST_ACTION, async (prefix: string) => {
-  return { ...(await suggestSearch(prefix)) };
+  return { ...(await suggestSearch(sanitizeInputForSuggestions(prefix))) };
 });
 
 /*


### PR DESCRIPTION
## Description

So they still work if the user puts the quotes in themselves - this has tripped up KHP QA so would probably trip up counselors too.

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A] Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-1989

### Verification steps

Add leading spaces, trailing spaces and double quotes to search terms - the suggestions & highlights should appear as if those characters were absent

Regression test that the terms are still suggested correctly without any of these