### PR TITLE
refactor: use guard pattern for shouldSendInsightsData

### DIFF
--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -301,6 +301,7 @@ export type OfflineContactTask = {
     channelType: 'default';
     helplineToSave?: string;
     preEngagementData?: Record<string, string>;
+    skipInsights?: boolean;
   };
   channelType: 'default';
 };

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -62,8 +62,7 @@ export const shouldSendInsightsData = (task: CustomITask) => {
   if (isOfflineContactTask(task)) return false;
   if (task.attributes?.skipInsights) return false;
 
-  const hasTaskControl = !featureFlags.enable_transfers || TransferHelpers.hasTaskControl(task);
-  if (!hasTaskControl) return false;
+  if (featureFlags.enable_transfers && !TransferHelpers.hasTaskControl(task)) return false;
 
   return true;
 };

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -59,7 +59,7 @@ export const shouldSendInsightsData = (task: CustomITask) => {
   const featureFlags = getAseloFeatureFlags();
 
   if (!featureFlags.enable_save_insights) return false;
-  if (!isOfflineContactTask(task) && task.attributes?.skipInsights) return false;
+  if (task.attributes?.skipInsights) return false;
   if (featureFlags.enable_transfers && !TransferHelpers.hasTaskControl(task)) return false;
 
   return true;

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -54,6 +54,7 @@ export const loadCurrentDefinitionVersion = async () => {
 /**
  * @param task
  */
+/* eslint-disable sonarjs/prefer-single-boolean-return */
 export const shouldSendInsightsData = (task: CustomITask) => {
   const featureFlags = getAseloFeatureFlags();
 
@@ -66,6 +67,7 @@ export const shouldSendInsightsData = (task: CustomITask) => {
 
   return true;
 };
+/* eslint-enable sonarjs/prefer-single-boolean-return */
 
 const saveEndMillis = async (payload: ActionPayload) => {
   Manager.getInstance().store.dispatch(Actions.saveEndMillis(payload.task.taskSid));

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -59,9 +59,7 @@ export const shouldSendInsightsData = (task: CustomITask) => {
   const featureFlags = getAseloFeatureFlags();
 
   if (!featureFlags.enable_save_insights) return false;
-  if (isOfflineContactTask(task)) return false;
-  if (task.attributes?.skipInsights) return false;
-
+  if (!isOfflineContactTask(task) && task.attributes?.skipInsights) return false;
   if (featureFlags.enable_transfers && !TransferHelpers.hasTaskControl(task)) return false;
 
   return true;


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Quick refactor to get rid of `as any` and move to guard pattern for complex bool