### PR TITLE
refactor: use insights player for external recordings

### DIFF
--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -424,11 +424,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
           showEditButton={false}
         >
           <Flex justifyContent="center" flexDirection="row" paddingTop="20px">
-            <RecordingSection
-              contactId={contactId}
-              externalStoredRecording={externalStoredRecording}
-              loadConversationIntoOverlay={loadConversationIntoOverlay}
-            />{' '}
+            <RecordingSection loadConversationIntoOverlay={loadConversationIntoOverlay} />{' '}
           </Flex>
         </ContactDetailsSection>
       )}

--- a/plugin-hrm-form/src/components/contact/MediaSection/RecordingSection.tsx
+++ b/plugin-hrm-form/src/components/contact/MediaSection/RecordingSection.tsx
@@ -17,99 +17,38 @@ import React, { useState } from 'react';
 import { Template } from '@twilio/flex-ui';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
-import { ErrorFont, LoadMediaButton, LoadMediaButtonText } from './styles';
+import { LoadMediaButton, LoadMediaButtonText } from './styles';
 import { S3StoredRecording } from '../../../types/types';
-import { fetchHrmApi, generateSignedURLPath } from '../../../services/fetchHrmApi';
 
 type OwnProps = {
-  contactId: string;
-  externalStoredRecording?: S3StoredRecording;
   loadConversationIntoOverlay: () => Promise<void>;
 };
 
-const RecordingSection: React.FC<OwnProps> = ({ contactId, externalStoredRecording, loadConversationIntoOverlay }) => {
-  const [voiceRecording, setVoiceRecording] = useState(null);
+const RecordingSection: React.FC<OwnProps> = ({ loadConversationIntoOverlay }) => {
   const [loading, setLoading] = useState(false);
-  const [showButton, setShowButton] = useState(true);
-  const [errorMessage, setErrorMessage] = useState(null);
 
   const fetchAndLoadRecording = async () => {
-    try {
-      setLoading(true);
-      setShowButton(false);
+    setLoading(true);
 
-      if (externalStoredRecording) {
-        const { media_url: recordingPreSignedUrl } = await fetchHrmApi(
-          generateSignedURLPath({
-            method: 'getObject',
-            objectType: 'contact',
-            objectId: contactId,
-            fileType: 'recording',
-            location: externalStoredRecording.storeTypeSpecificData.location,
-          }),
-        );
+    await loadConversationIntoOverlay();
 
-        setVoiceRecording(recordingPreSignedUrl);
-      } else {
-        await loadConversationIntoOverlay();
-        setShowButton(true);
-      }
-
-      setLoading(false);
-    } catch (error) {
-      handleFetchAndLoadException(error);
-    }
-  };
-
-  const handleFetchAndLoadException = err => {
-    console.error(
-      `Error loading the recording for contact ${contactId}, recording url ${externalStoredRecording?.storeTypeSpecificData?.location.key}`,
-      err,
-    );
-    const errorMessage = 'RecordingSection-Error';
-
-    setErrorMessage(errorMessage);
     setLoading(false);
   };
-
-  if (errorMessage) {
-    return (
-      <ErrorFont>
-        <Template code={errorMessage} />
-      </ErrorFont>
-    );
-  }
 
   if (loading) {
     return <CircularProgress size={30} />;
   }
 
-  if (showButton) {
-    return (
-      <LoadMediaButton
-        style={{ justifyContent: 'center', paddingTop: '10px', paddingBottom: '10px', whiteSpace: 'nowrap' }}
-        type="button"
-        onClick={fetchAndLoadRecording}
-      >
-        <LoadMediaButtonText>
-          <Template code="ContactDetails-LoadRecording-Button" />
-        </LoadMediaButtonText>
-      </LoadMediaButton>
-    );
-  }
-
   return (
-    <div>
-      {voiceRecording ? (
-        <audio controls src={voiceRecording} preload="metadata" onError={handleFetchAndLoadException}>
-          <track kind="captions" />
-        </audio>
-      ) : (
-        <ErrorFont>
-          <Template code={errorMessage} />
-        </ErrorFont>
-      )}
-    </div>
+    <LoadMediaButton
+      style={{ justifyContent: 'center', paddingTop: '10px', paddingBottom: '10px', whiteSpace: 'nowrap' }}
+      type="button"
+      onClick={fetchAndLoadRecording}
+    >
+      <LoadMediaButtonText>
+        <Template code="ContactDetails-LoadRecording-Button" />
+      </LoadMediaButtonText>
+    </LoadMediaButton>
   );
 };
 


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Because of the task modifications to support for the insights player in insights, the insights player also works from the contact page which reduces complexity, gets rid of the "download recording" button from the browser player, and provides a more standard user experience.

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Play back an external recording