### PR TITLE
CHI-1974: Various styling tweaks to tidy up modals

### DIFF
--- a/plugin-hrm-form/src/components/NavigableContainer.tsx
+++ b/plugin-hrm-form/src/components/NavigableContainer.tsx
@@ -29,8 +29,13 @@ import { changeRoute, newCloseModalAction, newGoBackAction } from '../states/rou
 import { Contact, CustomITask, StandaloneITask } from '../types/types';
 import * as CaseActions from '../states/case/actions';
 import * as RoutingActions from '../states/routing/actions';
-import { HeaderCloseButton, HiddenText, Row, StyledBackButton } from '../styles/HrmStyles';
-import { LargeBackIcon, NavigableContainerBox, NavigableContainerTitle } from '../styles/NavigableContainerStyles';
+import { Box, HeaderCloseButton, HiddenText, Row, StyledBackButton } from '../styles/HrmStyles';
+import {
+  LargeBackIcon,
+  NavigableContainerBox,
+  NavigableContainerContentBox,
+  NavigableContainerTitle,
+} from '../styles/NavigableContainerStyles';
 
 type OwnProps = {
   task: CustomITask | StandaloneITask;
@@ -83,16 +88,19 @@ const NavigableContainer: React.FC<Props> = ({
   return (
     <NavigableContainerBox modal={isModal} {...boxProps}>
       <Row style={{ alignItems: 'start' }}>
-        {hasHistory && (
-          <StyledBackButton onClick={onGoBack} data-testid="NavigableContainer-BackButton">
-            <Row style={{ paddingTop: '7px' }}>
-              <LargeBackIcon />
-              <HiddenText>
-                <Template code="NavigableContainer-BackButton" />
-              </HiddenText>
-            </Row>
-          </StyledBackButton>
-        )}
+        <Box width="30px">
+          {hasHistory && (
+            <StyledBackButton onClick={onGoBack} data-testid="NavigableContainer-BackButton">
+              <Row style={{ paddingTop: '7px' }}>
+                <LargeBackIcon />
+                <HiddenText>
+                  <Template code="NavigableContainer-BackButton" />
+                </HiddenText>
+              </Row>
+            </StyledBackButton>
+          )}
+        </Box>
+
         <NavigableContainerTitle data-testid="NavigableContainer-Title">
           <Template code={titleCode} />
         </NavigableContainerTitle>
@@ -109,7 +117,7 @@ const NavigableContainer: React.FC<Props> = ({
           </HeaderCloseButton>
         )}
       </Row>
-      {children}
+      <NavigableContainerContentBox>{children}</NavigableContainerContentBox>
     </NavigableContainerBox>
   );
 };

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -252,7 +252,7 @@ const AddEditCaseItem: React.FC<Props> = ({
             updatingCounsellor={updatingCounsellorName}
             updated={updated}
           />
-          <Container>
+          <Container removePadding={true}>
             <Box paddingBottom={`${BottomButtonBarHeight}px`}>
               <TwoColumnLayout>
                 <ColumnarBlock>

--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -209,8 +209,18 @@ const CaseHome: React.FC<Props> = ({
   };
 
   return (
-    <NavigableContainer titleCode={contactIdentifier} task={task} onGoBack={handleClose} onCloseModal={handleClose}>
-      <CaseContainer data-testid="CaseHome-CaseDetailsComponent">
+    <NavigableContainer
+      titleCode={contactIdentifier}
+      task={task}
+      onGoBack={handleClose}
+      onCloseModal={handleClose}
+      data-testid="CaseHome-CaseDetailsComponent"
+    >
+      <CaseContainer
+        style={{
+          overflowY: isCreating ? 'scroll' : 'visible',
+        }}
+      >
         {showConnectToCaseButton && (
           <BannerContainer color="yellow" style={{ paddingTop: '12px', paddingBottom: '12px' }}>
             <Flex width="100%" justifyContent="space-between">
@@ -231,7 +241,7 @@ const CaseHome: React.FC<Props> = ({
             </Flex>
           </BannerContainer>
         )}
-        <Box marginLeft="25px" marginTop="13px">
+        <Box marginTop="13px">
           <CaseDetailsComponent
             caseId={id.toString()}
             statusLabel={statusLabel}
@@ -250,13 +260,13 @@ const CaseHome: React.FC<Props> = ({
             editCaseSummary={onEditCaseSummaryClick}
           />
         </Box>
-        <Box margin="25px 0 0 25px">
+        <Box margin="25px 0 0 0">
           <CaseSummary task={task} />
         </Box>
-        <Box margin="25px 0 0 25px">
+        <Box margin="25px 0 0 0">
           <Timeline taskSid={task.taskSid} can={can} />
         </Box>
-        <Box margin="25px 0 0 25px">
+        <Box margin="25px 0 0 0">
           <CaseSection
             canAdd={() => can(PermissionActions.ADD_HOUSEHOLD)}
             onClickAddItem={onAddCaseItemClick(NewCaseSubroutes.Household)}
@@ -265,7 +275,7 @@ const CaseHome: React.FC<Props> = ({
             {householdRows()}
           </CaseSection>
         </Box>
-        <Box margin="25px 0 0 25px">
+        <Box margin="25px 0 0 0">
           <CaseSection
             canAdd={() => can(PermissionActions.ADD_PERPETRATOR)}
             onClickAddItem={onAddCaseItemClick(NewCaseSubroutes.Perpetrator)}
@@ -274,7 +284,7 @@ const CaseHome: React.FC<Props> = ({
             {perpetratorRows()}
           </CaseSection>
         </Box>
-        <Box margin="25px 0 0 25px">
+        <Box margin="25px 0 0 0">
           <CaseSection
             canAdd={() => can(PermissionActions.ADD_INCIDENT)}
             onClickAddItem={onAddCaseItemClick(NewCaseSubroutes.Incident)}
@@ -284,7 +294,7 @@ const CaseHome: React.FC<Props> = ({
           </CaseSection>
         </Box>
         {featureFlags.enable_upload_documents && (
-          <Box margin="25px 0 0 25px">
+          <Box margin="25px 0 0 0">
             <CaseSection
               onClickAddItem={onAddCaseItemClick(NewCaseSubroutes.Document)}
               canAdd={() => can(PermissionActions.ADD_DOCUMENT)}

--- a/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
+++ b/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
@@ -33,7 +33,6 @@ import {
   StyledNextStepButton,
   TwoColumnLayout,
 } from '../../styles/HrmStyles';
-import { CaseActionFormContainer } from '../../styles/case';
 import ActionHeader from './ActionHeader';
 import { RootState } from '../../states';
 import * as CaseActions from '../../states/case/actions';
@@ -201,22 +200,20 @@ const EditCaseSummary: React.FC<Props> = ({
         onGoBack={checkForEdits}
         onCloseModal={checkForEdits}
       >
-        <CaseActionFormContainer>
-          <ActionHeader
-            addingCounsellor={addingCounsellorName}
-            added={added}
-            updated={updated}
-            updatingCounsellor={updatingCounsellorName}
-          />
-          <Container>
-            <Box paddingBottom={`${BottomButtonBarHeight}px`}>
-              <TwoColumnLayout>
-                <ColumnarBlock>{l}</ColumnarBlock>
-                <ColumnarBlock>{r}</ColumnarBlock>
-              </TwoColumnLayout>
-            </Box>
-          </Container>{' '}
-        </CaseActionFormContainer>
+        <ActionHeader
+          addingCounsellor={addingCounsellorName}
+          added={added}
+          updated={updated}
+          updatingCounsellor={updatingCounsellorName}
+        />
+        <Container removePadding={true}>
+          <Box paddingBottom={`${BottomButtonBarHeight}px`}>
+            <TwoColumnLayout>
+              <ColumnarBlock>{l}</ColumnarBlock>
+              <ColumnarBlock>{r}</ColumnarBlock>
+            </TwoColumnLayout>
+          </Box>
+        </Container>{' '}
         <div style={{ width: '100%', height: 5, backgroundColor: '#ffffff' }} />
         <BottomButtonBar>
           <StyledNextStepButton

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -33,13 +33,7 @@ import {
   CustomITask,
   StandaloneITask,
 } from '../../types/types';
-import {
-  DetailsContainer,
-  ContactAddedFont,
-  SectionActionButton,
-  SectionValueText,
-  ContactDetailsIcon,
-} from '../../styles/search';
+import { ContactAddedFont, SectionActionButton, SectionValueText, ContactDetailsIcon } from '../../styles/search';
 import ContactDetailsSection from './ContactDetailsSection';
 import { SectionEntry, SectionEntryValue } from '../common/forms/SectionEntry';
 import { channelTypes, isChatChannel, isVoiceChannel } from '../../states/DomainConstants';
@@ -262,7 +256,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
   );
 
   return (
-    <DetailsContainer data-testid="ContactDetails-Container">
+    <Box data-testid="ContactDetails-Container">
       {auditMessage(timeOfContact, createdBy, 'ContactDetails-ActionHeaderAdded')}
       {auditMessage(updatedAt, updatedBy, 'ContactDetails-ActionHeaderUpdated')}
 
@@ -431,7 +425,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
           </Flex>
         </ContactDetailsSection>
       )}
-    </DetailsContainer>
+    </Box>
   );
 };
 

--- a/plugin-hrm-form/src/components/contact/ContactDetailsSectionForm.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsSectionForm.tsx
@@ -83,7 +83,7 @@ const ContactDetailsSectionForm: React.FC<Props> = ({
   }, [layoutDefinition, form]);
 
   return (
-    <Container>
+    <Container removePadding={true}>
       <Box paddingBottom={`${BottomButtonBarHeight}px`}>
         <TwoColumnLayout>
           <ColumnarBlock>

--- a/plugin-hrm-form/src/components/contact/IssueCategorizationSectionForm.tsx
+++ b/plugin-hrm-form/src/components/contact/IssueCategorizationSectionForm.tsx
@@ -64,7 +64,7 @@ const IssueCategorizationSectionForm: React.FC<Props> = ({
   const selectedCount = Object.values(selectedCategories).reduce((acc, curr) => acc + curr.length, 0);
 
   return (
-    <Container>
+    <Container removePadding={true}>
       <CategoryTitle>
         <Template code="Categories-Title" />
       </CategoryTitle>

--- a/plugin-hrm-form/src/components/search/SearchForm/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.tsx
@@ -159,7 +159,7 @@ const SearchForm: React.FC<Props> = ({
 
   return (
     <>
-      <Container data-testid="SearchForm">
+      <Container data-testid="SearchForm" removePadding={true}>
         <Row>
           <FieldText
             id="Search_FirstName"

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
@@ -135,7 +135,7 @@ const ContactlessTaskTab: React.FC<Props> = ({
   }, [setValue, time]);
 
   return (
-    <Container>
+    <Container removePadding={true}>
       <TwoColumnLayout>
         <ColumnarBlock>
           <ColumnarContent>{contactlessTaskForm}</ColumnarContent>

--- a/plugin-hrm-form/src/states/routing/reducer.ts
+++ b/plugin-hrm-form/src/states/routing/reducer.ts
@@ -67,21 +67,10 @@ const contactUpdatingReducer = (state: RoutingState, action: ContactUpdatingActi
         previousContact.taskId === getOfflineContactTaskSid() ? false : state.isAddingOfflineContact,
     };
   }
-  const { taskId, rawJson, caseId } = contact;
+  const { taskId, rawJson } = contact;
   let initialEntry: AppRoutes = newTaskEntry;
   const { callType } = rawJson;
-  if (caseId && callType) {
-    initialEntry = {
-      route: 'tabbed-forms',
-      subroute: 'caseInformation',
-      activeModal: [
-        {
-          route: 'case',
-          subroute: 'home',
-        },
-      ],
-    };
-  } else if (callType === callTypes.child) {
+  if (callType === callTypes.child) {
     initialEntry = {
       route: 'tabbed-forms',
       subroute: 'childInformation',

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -109,6 +109,8 @@ type TabbedFormTabContainerProps = {
 export const TabbedFormTabContainer = styled(({ display, ...rest }: TabbedFormTabContainerProps) => <Box {...rest} />)<
   TabbedFormTabContainerProps
 >`
+  padding: 32px 20px 12px 20px;
+  background-color: white;
   display: ${({ display }) => (display ? 'block' : 'none')};
   height: ${({ display }) => (display ? '100%' : '0px')};
 `;
@@ -355,7 +357,6 @@ export const BottomButtonBar = styled('div')`
   height: ${BottomButtonBarHeight}px;
   flex-shrink: 0;
   padding: 0 20px;
-  background-color: #f9fafb;
   z-index: 1;
   box-shadow: 0 -2px 2px 0 rgba(0, 0, 0, 0.1);
 `;
@@ -366,7 +367,7 @@ export const ColumnarBlock = styled('div')`
   flex-direction: column;
   flex-grow: 1;
   flex-basis: 0;
-  margin: 0 10px;
+  margin: 0;
 `;
 ColumnarBlock.displayName = 'ColumnarBlock';
 

--- a/plugin-hrm-form/src/styles/NavigableContainerStyles.tsx
+++ b/plugin-hrm-form/src/styles/NavigableContainerStyles.tsx
@@ -25,18 +25,31 @@ type NavigableContainerProps = {
 
 export const NavigableContainerBox = styled('div')<NavigableContainerProps>`
   display: flex;
-  padding: 20px 20px 12px 20px;
+  padding: 20px 5px 12px 5px;
   flex-direction: column;
   flex-wrap: nowrap;
   background-color: #ffffff;
   ${({ modal }) => (modal ? `border-radius: 8px;` : ``)}
   margin: ${({ modal }) => (modal ? `5px` : `0`)};
   height: 100%;
+  overflow-y: hidden;
+`;
+
+NavigableContainerBox.displayName = 'NavigableContainerBox';
+
+export const NavigableContainerContentBox = styled('div')<NavigableContainerProps>`
+  padding: 0 30px 0 30px;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  height: 100%;
   overflow-y: auto;
 `;
 
+NavigableContainerContentBox.displayName = 'NavigableContainerContentBox';
+
 export const NavigableContainerTitle = styled(FontOpenSans)`
-  font-size: 22pt;
+  font-size: 14pt;
   font-weight: 700;
   display: inline-block;
   margin-bottom: 20px;

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -32,9 +32,9 @@ CaseLayout.displayName = 'CaseLayout';
 export const CaseContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
   height: 100%;
   background-color: #ffffff;
+  padding-right: 5px;
 `;
 CaseContainer.displayName = 'CaseContainer';
 
@@ -44,7 +44,6 @@ export const CaseActionFormContainer = styled('div')`
   flex-direction: column;
   flex-wrap: nowrap;
   overflow-y: auto;
-  padding: 20px 10px 0 30px;
 `;
 
 export const CenteredContainer = styled(CaseContainer)`
@@ -372,7 +371,6 @@ type CaseDetailsBorderProps = {
 
 export const CaseDetailsBorder = styled('div')<CaseDetailsBorderProps>`
   border-bottom: ${props => (props.sectionTypeId ? 'none' : '1px solid #e5e6e7')};
-  margin-right: 25px;
   margin-bottom: ${props => (props.marginBottom ? props.marginBottom : '')};
   padding-bottom: ${props => (props.paddingBottom ? props.paddingBottom : '25px')};
 `;


### PR DESCRIPTION
## Description

* Modal titles are now 14pt not 22pt
* All modal titles are now 'sticky' when you scroll the content
* Modal titles should line up with the start of the content on the left
* This should also apply to 'non modal' versions of pages that can be modal or not modal, like search

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
CHI-1974

### Verification steps

* Review each place where modals are used and ensure the styling is correct