### PR TITLE
Exclude chat orchestration under flag condition

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -143,7 +143,7 @@ const setUpActions = (
   setupObject: ReturnType<typeof getHrmConfig>,
   getMessage: (key: string) => (language: string) => Promise<string>,
 ) => {
-  ActionFunctions.setUpPostSurvey(featureFlags);
+  ActionFunctions.excludeDeactivateConversationOrchestration(featureFlags);
 
   // bind setupObject to the functions that requires some initialization
   const transferOverride = ActionFunctions.customTransferTask(setupObject);

--- a/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
@@ -17,7 +17,7 @@
 /* eslint-disable camelcase */
 import { ITask, ChatOrchestrator } from '@twilio/flex-ui';
 
-import { afterCompleteTask, setUpPostSurvey } from '../../utils/setUpActions';
+import { afterCompleteTask, excludeDeactivateConversationOrchestration } from '../../utils/setUpActions';
 import { REMOVE_CONTACT_STATE } from '../../states/types';
 import { FeatureFlags } from '../../types/types';
 
@@ -54,10 +54,10 @@ describe('afterCompleteTask', () => {
   });
 });
 
-describe('setUpPostSurvey', () => {
-  test('featureFlags.enable_post_survey === false should not change ChatOrchestrator', async () => {
+describe('excludeDeactivateConversationOrchestration', () => {
+  test('backend_handled_chat_janitor === false and enable_post_survey === false should not change ChatOrchestrator', async () => {
     const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations');
-    setUpPostSurvey(<FeatureFlags>{ enable_post_survey: false });
+    excludeDeactivateConversationOrchestration(<FeatureFlags>{ enable_post_survey: false, backend_handled_chat_janitor: false });
 
     expect(setOrchestrationsSpy).not.toHaveBeenCalled();
   });
@@ -65,7 +65,16 @@ describe('setUpPostSurvey', () => {
   test('featureFlags.enable_post_survey === true should change ChatOrchestrator', async () => {
     const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
 
-    setUpPostSurvey(<FeatureFlags>{ enable_post_survey: true });
+    excludeDeactivateConversationOrchestration(<FeatureFlags>{ enable_post_survey: true });
+
+    expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
+    expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));
+    expect(setOrchestrationsSpy).toHaveBeenCalledWith('completed', expect.any(Function));
+  });
+  test('backend_handled_chat_janitor === true should change ChatOrchestrator', async () => {
+    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
+
+    excludeDeactivateConversationOrchestration(<FeatureFlags>{ backend_handled_chat_janitor: true });
 
     expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
     expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -258,13 +258,13 @@ export type FeatureFlags = {
   enable_voice_recordings: boolean; // Enables Loading Voice Recordings
   enable_twilio_transcripts: boolean; // Enables Viewing Transcripts Stored at Twilio
   enable_external_transcripts: boolean; // Enables Viewing Transcripts Stored Outside of Twilio
-  post_survey_serverless_handled: boolean; // Post Survey handled in serverless instead of in Flex
   enable_csam_clc_report: boolean; // Enables CSAM child Reports
   enable_counselor_toolkits: boolean; // Enables Counselor Toolkits
   enable_emoji_picker: boolean; // Enables Emoji Picker
   enable_aselo_messaging_ui: boolean; // Enables Aselo Messaging UI iinstead of the default Twilio one - reduced functionality for low spec clients.
   enable_conferencing: boolean; // Enables Conferencing UI and replaces default Twilio components and behavior
   enable_lex: boolean; // Enables consuming from Lex bots
+  backend_handled_chat_janitor: boolean; // [Temporary flag until all accounts are migrated] Enables handling the janitor from taskrouter event listeners
 };
 /* eslint-enable camelcase */
 

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -309,29 +309,26 @@ const isAseloCustomChannelTask = (task: CustomITask) =>
  * - task wrapup: removes DeactivateConversation
  * - task completed: removes DeactivateConversation
  */
-const setChatOrchestrationsForPostSurvey = () => {
-  const setExcludedDeactivateConversation = (event: keyof ChatOrchestrationsEvents) => {
-    const excludeDeactivateConversation = (orchestrations: ChatOrchestratorEvent[]) =>
-      orchestrations.filter(e => e !== ChatOrchestratorEvent.DeactivateConversation);
+export const excludeDeactivateConversationOrchestration = (featureFlags: FeatureFlags) => {
+  // TODO: remove conditions once all accounts are updated, since we want this code to be executed in all Flex instances once CHI-2202 is implemented and in place
+  if (featureFlags.backend_handled_chat_janitor || featureFlags.enable_post_survey) {
+    const setExcludedDeactivateConversation = (event: keyof ChatOrchestrationsEvents) => {
+      const excludeDeactivateConversation = (orchestrations: ChatOrchestratorEvent[]) =>
+        orchestrations.filter(e => e !== ChatOrchestratorEvent.DeactivateConversation);
 
-    const defaultOrchestrations = ChatOrchestrator.getOrchestrations(event);
+      const defaultOrchestrations = ChatOrchestrator.getOrchestrations(event);
 
-    if (Array.isArray(defaultOrchestrations)) {
-      ChatOrchestrator.setOrchestrations(event, task => {
-        return isAseloCustomChannelTask(task)
-          ? defaultOrchestrations
-          : excludeDeactivateConversation(defaultOrchestrations);
-      });
-    }
-  };
+      if (Array.isArray(defaultOrchestrations)) {
+        ChatOrchestrator.setOrchestrations(event, task => {
+          return isAseloCustomChannelTask(task)
+            ? defaultOrchestrations
+            : excludeDeactivateConversation(defaultOrchestrations);
+        });
+      }
+    };
 
-  setExcludedDeactivateConversation('wrapup');
-  setExcludedDeactivateConversation('completed');
-};
-
-export const setUpPostSurvey = (featureFlags: FeatureFlags) => {
-  if (featureFlags.enable_post_survey) {
-    setChatOrchestrationsForPostSurvey();
+    setExcludedDeactivateConversation('wrapup');
+    setExcludedDeactivateConversation('completed');
   }
 };
 

--- a/twilio-iac/docs/service_configuration.md
+++ b/twilio-iac/docs/service_configuration.md
@@ -4,6 +4,10 @@
 
 See requirements in [twilio-iac/README.md](../README.md)
 
+If at some point you run into an error inside the container, you can try pulling the latest docker image by running
+`docker pull public.ecr.aws/techmatters/terraform:x.y.z` where x.y.z is the docker image defined in `/home/buonapasta/Desktop/TechMatters/flex-plugins/twilio-iac/makefiles/00-setup.make`.
+
+
 ## Usage
 
 All make commands are run from the `twilio-iac` directory.


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/serverless/pull/507

## Description
This PR moces the "exclude DeactivateConversation Orchestration" logic to be executed under two circumstances: 
- If `enable_post_survey` feature flag is enabled, preserving the existing logic.
- If `backend_handled_chat_janitor`is enabled, which will be turned on for those accounts where the post survey is not enabled but we will want to move this logic to be handled by the backend services. This is a change in line with the fix of [this bug](https://tech-matters.atlassian.net/browse/CHI-2202), and is intended to be temporarily enabled until all accounts have been updated with this PR and the corresponding Serverless code, at which point we'll want to remove them - this change should be the default way to handle the orchestrations moving forward at that point.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2202)
- [x] New tests added
- [x] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
See related PR.