### PR TITLE
CHI-2166: Get rid of zero appearing when there are no referrals in the contact view.

### DIFF
--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -372,7 +372,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
               />
             </SectionEntry>
           ))}
-          {referrals && referrals.length && (
+          {referrals && Boolean(referrals.length) && (
             <SectionEntry descriptionKey="ContactDetails-GeneralDetails-ResourcesReferrals">
               {referrals.map(formatResourceReferral)}
             </SectionEntry>


### PR DESCRIPTION
## Description

* Checking an array length without casting it to a boolean or null / undefined to determine if a react element should be included results in a '0' being written in the negative case

### Related Issues
CHI-2166

### Verification steps

See ticket

@GPaoloni 