### PR TITLE
Fix teams page column width

### DIFF
--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -138,12 +138,9 @@ div.Twilio-Splitter div.Twilio-AgentDesktopView\.Panel2 {
 
 /**
  * Teams View CSS Overrides:
- * 1. Make first column wider (Agent column)
+ * - Overrides first column (Agent) width from fixed to auto.
+ * - Now, column 1 and 3 have auto width, meaning they'll take the available space equally
  */
- .Twilio-WorkersDataTable th:not(:first-of-type) {
-    width: calc(14rem) !important;
- }
-
  .Twilio-WorkersDataTable th:first-of-type {
     width: auto !important;
  }


### PR DESCRIPTION
## Description
Now it will **only override the first column width**, making it `auto`.
Column 3 is set to `auto` by default.
So now, columns 1 and 3 with equally take the available space, while column 2 has a fixed width.

![image](https://github.com/techmatters/flex-plugins/assets/1504544/f7be2a64-e142-4891-8909-6a5b51c21bbe)

### Related Issues
Fixes [CHI-2080](https://tech-matters.atlassian.net/browse/CHI-2080)

### Verification steps
See teams page.

[CHI-2080]: https://tech-matters.atlassian.net/browse/CHI-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ