### PR TITLE
[filesUrlsMigration] Transcripts use getFileDownloadUrl lambda instead of serverless 

### DIFF
--- a/plugin-hrm-form/src/components/contact/MediaSection/RecordingSection.tsx
+++ b/plugin-hrm-form/src/components/contact/MediaSection/RecordingSection.tsx
@@ -35,10 +35,13 @@ const RecordingSection: React.FC<OwnProps> = ({ contactId, externalStoredRecordi
       setLoading(true);
       setShowButton(false);
 
+      const mediaType = 'recording';
+
       // TODO: this won't currently work for local dev env
       const { media_url: recordingPreSignedUrl } = await fetchHrmApi(
         generateExternalMediaPath(
           contactId,
+          mediaType,
           externalStoredRecording.location.bucket,
           externalStoredRecording.location.key,
         ),

--- a/plugin-hrm-form/src/components/contact/MediaSection/RecordingSection.tsx
+++ b/plugin-hrm-form/src/components/contact/MediaSection/RecordingSection.tsx
@@ -37,7 +37,6 @@ const RecordingSection: React.FC<OwnProps> = ({ contactId, externalStoredRecordi
 
       const mediaType = 'recording';
 
-      // TODO: this won't currently work for local dev env
       const { media_url: recordingPreSignedUrl } = await fetchHrmApi(
         generateExternalMediaPath(
           contactId,

--- a/plugin-hrm-form/src/components/contact/MediaSection/TranscriptSection.tsx
+++ b/plugin-hrm-form/src/components/contact/MediaSection/TranscriptSection.tsx
@@ -24,7 +24,6 @@ import type { TwilioStoredMedia, S3StoredTranscript } from '../../../types/types
 import { contactFormsBase, namespace, RootState } from '../../../states';
 import { generateExternalMediaPath } from '../../../services/ContactService';
 import fetchHrmApi from '../../../services/fetchHrmApi';
-
 import { loadTranscript, TranscriptMessage, TranscriptResult } from '../../../states/contacts/existingContacts';
 import { Box } from '../../../styles/HrmStyles';
 import { GroupedMessage } from '../../Messaging/MessageItem';
@@ -127,12 +126,6 @@ const TranscriptSection: React.FC<Props> = ({
 
       const mediaType = 'transcript';
 
-      console.log('>>> fetchAndLoadTranscript',contactId,
-      mediaType,
-      externalStoredTranscript.location.bucket,
-      externalStoredTranscript.location.key)
-      //fetchAndLoadTranscript 14799 transcript tl-aselo-docs-as-development transcripts/2023/09/11/20230911183503-WT1c08de7b919803824bd60b7228a1190a.json
-
       const transcriptPreSignedUrl = await fetchHrmApi(
         generateExternalMediaPath(
           contactId,
@@ -141,7 +134,6 @@ const TranscriptSection: React.FC<Props> = ({
           externalStoredTranscript.location.key,
         ),
       );
-      console.log('>>> transcriptPreSignedUrl', transcriptPreSignedUrl)
 
       const transcriptResponse = await fetch(transcriptPreSignedUrl.downloadUrl);
 
@@ -152,7 +144,6 @@ const TranscriptSection: React.FC<Props> = ({
 
       setLoading(false);
     } catch (err) {
-      console.log('>>>', err)
       handleFetchAndLoadException(err);
     }
   };

--- a/plugin-hrm-form/src/components/contact/MediaSection/TranscriptSection.tsx
+++ b/plugin-hrm-form/src/components/contact/MediaSection/TranscriptSection.tsx
@@ -22,7 +22,9 @@ import format from 'date-fns/format';
 
 import type { TwilioStoredMedia, S3StoredTranscript } from '../../../types/types';
 import { contactFormsBase, namespace, RootState } from '../../../states';
-import { getFileDownloadUrl } from '../../../services/ServerlessService';
+import { generateExternalMediaPath } from '../../../services/ContactService';
+import fetchHrmApi from '../../../services/fetchHrmApi';
+
 import { loadTranscript, TranscriptMessage, TranscriptResult } from '../../../states/contacts/existingContacts';
 import { Box } from '../../../styles/HrmStyles';
 import { GroupedMessage } from '../../Messaging/MessageItem';
@@ -123,7 +125,24 @@ const TranscriptSection: React.FC<Props> = ({
     try {
       setLoading(true);
 
-      const transcriptPreSignedUrl = await getFileDownloadUrl(externalStoredTranscript.location.key);
+      const mediaType = 'transcript';
+
+      console.log('>>> fetchAndLoadTranscript',contactId,
+      mediaType,
+      externalStoredTranscript.location.bucket,
+      externalStoredTranscript.location.key)
+      //fetchAndLoadTranscript 14799 transcript tl-aselo-docs-as-development transcripts/2023/09/11/20230911183503-WT1c08de7b919803824bd60b7228a1190a.json
+
+      const transcriptPreSignedUrl = await fetchHrmApi(
+        generateExternalMediaPath(
+          contactId,
+          mediaType,
+          externalStoredTranscript.location.bucket,
+          externalStoredTranscript.location.key,
+        ),
+      );
+      console.log('>>> transcriptPreSignedUrl', transcriptPreSignedUrl)
+
       const transcriptResponse = await fetch(transcriptPreSignedUrl.downloadUrl);
 
       validateFetchResponse(transcriptResponse);
@@ -133,6 +152,7 @@ const TranscriptSection: React.FC<Props> = ({
 
       setLoading(false);
     } catch (err) {
+      console.log('>>>', err)
       handleFetchAndLoadException(err);
     }
   };

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -40,6 +40,7 @@ import {
   isOfflineContactTask,
   isTwilioTask,
   SearchAPIContact,
+  ContactMediaType
 } from '../types/types';
 import { saveContactToExternalBackend } from '../dualWrite';
 import { getNumberFromTask } from '../utils';
@@ -396,5 +397,6 @@ export async function connectToCase(contactId, caseId) {
   return fetchHrmApi(`/contacts/${contactId}/connectToCase`, options);
 }
 
-export const generateExternalMediaPath = (contactId: string, bucket: string, key: string) =>
-  `/files/urls?method=getObject&objectType=contact&objectId=${contactId}&fileType=recording&bucket=${bucket}&key=${key}`;
+
+export const generateExternalMediaPath = (contactId: string, mediaType: ContactMediaType, bucket: string, key: string) =>
+  `/files/urls?method=getObject&objectType=contact&objectId=${contactId}&fileType=${mediaType}&bucket=${bucket}&key=${key}`;

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -40,7 +40,7 @@ import {
   isOfflineContactTask,
   isTwilioTask,
   SearchAPIContact,
-  ContactMediaType
+  ContactMediaType,
 } from '../types/types';
 import { saveContactToExternalBackend } from '../dualWrite';
 import { getNumberFromTask } from '../utils';
@@ -397,6 +397,10 @@ export async function connectToCase(contactId, caseId) {
   return fetchHrmApi(`/contacts/${contactId}/connectToCase`, options);
 }
 
-
-export const generateExternalMediaPath = (contactId: string, mediaType: ContactMediaType, bucket: string, key: string) =>
+export const generateExternalMediaPath = (
+  contactId: string,
+  mediaType: ContactMediaType,
+  bucket: string,
+  key: string,
+) =>
   `/files/urls?method=getObject&objectType=contact&objectId=${contactId}&fileType=${mediaType}&bucket=${bucket}&key=${key}`;

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -400,11 +400,12 @@ const getInsightsUpdateFunctionsForConfig = (
 
 const generateUrlProviderBlock = (externalRecordingInfo: ExternalRecordingInfoSuccess, contact: HrmServiceContact) => {
   const { hrmMicroserviceBaseUrl } = getHrmConfig();
+  const mediaType = 'recording';
   const { bucket, key } = externalRecordingInfo;
 
   const url_provider = generateUrl(
     new URL(hrmMicroserviceBaseUrl),
-    generateExternalMediaPath(contact.id, bucket, key),
+    generateExternalMediaPath(contact.id, mediaType, bucket, key),
   ).toString();
 
   return [

--- a/plugin-hrm-form/src/services/fetchApi.ts
+++ b/plugin-hrm-form/src/services/fetchApi.ts
@@ -47,7 +47,7 @@ export const generateUrl = (baseUrl: URL, endpointPath: string): URL => {
  */
 export const fetchApi = async (baseUrl: URL, endpointPath: string, options: RequestInit): Promise<any> => {
   const url = generateUrl(baseUrl, endpointPath);
-  console.log('>>> fetchApi url', url)
+
   const defaultOptions = {
     method: 'GET',
     headers: {
@@ -75,7 +75,6 @@ export const fetchApi = async (baseUrl: URL, endpointPath: string, options: Requ
     try {
       body = await response.json();
     } catch (err) {
-      console.log('>>> fetchApi err', err)
       body = await response.text();
     }
     throw new ApiError(`Error response: ${response.status} (${response.statusText})`, { response, body });

--- a/plugin-hrm-form/src/services/fetchApi.ts
+++ b/plugin-hrm-form/src/services/fetchApi.ts
@@ -47,7 +47,7 @@ export const generateUrl = (baseUrl: URL, endpointPath: string): URL => {
  */
 export const fetchApi = async (baseUrl: URL, endpointPath: string, options: RequestInit): Promise<any> => {
   const url = generateUrl(baseUrl, endpointPath);
-
+  console.log('>>> fetchApi url', url)
   const defaultOptions = {
     method: 'GET',
     headers: {
@@ -75,6 +75,7 @@ export const fetchApi = async (baseUrl: URL, endpointPath: string, options: Requ
     try {
       body = await response.json();
     } catch (err) {
+      console.log('>>> fetchApi err', err)
       body = await response.text();
     }
     throw new ApiError(`Error response: ${response.status} (${response.statusText})`, { response, body });

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -120,6 +120,9 @@ export type S3StoredRecording = {
 
 type S3StoredMedia = S3StoredTranscript | S3StoredRecording;
 
+// Extract the 'type' property from S3StoredMedia to create ContactMediaType
+export type ContactMediaType = S3StoredMedia['type'];
+
 export type ConversationMedia = TwilioStoredMedia | S3StoredMedia;
 
 export const isTwilioStoredMedia = (m: ConversationMedia): m is TwilioStoredMedia => m.store === 'twilio';


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- Made necessary changes to use mediaType as transcript or recording for the `files-urls` lambda instead of the getFileDownloadUrl in serverless

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Related Issues
Fixes # https://tech-matters.atlassian.net/browse/CHI-2228

### Verification steps
- Check a transcript and recording for any contact