### PR TITLE
Increase ringtone timeout to 3 seconds to fix AudioPlayerError

### DIFF
--- a/plugin-hrm-form/src/notifications/reservedTask.ts
+++ b/plugin-hrm-form/src/notifications/reservedTask.ts
@@ -44,7 +44,7 @@ const playWhilePending = (reservation: { sid: string; status: string }) => {
       const mediaId = playNotification(notificationTone);
 
       reservedTaskMedias[reservation.sid] = mediaId;
-      setTimeout(playNotificationIfPending, 500);
+      setTimeout(playNotificationIfPending, 3000);
     }
   };
 


### PR DESCRIPTION
## Description
We have been seeing a constant AudioPlayerError on the ringtone for a new reserved task. The issue is that we only had a timeout of 500 milliseconds, but the ringtone audio file was 2 seconds long. Therefore we were trying to enqueue up to 4 more tones while one was still playing. Twilio does not allow more than one non-repeatable tone to be in the queue at a time. This is why we ended up seeing a string of 4 error messages in the console logs every time the tone played. And it was why a tone played about every 3 seconds, rather than every half second as defined in the code.

I increased the timeout to 3 seconds, which gets rid of the errors and keeps the frequency of the tones to about what it was before.

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [x] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Addresses CHI-1964

### Verification steps
- Open Flex on this branch
- Open the dev console
- Send a chat or voice task
- While the task is pending for you, note that the notification sound repeats every 3 seconds but there are no AudioPlayerErrors as described in CHI-1964