### PR TITLE
refactor: move profile modal into hrmForm and begin refactor of HRM f…

### DIFF
--- a/plugin-hrm-form/src/components/HrmForm.tsx
+++ b/plugin-hrm-form/src/components/HrmForm.tsx
@@ -47,8 +47,9 @@ const HrmForm: React.FC<Props> = ({ activeModal, routing, task, featureFlags, sa
       activeModalRoutes: ['profile'],
       component: <Profile task={task} />,
     },
+    // TODO: move hrm form search into it's own component and use it here so all routes are in one place
     {
-      baseRoutes: ['tabbed-forms', 'search', 'contact', 'case', 'profileEdit', 'profile'],
+      baseRoutes: ['tabbed-forms', 'search', 'contact', 'case'],
       component: (
         <TabbedForms
           task={task}

--- a/plugin-hrm-form/src/components/HrmForm.tsx
+++ b/plugin-hrm-form/src/components/HrmForm.tsx
@@ -19,6 +19,7 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import CallTypeButtons from './callTypeButtons';
+import Profile from './profile/Profile';
 import TabbedForms from './tabbedForms';
 import CSAMReport from './CSAMReport/CSAMReport';
 import { RootState } from '../states';
@@ -26,7 +27,8 @@ import type { CustomITask } from '../types/types';
 import { newContactCSAMApi } from './CSAMReport/csamReportApi';
 import findContactByTaskSid from '../states/contacts/findContactByTaskSid';
 import { namespace } from '../states/storeNamespaces';
-import { getCurrentTopmostRouteForTask } from '../states/routing/getRoute';
+import { getCurrentBaseRoute, getCurrentTopmostRouteForTask } from '../states/routing/getRoute';
+import { CSAMReportRoute, isRouteWithModalSupport } from '../states/routing/types';
 
 type OwnProps = {
   task: CustomITask;
@@ -36,32 +38,45 @@ type OwnProps = {
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const HrmForm: React.FC<Props> = ({ routing, task, featureFlags, savedContact }) => {
+const HrmForm: React.FC<Props> = ({ activeModal, routing, task, featureFlags, savedContact }) => {
   if (!routing) return null;
   const { route } = routing;
 
-  switch (route) {
-    case 'tabbed-forms':
-    case 'search':
-    case 'contact':
-    case 'case':
-    case 'profileEdit':
-    case 'profile':
-      return (
+  const routes = [
+    {
+      activeModalRoutes: ['profile'],
+      component: <Profile task={task} />,
+    },
+    {
+      baseRoutes: ['tabbed-forms', 'search', 'contact', 'case', 'profileEdit', 'profile'],
+      component: (
         <TabbedForms
           task={task}
           contactId={savedContact?.id}
           csamClcReportEnabled={featureFlags.enable_csam_clc_report}
           csamReportEnabled={featureFlags.enable_csam_report}
         />
-      );
+      ),
+    },
+    {
+      baseRoutes: ['csam-report'],
+      component: (
+        <CSAMReport
+          api={newContactCSAMApi(savedContact.id, task.taskSid, (routing as CSAMReportRoute).previousRoute)}
+        />
+      ),
+    },
+    { baseRoutes: ['select-call-type'], component: <CallTypeButtons task={task} /> },
+  ];
 
-    case 'csam-report':
-      return <CSAMReport api={newContactCSAMApi(savedContact.id, task.taskSid, routing.previousRoute)} />;
-    case 'select-call-type':
-    default:
-      return <CallTypeButtons task={task} />;
-  }
+  // Modals take precedence over routes
+  const modalComponent = routes.find(m => m.activeModalRoutes?.includes(activeModal));
+  if (modalComponent) return modalComponent.component;
+
+  const routeComponent = routes.find(r => r.baseRoutes?.includes(route));
+  if (routeComponent) return routeComponent.component;
+
+  return null;
 };
 
 HrmForm.displayName = 'HrmForm';
@@ -69,8 +84,11 @@ HrmForm.displayName = 'HrmForm';
 const mapStateToProps = (state: RootState, { task }: OwnProps) => {
   const routingState = state[namespace].routing;
   const { savedContact, metadata } = findContactByTaskSid(state, task.taskSid) ?? {};
+  const baseRoute = getCurrentBaseRoute(routingState, task.taskSid);
+  const activeModal =
+    isRouteWithModalSupport(baseRoute) && baseRoute.activeModal?.length && baseRoute.activeModal[0].route;
 
-  return { routing: getCurrentTopmostRouteForTask(routingState, task.taskSid), savedContact, metadata };
+  return { activeModal, routing: getCurrentTopmostRouteForTask(routingState, task.taskSid), savedContact, metadata };
 };
 
 const connector = connect(mapStateToProps);

--- a/plugin-hrm-form/src/components/HrmForm.tsx
+++ b/plugin-hrm-form/src/components/HrmForm.tsx
@@ -73,10 +73,7 @@ const HrmForm: React.FC<Props> = ({ activeModal, routing, task, featureFlags, sa
   const modalComponent = routes.find(m => m.activeModalRoutes?.includes(activeModal));
   if (modalComponent) return modalComponent.component;
 
-  const routeComponent = routes.find(r => r.baseRoutes?.includes(route));
-  if (routeComponent) return routeComponent.component;
-
-  return null;
+  return routes.find(r => r.baseRoutes?.includes(route))?.component || null;
 };
 
 HrmForm.displayName = 'HrmForm';

--- a/plugin-hrm-form/src/components/profile/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/PreviousContactsBanner.tsx
@@ -16,7 +16,7 @@
 
 /* eslint-disable react/prop-types */
 import React, { useState, useEffect } from 'react';
-import { connect } from 'react-redux';
+import { connect, ConnectedProps } from 'react-redux';
 import { Template } from '@twilio/flex-ui';
 
 import asyncDispatch from '../../states/asyncDispatch';
@@ -49,7 +49,7 @@ type OwnProps = {
 };
 
 // eslint-disable-next-line no-use-before-define
-type Props = OwnProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
+type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const PreviousContactsBanner: React.FC<Props> = ({
   contactIdentifier,
@@ -223,4 +223,5 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 };
 
 export const UnconnectedPreviousContactsBanner = PreviousContactsBanner;
-export default connect(mapStateToProps, mapDispatchToProps)(PreviousContactsBanner);
+const connector = connect(mapStateToProps, mapDispatchToProps);
+export default connector(PreviousContactsBanner);

--- a/plugin-hrm-form/src/components/profile/Profile.tsx
+++ b/plugin-hrm-form/src/components/profile/Profile.tsx
@@ -125,8 +125,8 @@ const mapStateToProps = (state: RootState, { task: { taskSid } }: OwnProps) => {
   const { data: profile } = currentProfileState;
 
   const currentRoute = getCurrentTopmostRouteForTask(routingState, taskSid);
-  const profileEditModalOpen =
-    RoutingTypes.isRouteWithModalSupport(currentRoute) && currentRoute.route.toString() === 'profileEdit';
+
+  const profileEditModalOpen = currentRoute.route.toString() === 'profileEdit';
 
   return {
     currentTab,

--- a/plugin-hrm-form/src/components/profile/ProfileContacts.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileContacts.tsx
@@ -14,30 +14,34 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
 
 import { getPermissionsForContact, PermissionActions } from '../../permissions';
-import { Contact, Profile } from '../../types/types';
+import { Contact, CustomITask, Profile } from '../../types/types';
 import ContactPreview from '../search/ContactPreview';
 import * as ProfileTypes from '../../states/profile/types';
+import * as RoutingActions from '../../states/routing/actions';
 import ProfileRelationshipList from './ProfileRelationshipList';
 
 type OwnProps = {
   profileId: Profile['id'];
+  task: CustomITask;
 };
 
-const ProfileContacts: React.FC<OwnProps> = ({ profileId }) => {
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+const ProfileContacts: React.FC<Props> = ({ profileId, viewContactDetails }) => {
   const renderItem = (contact: Contact) => {
     const { can } = getPermissionsForContact(contact.twilioWorkerId);
     const handleViewDetails = () => {
-      // load contact modal? or page?
+      console.log('>>>handleViewDetails', contact);
+      if (can(PermissionActions.VIEW_CONTACT)) viewContactDetails(contact);
     };
 
+    console.log('>>>can(PermissionActions.VIEW_CONTACT)', can(PermissionActions.VIEW_CONTACT));
+
     return (
-      <ContactPreview
-        key={`ContactPreview-${contact.id}`}
-        contact={contact}
-        handleViewDetails={() => can(PermissionActions.VIEW_CONTACT) && handleViewDetails}
-      />
+      <ContactPreview key={`ContactPreview-${contact.id}`} contact={contact} handleViewDetails={handleViewDetails} />
     );
   };
 
@@ -50,4 +54,14 @@ const ProfileContacts: React.FC<OwnProps> = ({ profileId }) => {
   );
 };
 
-export default ProfileContacts;
+const mapDispatchToProps = (dispatch, { task: { taskSid } }) => {
+  return {
+    viewContactDetails: ({ id }: Contact) => {
+      dispatch(RoutingActions.newOpenModalAction({ route: 'contact', subroute: 'view', id: id.toString() }, taskSid));
+    },
+  };
+};
+
+const connector = connect(null, mapDispatchToProps);
+
+export default connector(ProfileContacts);

--- a/plugin-hrm-form/src/components/profile/ProfileDetails.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileDetails.tsx
@@ -23,7 +23,7 @@ import { RootState } from '../../states';
 import { getCurrentProfileState } from '../../states/profile/selectors';
 import { DetailsWrapper, EditButton, ProfileSubtitle, StatusLabelPill } from './styles';
 import { Bold, Box, Column } from '../../styles/HrmStyles';
-import { changeRoute, newOpenModalAction } from '../../states/routing/actions';
+import { newOpenModalAction } from '../../states/routing/actions';
 
 type OwnProps = {
   profileId: Profile['id'];

--- a/plugin-hrm-form/src/components/profile/ProfileTabs.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileTabs.tsx
@@ -51,7 +51,7 @@ const ProfileTabs: React.FC<Props> = ({ profileId, task, casesCount, contactsCou
     {
       label: `Contacts (${contactsCount})`,
       key: 'contacts',
-      component: <ProfileContacts profileId={profileId} />,
+      component: <ProfileContacts profileId={profileId} task={task} />,
     },
     {
       label: `Cases (${casesCount})`,

--- a/plugin-hrm-form/src/components/profile/ProfileTabs.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileTabs.tsx
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+import { Tab as TwilioTab } from '@twilio/flex-ui';
+
+import NavigableContainer from '../NavigableContainer';
+import ProfileCases from './ProfileCases';
+import ProfileContacts from './ProfileContacts';
+import ProfileDetails from './ProfileDetails';
+import { Row } from '../../styles/HrmStyles';
+import { getCurrentProfileState } from '../../states/profile/selectors';
+import * as RoutingTypes from '../../states/routing/types';
+import { getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
+import * as RoutingActions from '../../states/routing/actions';
+import { namespace, profileBase } from '../../states/storeNamespaces';
+import { RootState } from '../../states';
+import { ProfileRoute } from '../../states/routing/types';
+import { CustomITask, Profile } from '../../types/types';
+import { StyledTabs } from '../../styles/search'; // just stealing from search until we have a centralized tab style
+
+type OwnProps = {
+  profileId: Profile['id'];
+  task: CustomITask;
+};
+
+// eslint-disable-next-line no-use-before-define
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+const ProfileTabs: React.FC<Props> = ({ profileId, task, casesCount, contactsCount, currentTab, changeProfileTab }) => {
+  const tabs = [
+    {
+      label: 'Profile',
+      key: 'details',
+      component: <ProfileDetails profileId={profileId} task={task} />,
+    },
+    {
+      label: `Contacts (${contactsCount})`,
+      key: 'contacts',
+      component: <ProfileContacts profileId={profileId} />,
+    },
+    {
+      label: `Cases (${casesCount})`,
+      key: 'cases',
+      component: <ProfileCases profileId={profileId} />,
+    },
+  ];
+
+  const renderedTabs = tabs.map(tab => (
+    <TwilioTab key={`ProfileTabs-${profileId}-${tab.key}`} label={tab.label} uniqueName={tab.key}>
+      {[]}
+    </TwilioTab>
+  ));
+
+  const renderedLabels = (
+    <Row style={{ justifyContent: 'center' }}>
+      <div style={{ width: '400px' }}>
+        <StyledTabs
+          selectedTabName={currentTab}
+          onTabSelected={(selectedTab: RoutingTypes.ProfileTabs) => changeProfileTab(profileId, selectedTab)}
+          alignment="center"
+          keepTabsMounted={false}
+        >
+          {renderedTabs}
+        </StyledTabs>
+      </div>
+    </Row>
+  );
+
+  const renderedTab = tabs.find(tab => tab.key === currentTab).component;
+
+  return (
+    <NavigableContainer task={task} titleCode="Profile-Title">
+      {renderedLabels}
+      {renderedTab}
+    </NavigableContainer>
+  );
+};
+
+const mapStateToProps = (state: RootState, { profileId, task: { taskSid } }: OwnProps) => {
+  const routingState = state[namespace].routing;
+  const route = getCurrentTopmostRouteForTask(routingState, taskSid);
+  const currentTab = (route as ProfileRoute).subroute || 'details';
+
+  const currentProfileState = getCurrentProfileState(state, profileId);
+  const contactsCount = currentProfileState?.data?.contactsCount || 0;
+  const casesCount = currentProfileState?.data?.casesCount || 0;
+
+  return {
+    casesCount,
+    contactsCount,
+    currentTab,
+  };
+};
+
+const mapDispatchToProps = (dispatch, { task }: OwnProps) => ({
+  changeProfileTab: (id, subroute) =>
+    dispatch(
+      RoutingActions.changeRoute(
+        { route: 'profile', id, subroute },
+        task.taskSid,
+        RoutingTypes.ChangeRouteMode.Replace,
+      ),
+    ),
+});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+export default connector(ProfileTabs);

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -124,7 +124,6 @@ const TabbedForms: React.FC<Props> = ({
   currentDefinitionVersion,
   csamReportEnabled,
   csamClcReportEnabled,
-  profileModalOpen,
   searchModalOpen,
   updateDraftForm,
   newCSAMReport,
@@ -193,10 +192,6 @@ const TabbedForms: React.FC<Props> = ({
         handleSelectSearchResult={onSelectSearchResult}
       />
     );
-  }
-
-  if (profileModalOpen) {
-    return <Profile task={task} />;
   }
 
   if (currentRoute.route === 'case') {
@@ -396,12 +391,7 @@ const mapStateToProps = (
   const baseRoute = getCurrentBaseRoute(routing, taskSid);
   const searchModalOpen =
     isRouteWithModalSupport(baseRoute) && baseRoute.activeModal?.length && baseRoute.activeModal[0].route === 'search';
-  const profileModalOpen =
-    isRouteWithModalSupport(baseRoute) && baseRoute.activeModal?.length && baseRoute.activeModal[0].route === 'profile';
-  // const profileEditModalOpen =
-  //   isRouteWithModalSupport(baseRoute) &&
-  //   baseRoute.activeModal?.length &&
-  //   baseRoute.activeModal[0].route === 'profileEdit';
+
   const { currentDefinitionVersion } = configuration;
   return {
     currentRoute,
@@ -409,8 +399,6 @@ const mapStateToProps = (
     draftContact,
     updatedContact: getUnsavedContact(savedContact, draftContact),
     currentDefinitionVersion,
-    profileModalOpen,
-    // profileEditModalOpen,
     searchModalOpen,
     isCallTypeCaller,
     metadata,

--- a/plugin-hrm-form/src/states/routing/types.ts
+++ b/plugin-hrm-form/src/states/routing/types.ts
@@ -196,7 +196,7 @@ type OtherRoutes =
 export type AppRoutes = AppRoutesWithCase | OtherRoutes;
 
 export function isRouteWithModalSupport(appRoute: any): appRoute is RouteWithModalSupport {
-  return ['tabbed-forms', 'case', 'case-list', 'profile', 'profileEdit', 'search'].includes(appRoute.route);
+  return ['tabbed-forms', 'case', 'case-list', 'profile', 'search', 'select-call-type'].includes(appRoute.route);
 }
 
 export enum ChangeRouteMode {


### PR DESCRIPTION
…orm router

<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This moves profile routing into HRM form so it works from the categorize call menu and also refactors route handling a bit.