### PR TITLE
Move contact creation to after accept task hook

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -150,8 +150,6 @@ const setUpActions = (
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject, getMessage);
   const beforeCompleteAction = ActionFunctions.beforeCompleteTask(featureFlags);
 
-  Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.initializeContactForm);
-
   Flex.Actions.addListener('afterAcceptTask', ActionFunctions.afterAcceptTask(featureFlags, setupObject, getMessage));
 
   setUpTransferActions(featureFlags.enable_transfers, setupObject);

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -145,6 +145,7 @@ const sendWelcomeMessageOnConversationJoined = (
 export const afterAcceptTask = (featureFlags: FeatureFlags, setupObject: SetupObject, getMessage: GetMessage) => async (
   payload: ActionPayload,
 ) => {
+  await initializeContactForm(payload);
   const { task } = payload;
 
   if (TaskHelper.isChatBasedTask(task)) {


### PR DESCRIPTION
An issue where contacts could not be updated by the person who accepts the task because the createdBy / twilioWorkerId were given to someone else who rejected the task necessitate moving the contact creation to 'afterAcceptTask'