### PR TITLE
CHI-1434: Remove transformation of search results

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -18,7 +18,6 @@ import {
   callTypes,
   CategoriesDefinition,
   CategoryEntry,
-  DefinitionVersion,
   DefinitionVersionId,
   loadDefinition,
   useFetchDefinitions,
@@ -26,12 +25,7 @@ import {
 import { TaskHelper } from '@twilio/flex-ui';
 
 import { baseMockConfig as mockBaseConfig, mockGetDefinitionsResponse } from '../mockGetConfig';
-import {
-  handleTwilioTask,
-  saveContact,
-  transformCategories,
-  updateContactsFormInHrm,
-} from '../../services/ContactService';
+import { handleTwilioTask, saveContact, updateContactsFormInHrm } from '../../services/ContactService';
 import { channelTypes } from '../../states/DomainConstants';
 import { getDefinitionVersions, getHrmConfig } from '../../hrmConfig';
 import { VALID_EMPTY_CONTACT, VALID_EMPTY_METADATA } from '../testContacts';
@@ -378,108 +372,6 @@ test('updateContactsFormInHrm - calls a PATCH HRM endpoint using the supplied co
   } finally {
     mockedFetch.mockClear();
   }
-});
-
-describe('transformCategories', () => {
-  let mockDef: DefinitionVersion;
-  beforeAll(async () => {
-    const formDefinitionsBaseUrl = buildBaseURL(DefinitionVersionId.v1);
-    await mockFetchImplementation(formDefinitionsBaseUrl);
-
-    const v1Defs = await loadDefinition(formDefinitionsBaseUrl);
-    mockDef = {
-      ...v1Defs,
-      tabbedForms: {
-        ...v1Defs.tabbedForms,
-        IssueCategorizationTab: jest.fn(() => ({
-          category1: {
-            color: '',
-            subcategories: [
-              { label: 'subCategory1', toolkitUrl: '' },
-              { label: 'subCategory2', toolkitUrl: '' },
-            ],
-          },
-          category2: {
-            color: '',
-            subcategories: [
-              { label: 'subCategory1', toolkitUrl: '' },
-              { label: 'subCategory2', toolkitUrl: '' },
-            ],
-          },
-        })),
-      },
-    };
-  });
-
-  test("Categories in input match the paths of those in definition - sets the subcategories found in defintions to 'true'", () => {
-    const transformed = transformCategories(
-      'a helpline',
-      { category1: ['subCategory2'], category2: ['subCategory1'] },
-      mockDef,
-    );
-    expect(transformed).toStrictEqual({
-      category1: {
-        subCategory1: false,
-        subCategory2: true,
-      },
-      category2: {
-        subCategory1: true,
-        subCategory2: false,
-      },
-    });
-    // Supplied helpline should be used to look up the categories
-    expect(mockDef.tabbedForms.IssueCategorizationTab).toBeCalledWith('a helpline');
-  });
-
-  test("Empty array of categories - produces matrix of categories all set 'false'", () => {
-    const transformed = transformCategories('a helpline', {}, mockDef);
-    expect(transformed).toStrictEqual({
-      category1: {
-        subCategory1: false,
-        subCategory2: false,
-      },
-      category2: {
-        subCategory1: false,
-        subCategory2: false,
-      },
-    });
-  });
-
-  test("Categories in input don't match the paths of those in definition - adds the missing paths to the output set to 'true'", () => {
-    const transformed = transformCategories(
-      'a helpline',
-      { category3: ['subCategory2'], category2: ['subCategory1'] },
-      mockDef,
-    );
-    expect(transformed).toStrictEqual({
-      category1: {
-        subCategory1: false,
-        subCategory2: false,
-      },
-      category2: {
-        subCategory1: true,
-        subCategory2: false,
-      },
-      category3: {
-        subCategory2: true,
-      },
-    });
-  });
-
-  test('Empty categories in input - adds empty category to output', () => {
-    const transformed = transformCategories('a helpline', { category3: [] }, mockDef);
-    expect(transformed).toStrictEqual({
-      category1: {
-        subCategory1: false,
-        subCategory2: false,
-      },
-      category2: {
-        subCategory1: false,
-        subCategory2: false,
-      },
-      category3: {},
-    });
-  });
 });
 
 describe('handleTwilioTask() (externalRecording)', () => {

--- a/plugin-hrm-form/src/___tests__/utils/sharedState.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/sharedState.test.ts
@@ -21,29 +21,24 @@ import SyncClient from 'twilio-sync';
 import { DefinitionVersionId, loadDefinition, useFetchDefinitions } from 'hrm-form-definitions';
 import { Manager } from '@twilio/flex-ui';
 
+import { baseMockConfig, mockGetDefinitionsResponse } from '../mockGetConfig';
 import { transferStatuses } from '../../states/DomainConstants';
 import { createTask } from '../helpers';
-import { mockGetDefinitionsResponse } from '../mockGetConfig';
-import { getAseloFeatureFlags, getDefinitionVersions, getTemplateStrings } from '../../hrmConfig';
+import { getDefinitionVersions } from '../../hrmConfig';
+import { ContactState, saveContactChangesInHrm } from '../../states/contacts/existingContacts';
 import { Contact } from '../../types/types';
 import { ContactMetadata } from '../../states/contacts/types';
 import { VALID_EMPTY_CONTACT } from '../testContacts';
 import { RootState } from '../../states';
-import { ContactState } from '../../states/contacts/existingContacts';
 import { RecursivePartial } from '../RecursivePartial';
 import { loadFormSharedState, saveFormSharedState, setUpSharedStateClient } from '../../utils/sharedState';
 
-jest.mock('../../hrmConfig', () => ({
-  getAseloFeatureFlags: jest.fn(),
-  getTemplateStrings: () => ({
-    SharedStateSaveFormError: 'Error saving',
-    SharedStateLoadFormError: 'Error loading',
-  }),
-}));
-
 jest.mock('../../states/contacts/existingContacts', () => ({
   ...jest.requireActual('../../states/contacts/existingContacts'),
-  saveContactChangesInHrm: jest.fn(),
+  saveContactChangesInHrm: jest.fn((id, contact, _, task) => {
+    console.log('saveContactChangesInHrm', id, contact, task);
+    return Promise.resolve({ ...contact, taskId: task });
+  }),
 }));
 
 jest.mock('../../states/contacts/actions', () => ({
@@ -66,41 +61,9 @@ jest.mock('../../fullStory', () => ({
 }));
 
 jest.mock('twilio-sync', () => jest.fn());
-const transferContactState = {
-  savedContact: {
-    ...VALID_EMPTY_CONTACT,
-    rawJson: {
-      categories: undefined,
-      contactlessTask: undefined,
-      draft: undefined,
-    } as any,
-    timeOfContact: new Date().toISOString(),
-    csamReports: undefined,
-    referrals: undefined,
-    helpline: 'a helpline',
-    channel: 'web',
-    taskId: 'transferred-task-id',
-  },
-  metadata: {
-    draft: undefined,
-  } as ContactMetadata,
-  references: new Set<string>(),
-};
+let transferContactState;
 
-const mockFlexManager = {
-  store: {
-    getState: (): RecursivePartial<RootState> => ({
-      'plugin-hrm-form': {
-        activeContacts: {
-          existingContacts: {
-            12345: transferContactState as ContactState,
-          },
-        },
-      },
-    }),
-    dispatch: jest.fn(),
-  },
-};
+let mockFlexManager;
 
 const contact = { helpline: 'a helpline' } as Contact;
 const metadata = {} as ContactMetadata;
@@ -132,9 +95,7 @@ const mockSharedState = {
   },
 };
 
-const mockGetAseloFeatureFlags: jest.Mock = getAseloFeatureFlags as jest.Mock;
 let mockSyncClient: jest.Mock = (SyncClient as unknown) as jest.Mock;
-window.alert = jest.fn();
 let mockV1;
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -144,146 +105,190 @@ beforeAll(async () => {
   const formDefinitionsBaseUrl = buildBaseURL(DefinitionVersionId.v1);
   await mockFetchImplementation(formDefinitionsBaseUrl);
   mockV1 = await loadDefinition(formDefinitionsBaseUrl);
-});
-
-beforeEach(() => {
-  jest.resetAllMocks();
   mockSyncClient = (SyncClient as unknown) as jest.Mock;
   mockGetDefinitionsResponse(getDefinitionVersions, DefinitionVersionId.v1, mockV1);
-  (getTemplateStrings as jest.Mock).mockReturnValue({
-    SharedStateSaveFormError: 'Error saving',
-    SharedStateLoadFormError: 'Error loading',
-  });
-  (Manager.getInstance as jest.Mock).mockReturnValue(mockFlexManager);
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
   mockSharedStateDocuments = {};
-  task.attributes.transferMeta = {
-    originalTask: 'transferred-task-id',
-  };
-});
-
-describe('Test with no feature flag', () => {
-  test('saveFormSharedState', async () => {
-    mockGetAseloFeatureFlags.mockReturnValue({});
-    const { saveFormSharedState } = require('../../utils/sharedState');
-
-    const documentName = await saveFormSharedState(form, task);
-    expect(documentName).toBeNull();
-  });
-
-  test('loadFormSharedState', async () => {
-    mockGetAseloFeatureFlags.mockReturnValue({});
-    const { loadFormSharedState } = require('../../utils/sharedState');
-
-    const loadedForm = await loadFormSharedState(task);
-    expect(loadedForm).toBeNull();
-  });
-});
-
-describe('Test with undefined sharedState', () => {
-  test('saveFormSharedState', async () => {
-    mockGetAseloFeatureFlags.mockReturnValue({ enable_transfers: true });
-    const documentName = await saveFormSharedState(form, task);
-    expect(documentName).toBeNull();
-    expect(window.alert).toBeCalledWith('Error saving');
-  });
-
-  test('loadFormSharedState', async () => {
-    mockGetAseloFeatureFlags.mockReturnValue({ enable_transfers: true });
-
-    const loadedForm = await loadFormSharedState(task);
-    expect(loadedForm).toBeNull();
-    expect(window.alert).toBeCalledWith('Error loading');
-  });
-});
-
-describe('Test with not connected sharedState', () => {
-  beforeEach(async () => {
-    mockGetAseloFeatureFlags.mockReturnValue({ enable_transfers: true });
-    mockSyncClient.mockImplementation(() => ({
-      on: jest.fn(),
-      connectionState: 'not connected',
-    }));
-    await setUpSharedStateClient();
-  });
-
-  test('saveFormSharedState', async () => {
-    const documentName = await saveFormSharedState(form, task);
-    expect(documentName).toBeNull();
-    expect(window.alert).toBeCalledWith('Error saving');
-  });
-
-  test('loadFormSharedState', async () => {
-    const loadedForm = await loadFormSharedState(task);
-    expect(loadedForm).toBeNull();
-    expect(window.alert).toBeCalledWith('Error loading');
-  });
-});
-
-describe('Test with connected sharedState', () => {
-  beforeEach(async () => {
-    mockGetAseloFeatureFlags.mockReturnValue({ enable_transfers: true });
-    mockSyncClient.mockImplementation(() => mockSharedState);
-    await setUpSharedStateClient();
-  });
-
-  test('saveFormSharedState', async () => {
-    const expected = {
-      helpline: 'a helpline',
-      categories: undefined,
+  transferContactState = {
+    savedContact: {
+      ...VALID_EMPTY_CONTACT,
+      rawJson: {
+        categories: undefined,
+        contactlessTask: undefined,
+        draft: undefined,
+      } as any,
+      timeOfContact: new Date().toISOString(),
       csamReports: undefined,
-      draft: undefined,
-      metadata: {},
       referrals: undefined,
-    };
-    const documentName = await saveFormSharedState(form, task);
-    expect(documentName).toBe('pending-form-taskSid');
-    expect(mockSharedStateDocuments[documentName].data).toStrictEqual(expected);
-    await task.setAttributes({
-      transferMeta: { transferStatus: transferStatuses.accepted, formDocument: documentName },
+      helpline: 'a helpline',
+      channel: 'web',
+      taskId: 'transferred-task-id',
+    },
+    metadata: {
+      draft: undefined,
+    } as ContactMetadata,
+    references: new Set<string>(),
+  };
+
+  mockFlexManager = {
+    store: {
+      getState: (): RecursivePartial<RootState> => ({
+        'plugin-hrm-form': {
+          activeContacts: {
+            existingContacts: {
+              12345: transferContactState as ContactState,
+            },
+          },
+        },
+      }),
+      dispatch: jest.fn(),
+    },
+  };
+  (Manager.getInstance as jest.Mock).mockReturnValue(mockFlexManager);
+  await task.setAttributes({
+    transferMeta: {
+      originalTask: 'transferred-task-id',
+    },
+  });
+});
+describe('sharedState', () => {
+  describe('Test with no feature flag', () => {
+    test('saveFormSharedState', async () => {
+      baseMockConfig.featureFlags.enable_transfers = false;
+      const { saveFormSharedState } = require('../../utils/sharedState');
+
+      const documentName = await saveFormSharedState(form, task);
+      expect(documentName).toBeNull();
+    });
+
+    test('loadFormSharedState', async () => {
+      baseMockConfig.featureFlags.enable_transfers = false;
+      const { loadFormSharedState } = require('../../utils/sharedState');
+
+      const loadedForm = await loadFormSharedState(task);
+      expect(loadedForm).toBeNull();
     });
   });
 
-  test('loadFormSharedState', async () => {
-    const expected: ContactState = {
-      ...transferContactState,
-      savedContact: {
-        ...transferContactState.savedContact,
-        timeOfContact: expect.any(String),
-        taskId: 'transferred-task-id',
-      } as Contact,
-    };
-    const loadedForm = await loadFormSharedState(task);
-    expect(loadedForm).toStrictEqual(expected);
-  });
-});
+  describe('Test with undefined sharedState', () => {
+    test('saveFormSharedState', async () => {
+      baseMockConfig.featureFlags.enable_transfers = true;
+      const documentName = await saveFormSharedState(form, task);
+      expect(documentName).toBeNull();
+    });
 
-describe('Test throwing errors', () => {
-  const error = jest.fn();
-  console.error = error;
+    test('loadFormSharedState', async () => {
+      baseMockConfig.featureFlags.enable_transfers = true;
 
-  beforeEach(async () => {
-    mockGetAseloFeatureFlags.mockReturnValue({ enable_transfers: true });
-    mockSyncClient.mockImplementation(() => ({
-      document: () => {
-        throw new Error();
-      },
-      on: jest.fn(),
-    }));
-    await setUpSharedStateClient();
-    error.mockReset();
+      const loadedForm = await loadFormSharedState(task);
+      expect(loadedForm).toBe(transferContactState);
+    });
   });
 
-  test('saveFormSharedState', async () => {
-    expect(error).not.toBeCalled();
-    const documentName = await saveFormSharedState(form, task);
-    expect(documentName).toBeNull();
-    expect(error).toBeCalled();
+  describe('Test with not connected sharedState', () => {
+    beforeEach(async () => {
+      baseMockConfig.featureFlags.enable_transfers = true;
+      mockSyncClient.mockImplementation(() => ({
+        on: jest.fn(),
+        connectionState: 'not connected',
+      }));
+      await setUpSharedStateClient();
+    });
+
+    test('saveFormSharedState', async () => {
+      const documentName = await saveFormSharedState(form, task);
+      expect(documentName).toBeNull();
+    });
+
+    test('loadFormSharedState', async () => {
+      const loadedForm = await loadFormSharedState(task);
+      expect(loadedForm).toBe(transferContactState);
+    });
   });
 
-  test('loadFormSharedState', async () => {
-    expect(error).not.toBeCalled();
-    const loadedForm = await loadFormSharedState(task);
-    expect(loadedForm).toBeNull();
-    expect(error).toBeCalled();
+  describe('Test with connected sharedState', () => {
+    beforeEach(async () => {
+      baseMockConfig.featureFlags.enable_transfers = true;
+      mockSyncClient.mockImplementation(() => mockSharedState);
+      await setUpSharedStateClient();
+    });
+
+    test('saveFormSharedState', async () => {
+      const expected = {
+        helpline: 'a helpline',
+        categories: undefined,
+        csamReports: undefined,
+        draft: undefined,
+        metadata: {},
+        referrals: undefined,
+      };
+      const documentName = await saveFormSharedState(form, task);
+      expect(documentName).toBe('pending-form-taskSid');
+      expect(mockSharedStateDocuments[documentName].data).toStrictEqual(expected);
+      await task.setAttributes({
+        transferMeta: { transferStatus: transferStatuses.accepted, formDocument: documentName },
+      });
+    });
+
+    test('loadFormSharedState', async () => {
+      const expected: ContactState = {
+        ...transferContactState,
+        savedContact: {
+          ...transferContactState.savedContact,
+          timeOfContact: expect.any(String),
+          taskId: 'taskSid',
+        } as Contact,
+      };
+      await task.setAttributes({
+        transferMeta: {
+          originalTask: 'transferred-task-id',
+          formDocument: 'pending-form-transferred-task-id',
+        },
+      });
+      mockSharedStateDocuments['pending-form-transferred-task-id'] = {
+        data: {
+          categories: undefined,
+          contactlessTask: undefined,
+          draft: undefined,
+          helpline: 'a helpline',
+        },
+      };
+      const loadedForm = await loadFormSharedState(task);
+      expect(loadedForm).toStrictEqual(expected);
+    });
+  });
+
+  describe('Test throwing errors', () => {
+    const error = jest.fn();
+    console.error = error;
+
+    beforeEach(async () => {
+      baseMockConfig.featureFlags.enable_transfers = true;
+      mockSyncClient.mockImplementation(() => ({
+        document: () => {
+          throw new Error();
+        },
+        on: jest.fn(),
+      }));
+      await setUpSharedStateClient();
+      error.mockClear();
+    });
+
+    test('saveFormSharedState', async () => {
+      expect(error).not.toBeCalled();
+      const documentName = await saveFormSharedState(form, task);
+      expect(documentName).toBeNull();
+      expect(error).toBeCalled();
+    });
+
+    test('loadFormSharedState', async () => {
+      expect(error).not.toBeCalled();
+      const loadedForm = await loadFormSharedState(task);
+      expect(loadedForm).toBe(transferContactState);
+      expect(error).toBeCalled();
+    });
   });
 });

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -15,7 +15,6 @@
  */
 
 import { TaskHelper } from '@twilio/flex-ui';
-import { CallTypes, DefinitionVersion } from 'hrm-form-definitions';
 
 import { isNonDataCallType } from '../states/validationRules';
 import { getQueryParams } from './PaginationParams';
@@ -23,14 +22,7 @@ import { fillEndMillis, getConversationDuration } from '../utils/conversationDur
 import { fetchHrmApi } from './fetchHrmApi';
 import { getDateTime } from '../utils/helpers';
 import { getDefinitionVersions, getHrmConfig } from '../hrmConfig';
-import {
-  ContactRawJson,
-  ConversationMedia,
-  CSAMReportEntry,
-  Contact,
-  isOfflineContactTask,
-  isTwilioTask,
-} from '../types/types';
+import { ContactRawJson, ConversationMedia, Contact, isOfflineContactTask, isTwilioTask } from '../types/types';
 import { saveContactToExternalBackend } from '../dualWrite';
 import { getNumberFromTask } from '../utils';
 import { ContactMetadata } from '../states/contacts/types';
@@ -41,8 +33,6 @@ import {
   shouldGetExternalRecordingInfo,
 } from './getExternalRecordingInfo';
 import { SearchParams } from '../states/search/types';
-import { ChannelTypes } from '../states/DomainConstants';
-import { ResourceReferral } from '../states/contacts/resourceReferral';
 import { ContactDraftChanges } from '../states/contacts/existingContacts';
 import { newContactState } from '../states/contacts/contactState';
 import { ApiError, FetchOptions } from './fetchApi';
@@ -61,114 +51,7 @@ export async function searchContacts(
     body: JSON.stringify(searchParams),
   };
 
-  const rawResult = await fetchHrmApi(`/contacts/search${queryParams}`, options);
-
-  return {
-    ...rawResult,
-    contacts: transformSearchAPIContactToContact(rawResult.contacts),
-  };
-}
-
-// Represents contacts in the format returned by the search contacts API.
-// TODO: Remove this once this API is aligned with the standard contact format
-type SearchAPIContact = {
-  contactId: string;
-  overview: {
-    helpline: string;
-    dateTime: string;
-    name: string;
-    customerNumber: string;
-    callType: CallTypes | '';
-    categories: {};
-    counselor: string;
-    notes: string;
-    channel: ChannelTypes | 'default';
-    conversationDuration: number;
-    createdBy: string;
-    taskId: string;
-    updatedBy?: string;
-    updatedAt?: string;
-  };
-  details: ContactRawJson;
-  csamReports: CSAMReportEntry[];
-  referrals?: ResourceReferral[];
-};
-/**
- * This function converts contacts returned by /searchContacts into pure HRM Contacts.
- * This function is meant to be temporary, while HRM is not updated yet.
- */
-const transformSearchAPIContactToContact = (contacts: SearchAPIContact[] | Contact[]): Partial<Contact>[] => {
-  const isSearchAPIContact = contact => contact.contactId !== undefined;
-  const shouldTransform = contacts.length > 0 && isSearchAPIContact(contacts[0]);
-
-  if (!shouldTransform) {
-    return contacts as Contact[];
-  }
-
-  /**
-   * Fields that cannot be mapped:
-   * - accountSid
-   * - createdAt
-   * - queueName
-   * - channelSid
-   * - serviceSid
-   */
-  return contacts.map(contact => {
-    const { categories, ...caseInformation } = contact.details?.caseInformation ?? {};
-    return {
-      id: contact.contactId,
-      twilioWorkerId: contact.overview.counselor,
-      number: contact.overview.customerNumber,
-      conversationDuration: contact.overview.conversationDuration,
-      csamReports: contact.csamReports,
-      referrals: contact.referrals,
-      conversationMedia: contact.conversationMedia,
-      createdBy: contact.overview.createdBy,
-      helpline: contact.overview.helpline,
-      taskId: contact.overview.taskId,
-      channel: contact.overview.channel,
-      updatedBy: contact.overview.updatedBy,
-      updatedAt: contact.overview.updatedAt,
-      rawJson: {
-        ...contact.details,
-        categories: {
-          ...contact.overview.categories,
-          ...contact.details.categories,
-        },
-        caseInformation,
-      },
-      timeOfContact: contact.overview.dateTime,
-    };
-  });
-};
-
-// @VisibleForTesting
-// TODO: Remove this once the API is aligned with the type we use in the front end
-export function transformCategories(
-  helpline,
-  categories: ContactRawJson['categories'],
-  definition: DefinitionVersion,
-): Record<string, Record<string, boolean>> {
-  const definitionCategories = definition.tabbedForms.IssueCategorizationTab(helpline);
-  // Expand a full set of categories with all subcategories set to false
-  const emptyCategoryList = Object.entries(definitionCategories).map(([category, { subcategories }]) => {
-    const subcategoryChecklist = subcategories.map<[string, boolean]>(({ label }) => [
-      label,
-      (categories[category] ?? []).includes(label),
-    ]);
-    return [category, Object.fromEntries(subcategoryChecklist)];
-  });
-  const expandedCategories = Object.fromEntries(emptyCategoryList);
-
-  // Merge the empty categories with the ones that have been set
-  Object.entries(categories).forEach(([category, subcategories]) => {
-    expandedCategories[category] = expandedCategories[category] ?? {};
-    subcategories.forEach(subcategory => {
-      expandedCategories[category][subcategory] = true;
-    });
-  });
-
-  return expandedCategories;
+  return fetchHrmApi(`/contacts/search${queryParams}`, options);
 }
 
 type HandleTwilioTaskResponse = {
@@ -363,13 +246,28 @@ export const saveContact = async (
 
   // TODO: add catch clause to handle saving to Sync Doc
   try {
-    await saveContactToExternalBackend(task, payloads.response);
+    // Add the old category format back, but leave out all the explicit false values
+    const legacyCategories = {};
+    Object.entries(payloads.response.rawJson.categories).forEach(([key, value]) => {
+      legacyCategories[key] = Object.fromEntries(value.map(category => [category, true]));
+    });
+    await saveContactToExternalBackend(task, {
+      ...payloads.response,
+      rawJson: {
+        ...payloads.response.rawJson,
+        caseInformation: {
+          ...payloads.response.rawJson.caseInformation,
+          categories: legacyCategories,
+        },
+      },
+    });
   } catch (err) {
     console.error(
       `Saving task with sid ${task.taskSid} failed, presumably the attempt to add it to the pending store also failed so this data is likely lost`,
       err,
     );
   }
+
   return {
     contact: payloads.response,
     externalRecordingInfo: payloads.externalRecordingInfo,

--- a/plugin-hrm-form/src/services/PaginationParams.ts
+++ b/plugin-hrm-form/src/services/PaginationParams.ts
@@ -16,7 +16,13 @@
 
 import { isNullOrUndefined } from '../utils';
 
-export function getQueryParams({ limit, offset, sortBy = undefined, sortDirection = undefined, helpline = undefined }) {
+export function getQueryParams({
+  limit,
+  offset,
+  sortBy = undefined,
+  sortDirection = undefined,
+  helpline = undefined,
+}): string {
   const hasLimit = !isNullOrUndefined(limit);
   const hasOffset = !isNullOrUndefined(offset);
   const hasSortBy = !isNullOrUndefined(sortBy);
@@ -28,5 +34,7 @@ export function getQueryParams({ limit, offset, sortBy = undefined, sortDirectio
   const appendSortBy = hasSortBy ? `sortBy=${sortBy}` : '';
   const appendSortDirection = hasSortDirection ? `sortDirection=${sortDirection}` : '';
   const appendHelpline = hasHelpline ? `helpline=${helpline}` : '';
-  return `?${[appendLimit, appendOffset, appendSortBy, appendSortDirection, appendHelpline].filter(e => e).join('&')}`;
+  return `?${[appendLimit, appendOffset, appendSortBy, appendSortDirection, appendHelpline, 'legacyFormat=false']
+    .filter(e => e)
+    .join('&')}`;
 }


### PR DESCRIPTION
## Description

* Get standard contacts from search endpoint instead of converting them
* Make missing shared state not throw transfer errors - this is so it will be compatible with the next version of Flex that won't use the sync service

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- [N/A] Feature flags added
- [X] Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-1434

### Verification steps

None - folded into upcoming QA run