### PR TITLE
CHI-2314: Fix non data call type buttons to submit finalized contact. 

### DIFF
--- a/plugin-hrm-form/src/___tests__/callTypeButtons/CallTypeButtons.test.tsx
+++ b/plugin-hrm-form/src/___tests__/callTypeButtons/CallTypeButtons.test.tsx
@@ -32,7 +32,7 @@ import { changeRoute } from '../../states/routing/actions';
 import { updateDraft } from '../../states/contacts/existingContacts';
 import { completeTask } from '../../services/formSubmissionHelpers';
 import CallTypeButtons from '../../components/callTypeButtons';
-import { updateContactInHrmAsyncAction } from '../../states/contacts/saveContact';
+import { submitContactFormAsyncAction, updateContactInHrmAsyncAction } from '../../states/contacts/saveContact';
 import { configurationBase, connectedCaseBase, contactFormsBase, namespace } from '../../states/storeNamespaces';
 
 jest.mock('../../states/conferencing', () => ({}));
@@ -41,6 +41,7 @@ jest.mock('../../states/contacts/saveContact', () => ({
   updateContactInHrmAsyncAction: jest.fn(),
   saveContactReducer: jest.fn(state => state),
   loadContactFromHrmByTaskSidAsyncAction: jest.fn(),
+  submitContactFormAsyncAction: jest.fn(),
   createContactAsyncAction: jest.fn(),
 }));
 
@@ -397,7 +398,7 @@ test('<CallTypeButtons> click on END CHAT button', async () => {
   expect(screen.getByText('TaskHeaderEndChat')).toBeInTheDocument();
   screen.getByText('TaskHeaderEndChat').click();
 
-  await waitFor(() => expect(updateContactInHrmAsyncAction).toHaveBeenCalled());
+  await waitFor(() => expect(submitContactFormAsyncAction).toHaveBeenCalled());
   await waitFor(() => expect(completeTask).toHaveBeenCalledWith(task));
 });
 

--- a/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.tsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.tsx
@@ -37,8 +37,10 @@ import { getTemplateStrings } from '../../hrmConfig';
 import { AppRoutes } from '../../states/routing/types';
 import findContactByTaskSid from '../../states/contacts/findContactByTaskSid';
 import asyncDispatch from '../../states/asyncDispatch';
-import { updateContactInHrmAsyncAction } from '../../states/contacts/saveContact';
-import { configurationBase, connectedCaseBase, namespace } from '../../states/storeNamespaces';
+import { submitContactFormAsyncAction, updateContactInHrmAsyncAction } from '../../states/contacts/saveContact';
+import { configurationBase, namespace } from '../../states/storeNamespaces';
+import { ContactMetadata } from '../../states/contacts/types';
+import { getUnsavedContact } from '../../states/contacts/getUnsavedContact';
 
 const isDialogOpen = (task: CustomITask, contact: ContactDraftChanges) =>
   Boolean(!isOfflineContactTask(task) && contact?.rawJson?.callType && isNonDataCallType(contact?.rawJson?.callType));
@@ -55,12 +57,14 @@ const CallTypeButtons: React.FC<Props> = ({
   savedContact,
   draftContact,
   task,
+  metadata,
   localization,
   currentDefinitionVersion,
   updateCallType,
   clearCallType,
   changeRoute,
   saveContactChangesInHrm,
+  saveFinalizedNonDataContact,
 }) => {
   const { isCallTask } = localization;
 
@@ -109,7 +113,7 @@ const CallTypeButtons: React.FC<Props> = ({
     if (!hasTaskControl(task)) return;
 
     try {
-      await saveContactChangesInHrm(savedContact, draftContact);
+      await saveFinalizedNonDataContact(savedContact, draftContact, metadata);
       await completeTask(task);
     } catch (error) {
       const strings = getTemplateStrings();
@@ -177,16 +181,20 @@ const CallTypeButtons: React.FC<Props> = ({
 CallTypeButtons.displayName = 'CallTypeButtons';
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
-  const { savedContact, draftContact } = findContactByTaskSid(state, ownProps.task.taskSid) ?? {};
+  const { savedContact, draftContact, metadata } = findContactByTaskSid(state, ownProps.task.taskSid) ?? {};
   const { currentDefinitionVersion } = state[namespace][configurationBase];
 
-  return { savedContact, draftContact, currentDefinitionVersion };
+  return { savedContact, draftContact, metadata, currentDefinitionVersion };
 };
 
-const mapDispatchToProps = (dispatch, { task: { taskSid } }: OwnProps) => ({
-  changeRoute: (route: AppRoutes) => dispatch(newChangeRouteAction(route, taskSid)),
+const mapDispatchToProps = (dispatch, { task }: OwnProps) => ({
+  changeRoute: (route: AppRoutes) => dispatch(newChangeRouteAction(route, task.taskSid)),
   saveContactChangesInHrm: (contact: Contact, changes: ContactDraftChanges) =>
-    asyncDispatch(dispatch)(updateContactInHrmAsyncAction(contact, changes, taskSid)),
+    asyncDispatch(dispatch)(updateContactInHrmAsyncAction(contact, changes, task.taskSid)),
+  saveFinalizedNonDataContact: (contact: Contact, changes: ContactDraftChanges, metaData: ContactMetadata) =>
+    // Deliberately using dispatch rather than asyncDispatch here, because we still handle the error from where the action is dispatched.
+    // TODO: Rework error handling to be based on redux state set by the _REJECTED action
+    dispatch(submitContactFormAsyncAction(task, getUnsavedContact(contact, changes), metaData, undefined)),
   updateCallType: (contactId: string, callType: string) =>
     dispatch(newUpdateDraftAction(contactId, { rawJson: { callType } })),
   clearCallType: (contactId: string) => dispatch(newUpdateDraftAction(contactId, { rawJson: { callType: null } })),

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -16,7 +16,7 @@
 
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import { AnyAction, bindActionCreators } from 'redux';
+import { bindActionCreators } from 'redux';
 import { Template } from '@twilio/flex-ui';
 import { CircularProgress } from '@material-ui/core';
 import FolderIcon from '@material-ui/icons/Folder';
@@ -34,7 +34,6 @@ import { recordBackendError, recordingErrorHandler } from '../../fullStory';
 import { Case, CustomITask, Contact } from '../../types/types';
 import { getAseloFeatureFlags, getHrmConfig, getTemplateStrings } from '../../hrmConfig';
 import { createCaseAsyncAction } from '../../states/case/saveCase';
-import asyncDispatch from '../../states/asyncDispatch';
 import { getUnsavedContact } from '../../states/contacts/getUnsavedContact';
 import { submitContactFormAsyncAction } from '../../states/contacts/saveContact';
 import { ContactMetadata } from '../../states/contacts/types';
@@ -188,16 +187,17 @@ const mapStateToProps = (state: RootState, ownProps: BottomBarProps) => {
   };
 };
 
-const mapDispatchToProps = (dispatch, { task }: BottomBarProps) => {
-  const createCaseAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
-  return {
-    changeRoute: bindActionCreators(RoutingActions.changeRoute, dispatch),
-    setConnectedCase: bindActionCreators(CaseActions.setConnectedCase, dispatch),
-    createCaseAsyncAction: (contact, workerSid: string, definitionVersion: DefinitionVersionId) =>
-      createCaseAsyncDispatch(createCaseAsyncAction(contact, task.taskSid, workerSid, definitionVersion)),
-    submitContactFormAsyncAction: (task: CustomITask, contact: Contact, metadata: ContactMetadata, caseForm: Case) =>
-      createCaseAsyncDispatch(submitContactFormAsyncAction(task, contact, metadata, caseForm)),
-  };
-};
+const mapDispatchToProps = (dispatch, { task }: BottomBarProps) => ({
+  changeRoute: bindActionCreators(RoutingActions.changeRoute, dispatch),
+  setConnectedCase: bindActionCreators(CaseActions.setConnectedCase, dispatch),
+  createCaseAsyncAction: (contact, workerSid: string, definitionVersion: DefinitionVersionId) =>
+    // Deliberately using dispatch rather than asyncDispatch here, because we still handle the error from where the action is dispatched.
+    // TODO: Rework error handling to be based on redux state set by the _REJECTED action
+    dispatch(createCaseAsyncAction(contact, task.taskSid, workerSid, definitionVersion)),
+  submitContactFormAsyncAction: (task: CustomITask, contact: Contact, metadata: ContactMetadata, caseForm: Case) =>
+    // Deliberately using dispatch rather than asyncDispatch here, because we still handle the error from where the action is dispatched.
+    // TODO: Rework error handling to be based on redux state set by the _REJECTED action
+    dispatch(submitContactFormAsyncAction(task, contact, metadata, caseForm)),
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(BottomBar);


### PR DESCRIPTION
## Description

Also updated save button actions to use regular dispatch rather than async dispatch to ensure alert popups show when saving fails

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Related Issues
CHI-2314

### Verification steps

Save non-data chat contact (not an offline one). ensure that the call to HRM is sent with a `finalize=true` query parameter