### PR TITLE
Bring back Twilio recordings overlay

### DIFF
--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -240,12 +240,15 @@ const ContactDetailsHome: React.FC<Props> = function ({
       (twilioStoredTranscript || externalStoredTranscript),
   );
 
+  const twilioStoredRecording =
+    featureFlags.enable_voice_recordings && savedContact.details.conversationMedia?.find(isTwilioStoredMedia);
+  const externalStoredRecording = savedContact.details.conversationMedia?.find(isS3StoredRecording);
   const showRecordingSection = Boolean(
     isVoiceChannel(channel) &&
+      savedContact.details.conversationMedia?.length &&
       can(PermissionActions.VIEW_RECORDING) &&
-      savedContact.details.conversationMedia?.find(isS3StoredRecording),
+      (twilioStoredRecording || externalStoredRecording),
   );
-  const externalStoredRecording = savedContact.details.conversationMedia?.find(isS3StoredRecording);
 
   const csamReportEnabled = featureFlags.enable_csam_report && featureFlags.enable_csam_clc_report;
 
@@ -421,7 +424,11 @@ const ContactDetailsHome: React.FC<Props> = function ({
           showEditButton={false}
         >
           <Flex justifyContent="center" flexDirection="row" paddingTop="20px">
-            <RecordingSection contactId={contactId} externalStoredRecording={externalStoredRecording} />{' '}
+            <RecordingSection
+              contactId={contactId}
+              externalStoredRecording={externalStoredRecording}
+              loadConversationIntoOverlay={loadConversationIntoOverlay}
+            />{' '}
           </Flex>
         </ContactDetailsSection>
       )}


### PR DESCRIPTION
## Description
This PR is a hotfix for the 2023-09-21 production deploy, to bring back the Twilio recordings overlay if external recordings is not enabled for a given account (also use for older contact records where external recordings was not implemented).
