### PR TITLE
Client Profiles - 2a - enable linking to case from case list

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/routing/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/routing/reducer.test.ts
@@ -312,8 +312,12 @@ describe('test reducer (specific actions)', () => {
       },
       {
         description: 'Current route is the only route in the base stack - should do nothing',
-        startingState: stateWithRouteStack([{ route: 'contact', subroute: 'view', id: 'contact1' }]),
-        expected: stateWithRouteStack([{ route: 'contact', subroute: 'view', id: 'contact1' }]),
+        startingState: stateWithRouteStack([
+          { route: 'csam-report', subroute: 'status', previousRoute: { route: 'select-call-type' } },
+        ]),
+        expected: stateWithRouteStack([
+          { route: 'csam-report', subroute: 'status', previousRoute: { route: 'select-call-type' } },
+        ]),
         action: actions.newGoBackAction(task.taskSid),
       },
       {

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -255,7 +255,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
   const { canView } = getPermissionsForViewingIdentifiers();
   const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
-  const profileLink = featureFlags.enable_client_profiles && (
+  const profileLink = featureFlags.enable_client_profiles && savedContact.profileId && (
     <SectionActionButton padding="0" type="button" onClick={() => openProfileModal(savedContact.profileId)}>
       View Profile
     </SectionActionButton>

--- a/plugin-hrm-form/src/states/routing/types.ts
+++ b/plugin-hrm-form/src/states/routing/types.ts
@@ -209,7 +209,9 @@ type OtherRoutes =
 export type AppRoutes = AppRoutesWithCase | OtherRoutes;
 
 export function isRouteWithModalSupport(appRoute: any): appRoute is RouteWithModalSupport {
-  return ['tabbed-forms', 'case', 'case-list', 'profile', 'search', 'select-call-type'].includes(appRoute.route);
+  return ['tabbed-forms', 'case', 'case-list', 'contact', 'profile', 'search', 'select-call-type'].includes(
+    appRoute.route,
+  );
 }
 
 export enum ChangeRouteMode {


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This enables linking to the full view of a case from a profile list. Also fixes a nit so the profile link doesn't show on contacts (like offline contacts) that don't have profiles attached on the contacts detail page.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->