### PR TITLE
CHI-2309: Search page navigation controls disabled while a list is loading

### DIFF
--- a/plugin-hrm-form/src/components/Pagination.tsx
+++ b/plugin-hrm-form/src/components/Pagination.tsx
@@ -32,7 +32,7 @@ export const getPaginationNumbers = (page, pageCount) => {
 };
 
 // eslint-disable-next-line react/display-name
-const renderPaginationButton = (page, handleChangePage) => n => {
+const renderPaginationButton = (page, handleChangePage, disabled) => n => {
   if (n === -1)
     return (
       <ButtonText style={{ padding: '6px 10px', margin: '0 2px' }} key={`ellipsis-${Math.random()}`}>
@@ -46,6 +46,7 @@ const renderPaginationButton = (page, handleChangePage) => n => {
       highlight={page === n}
       key={`CaseList-pagination-${n}`}
       onClick={() => handleChangePage(n)}
+      disabled={disabled}
     >
       <ButtonText highlight={page === n}>{n + 1}</ButtonText>
     </PaginationButton>
@@ -77,10 +78,17 @@ type PaginationProps = {
   pagesCount: number;
   handleChangePage: (page: number) => void;
   transparent?: boolean;
+  disabled?: boolean;
 };
 
-const Pagination: React.FC<PaginationProps> = ({ page, pagesCount, handleChangePage, transparent }) => {
-  const renderButtons = renderPaginationButton(page, handleChangePage);
+const Pagination: React.FC<PaginationProps> = ({
+  page,
+  pagesCount,
+  handleChangePage,
+  transparent,
+  disabled = false,
+}) => {
+  const renderButtons = renderPaginationButton(page, handleChangePage, disabled);
 
   const decreasePage = () => {
     if (page > 0) handleChangePage(page - 1);
@@ -93,14 +101,14 @@ const Pagination: React.FC<PaginationProps> = ({ page, pagesCount, handleChangeP
   return (
     <PaginationRow transparent={transparent} data-testid="CaseList-TableFooter">
       <ChevronButton
-        disabled={page === 0}
+        disabled={disabled || page === 0}
         chevronDirection="left"
         onClick={decreasePage}
         templateCode="CaseList-PrevPage"
       />
       {getPaginationNumbers(page, pagesCount).map(renderButtons)}
       <ChevronButton
-        disabled={page === pagesCount - 1}
+        disabled={disabled || page === pagesCount - 1}
         chevronDirection="right"
         onClick={increasePage}
         templateCode="CaseList-NextPage"

--- a/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
@@ -29,7 +29,8 @@ import { CASES_PER_PAGE } from './CaseList';
 import type { Case } from '../../types/types';
 import * as CaseListSettingsActions from '../../states/caseList/settings';
 import { getPermissionsForCase, PermissionActions } from '../../permissions';
-import { caseListBase, configurationBase, namespace } from '../../states/storeNamespaces';
+import { namespace } from '../../states/storeNamespaces';
+import { RootState } from '../../states';
 
 const ROW_HEIGHT = 89;
 
@@ -111,7 +112,13 @@ const CaseListTable: React.FC<Props> = ({
       </TableContainer>
       {caseList.length > 0 ? (
         <div style={{ minHeight: '100px' }}>
-          <Pagination transparent page={currentPage} pagesCount={pagesCount} handleChangePage={updateCaseListPage} />
+          <Pagination
+            transparent
+            page={currentPage}
+            pagesCount={pagesCount}
+            handleChangePage={updateCaseListPage}
+            disabled={loading}
+          />
         </div>
       ) : null}
     </>
@@ -120,10 +127,10 @@ const CaseListTable: React.FC<Props> = ({
 
 CaseListTable.displayName = 'CaseListTable';
 
-const mapStateToProps = state => ({
-  counselorsHash: state[namespace][configurationBase].counselors.hash,
-  currentDefinitionVersion: state[namespace][configurationBase].currentDefinitionVersion,
-  currentPage: state[namespace][caseListBase].currentSettings.page,
+const mapStateToProps = ({ [namespace]: { configuration, caseList } }: RootState) => ({
+  counselorsHash: configuration.counselors.hash,
+  currentDefinitionVersion: configuration.currentDefinitionVersion,
+  currentPage: caseList.currentSettings.page,
 });
 
 const mapDispatchToProps = {

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -48,7 +48,8 @@ import * as CaseActions from '../../../states/case/actions';
 import * as RoutingActions from '../../../states/routing/actions';
 import { SearchPages, SearchPagesType } from '../../../states/search/types';
 import { getPermissionsForContact, getPermissionsForCase, PermissionActions } from '../../../permissions';
-import { configurationBase, namespace, searchContactsBase } from '../../../states/storeNamespaces';
+import { namespace } from '../../../states/storeNamespaces';
+import { RootState } from '../../../states';
 
 export const CONTACTS_PER_PAGE = 20;
 export const CASES_PER_PAGE = 20;
@@ -89,6 +90,8 @@ const SearchResults: React.FC<Props> = ({
   setConnectedCase,
   currentPage,
   counselorsHash,
+  isRequestingCases,
+  isRequestingContacts,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const [contactsPage, setContactsPage] = useState(0);
@@ -229,6 +232,7 @@ const SearchResults: React.FC<Props> = ({
                       size="small"
                       checked={!onlyDataContacts}
                       onChange={handleToggleNonDataContact}
+                      disabled={isRequestingContacts}
                     />
                   }
                   label={
@@ -257,6 +261,7 @@ const SearchResults: React.FC<Props> = ({
                   pagesCount={contactsPageCount}
                   handleChangePage={handleContactsChangePage}
                   transparent
+                  disabled={isRequestingContacts}
                 />
               )}
             </>
@@ -279,6 +284,7 @@ const SearchResults: React.FC<Props> = ({
                       size="small"
                       checked={closedCases}
                       onChange={handleToggleClosedCases}
+                      disabled={isRequestingContacts}
                     />
                   }
                   label={
@@ -309,6 +315,7 @@ const SearchResults: React.FC<Props> = ({
                   pagesCount={casesPageCount}
                   handleChangePage={handleCasesChangePage}
                   transparent
+                  disabled={isRequestingCases}
                 />
               )}
             </>
@@ -320,14 +327,17 @@ const SearchResults: React.FC<Props> = ({
 };
 SearchResults.displayName = 'SearchResults';
 
-const mapStateToProps = (state, ownProps) => {
-  const searchContactsState = state[namespace][searchContactsBase];
-  const taskId = ownProps.task.taskSid;
-  const taskSearchState = searchContactsState.tasks[taskId];
-  const { counselors } = state[namespace][configurationBase];
-
+const mapStateToProps = (
+  { [namespace]: { searchContacts, configuration, routing } }: RootState,
+  { task }: OwnProps,
+) => {
+  const taskId = task.taskSid;
+  const { isRequesting, isRequestingCases, currentPage } = searchContacts.tasks[taskId];
+  const { counselors } = configuration;
   return {
-    currentPage: taskSearchState.currentPage,
+    isRequestingContacts: isRequesting,
+    isRequestingCases,
+    currentPage,
     counselorsHash: counselors.hash,
   };
 };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description

* Uses the various 'loading' redux properties on case list & search to disable controls that can kick off another search request, to prevent users being able to spam requests

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
CHI-2309

### Verification steps

Try to quickly paginate through case search, contact search and case list results, they should disable whilst loading new results, reducing the rate that you can click the buttons

Try to toggle the setting sliders on the search pages, these should disable when loading the new results too