### PR TITLE
[Bug Fix] Sound alert does not play on first contact

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -210,7 +210,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     subscribeReservedTaskAlert();
     subscribeNewMessageAlertOnPluginInit();
     // Force one notification on init so AudioPlayer is eagerly loaded
-    playNotification('bell');
+    playNotification('silence');
 
     const managerConfiguration: Flex.Config = {
       // colorTheme: HrmTheme,

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -46,6 +46,7 @@ import { subscribeReservedTaskAlert } from './notifications/reservedTask';
 import { setUpCounselorToolkits } from './components/toolkits/setUpCounselorToolkits';
 import { setupConferenceComponents, setUpConferenceActions } from './conference';
 import { setUpTransferActions } from './transfer/setUpTransferActions';
+import { playNotification } from './notifications/playNotification';
 
 const PLUGIN_NAME = 'HrmFormPlugin';
 
@@ -208,6 +209,8 @@ export default class HrmFormPlugin extends FlexPlugin {
 
     subscribeReservedTaskAlert();
     subscribeNewMessageAlertOnPluginInit();
+    // Force one notification on init so AudioPlayer is eagerly loaded
+    playNotification('bell');
 
     const managerConfiguration: Flex.Config = {
       // colorTheme: HrmTheme,

--- a/plugin-hrm-form/src/notifications/newMessage.ts
+++ b/plugin-hrm-form/src/notifications/newMessage.ts
@@ -14,10 +14,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Manager, StateHelper, AudioPlayerManager, AudioPlayerError } from '@twilio/flex-ui';
+import { Manager, StateHelper } from '@twilio/flex-ui';
 
-import { getHrmConfig } from '../hrmConfig';
 import { addAseloListener } from '../conversationListeners';
+import { playNotification } from './playNotification';
 
 export const subscribeAlertOnConversationJoined = task => {
   const manager = Manager.getInstance();
@@ -46,23 +46,13 @@ const trySubscribeAudioAlerts = (task, ms: number, retries: number) => {
 const notifyNewMessage = messageInstance => {
   try {
     const manager = Manager.getInstance();
-    const { assetsBucketUrl } = getHrmConfig();
 
     const notificationTone = 'bell';
-    const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
 
     const isCounsellor = manager.conversationsClient.user.identity === messageInstance.author;
 
     if (!isCounsellor && document.visibilityState === 'hidden') {
-      AudioPlayerManager.play(
-        {
-          url: notificationUrl,
-          repeatable: false,
-        },
-        (error: AudioPlayerError) => {
-          console.log('AudioPlayerError:', error);
-        },
-      );
+      playNotification(notificationTone);
     }
   } catch (error) {
     console.error('Error in notifyNewMessage:', error);

--- a/plugin-hrm-form/src/notifications/playNotification.ts
+++ b/plugin-hrm-form/src/notifications/playNotification.ts
@@ -1,0 +1,19 @@
+import { AudioPlayerError, AudioPlayerManager } from '@twilio/flex-ui';
+
+import { getHrmConfig } from '../hrmConfig';
+
+export const playNotification = (notificationTone: string) => {
+  const { assetsBucketUrl } = getHrmConfig();
+
+  const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
+
+  return AudioPlayerManager.play(
+    {
+      url: notificationUrl,
+      repeatable: false,
+    },
+    (error: AudioPlayerError) => {
+      console.log('AudioPlayerError:', error);
+    },
+  );
+};

--- a/plugin-hrm-form/src/notifications/playNotification.ts
+++ b/plugin-hrm-form/src/notifications/playNotification.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 import { AudioPlayerError, AudioPlayerManager } from '@twilio/flex-ui';
 
 import { getHrmConfig } from '../hrmConfig';

--- a/plugin-hrm-form/src/notifications/reservedTask.ts
+++ b/plugin-hrm-form/src/notifications/reservedTask.ts
@@ -14,10 +14,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Manager, AudioPlayerManager, AudioPlayerError } from '@twilio/flex-ui';
+import { Manager } from '@twilio/flex-ui';
 
 import { isTwilioTask } from '../types/types';
-import { getHrmConfig } from '../hrmConfig';
+import { playNotification } from './playNotification';
 
 const reservedTaskMedias: { [reservationSid: string]: string } = {};
 
@@ -29,30 +29,19 @@ export const subscribeReservedTaskAlert = () => {
 const notifyReservedTask = reservation => {
   try {
     if (isTwilioTask(reservation.task)) {
-      const { assetsBucketUrl } = getHrmConfig();
-
-      const notificationTone = 'ringtone';
-      const notificationUrl = `${assetsBucketUrl}/notifications/${notificationTone}.mp3`;
-
-      playWhilePending(reservation, notificationUrl);
+      playWhilePending(reservation);
     }
   } catch (error) {
     console.error('Error in notifyReservedTask:', error);
   }
 };
 
-const playWhilePending = (reservation: { sid: string; status: string }, notificationUrl: string) => {
+const playWhilePending = (reservation: { sid: string; status: string }) => {
   const playNotificationIfPending = () => {
     if (reservation.status === 'pending') {
-      const mediaId = AudioPlayerManager.play(
-        {
-          url: notificationUrl,
-          repeatable: false,
-        },
-        (error: AudioPlayerError) => {
-          console.log('AudioPlayerError:', error);
-        },
-      );
+      const notificationTone = 'ringtone';
+
+      const mediaId = playNotification(notificationTone);
 
       reservedTaskMedias[reservation.sid] = mediaId;
       setTimeout(playNotificationIfPending, 500);


### PR DESCRIPTION
## Description
This PR proposes a solution for the below linked bug ticket.
The proposed solution is to play a sound in plugin initialization, in a way that the Audio Player is already loaded and working from the beginning. 
One thing we could/should do is to upload a new "empty sound" to play, but as this requires uploading to every bucket I'll wait for @robert-bo-davis assistance.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2209)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Verification steps
Start a local server on this branch, and confirm that the bug described in the ticket is not reproducible anymore.