### PR TITLE
webchat: replace window location on quick exit

### DIFF
--- a/webchat/src/aselo-webchat.tsx
+++ b/webchat/src/aselo-webchat.tsx
@@ -207,7 +207,7 @@ export const initWebchat = async () => {
 
   FlexWebChat.Actions.addListener('afterRestartEngagement', (payload) => {
     if (payload.exit) {
-      setTimeout(() => window.open('https://google.com', '_self'), 1000);
+      setTimeout(() => window.location.replace('https://google.com'), 1000);
     }
   });
 


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- This replaces window location on quick exit instead of navigating so the back button won't work.
- Webchat was moved to flex before this change. This is an identical PR to https://github.com/techmatters/webchat/pull/276. 

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes # https://tech-matters.atlassian.net/browse/CHI-2204

### Verification steps
- Ensure that Quick Exit button actually clears browsing history