### PR TITLE
CHI-2319 cancel offline contacts

### DIFF
--- a/e2e-tests/browser.ts
+++ b/e2e-tests/browser.ts
@@ -16,6 +16,7 @@
 
 import { Browser, BrowserContext, Page, chromium } from '@playwright/test';
 import { logPageTelemetry } from './browser-logs';
+import { getConfigValue } from './config';
 
 export type SetupPageReturn = {
   context: BrowserContext;
@@ -45,7 +46,9 @@ export const setupContextAndPage = async (browser: Browser): Promise<SetupPageRe
   await waitForBrowser(browser);
 
   console.log('Launching page');
-  const context = await browser.newContext();
+  const context = await browser.newContext({
+    storageState: getConfigValue('storageStatePath') as string,
+  });
   const page = await context.newPage();
 
   logPageTelemetry(page);

--- a/e2e-tests/caseList.ts
+++ b/e2e-tests/caseList.ts
@@ -63,6 +63,7 @@ export const caseList = (page: Page) => {
     caseEditButton: caseListPage.locator(`//button[@data-testid='Case-EditButton']`),
 
     //Case Section view
+    formItem: (itemId: string) => caseListPage.locator(`#${itemId}`),
     formInput: (itemId: string) => caseListPage.locator(`input#${itemId}`),
     formSelect: (itemId: string) => caseListPage.locator(`select#${itemId}`),
     formTextarea: (itemId: string) => caseListPage.locator(`textarea#${itemId}`),
@@ -132,6 +133,8 @@ export const caseList = (page: Page) => {
 
   async function fillSectionForm({ items }: CaseSectionForm) {
     for (let [itemId, value] of Object.entries(items)) {
+      await expect(selectors.formItem(itemId)).toBeVisible();
+      await expect(selectors.formItem(itemId)).toBeEnabled();
       if (await selectors.formInput(itemId).count()) {
         await selectors.formInput(itemId).fill(value);
       } else if (await selectors.formSelect(itemId).count()) {
@@ -150,12 +153,13 @@ export const caseList = (page: Page) => {
     await newSectionButton.waitFor({ state: 'visible' });
     await expect(newSectionButton).toContainText(sectionId);
     await newSectionButton.click();
-
     await fillSectionForm(section);
 
     const saveItemButton = selectors.saveCaseItemButton;
-    await saveItemButton.waitFor({ state: 'visible' });
+    await expect(saveItemButton).toBeVisible();
+    await expect(saveItemButton).toBeEnabled();
     await saveItemButton.click();
+    await page.waitForResponse('**/cases/**');
   }
 
   //Edit Case
@@ -179,6 +183,7 @@ export const caseList = (page: Page) => {
     await updateCaseButton.waitFor({ state: 'visible' });
     await expect(updateCaseButton).toContainText('Save');
     await updateCaseButton.click();
+    await page.waitForResponse('**/cases/**');
 
     console.log('Updated Case Summary');
   }

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -28,7 +28,6 @@ export const defaultScript: ChatStatement[] = [
     'Welcome. To help us better serve you, please answer the following questions. Are you calling about yourself? Please answer Yes or No.',
   ),
   callerStatement('yes'),
-  botStatement("Thank you. You can say 'prefer not to answer' (or type X) to any question."),
   botStatement('How old are you?'),
   callerStatement('10'),
   botStatement('What is your gender?'),

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -25,9 +25,8 @@ import { getConfigValue } from './config';
 
 export const defaultScript: ChatStatement[] = [
   botStatement(
-    'Welcome. To help us better serve you, please answer the following three questions.',
+    'Welcome. To help us better serve you, please answer the following questions. Are you calling about yourself? Please answer Yes or No.',
   ),
-  botStatement('Are you calling about yourself? Please answer Yes or No.'),
   callerStatement('yes'),
   botStatement("Thank you. You can say 'prefer not to answer' (or type X) to any question."),
   botStatement('How old are you?'),

--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -25,7 +25,7 @@ import { getConfigValue } from './config';
 
 export const defaultScript: ChatStatement[] = [
   botStatement(
-    'Welcome to the helpline. To help us better serve you, please answer the following three questions.',
+    'Welcome. To help us better serve you, please answer the following three questions.',
   ),
   botStatement('Are you calling about yourself? Please answer Yes or No.'),
   callerStatement('yes'),

--- a/e2e-tests/config.ts
+++ b/e2e-tests/config.ts
@@ -127,6 +127,7 @@ const configOptions: ConfigOptions = {
   twilioAccountSid: {
     envKey: 'TWILIO_ACCOUNT_SID',
     ssmPath: `/${localOverrideEnv}/twilio/${helplineShortCode.toUpperCase()}/account_sid`,
+    default: 'AC_FAKE_UI_TEST_ACCOUNT',
   },
   twilioAuthToken: {
     envKey: 'TWILIO_AUTH_TOKEN',

--- a/e2e-tests/config.ts
+++ b/e2e-tests/config.ts
@@ -51,7 +51,7 @@ const skipDataUpdateEnvs = ['staging', 'production'];
 const flexEnvs = ['development', 'staging', 'production'];
 
 // This is kindof a hack to get the correct default remote webchat url and twilio account info for the local env
-const localOverrideEnv = helplineEnv == 'local' ? 'development' : helplineEnv;
+export const localOverrideEnv = helplineEnv == 'local' ? 'development' : helplineEnv;
 
 export const config: Config = {};
 
@@ -190,10 +190,7 @@ const configOptions: ConfigOptions = {
 
   hrmRoot: {
     envKey: 'HRM_ROOT',
-    default: () =>
-      `https://hrm-${localOverrideEnv}.tl.techmatters.org/v0/accounts/${getConfigValue(
-        'twilioAccountSid',
-      )}`,
+    default: '', // Default cannot be set up front due to the account sid might not calculated.
   },
 };
 

--- a/e2e-tests/config.ts
+++ b/e2e-tests/config.ts
@@ -186,6 +186,14 @@ const configOptions: ConfigOptions = {
     envKey: 'TEST_NAME',
     default: () => (getConfigValue('inLambda') ? 'login' : ''),
   },
+
+  hrmRoot: {
+    envKey: 'HRM_ROOT',
+    default: () =>
+      `https://hrm-${localOverrideEnv}.tl.techmatters.org/v0/accounts/${getConfigValue(
+        'twilioAccountSid',
+      )}`,
+  },
 };
 
 export const setConfigValue = (key: string, value: ConfigValue) => {

--- a/e2e-tests/contactForm.ts
+++ b/e2e-tests/contactForm.ts
@@ -50,9 +50,11 @@ export function contactForm(page: Page) {
     const button = selectors.tabButton(tab);
     await expect(button).toBeVisible();
     await expect(button).toBeEnabled();
+    const responsePromise = page.waitForResponse('**/contacts/**');
     if ((await button.getAttribute('aria-selected')) !== 'true') {
       await button.click();
     }
+    await responsePromise;
   }
 
   async function fillStandardTab({ id, items }: ContactFormTab) {
@@ -77,12 +79,11 @@ export function contactForm(page: Page) {
   }
 
   return {
-    selectChildCallType: async (allowSkip: boolean = false) => {
+    selectChildCallType: async () => {
       const childCallTypeButton = selectors.childCallTypeButton();
-      if (!(await childCallTypeButton.isVisible({ timeout: 200 })) && allowSkip) {
-        return;
-      }
+      const responsePromise = page.waitForResponse('**/contacts/**');
       await childCallTypeButton.click();
+      await responsePromise;
     },
     fill: async (tabs: ContactFormTab<any>[]) => {
       for (const tab of tabs) {
@@ -100,9 +101,14 @@ export function contactForm(page: Page) {
       await selectTab(tab);
 
       if (saveAndAddToCase) {
+        const responsePromise = page.waitForResponse('**/connectToCase');
         await selectors.saveAndAddToCaseButton.click();
-        await page.waitForResponse('**/connectToCase');
-      } else await selectors.saveContactButton.click();
+        await responsePromise;
+      } else {
+        const responsePromise = page.waitForResponse('**/contacts/**');
+        await selectors.saveContactButton.click();
+        await responsePromise;
+      }
 
       await selectors.tabButton(tab).waitFor({ state: 'detached' });
     },

--- a/e2e-tests/contactForm.ts
+++ b/e2e-tests/contactForm.ts
@@ -15,7 +15,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { Page } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 
 export type Categories = Record<string, string[]>;
 
@@ -48,6 +48,8 @@ export function contactForm(page: Page) {
 
   async function selectTab(tab: ContactFormTab<unknown>) {
     const button = selectors.tabButton(tab);
+    await expect(button).toBeVisible();
+    await expect(button).toBeEnabled();
     if ((await button.getAttribute('aria-selected')) !== 'true') {
       await button.click();
     }

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -40,7 +40,7 @@ async function globalSetup(config: FullConfig) {
   );
   const workerSid = await getSidForWorker(getConfigValue('oktaUsername') as string);
   if (workerSid) {
-    await clearOfflineTask(config, getConfigValue('hrmRoot') as string, workerSid);
+    await clearOfflineTask(getConfigValue('hrmRoot') as string, workerSid);
   } else {
     console.warn(
       `Could not find worker with username ${getConfigValue(

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -40,7 +40,7 @@ async function globalSetup(config: FullConfig) {
   );
   const workerSid = await getSidForWorker(getConfigValue('oktaUsername') as string);
   if (workerSid) {
-    await clearOfflineTask(getConfigValue('hrmRoot') as string, workerSid);
+    await clearOfflineTask(config, getConfigValue('hrmRoot') as string, workerSid);
   } else {
     console.warn(
       `Could not find worker with username ${getConfigValue(

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -32,7 +32,7 @@ async function globalSetup(config: FullConfig) {
   }
 
   await initConfig();
-  await oktaSsoLoginViaApi(
+  const flexToken = await oktaSsoLoginViaApi(
     getConfigValue('baseURL') as string,
     getConfigValue('oktaUsername') as string,
     getConfigValue('oktaPassword') as string,
@@ -40,7 +40,7 @@ async function globalSetup(config: FullConfig) {
   );
   const workerSid = await getSidForWorker(getConfigValue('oktaUsername') as string);
   if (workerSid) {
-    await clearOfflineTask(getConfigValue('hrmRoot') as string, workerSid);
+    await clearOfflineTask(getConfigValue('hrmRoot') as string, workerSid, flexToken);
   } else {
     console.warn(
       `Could not find worker with username ${getConfigValue(

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -18,7 +18,7 @@
 import { FullConfig } from '@playwright/test';
 import { differenceInMilliseconds } from 'date-fns';
 import { oktaSsoLoginViaApi } from './okta/sso-login';
-import { getConfigValue, initConfig } from './config';
+import { getConfigValue, initConfig, localOverrideEnv } from './config';
 import { getSidForWorker } from './twilio/worker';
 import { clearOfflineTask } from './hrm/clearOfflineTask';
 
@@ -40,7 +40,14 @@ async function globalSetup(config: FullConfig) {
   );
   const workerSid = await getSidForWorker(getConfigValue('oktaUsername') as string);
   if (workerSid) {
-    await clearOfflineTask(getConfigValue('hrmRoot') as string, workerSid, flexToken);
+    await clearOfflineTask(
+      (getConfigValue('hrmRoot') as string) ??
+        `https://hrm-${localOverrideEnv}.tl.techmatters.org/v0/accounts/${getConfigValue(
+          'twilioAccountSid',
+        )}`,
+      workerSid,
+      flexToken,
+    );
   } else {
     console.warn(
       `Could not find worker with username ${getConfigValue(

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -41,7 +41,7 @@ async function globalSetup(config: FullConfig) {
   const workerSid = await getSidForWorker(getConfigValue('oktaUsername') as string);
   if (workerSid) {
     await clearOfflineTask(
-      (getConfigValue('hrmRoot') as string) ??
+      (getConfigValue('hrmRoot') as string) ||
         `https://hrm-${localOverrideEnv}.tl.techmatters.org/v0/accounts/${getConfigValue(
           'twilioAccountSid',
         )}`,

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -17,9 +17,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { FullConfig } from '@playwright/test';
 import { differenceInMilliseconds } from 'date-fns';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { oktaSsoLoginViaApi, oktaSsoLoginViaGui } from './okta/sso-login';
+import { oktaSsoLoginViaApi } from './okta/sso-login';
 import { getConfigValue, initConfig } from './config';
+import { getSidForWorker } from './twilio/worker';
+import { clearOfflineTask } from './hrm/clearOfflineTask';
 
 async function globalSetup(config: FullConfig) {
   const start = new Date();
@@ -37,13 +38,16 @@ async function globalSetup(config: FullConfig) {
     getConfigValue('oktaPassword') as string,
     getConfigValue('twilioAccountSid') as string,
   );
-  /* await oktaSsoLoginViaGui(
-    config,
-    getConfigValue('oktaUsername') ?? 'NOT SET',
-    getConfigValue('oktaPassword') ?? 'NOT SET',
-  );
-   */
-
+  const workerSid = await getSidForWorker(getConfigValue('oktaUsername') as string);
+  if (workerSid) {
+    await clearOfflineTask(getConfigValue('hrmRoot') as string, workerSid);
+  } else {
+    console.warn(
+      `Could not find worker with username ${getConfigValue(
+        'oktaUsername',
+      )} to clear out offline tasks.`,
+    );
+  }
   process.env.ARTIFACT_PATH = config.projects[0].outputDir;
   console.log(
     'Global setup completed',

--- a/e2e-tests/hrm/clearOfflineTask.ts
+++ b/e2e-tests/hrm/clearOfflineTask.ts
@@ -20,12 +20,15 @@ import { request } from '@playwright/test';
 export const clearOfflineTask = async (hrmRoot: string, workerSid: string, flexToken: string) => {
   const apiRequest = await request.newContext();
   new URL(`${hrmRoot}/contacts/byTaskSid/offline-task-${workerSid}`);
-  const resp = await apiRequest.get(`${hrmRoot}/contacts/byTaskSid/offline-task-${workerSid}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${flexToken}`,
+  const resp = await apiRequest.get(
+    `${hrmRoot}/contacts/byTaskSid/offline-contact-task-${workerSid}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${flexToken}`,
+      },
     },
-  });
+  );
   if (resp.ok()) {
     const contactId: string = (await resp.json()).id;
     await apiRequest.patch(`${hrmRoot}/contacts/${contactId}`, {

--- a/e2e-tests/hrm/clearOfflineTask.ts
+++ b/e2e-tests/hrm/clearOfflineTask.ts
@@ -31,7 +31,7 @@ export const clearOfflineTask = async (hrmRoot: string, workerSid: string, flexT
   );
   if (resp.ok()) {
     const contactId: string = (await resp.json()).id;
-    await apiRequest.patch(`${hrmRoot}/contacts/${contactId}`, {
+    await apiRequest.patch(`${hrmRoot}/contacts/${contactId}?finalize=false`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${flexToken}`,

--- a/e2e-tests/hrm/clearOfflineTask.ts
+++ b/e2e-tests/hrm/clearOfflineTask.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { request } from '@playwright/test';
+import { getConfigValue } from '../config';
+import * as fs from 'fs/promises';
+
+// Clears out any residual offline task data for a worker so the test env is clean
+export const clearOfflineTask = async (hrmRoot: string, workerSid: string) => {
+  const stateFile = await fs.readFile(getConfigValue('storageStatePath') as string, 'utf-8');
+
+  // Parsing the flex token from the playwright state file seems like the lesser of 2 evils vs starting up a new browser context just to get the cookie value :-)
+  const flexToken = JSON.parse(stateFile).cookies.find((c: any) => c.name === 'flex-jwe')?.value;
+  if (!flexToken) {
+    throw new Error(
+      `Could not find Flex token in playwright session state file following login, so we cannot clear offline task data in HRM. Please check your playwright config.`,
+    );
+  }
+  const apiRequest = await request.newContext({
+    storageState: getConfigValue('storageStatePath') as string,
+  });
+  new URL(`${hrmRoot}/contacts/byTaskSid/offline-task-${workerSid}`);
+  const resp = await apiRequest.get(`${hrmRoot}/contacts/byTaskSid/offline-task-${workerSid}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${flexToken}`,
+    },
+  });
+  if (resp.ok()) {
+    const contactId: string = (await resp.json()).id;
+    await apiRequest.patch(`${hrmRoot}/contacts/${contactId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${flexToken}`,
+      },
+      // Copied from plugin-hrm-form/src/services/ContactService.ts
+      data: {
+        conversationDuration: 0,
+        rawJson: {
+          callType: '',
+          childInformation: {},
+          callerInformation: {},
+          caseInformation: {},
+          categories: {},
+          contactlessTask: {
+            channel: null,
+            createdOnBehalfOf: null,
+            date: null,
+            time: null,
+          },
+        },
+      },
+    });
+  } else {
+    if (resp.status() === 404) {
+      console.warn(`No offline task found for worker ${workerSid}, cannot clear out offline tasks`);
+      return;
+    } else {
+      throw new Error(
+        `Error occurred finding offline tasks for ${workerSid} in HRM: ${resp.status()}`,
+      );
+    }
+  }
+};

--- a/e2e-tests/hrm/clearOfflineTask.ts
+++ b/e2e-tests/hrm/clearOfflineTask.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs/promises';
 // Clears out any residual offline task data for a worker so the test env is clean
 export const clearOfflineTask = async (hrmRoot: string, workerSid: string) => {
   let flexToken;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 30; i++) {
     const stateFile = await fs.readFile(getConfigValue('storageStatePath') as string, 'utf-8');
     console.log(`Stored cookie value lengths:`);
     const cookies = JSON.parse(stateFile).cookies;

--- a/e2e-tests/hrm/clearOfflineTask.ts
+++ b/e2e-tests/hrm/clearOfflineTask.ts
@@ -20,9 +20,11 @@ import * as fs from 'fs/promises';
 
 // Clears out any residual offline task data for a worker so the test env is clean
 export const clearOfflineTask = async (hrmRoot: string, workerSid: string) => {
+  //waitForBrowser()
   let flexToken;
   for (let i = 0; i < 30; i++) {
     const stateFile = await fs.readFile(getConfigValue('storageStatePath') as string, 'utf-8');
+    console.log('Stored state:', stateFile);
     console.log(`Stored cookie value lengths:`);
     const cookies = JSON.parse(stateFile).cookies;
     // eslint-disable-next-line @typescript-eslint/no-loop-func

--- a/e2e-tests/hrm/clearOfflineTask.ts
+++ b/e2e-tests/hrm/clearOfflineTask.ts
@@ -21,7 +21,11 @@ import * as fs from 'fs/promises';
 // Clears out any residual offline task data for a worker so the test env is clean
 export const clearOfflineTask = async (hrmRoot: string, workerSid: string) => {
   const stateFile = await fs.readFile(getConfigValue('storageStatePath') as string, 'utf-8');
-
+  console.log(`Stored cookie value lengths:`);
+  const cookies = JSON.parse(stateFile).cookies;
+  cookies.forEach(({ name, value }: { name: string; value: string }) => {
+    console.log(`${name}: ${value.length}`);
+  });
   // Parsing the flex token from the playwright state file seems like the lesser of 2 evils vs starting up a new browser context just to get the cookie value :-)
   const flexToken = JSON.parse(stateFile).cookies.find((c: any) => c.name === 'flex-jwe')?.value;
   if (!flexToken) {

--- a/e2e-tests/okta/sso-login.ts
+++ b/e2e-tests/okta/sso-login.ts
@@ -15,7 +15,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { chromium, expect, FullConfig, request } from '@playwright/test';
+import { expect, request } from '@playwright/test';
 import { getConfigValue } from '../config';
 
 export function delay(time: number) {
@@ -112,33 +112,4 @@ export async function oktaSsoLoginViaApi(
   await flexPageResponse.dispose(); //Not sure if this is strictly necessary
 
   await apiRequest.storageState({ path: getConfigValue('storageStatePath') as string });
-}
-
-export async function oktaSsoLoginViaGui(
-  config: FullConfig,
-  username: string,
-  password: string,
-): Promise<void> {
-  const project = config.projects[0];
-  const browser = await chromium.launch(project.use);
-  console.log('Global setup browser launched');
-  const page = await browser.newPage();
-  page.goto(project.use.baseURL!, { timeout: 30000 });
-  await page.waitForNavigation({ timeout: 30001 });
-  const usernameBox = page.locator('input#okta-signin-username');
-  const passwordBox = page.locator('input#okta-signin-password');
-  const submitButton = page.locator('input#okta-signin-submit');
-  await Promise.all([usernameBox.waitFor(), passwordBox.waitFor(), submitButton.waitFor()]);
-  console.log('Global setup boxes found');
-  await usernameBox.fill(username);
-  await passwordBox.fill(password);
-  await Promise.all([
-    page.waitForNavigation({ timeout: 30000 }), // Waits for the next navigation
-    submitButton.click(), // Triggers a navigation after a timeout
-  ]);
-  const logoImage = page.locator('.Twilio.Twilio-MainHeader img');
-  await logoImage.waitFor();
-  await expect(logoImage).toHaveAttribute('src', /.*aselo.*/);
-  await page.context().storageState({ path: getConfigValue('storageStatePath') as string });
-  await browser.close();
 }

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npx playwright install chromium",
     "test": "cross-env DEBUG=pw:api npx playwright test --workers 1",
     "test:ui": "npx playwright test --config ui-tests/playwright.ui-test.config.ts",
-    "test:local": "DEBUG=pw:api LOAD_SSM_CONFIG=true npm run test",
+    "test:local": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true npm run test",
     "test:development:as": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=as SKIP_DATA_UPDATE=true npm run test",
     "test:development:e2e": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=e2e npm run test",
     "test:development:e2e:debug": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=e2e npm run test -- --headed --retries 0 webchat",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "npx playwright install chromium",
-    "test": "npx playwright test --workers 1",
+    "test": "cross-env DEBUG=pw:api npx playwright test --workers 1",
     "test:ui": "npx playwright test --config ui-tests/playwright.ui-test.config.ts",
     "test:local": "DEBUG=pw:api LOAD_SSM_CONFIG=true npm run test",
     "test:development:as": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=as SKIP_DATA_UPDATE=true npm run test",

--- a/e2e-tests/tests/caselist.spec.ts
+++ b/e2e-tests/tests/caselist.spec.ts
@@ -48,21 +48,21 @@ test.describe.serial('Open and Edit a Case in Case List page', () => {
     //for Categories filter, 2 valid options are required
     await page.filterCases('Categories', 'Accessibility', 'Education');
 
-    await page.openFirstCaseButton();
+    const caseHomePage = await page.openFirstCaseButton();
 
     // Open notifications cover up the print icon :facepalm
     await notificationBar(pluginPage).dismissAllNotifications();
 
     await page.viewClosePrintView();
 
-    await page.addCaseSection({
+    await caseHomePage.addCaseSection({
       sectionTypeId: 'note',
       items: {
         note: 'TEST NOTE',
       },
     });
 
-    await page.addCaseSection({
+    await caseHomePage.addCaseSection({
       sectionTypeId: 'household',
       items: {
         firstName: 'FIRST NAME',

--- a/e2e-tests/tests/offlineContact.spec.ts
+++ b/e2e-tests/tests/offlineContact.spec.ts
@@ -52,7 +52,7 @@ test.describe.serial('Offline Contact (with Case)', () => {
     console.log('Starting filling form');
 
     const form = contactForm(pluginPage);
-    await form.selectChildCallType(true);
+    await form.selectChildCallType();
     await form.fill([
       <ContactFormTab>{
         id: 'contactlessTask',

--- a/e2e-tests/tests/referrableResources.spec.ts
+++ b/e2e-tests/tests/referrableResources.spec.ts
@@ -51,7 +51,7 @@ test.describe.serial('Resource Search', () => {
 
     console.log('Starting filling form');
     const form = contactForm(pluginPage);
-    await form.selectChildCallType(true);
+    await form.selectChildCallType();
     await form.fill([
       <ContactFormTab>{
         id: 'contactlessTask',

--- a/e2e-tests/twilio/worker.ts
+++ b/e2e-tests/twilio/worker.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { getConfigValue } from '../config';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import twilio from 'twilio';
+
+export const getSidForWorker = async (friendlyName: string): Promise<string | undefined> => {
+  const accountSid = getConfigValue('twilioAccountSid') as string;
+  const authToken = getConfigValue('twilioAuthToken') as string;
+  const twilioClient = twilio(accountSid, authToken);
+
+  const workspaces = await twilioClient.taskrouter.v1.workspaces.list();
+  if (!workspaces) {
+    throw new Error(`Workspaces not found.`);
+  }
+  for (const workspace of workspaces) {
+    const workersInWorkspace = await workspace.workers().list();
+    const sid = workersInWorkspace.find((worker) => worker.friendlyName === friendlyName)?.sid;
+    if (sid) {
+      return sid;
+    }
+  }
+  return undefined;
+};

--- a/plugin-hrm-form/src/___tests__/states/routing/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/routing/reducer.test.ts
@@ -169,7 +169,17 @@ describe('test reducer (specific actions)', () => {
     const result = reduce(state, {
       type: LOAD_CONTACT_FROM_HRM_BY_TASK_ID_ACTION_FULFILLED,
       payload: {
-        contact: { ...VALID_EMPTY_CONTACT, taskId: offlineContactTaskSid },
+        contact: {
+          ...VALID_EMPTY_CONTACT,
+          taskId: offlineContactTaskSid,
+          rawJson: {
+            ...VALID_EMPTY_CONTACT.rawJson,
+            contactlessTask: {
+              ...VALID_EMPTY_CONTACT.rawJson.contactlessTask,
+              createdOnBehalfOf: 'workerSid',
+            },
+          },
+        },
         metadata: VALID_EMPTY_METADATA,
       },
     } as any);

--- a/plugin-hrm-form/src/components/CustomCRMContainer.tsx
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.tsx
@@ -15,9 +15,10 @@
  */
 
 /* eslint-disable react/prop-types */
-import React, { useEffect } from 'react';
+import React, { Dispatch, useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { ITask, withTaskContext } from '@twilio/flex-ui';
+import { DefinitionVersion } from 'hrm-form-definitions';
 
 import TaskView from './TaskView';
 import { Absolute } from '../styles/HrmStyles';
@@ -26,7 +27,11 @@ import { populateCounselorsState } from '../states/configuration/actions';
 import { RootState } from '../states';
 import { OfflineContactTask } from '../types/types';
 import getOfflineContactTaskSid from '../states/contacts/offlineContactTaskSid';
-import { namespace, routingBase } from '../states/storeNamespaces';
+import { namespace } from '../states/storeNamespaces';
+import asyncDispatch from '../states/asyncDispatch';
+import { createContactAsyncAction } from '../states/contacts/saveContact';
+import { getHrmConfig } from '../hrmConfig';
+import { newContact } from '../states/contacts/contactState';
 
 type OwnProps = {
   task?: ITask;
@@ -35,12 +40,20 @@ type OwnProps = {
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const CustomCRMContainer: React.FC<Props> = ({ selectedTaskSid, isAddingOfflineContact, task, dispatch }) => {
+const CustomCRMContainer: React.FC<Props> = ({
+  selectedTaskSid,
+  isAddingOfflineContact,
+  task,
+  populateCounselorList,
+  currentOfflineContact,
+  definitionVersion,
+  loadOrCreateDraftOfflineContact,
+}) => {
   useEffect(() => {
     const fetchPopulateCounselors = async () => {
       try {
         const counselorsList = await populateCounselors();
-        dispatch(populateCounselorsState(counselorsList));
+        populateCounselorList(counselorsList);
       } catch (err) {
         // TODO (Gian): probably we need to handle this in a nicer way
         console.error(err.message);
@@ -48,7 +61,13 @@ const CustomCRMContainer: React.FC<Props> = ({ selectedTaskSid, isAddingOfflineC
     };
 
     fetchPopulateCounselors();
-  }, [dispatch]);
+  }, [populateCounselorList]);
+
+  useEffect(() => {
+    if (!currentOfflineContact && definitionVersion) {
+      loadOrCreateDraftOfflineContact(definitionVersion);
+    }
+  }, [currentOfflineContact, definitionVersion, loadOrCreateDraftOfflineContact]);
 
   const offlineContactTask: OfflineContactTask = {
     taskSid: getOfflineContactTaskSid(),
@@ -71,15 +90,31 @@ const CustomCRMContainer: React.FC<Props> = ({ selectedTaskSid, isAddingOfflineC
 
 CustomCRMContainer.displayName = 'CustomCRMContainer';
 
-const mapStateToProps = (state: RootState) => {
-  const { selectedTaskSid } = state.flex.view;
-  const { isAddingOfflineContact } = state[namespace][routingBase];
+const mapStateToProps = ({ [namespace]: { routing, activeContacts, configuration }, flex }: RootState) => {
+  const { selectedTaskSid } = flex.view;
+  const { isAddingOfflineContact } = routing;
+  const currentOfflineContact = Object.values(activeContacts.existingContacts).find(
+    contact => contact.savedContact.taskId === getOfflineContactTaskSid(),
+  );
 
   return {
     selectedTaskSid,
     isAddingOfflineContact,
+    currentOfflineContact,
+    definitionVersion: configuration.currentDefinitionVersion,
   };
 };
 
-const connector = connect(mapStateToProps);
+const mapDispatchToProps = (dispatch: Dispatch<any>) => {
+  return {
+    loadOrCreateDraftOfflineContact: (definition: DefinitionVersion) =>
+      asyncDispatch(dispatch)(
+        createContactAsyncAction(newContact(definition), getHrmConfig().workerSid, getOfflineContactTaskSid()),
+      ),
+    populateCounselorList: (listPayload: Awaited<ReturnType<typeof populateCounselors>>) =>
+      dispatch(populateCounselorsState(listPayload)),
+  };
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
 export default withTaskContext(connector(CustomCRMContainer));

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -89,11 +89,8 @@ const TaskView: React.FC<Props> = props => {
     };
 
     // Only run setHelpline if a) contactForm.helpline is not set or b) if the task is an offline contact and contactlessTask.helpline has changed
-    const helplineChanged = contactlessTask?.helpline && helpline !== contactlessTask.helpline;
     const shouldSetHelpline =
-      contactInitialized &&
-      contactlessTask?.createdOnBehalfOf &&
-      (!helpline || (isOfflineContactTask(task) && helplineChanged));
+      contactInitialized && (!isOfflineContactTask(task) || contactlessTask?.createdOnBehalfOf) && !helpline;
 
     if (shouldSetHelpline) {
       setHelpline();

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -39,6 +39,7 @@ import {
   routingBase,
   searchContactsBase,
 } from '../states/storeNamespaces';
+import { getUnsavedContact } from '../states/contacts/getUnsavedContact';
 
 type OwnProps = {
   task: CustomITask;
@@ -53,7 +54,7 @@ const TaskView: React.FC<Props> = props => {
     shouldRecreateState,
     currentDefinitionVersion,
     task,
-    contact,
+    unsavedContact,
     updateHelpline,
     loadContactFromHrmByTaskSid,
   } = props;
@@ -69,11 +70,12 @@ const TaskView: React.FC<Props> = props => {
     return () => {
       if (isOfflineContactTask(task)) rerenderAgentDesktop();
     };
-  }, [task]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const contactInitialized = Boolean(contact);
-  const helpline = contact?.helpline;
-  const contactlessTask = contact?.rawJson?.contactlessTask;
+  const contactInitialized = Boolean(unsavedContact);
+  const helpline = unsavedContact?.helpline;
+  const contactlessTask = unsavedContact?.rawJson?.contactlessTask;
 
   // Set contactForm.helpline for all contacts on the first run. React to helpline changes for offline contacts only
   React.useEffect(() => {
@@ -81,19 +83,22 @@ const TaskView: React.FC<Props> = props => {
       if (task && !isStandaloneITask(task)) {
         const helplineToSave = await getHelplineToSave(task, contactlessTask);
         if (helpline !== helplineToSave) {
-          updateHelpline(contact.id, helplineToSave);
+          updateHelpline(unsavedContact.id, helplineToSave);
         }
       }
     };
 
     // Only run setHelpline if a) contactForm.helpline is not set or b) if the task is an offline contact and contactlessTask.helpline has changed
     const helplineChanged = contactlessTask?.helpline && helpline !== contactlessTask.helpline;
-    const shouldSetHelpline = contactInitialized && (!helpline || (isOfflineContactTask(task) && helplineChanged));
+    const shouldSetHelpline =
+      contactInitialized &&
+      contactlessTask?.createdOnBehalfOf &&
+      (!helpline || (isOfflineContactTask(task) && helplineChanged));
 
     if (shouldSetHelpline) {
       setHelpline();
     }
-  }, [contactlessTask, contactInitialized, helpline, task, updateHelpline, contact]);
+  }, [contactlessTask, contactInitialized, helpline, task, updateHelpline, unsavedContact.id]);
 
   if (!currentDefinitionVersion) {
     return null;
@@ -136,10 +141,11 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const { task } = ownProps;
   const { currentDefinitionVersion } = state[namespace][configurationBase];
   // Check if the entry for this task exists in each reducer
-  const { savedContact: contact } =
+  const { savedContact, draftContact } =
     (task && Object.values(state[namespace][contactFormsBase]?.existingContacts).find(c => c.savedContact?.taskId)) ??
     {};
-  const contactFormStateExists = Boolean(contact);
+  const unsavedContact = getUnsavedContact(savedContact, draftContact);
+  const contactFormStateExists = Boolean(savedContact);
   const routingStateExists = Boolean(task && state[namespace][routingBase].tasks[task.taskSid]);
   const searchStateExists = Boolean(task && state[namespace][searchContactsBase].tasks[task.taskSid]);
 
@@ -147,7 +153,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
     currentDefinitionVersion && (!contactFormStateExists || !routingStateExists || !searchStateExists);
 
   return {
-    contact,
+    unsavedContact,
     shouldRecreateState,
     currentDefinitionVersion,
   };

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -122,8 +122,13 @@ export const RequiredAsterisk = () => (
 const getRules = (field: FormItemDefinition): RegisterOptions =>
   pick(field, ['max', 'maxLength', 'min', 'minLength', 'pattern', 'required', 'validate']);
 
-const bindCreateSelectOptions = (path: string) => (o: SelectOption) => (
-  <FormOption key={`${path}-${o.label}-${o.value}`} value={o.value} isEmptyValue={o.value === ''}>
+const bindCreateSelectOptions = (path: string, initialValue: string) => (o: SelectOption) => (
+  <FormOption
+    key={`${path}-${o.label}-${o.value}`}
+    value={o.value}
+    isEmptyValue={o.value === ''}
+    selected={o.value === initialValue}
+  >
     {o.label}
   </FormOption>
 );
@@ -485,7 +490,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
         <ConnectForm key={path}>
           {({ errors, register }) => {
             const error = get(errors, path);
-            const createSelectOptions = bindCreateSelectOptions(path);
+            const createSelectOptions = bindCreateSelectOptions(path, initialValue);
 
             return (
               <FormLabel htmlFor={path}>
@@ -503,7 +508,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
                     error={Boolean(error)}
                     aria-invalid={Boolean(error)}
                     aria-describedby={`${path}-error`}
-                    onBlur={updateCallback}
+                    onChange={updateCallback}
                     ref={ref => {
                       if (htmlElRef) {
                         htmlElRef.current = ref;
@@ -511,7 +516,6 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
 
                       register(rules)(ref);
                     }}
-                    defaultValue={initialValue}
                     disabled={!isEnabled}
                   >
                     {def.options.map(createSelectOptions)}
@@ -561,7 +565,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
 
             const disabled = !hasOptions && !shouldInitialize;
 
-            const createSelectOptions = bindCreateSelectOptions(path);
+            const createSelectOptions = bindCreateSelectOptions(path, initialValue);
 
             return (
               <DependentSelectLabel htmlFor={path} disabled={disabled}>
@@ -579,7 +583,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
                     error={Boolean(error)}
                     aria-invalid={Boolean(error)}
                     aria-describedby={`${path}-error`}
-                    onBlur={updateCallback}
+                    onChange={updateCallback}
                     ref={ref => {
                       if (htmlElRef) {
                         htmlElRef.current = ref;
@@ -588,7 +592,6 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
                       register({ validate })(ref);
                     }}
                     disabled={!isEnabled || disabled}
-                    defaultValue={initialValue}
                   >
                     {options.map(createSelectOptions)}
                   </FormSelect>

--- a/plugin-hrm-form/src/components/contact/ResourceReferralList/index.tsx
+++ b/plugin-hrm-form/src/components/contact/ResourceReferralList/index.tsx
@@ -128,7 +128,9 @@ const ResourceReferralList: React.FC<Props> = ({
 
   useEffect(() => {
     if (!lookedUpResource) {
-      loadResource(resourceReferralIdToAdd);
+      if (resourceReferralIdToAdd) {
+        loadResource(resourceReferralIdToAdd);
+      }
     } else if (lookupStatus === ReferralLookupStatus.PENDING) {
       if (lookedUpResource.status === ResourceLoadStatus.Error) {
         updateResourceReferralLookupStatus(ReferralLookupStatus.NOT_FOUND);

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -93,7 +93,7 @@ const BottomBar: React.FC<
     setSubmitting(true);
 
     try {
-      submitContactFormAsyncAction(task, contact, metadata, caseForm as Case);
+      await submitContactFormAsyncAction(task, contact, metadata, caseForm as Case);
       await completeTask(task);
     } catch (error) {
       if (window.confirm(strings['Error-ContinueWithoutRecording'])) {

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -261,7 +261,7 @@ const TabbedForms: React.FC<Props> = ({
                     display={subroute === 'contactlessTask'}
                     helplineInformation={currentDefinitionVersion.helplineInformation}
                     definition={currentDefinitionVersion.tabbedForms.ContactlessTaskTab}
-                    initialValues={contactlessTask}
+                    initialValues={{ ...contactlessTask, helpline }}
                     autoFocus={autoFocus}
                   />
                 </TabbedFormTabContainer>

--- a/plugin-hrm-form/src/hrmConfig.ts
+++ b/plugin-hrm-form/src/hrmConfig.ts
@@ -19,6 +19,7 @@ import * as Flex from '@twilio/flex-ui';
 import { buildFormDefinitionsBaseUrlGetter, inferConfiguredFormDefinitionsBaseUrl } from './definitionVersions';
 import { FeatureFlags } from './types/types';
 import type { RootState } from './states';
+import { namespace } from './states/storeNamespaces';
 
 const featureFlagEnvVarPrefix = 'REACT_FF_';
 
@@ -155,5 +156,5 @@ export const getAseloFeatureFlags = (): FeatureFlags => cachedConfig.featureFlag
  */
 // eslint-disable-next-line import/no-unused-modules
 export const getDefinitionVersions = () => {
-  return (Flex.Manager.getInstance().store.getState() as RootState)['plugin-hrm-form'].configuration;
+  return (Flex.Manager.getInstance().store.getState() as RootState)[namespace].configuration;
 };

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -28,6 +28,8 @@ import findContactByTaskSid from '../states/contacts/findContactByTaskSid';
 import { RootState } from '../states';
 import * as GeneralActions from '../states/actions';
 import getOfflineContactTaskSid from '../states/contacts/offlineContactTaskSid';
+import asyncDispatch from '../states/asyncDispatch';
+import { newClearContactAsyncAction, connectToCaseAsyncAction } from '../states/contacts/saveContact';
 
 /**
  * Function used to manually complete a task (making sure it transitions to wrapping state first).
@@ -46,17 +48,19 @@ export const completeContactTask = async (task: ITask) => {
   await Actions.invokeAction('CompleteTask', { sid, task });
 };
 
-export const removeOfflineContact = () => {
+export const removeOfflineContact = async () => {
   const offlineContactTaskSid = getOfflineContactTaskSid();
   const manager = Manager.getInstance();
   const contactState = findContactByTaskSid(manager.store.getState() as RootState, offlineContactTaskSid);
   if (contactState) {
+    await asyncDispatch(manager.store.dispatch)(newClearContactAsyncAction(contactState.savedContact));
+    await asyncDispatch(manager.store.dispatch)(connectToCaseAsyncAction(contactState.savedContact.id, undefined));
     manager.store.dispatch(GeneralActions.removeContactState(offlineContactTaskSid, contactState.savedContact.id));
   }
 };
 
 export const completeContactlessTask = async () => {
-  removeOfflineContact();
+  await removeOfflineContact();
 };
 
 export const completeTask = (task: CustomITask) =>

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -15,6 +15,7 @@
  */
 
 import { createAsyncAction, createReducer } from 'redux-promise-middleware-actions';
+import { format } from 'date-fns';
 
 import { submitContactForm } from '../../services/formSubmissionHelpers';
 import { connectToCase, createContact, getContactByTaskSid, updateContactInHrm } from '../../services/ContactService';
@@ -58,6 +59,48 @@ export const updateContactInHrmAsyncAction = createAsyncAction(
     };
   },
 );
+
+const BLANK_CONTACT_CHANGES: ContactDraftChanges = {
+  conversationDuration: 0,
+  rawJson: {
+    callType: '',
+    childInformation: {},
+    callerInformation: {},
+    caseInformation: {},
+    categories: {},
+    contactlessTask: {
+      channel: null,
+      createdOnBehalfOf: null,
+      date: null,
+      time: null,
+    },
+  },
+};
+
+export const newClearContactAsyncAction = (contact: Contact) =>
+  updateContactInHrmAsyncAction(contact, {
+    ...BLANK_CONTACT_CHANGES,
+    timeOfContact: new Date().toISOString(),
+  });
+
+export const newRestartOfflineContactAsyncAction = (contact: Contact, createdOnBehalfOf: string) => {
+  const now = new Date();
+  const time = format(now, 'HH:mm');
+  const date = format(now, 'yyyy-MM-dd');
+  return updateContactInHrmAsyncAction(contact, {
+    ...BLANK_CONTACT_CHANGES,
+    timeOfContact: now.toISOString(),
+    rawJson: {
+      ...BLANK_CONTACT_CHANGES.rawJson,
+      contactlessTask: {
+        channel: null,
+        createdOnBehalfOf,
+        date,
+        time,
+      },
+    },
+  });
+};
 
 // TODO: Update connectedContacts on case in redux state
 export const connectToCaseAsyncAction = createAsyncAction(

--- a/plugin-hrm-form/src/states/routing/reducer.ts
+++ b/plugin-hrm-form/src/states/routing/reducer.ts
@@ -19,7 +19,7 @@ import { callTypes } from 'hrm-form-definitions';
 
 import { AppRoutes, RoutingActionType, CHANGE_ROUTE } from './types';
 import { REMOVE_CONTACT_STATE, RemoveContactStateAction } from '../types';
-import { Contact, standaloneTaskSid } from '../../types/types';
+import { standaloneTaskSid } from '../../types/types';
 import getOfflineContactTaskSid from '../contacts/offlineContactTaskSid';
 import {
   ContactUpdatingAction,
@@ -86,7 +86,9 @@ const contactUpdatingReducer = (state: RoutingState, action: ContactUpdatingActi
           : initialEntry,
     },
     isAddingOfflineContact:
-      taskId === getOfflineContactTaskSid() ? true : stateWithoutPreviousContact.isAddingOfflineContact,
+      taskId === getOfflineContactTaskSid() && contact?.rawJson?.contactlessTask?.createdOnBehalfOf
+        ? true
+        : stateWithoutPreviousContact.isAddingOfflineContact,
   };
 };
 


### PR DESCRIPTION
## Description

* Draft offline contacts get fully removed when cancelled
* In progress offline contacts get reloaded on browser session reloads

As an artefact of saving offline contacts under a single ID per user, 'draft offline contacts' may exist at unexpected times and cause confusion in search results, it might be best to just filter out all draft offline contacts from search results in HRM until the search experience is updated



### Checklist
- [ ] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
FixesCHI-2319

### Verification steps

* Cancel an offline contact, then start another - the data should all be reset to blanks / defaults
* Refresh the browser halfway through a contact, it should reload with the contact still in progress (minus and changes since you last changed tabs)
* Regression test offline contacts basic saving & searching