### PR TITLE
Import only `format` from `date-fns` lib

### DIFF
--- a/webchat/src/messagebubble-component/CustomMessageBubble.tsx
+++ b/webchat/src/messagebubble-component/CustomMessageBubble.tsx
@@ -16,7 +16,7 @@
 
 // import { MessageBubble } from '@twilio/flex-webchat-ui';
 import React from 'react';
-import { format } from 'date-fns';
+import format from 'date-fns/esm/format';
 
 import {
   CustomBubbleContainer,


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- Import only `format` from `date-fns` lib

This decreases the bundle size significantly
![Screenshot 2023-09-26 at 4 24 53 PM](https://github.com/techmatters/flex-plugins/assets/102122005/0daad91d-0cab-404a-aa68-356db3f40e5d)


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes # [CHI-2269](https://tech-matters.atlassian.net/browse/CHI-2269)

### Verification steps
Run `BUNDLE_ANALYZER=true npm run build:dev` 

[CHI-2269]: https://tech-matters.atlassian.net/browse/CHI-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ