### PR TITLE
Fixes misspelling in NZ Household form

### DIFF
--- a/hrm-form-definitions/form-definitions/nz/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/nz/v1/caseForms/HouseholdForm.json
@@ -213,7 +213,7 @@
     }
   },
   {
-    "name": "selHarmPlanDetails",
+    "name": "selfHarmPlanDetails",
     "label": "Details of any plan",
     "type": "textarea",
     "placeholder": ""


### PR DESCRIPTION
@janorivera I just happened to notice this while pulling the NZ sample export. If this looks good to you, please take it over and merge and deploy when you're ready.