### PR TITLE
CHI-2169: Fire an internal action to clear state after accepting a transfer

### DIFF
--- a/plugin-hrm-form/.eslintrc.json
+++ b/plugin-hrm-form/.eslintrc.json
@@ -11,6 +11,7 @@
   "rules": {
     "no-console": "off",
     "no-warning-comments": "off",
+    "multiline-comment-style": "off",
     "no-confusing-arrow": "off",
     "no-alert": "off",
     "no-shadow": "off",

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -125,9 +125,16 @@ const takeControlIfTransfer = async (task: ITask) => {
 
 const handleTransferredTask = async (task: ITask) => {
   await takeControlIfTransfer(task);
-  const convo = StateHelper.getConversationStateForTask(task);
-  if (convo?.source) {
-    reactivateAseloListeners(convo.source);
+  const convo = StateHelper.getConversationStateForTask(task)?.source;
+  if (convo) {
+    reactivateAseloListeners(convo);
+
+    // Force a refresh of the conversation state when accepting a transfer - this prevents issues caused by pre-existing state for the conversation being loaded prior to accepting the transfer.
+    // Reverse engineering an internal Flex action is one level of grevious hackery below deleting the conversation state from the redux store directly =-/
+    Manager.getInstance().store.dispatch({
+      type: 'CONVERSATION_UNLOAD',
+      meta: { channelSid: convo.sid, conversationSid: convo.sid },
+    });
   }
   await restoreFormIfTransfer(task);
 };


### PR DESCRIPTION
## Description

In order to work around the issue where the flex state can go out of sync if the conversation is already loaded prior to it being transferred, we are explicitly clearing the conversation being transferred from the flex redux state when accepting a text transfer

This forces it to be reloaded from the source and the correct state is then loaded into the UI

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
CHI-2169

### Verification steps

See ticket