### PR TITLE
Aligned conversation media types with backend expectations

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -204,6 +204,7 @@ const createContactWithMetadata = (
   };
 };
 
+const getContactFromPost = mockedFetch => JSON.parse(mockedFetch.mock.calls[0][1].body);
 const getFormFromPOST = mockedFetch => JSON.parse(mockedFetch.mock.calls[0][1].body).rawJson;
 const getTimeOfContactFromPOST = mockedFetch => JSON.parse(mockedFetch.mock.calls[0][1].body).timeOfContact;
 const getNumberFromPOST = mockedFetch => JSON.parse(mockedFetch.mock.calls[0][1].body).number;
@@ -405,9 +406,9 @@ describe('saveContact() (externalRecording)', () => {
     const { contact, metadata } = createContactWithMetadata({ callType: callTypes.child, childFirstName: 'Jill' });
     await saveContact(task, contact, metadata, 'workerSid', 'uniqueIdentifier');
 
-    const formFromPOST = getFormFromPOST(mockedFetch);
-    expect(formFromPOST.conversationMedia).toStrictEqual([
-      { storeType: 'twilio' },
+    const contactPOST = getContactFromPost(mockedFetch);
+    expect(contactPOST.conversationMedia).toStrictEqual([
+      { storeType: 'twilio', storeTypeSpecificData: {} },
       {
         storeType: 'S3',
         storeTypeSpecificData: {
@@ -589,7 +590,7 @@ describe('handleTwilioTask() (externalRecording)', () => {
     const result = await handleTwilioTask(task);
     expect(result).toStrictEqual({
       conversationMedia: [
-        { storeType: 'twilio', reservationSid: undefined },
+        { storeType: 'twilio', storeTypeSpecificData: { reservationSid: undefined } },
         {
           storeType: 'S3',
           storeTypeSpecificData: {

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -221,7 +221,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
   const loadConversationIntoOverlay = async () => {
     const twilioStoredMedia = savedContact.conversationMedia.find(isTwilioStoredMedia);
     await Actions.invokeAction(Insights.Player.Action.INSIGHTS_PLAYER_PLAY, {
-      taskSid: twilioStoredMedia.reservationSid,
+      taskSid: twilioStoredMedia.storeTypeSpecificData.reservationSid,
     });
   };
 

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -249,10 +249,10 @@ export function transformForm(rawJson: Partial<ContactRawJson>, helpline: string
 
 // TODO: Remove this once the API is aligned with the type we use in the front end
 const convertContactToApiContact = (contact: HrmServiceContact): HrmServiceContactForApi => {
-  return adaptConversationMedia({
+  return {
     ...contact,
     rawJson: transformForm(contact.rawJson, contact.helpline) as ContactRawJsonForApi,
-  });
+  };
 };
 
 type HandleTwilioTaskResponse = {
@@ -289,7 +289,9 @@ export const handleTwilioTask = async (task): Promise<HandleTwilioTaskResponse> 
     // Store reservation sid to use Twilio insights overlay (recordings/transcript)
     returnData.conversationMedia.push({
       storeType: 'twilio',
-      reservationSid: task.sid,
+      storeTypeSpecificData: {
+        reservationSid: task.sid,
+      },
     });
   }
 

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -50,10 +50,9 @@ type ContactRawJsonForApi = Omit<ContactRawJson, 'categories' | 'caseInformation
   caseInformation: Record<string, string | boolean | Record<string, Record<string, boolean>>> & {
     categories: Record<string, Record<string, boolean>>;
   };
-  conversationMedia: ConversationMedia[];
 };
 
-type HrmServiceContactForApi = Omit<HrmServiceContact, 'rawJson' | 'conversationMedia'> & {
+type HrmServiceContactForApi = Omit<HrmServiceContact, 'rawJson'> & {
   rawJson: ContactRawJsonForApi;
 };
 
@@ -200,29 +199,6 @@ export function transformCategories(
 }
 
 /**
- * Currently we're sending conversationMedia as part of rawJson.
- * But HrmServiceContact has conversationMedia as a top level attribute.
- * This function transforms a HrmServiceContact to the format the backend expects.
- *
- * This adapter is temporary, since we plan on passing conversationMedia as
- * a top level attribute, but it will have a slightly different format.
- * TODO: Remove this once the API is aligned with the type we use in the front end
- */
-const adaptConversationMedia = (
-  contact: HrmServiceContactForApi & { conversationMedia?: ConversationMedia[] },
-): HrmServiceContactForApi => {
-  const { conversationMedia = [], ...rest } = contact;
-
-  return {
-    ...rest,
-    rawJson: {
-      ...rest.rawJson,
-      conversationMedia,
-    },
-  };
-};
-
-/**
  * Transforms the form to be saved as the backend expects it
  * VisibleForTesting
  * TODO: Remove this once the API is aligned with the type we use in the front end
@@ -242,7 +218,6 @@ export function transformForm(rawJson: Partial<ContactRawJson>, helpline: string
 
   return {
     ...apiForm,
-
     definitionVersion,
   };
 }

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -95,7 +95,9 @@ export type Case = {
 
 export type TwilioStoredMedia = {
   storeType: 'twilio';
-  reservationSid: string;
+  storeTypeSpecificData: {
+    reservationSid: string;
+  };
 };
 
 export type S3StoredTranscript = {


### PR DESCRIPTION
## Description
This PR fixes an existing issue where saving contacts fails with 500 error status code.
The issue arises because the conversation medias in the create contact payload were using the new format, but bundled in the legacy `rawForm.conversationMedia` property. This PR fixes the issue by moving this to the root of the create contact payload, where the backend expects the new format to be present.

### Verification steps
- Start a new local HRM server in branch `v2.10-rc`.
- Start a new development Flex instance using this branch.
- Start a new chat contact and try saving it: it should succeed.
- Test that everything else around the fixes recently included in the RC branch are still working as intended.