### PR TITLE
Dialpad integration during calls and conferences

### DIFF
--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/ToogleDialpad.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/ToogleDialpad.tsx
@@ -35,7 +35,6 @@ const ToogleDialpad: React.FC<Props> = ({ call, task, conference, dialpadState }
   };
 
   const isLiveCall = TaskHelper.isLiveCall(task);
-  const buttonText = 'Dialpad';
 
   return (
     <StyledConferenceButtonWrapper>
@@ -43,7 +42,7 @@ const ToogleDialpad: React.FC<Props> = ({ call, task, conference, dialpadState }
         {dialpadState ? <CloseOutlined /> : <DialpadOutlined />}
       </StyledConferenceButton>
       <span>
-        <Template code={buttonText} />
+        <Template code="Dial" />
       </span>
     </StyledConferenceButtonWrapper>
   );

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/ToogleDialpad.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/ToogleDialpad.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import { TaskContextProps, TaskHelper, Template, withTaskContext, Actions } from '@twilio/flex-ui';
+import DialpadOutlined from '@material-ui/icons/DialpadOutlined';
+import CloseOutlined from '@material-ui/icons/CloseOutlined';
+
+import { StyledConferenceButtonWrapper, StyledConferenceButton } from './styles';
+
+type Props = TaskContextProps & { dialpadState?: {} | null };
+
+const ToogleDialpad: React.FC<Props> = ({ call, task, conference, dialpadState }) => {
+  if (!task || !call || !conference) {
+    return null;
+  }
+
+  const isDialpadOpen = Boolean(dialpadState);
+
+  const handleClick = async () => {
+    await Actions.invokeAction('ToggleDTMFDialpad', { task, sid: task.sid, open: !isDialpadOpen });
+  };
+
+  const isLiveCall = TaskHelper.isLiveCall(task);
+  const buttonText = 'Dialpad';
+
+  return (
+    <StyledConferenceButtonWrapper>
+      <StyledConferenceButton disabled={!isLiveCall} onClick={handleClick}>
+        {dialpadState ? <CloseOutlined /> : <DialpadOutlined />}
+      </StyledConferenceButton>
+      <span>
+        <Template code={buttonText} />
+      </span>
+    </StyledConferenceButtonWrapper>
+  );
+};
+
+export default withTaskContext(ToogleDialpad);

--- a/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.tsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.tsx
@@ -117,7 +117,7 @@ const CallTypeButtons: React.FC<Props> = ({
       await completeTask(task, savedContact);
     } catch (error) {
       const strings = getTemplateStrings();
-      if (!window.confirm(strings['Error-ContinueWithoutRecording'])) {
+      if (window.confirm(strings['Error-ContinueWithoutRecording'])) {
         await completeTask(task, savedContact);
       }
     }

--- a/plugin-hrm-form/src/conference/setUpConferenceComponents.tsx
+++ b/plugin-hrm-form/src/conference/setUpConferenceComponents.tsx
@@ -20,6 +20,7 @@ import { ParticipantCanvasChildrenProps } from '@twilio/flex-ui/src/components/c
 
 import ConferencePanel from '../components/Conference/ConferenceActions/ConferencePanel';
 import ToggleMute from '../components/Conference/ConferenceActions/ToggleMute';
+import ToogleDialpad from '../components/Conference/ConferenceActions/ToogleDialpad';
 import Hangup from '../components/Conference/ConferenceActions/Hangup';
 import HoldParticipantButton from '../components/Conference/HoldParticipantButton';
 import RemoveParticipantButton from '../components/Conference/RemoveParticipantButton';
@@ -41,12 +42,15 @@ export const setupConferenceComponents = () => {
   CallCanvasActions.Content.remove('hangup', {
     if: props => TaskHelper.isCallTask(props.task) && TaskHelper.isLiveCall(props.task),
   });
-
   CallCanvasActions.Content.add(<ConferencePanel key="conference-panel" />, {
     sortOrder: -1,
     if: props => TaskHelper.isCallTask(props.task) && TaskHelper.isLiveCall(props.task),
   });
   CallCanvasActions.Content.add(<ToggleMute key="conference-toggle" />, {
+    sortOrder: 1,
+    if: props => TaskHelper.isCallTask(props.task) && TaskHelper.isLiveCall(props.task),
+  });
+  CallCanvasActions.Content.add(<ToogleDialpad key="open-dialpad" />, {
     sortOrder: 1,
     if: props => TaskHelper.isCallTask(props.task) && TaskHelper.isLiveCall(props.task),
   });


### PR DESCRIPTION
## Description
This PR adds a dialpad toogle button that works during calls and conferences. The button will open the Twilio dialpad overlaying the current call participants, and can be dismissed by clicking the same button.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2360)
- [ ] New tests added
- [ ] Feature flags added
- [x] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Verification steps
- Start local HRM (`npm run start:light`) at `master` branch - until development is fixed.
- Start local Flex using this branch (`npm run dev:local`).
- [Optional] Open Aselo Beta Flex instance in an incognito tab.
- Make a phone call to the local instance (Aselo Development).
- Accept the call in the Flex end and confirm that the dialpad button appears and behaves as described above.
- Start a conference by adding a third participant and confirm that the dialpad button appears and behaves as described above.