### PR TITLE
(NR) Set debug log level on dev

### DIFF
--- a/twilio-iac/helplines/as/configs/service-configuration/development.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/development.json
@@ -63,6 +63,7 @@
                 "name": "Simple Light"
             }
         },
+        "logLevel": "debug",
         "showRealtimeQueuesStats": true
     }
 }


### PR DESCRIPTION
## Description
This adds configuration so that Flex will dump debug-level logs on Dev. This can help to better debug issues. Logs can be filtered under the "All Levels" menu:
![image](https://github.com/techmatters/flex-plugins/assets/10714292/be6adff1-8397-470f-beda-4fc459faf665)

Since this is a minor, very low risk change, I'm not going to ask for review, but please say something if this is an issue.