### PR TITLE
Wider column on Teams page

### DIFF
--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -135,4 +135,16 @@ div.Twilio-Splitter div.Twilio-AgentDesktopView\.Panel2 {
     width: 100%;
     justify-content: center;
  }
+
+/**
+ * Teams View CSS Overrides:
+ * 1. Make first column wider (Agent column)
+ */
+ .Twilio-WorkersDataTable th:not(:first-of-type) {
+    width: calc(14rem) !important;
+ }
+
+ .Twilio-WorkersDataTable th:first-of-type {
+    width: auto !important;
+ }
  


### PR DESCRIPTION
## Description
This PR adds a CSS override to make the first column on Teams page wider.

![image](https://github.com/techmatters/flex-plugins/assets/1504544/9ec4f01d-d319-4ac6-8a81-dcdb05c2c16d)

### Related Issues
Fixes [CHI-2080](https://tech-matters.atlassian.net/browse/CHI-2080)

### Verification steps
- Go to Teams Page
- See Agent column is very wide

[CHI-2080]: https://tech-matters.atlassian.net/browse/CHI-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ