### PR TITLE
chore: revert insights player for external recordings

### DIFF
--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -419,7 +419,11 @@ const ContactDetailsHome: React.FC<Props> = function ({
           showEditButton={false}
         >
           <Flex justifyContent="center" flexDirection="row" paddingTop="20px">
-            <RecordingSection loadConversationIntoOverlay={loadConversationIntoOverlay} />{' '}
+            <RecordingSection
+              contactId={contactId}
+              externalStoredRecording={externalStoredRecording}
+              loadConversationIntoOverlay={loadConversationIntoOverlay}
+            />{' '}
           </Flex>
         </ContactDetailsSection>
       )}


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This reverts the use of insights player for external recordings and updates the browser player to exclude the download file link.