### PR TITLE
CHI-2396 fix case merging off

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/case/actions.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/actions.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { Case } from '../../../types/types';
-import { CaseActionType, REMOVE_CONNECTED_CASE, SET_CONNECTED_CASE } from '../../../states/case/types';
+import { CaseActionType, SET_CONNECTED_CASE } from '../../../states/case/types';
 import * as actions from '../../../states/case/actions';
 
 const task = { taskSid: 'task1' };
@@ -42,14 +42,5 @@ describe('test action creators', () => {
     };
 
     expect(actions.setConnectedCase(connectedCase, task.taskSid)).toStrictEqual(expectedAction);
-  });
-
-  test('removeConnectedCase', async () => {
-    const expectedAction: CaseActionType = {
-      type: REMOVE_CONNECTED_CASE,
-      taskId: task.taskSid,
-    };
-
-    expect(actions.removeConnectedCase(task.taskSid)).toStrictEqual(expectedAction);
   });
 });

--- a/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
@@ -132,15 +132,6 @@ describe('test reducer', () => {
     expect(getAvailableCaseStatusTransitions).toHaveBeenCalledWith(connectedCase, mockV1);
   });
 
-  test('should handle REMOVE_CONNECTED_CASE', async () => {
-    const expected = { tasks: {} };
-
-    const result = reduce(stubRootState, state, actions.removeConnectedCase(task.taskSid));
-    expect(result).toStrictEqual(expected);
-
-    // state = result; no assignment here as we don't want to lose the only task in the state, it will be reused in following tests
-  });
-
   test('should handle REMOVE_CONTACT_STATE', async () => {
     const expected = { tasks: {} };
 

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -25,7 +25,6 @@ import { getDefinitionVersion } from '../../services/ServerlessService';
 import { getNoteActivities, sortActivities } from '../../states/case/caseActivities';
 import { getHelplineData } from './caseHelpers';
 import { getLocaleDateTime } from '../../utils/helpers';
-import * as CaseActions from '../../states/case/actions';
 import * as RoutingActions from '../../states/routing/actions';
 import * as ConfigActions from '../../states/configuration/actions';
 import { CaseDetails } from '../../states/case/types';
@@ -55,14 +54,15 @@ import { noteSectionApi } from '../../states/case/sections/note';
 import { CaseSectionApi } from '../../states/case/sections/api';
 import * as ContactActions from '../../states/contacts/existingContacts';
 import { contactLabelFromHrmContact } from '../../states/contacts/contactIdentifier';
-import { getHrmConfig, getTemplateStrings } from '../../hrmConfig';
+import { getAseloFeatureFlags, getHrmConfig, getTemplateStrings } from '../../hrmConfig';
 import { updateCaseAsyncAction } from '../../states/case/saveCase';
 import asyncDispatch from '../../states/asyncDispatch';
-import { submitContactFormAsyncAction } from '../../states/contacts/saveContact';
+import { removeFromCaseAsyncAction, submitContactFormAsyncAction } from '../../states/contacts/saveContact';
 import { ContactMetadata } from '../../states/contacts/types';
 import { configurationBase, connectedCaseBase, namespace } from '../../states/storeNamespaces';
 import { getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
 import { selectSavedContacts } from '../../states/case/connectedContacts';
+import selectContactByTaskSid from '../../states/contacts/selectContactByTaskSid';
 
 export const isStandaloneITask = (task): task is StandaloneITask => {
   return task && task.taskSid === 'standalone-task-sid';
@@ -94,6 +94,7 @@ const Case: React.FC<Props> = ({
   updateCaseAsyncAction,
   onNewCaseSaved = () => Promise.resolve(),
   submitContactFormAsyncAction,
+  taskContact,
   ...props
 }) => {
   const [loading, setLoading] = useState(false);
@@ -102,6 +103,7 @@ const Case: React.FC<Props> = ({
 
   const { workerSid } = getHrmConfig();
   const strings = getTemplateStrings();
+  const { enable_case_merging: enableCaseMerging } = getAseloFeatureFlags();
 
   useEffect(() => {
     if (!connectedCase) return;
@@ -195,6 +197,14 @@ const Case: React.FC<Props> = ({
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleCloseCase = async () => {
+    releaseContacts(loadedContactIds, task.taskSid);
+    if (!enableCaseMerging && taskContact && isCreating) {
+      await removeConnectedCase(taskContact.id);
+    }
+    handleClose();
   };
 
   const caseDetails: CaseDetails = {
@@ -306,10 +316,7 @@ const Case: React.FC<Props> = ({
       task={task}
       definitionVersion={definitionVersion}
       caseDetails={caseDetails}
-      handleClose={() => {
-        releaseContacts(loadedContactIds, task.taskSid);
-        handleClose();
-      }}
+      handleClose={handleCloseCase}
       handleUpdate={handleUpdate}
       handleSaveAndEnd={handleSaveAndEnd}
       isCreating={isCreating}
@@ -333,6 +340,7 @@ const mapStateToProps = (state: RootState, { task }: OwnProps) => {
     definitionVersions,
     currentDefinitionVersion,
     savedContacts: selectSavedContacts(state, connectedCase),
+    taskContact: selectContactByTaskSid(state, task.taskSid)?.savedContact,
   };
 };
 
@@ -345,7 +353,7 @@ const mapDispatchToProps = (dispatch, { task }: OwnProps) => {
     changeRoute: bindActionCreators(RoutingActions.changeRoute, dispatch),
     closeModal: () => dispatch(RoutingActions.newCloseModalAction(task.taskSid)),
     goBack: () => dispatch(RoutingActions.newGoBackAction(task.taskSid)),
-    removeConnectedCase: bindActionCreators(CaseActions.removeConnectedCase, dispatch),
+    removeConnectedCase: (contactId: string) => caseAsyncDispatch(removeFromCaseAsyncAction(contactId)),
     updateDefinitionVersion: updateCaseDefinition,
     releaseContacts: bindActionCreators(ContactActions.releaseContacts, dispatch),
     loadContacts: bindActionCreators(ContactActions.loadContacts, dispatch),

--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -85,7 +85,10 @@ const CaseHome: React.FC<Props> = ({
 }) => {
   if (!connectedCaseState) return null; // narrow type before deconstructing
 
-  const { enable_upload_documents: enableUploadDocuments } = getAseloFeatureFlags();
+  const {
+    enable_upload_documents: enableUploadDocuments,
+    enable_case_merging: enableCaseMerging,
+  } = getAseloFeatureFlags();
 
   const onViewCaseItemClick = (targetSubroute: CaseSectionSubroute) => (id: string) => {
     openModal({ route: 'case', subroute: targetSubroute, action: CaseItemAction.View, id });
@@ -307,16 +310,18 @@ const CaseHome: React.FC<Props> = ({
       </CaseContainer>
       {isCreating && (
         <BottomButtonBar>
-          <Box marginRight="15px">
-            <StyledNextStepButton
-              data-testid="CaseHome-CancelButton"
-              secondary="true"
-              roundCorners
-              onClick={handleClose}
-            >
-              <Template code="BottomBar-CancelNewCaseAndClose" />
-            </StyledNextStepButton>
-          </Box>
+          {!enableCaseMerging && (
+            <Box marginRight="15px">
+              <StyledNextStepButton
+                data-testid="CaseHome-CancelButton"
+                secondary="true"
+                roundCorners
+                onClick={handleClose}
+              >
+                <Template code="BottomBar-CancelNewCaseAndClose" />
+              </StyledNextStepButton>
+            </Box>
+          )}
           <StyledNextStepButton roundCorners onClick={handleSaveAndEnd} data-testid="BottomBar-SaveCaseAndEnd">
             <Template code="BottomBar-SaveAndEnd" />
           </StyledNextStepButton>

--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -85,7 +85,7 @@ const CaseHome: React.FC<Props> = ({
 }) => {
   if (!connectedCaseState) return null; // narrow type before deconstructing
 
-  const featureFlags = getAseloFeatureFlags();
+  const { enable_upload_documents: enableUploadDocuments } = getAseloFeatureFlags();
 
   const onViewCaseItemClick = (targetSubroute: CaseSectionSubroute) => (id: string) => {
     openModal({ route: 'case', subroute: targetSubroute, action: CaseItemAction.View, id });
@@ -293,7 +293,7 @@ const CaseHome: React.FC<Props> = ({
             {incidentRows()}
           </CaseSection>
         </Box>
-        {featureFlags.enable_upload_documents && (
+        {enableUploadDocuments && (
           <Box margin="25px 0 0 0">
             <CaseSection
               onClickAddItem={onAddCaseItemClick(NewCaseSubroutes.Document)}
@@ -307,11 +307,19 @@ const CaseHome: React.FC<Props> = ({
       </CaseContainer>
       {isCreating && (
         <BottomButtonBar>
-          <>
-            <StyledNextStepButton roundCorners onClick={handleSaveAndEnd} data-testid="BottomBar-SaveCaseAndEnd">
-              <Template code="BottomBar-SaveAndEnd" />
+          <Box marginRight="15px">
+            <StyledNextStepButton
+              data-testid="CaseHome-CancelButton"
+              secondary="true"
+              roundCorners
+              onClick={handleClose}
+            >
+              <Template code="BottomBar-CancelNewCaseAndClose" />
             </StyledNextStepButton>
-          </>
+          </Box>
+          <StyledNextStepButton roundCorners onClick={handleSaveAndEnd} data-testid="BottomBar-SaveCaseAndEnd">
+            <Template code="BottomBar-SaveAndEnd" />
+          </StyledNextStepButton>
         </BottomButtonBar>
       )}
     </NavigableContainer>

--- a/plugin-hrm-form/src/components/caseMergingBanners/ContactAddedToCaseBanner.tsx
+++ b/plugin-hrm-form/src/components/caseMergingBanners/ContactAddedToCaseBanner.tsx
@@ -49,8 +49,8 @@ const mapDispatchToProps = (dispatch, { taskId }: OwnProps) => ({
     dispatch(setConnectedCase(cas, taskId));
     dispatch(newOpenModalAction({ route: 'case', subroute: 'home', isCreating: false }, taskId));
   },
-  removeContactFromCase: async (contactId: string, caseId: number) => {
-    await asyncDispatch(dispatch)(removeFromCaseAsyncAction(contactId, caseId));
+  removeContactFromCase: async (contactId: string) => {
+    await asyncDispatch(dispatch)(removeFromCaseAsyncAction(contactId));
     dispatch(showRemovedFromCaseBannerAction(contactId));
   },
 });
@@ -73,7 +73,7 @@ const ContactAddedToCaseBanner: React.FC<Props> = ({
         <Template code="Case-CaseNumber" />
         {connectedCase.id}
       </CaseLink>
-      <RemoveFromCaseLink type="button" onClick={() => removeContactFromCase(contact.id, connectedCase.id)}>
+      <RemoveFromCaseLink type="button" onClick={() => removeContactFromCase(contact.id)}>
         <Template code="CaseMerging-RemoveFromCase" />
       </RemoveFromCaseLink>
     </BannerContainer>

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -130,97 +130,116 @@ const BottomBar: React.FC<
 
   const openSearchModal = () => {
     openModal({ route: 'search', subroute: 'form', action: 'select-case' });
-    // searchExistingCase(true);
+  };
+
+  const renderCaseButton = () => {
+    if (featureFlags.enable_case_merging) {
+      return (
+        <>
+          <AddNewCaseDropdown
+            handleNewCaseType={handleOpenNewCase}
+            handleExistingCaseType={openSearchModal}
+            dropdown={dropdown}
+          />
+
+          {isAddedToCase ? (
+            <Box marginRight="25px">
+              <AddedToCaseButton>
+                <Template code="BottomBar-AddedToCase" />
+              </AddedToCaseButton>
+            </Box>
+          ) : (
+            !isNonDataCallType(contact.rawJson.callType) && (
+              <Box marginRight="15px">
+                <StyledNextStepButton
+                  type="button"
+                  roundCorners
+                  secondary="true"
+                  onClick={handleDropdown}
+                  data-fs-id="Contact-SaveAndAddToCase-Button"
+                  data-testid="BottomBar-SaveAndAddToCase-Button"
+                >
+                  <FolderIcon style={{ fontSize: '16px', marginRight: '10px', width: '24px', height: '24px' }} />
+                  <Template code="BottomBar-AddContactToNewCase" />
+                  {dropdown && (
+                    <KeyboardArrowUpIcon
+                      style={{ fontSize: '20px', marginLeft: '10px', width: '24px', height: '24px' }}
+                    />
+                  )}
+                  {!dropdown && (
+                    <KeyboardArrowDownIcon
+                      style={{ fontSize: '20px', marginLeft: '10px', width: '24px', height: '24px' }}
+                    />
+                  )}
+                </StyledNextStepButton>
+              </Box>
+            )
+          )}
+        </>
+      );
+    }
+    return isAddedToCase ? null : (
+      <StyledNextStepButton
+        type="button"
+        roundCorners
+        secondary="true"
+        onClick={handleSubmitIfValid(handleOpenNewCase)}
+        data-fs-id="Contact-SaveAndAddToCase-Button"
+        data-testid="BottomBar-SaveAndAddToCase-Button"
+      >
+        <FolderIcon style={{ fontSize: '16px', marginRight: '10px', width: '24px', height: '24px' }} />
+        <Template code="BottomBar-AddContactToNewCase" />
+      </StyledNextStepButton>
+    );
   };
 
   return (
-    <>
-      <BottomButtonBar
-        onBlurCapture={event => {
-          if (!event.currentTarget.contains(event.relatedTarget)) {
-            setDropdown(false);
-          }
-        }}
-      >
-        {optionalButtons &&
-          optionalButtons.map((i, index) => (
-            <Box key={`optional-button-${index}`} marginRight="15px">
-              <StyledNextStepButton
-                type="button"
-                roundCorners
-                secondary="true"
-                onClick={i.onClick}
-                disabled={isSubmitting}
-              >
-                <Template code={i.label} />
-              </StyledNextStepButton>
-            </Box>
-          ))}
-
-        {showNextButton && (
-          <StyledNextStepButton type="button" roundCorners={true} onClick={nextTab}>
-            <Template code="BottomBar-Next" />
-          </StyledNextStepButton>
-        )}
-        {showSubmitButton && (
-          <>
-            {featureFlags.enable_case_management && (
-              <AddNewCaseDropdown
-                handleNewCaseType={handleOpenNewCase}
-                handleExistingCaseType={openSearchModal}
-                dropdown={dropdown}
-              />
-            )}
-            {isAddedToCase
-              ? featureFlags.enable_case_management && (
-                  <Box marginRight="25px">
-                    <AddedToCaseButton>
-                      <Template code="BottomBar-AddedToCase" />
-                    </AddedToCaseButton>
-                  </Box>
-                )
-              : featureFlags.enable_case_management &&
-                !isNonDataCallType(contact.rawJson.callType) && (
-                  <Box marginRight="15px">
-                    <StyledNextStepButton
-                      type="button"
-                      roundCorners
-                      secondary="true"
-                      onClick={handleDropdown}
-                      data-fs-id="Contact-SaveAndAddToCase-Button"
-                      data-testid="BottomBar-SaveAndAddToCase-Button"
-                    >
-                      <FolderIcon style={{ fontSize: '16px', marginRight: '10px', width: '24px', height: '24px' }} />
-                      <Template code="BottomBar-AddContactToNewCase" />
-                      {dropdown && (
-                        <KeyboardArrowUpIcon
-                          style={{ fontSize: '20px', marginLeft: '10px', width: '24px', height: '24px' }}
-                        />
-                      )}
-                      {!dropdown && (
-                        <KeyboardArrowDownIcon
-                          style={{ fontSize: '20px', marginLeft: '10px', width: '24px', height: '24px' }}
-                        />
-                      )}
-                    </StyledNextStepButton>
-                  </Box>
-                )}
-            <SaveAndEndContactButton
-              roundCorners={true}
-              onClick={handleSubmitIfValid(handleSubmit)}
+    <BottomButtonBar
+      onBlurCapture={event => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setDropdown(false);
+        }
+      }}
+    >
+      {optionalButtons &&
+        optionalButtons.map((i, index) => (
+          <Box key={`optional-button-${index}`} marginRight="15px">
+            <StyledNextStepButton
+              type="button"
+              roundCorners
+              secondary="true"
+              onClick={i.onClick}
               disabled={isSubmitting}
-              data-fs-id="Contact-SaveContact-Button"
-              data-testid="BottomBar-SaveContact-Button"
             >
-              <span style={{ visibility: isSubmitting ? 'hidden' : 'inherit' }}>
-                <Template code="BottomBar-SaveAndEnd" />
-              </span>
-              {isSubmitting ? <CircularProgress size={12} style={{ position: 'absolute' }} /> : null}
-            </SaveAndEndContactButton>
-          </>
-        )}
-      </BottomButtonBar>
-    </>
+              <Template code={i.label} />
+            </StyledNextStepButton>
+          </Box>
+        ))}
+
+      {showNextButton && (
+        <StyledNextStepButton type="button" roundCorners={true} onClick={nextTab}>
+          <Template code="BottomBar-Next" />
+        </StyledNextStepButton>
+      )}
+      {showSubmitButton && (
+        <>
+          {featureFlags.enable_case_management && renderCaseButton()}
+
+          <SaveAndEndContactButton
+            roundCorners={true}
+            onClick={handleSubmitIfValid(handleSubmit)}
+            disabled={isSubmitting}
+            data-fs-id="Contact-SaveContact-Button"
+            data-testid="BottomBar-SaveContact-Button"
+          >
+            <span style={{ visibility: isSubmitting ? 'hidden' : 'inherit' }}>
+              <Template code="BottomBar-SaveAndEnd" />
+            </span>
+            {isSubmitting ? <CircularProgress size={12} style={{ position: 'absolute' }} /> : null}
+          </SaveAndEndContactButton>
+        </>
+      )}
+    </BottomButtonBar>
   );
 };
 

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -179,17 +179,19 @@ const BottomBar: React.FC<
       );
     }
     return isAddedToCase ? null : (
-      <StyledNextStepButton
-        type="button"
-        roundCorners
-        secondary="true"
-        onClick={handleSubmitIfValid(handleOpenNewCase)}
-        data-fs-id="Contact-SaveAndAddToCase-Button"
-        data-testid="BottomBar-SaveAndAddToCase-Button"
-      >
-        <FolderIcon style={{ fontSize: '16px', marginRight: '10px', width: '24px', height: '24px' }} />
-        <Template code="BottomBar-AddContactToNewCase" />
-      </StyledNextStepButton>
+      <Box marginRight="15px">
+        <StyledNextStepButton
+          type="button"
+          roundCorners
+          secondary="true"
+          onClick={handleSubmitIfValid(handleOpenNewCase)}
+          data-fs-id="Contact-SaveAndAddToCase-Button"
+          data-testid="BottomBar-SaveAndAddToCase-Button"
+        >
+          <FolderIcon style={{ fontSize: '16px', marginRight: '10px', width: '24px', height: '24px' }} />
+          <Template code="BottomBar-AddContactToNewCase" />
+        </StyledNextStepButton>
+      </Box>
     );
   };
 

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -280,12 +280,9 @@ export async function connectToCase(contactId: string, caseId: number) {
   return fetchHrmApi(`/contacts/${contactId}/connectToCase`, options);
 }
 
-export async function removeFromCase(contactId: string, caseId: number) {
-  const body = { caseId };
-
+export async function removeFromCase(contactId: string) {
   const options = {
     method: 'DELETE',
-    body: JSON.stringify(body),
   };
 
   return fetchHrmApi(`/contacts/${contactId}/connectToCase`, options);

--- a/plugin-hrm-form/src/states/case/actions.ts
+++ b/plugin-hrm-form/src/states/case/actions.ts
@@ -15,16 +15,11 @@
  */
 
 import { Case } from '../../types/types';
-import { CaseActionType, REMOVE_CONNECTED_CASE, SET_CONNECTED_CASE } from './types';
+import { CaseActionType, SET_CONNECTED_CASE } from './types';
 
 // Action creators
 export const setConnectedCase = (connectedCase: Case, taskId: string): CaseActionType => ({
   type: SET_CONNECTED_CASE,
   connectedCase,
-  taskId,
-});
-
-export const removeConnectedCase = (taskId: string): CaseActionType => ({
-  type: REMOVE_CONNECTED_CASE,
   taskId,
 });

--- a/plugin-hrm-form/src/states/case/reducer.ts
+++ b/plugin-hrm-form/src/states/case/reducer.ts
@@ -16,7 +16,7 @@
 
 import { omit } from 'lodash';
 
-import { CaseActionType, CaseState, REMOVE_CONNECTED_CASE, SET_CONNECTED_CASE } from './types';
+import { CaseActionType, CaseState, SET_CONNECTED_CASE } from './types';
 import { REMOVE_CONTACT_STATE, RemoveContactStateAction } from '../types';
 import {
   CaseWorkingCopyActionType,
@@ -120,7 +120,6 @@ export function reduce(
           },
         },
       };
-    case REMOVE_CONNECTED_CASE:
     case REMOVE_CONTACT_STATE:
       return {
         ...state,

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -22,7 +22,6 @@ import { ChannelTypes } from '../DomainConstants';
 
 // Action types
 export const SET_CONNECTED_CASE = 'SET_CONNECTED_CASE';
-export const REMOVE_CONNECTED_CASE = 'REMOVE_CONNECTED_CASE';
 export const UPDATE_CASE_ACTION = 'case-action/update-case';
 export const UPDATE_CASE_ACTION_FULFILLED = `${UPDATE_CASE_ACTION}_FULFILLED` as const;
 export const CREATE_CASE_ACTION = 'case-action/create-case';
@@ -41,11 +40,6 @@ type SetConnectedCaseAction = {
   taskId: string;
 };
 
-type RemoveConnectedCaseAction = {
-  type: typeof REMOVE_CONNECTED_CASE;
-  taskId: string;
-};
-
 type UpdatedCaseAction = {
   type: typeof UPDATE_CASE_ACTION;
   payload: Promise<{ taskSid: string; case: t.Case }>;
@@ -60,7 +54,7 @@ type CreateCaseAction = {
   meta: unknown;
 };
 
-export type CaseActionType = SetConnectedCaseAction | RemoveConnectedCaseAction | UpdatedCaseAction | CreateCaseAction;
+export type CaseActionType = SetConnectedCaseAction | UpdatedCaseAction | CreateCaseAction;
 
 export type Activity = NoteActivity | ReferralActivity | ConnectedCaseActivity;
 

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -39,7 +39,7 @@ import {
 } from './types';
 import { ContactDraftChanges, ExistingContactsState } from './existingContacts';
 import { newContactMetaData } from './contactState';
-import { getCase } from '../../services/CaseService';
+import { cancelCase, getCase } from '../../services/CaseService';
 import { getUnsavedContact } from './getUnsavedContact';
 
 export const createContactAsyncAction = createAsyncAction(
@@ -124,7 +124,7 @@ export const newRestartOfflineContactAsyncAction = (contact: Contact, createdOnB
 };
 
 type ConnectToCaseActionPayload = { contactId: string; caseId: number; contact: Contact; contactCase: Case };
-type RemoveFromCaseActionPayload = { contactId: string; caseId: number; contact: Contact };
+type RemoveFromCaseActionPayload = { contactId: string; contact: Contact };
 
 // TODO: Update connectedContacts on case in redux state
 export const connectToCaseAsyncAction = createAsyncAction(
@@ -138,9 +138,12 @@ export const connectToCaseAsyncAction = createAsyncAction(
 
 export const removeFromCaseAsyncAction = createAsyncAction(
   REMOVE_FROM_CASE,
-  async (contactId: string, caseId: number | null): Promise<RemoveFromCaseActionPayload> => {
-    const contact = await removeFromCase(contactId, caseId);
-    return { contactId, caseId, contact };
+  async (contactId: string, deleteCase = false): Promise<RemoveFromCaseActionPayload> => {
+    const contact = await removeFromCase(contactId);
+    if (deleteCase) {
+      await cancelCase(contact.caseId);
+    }
+    return { contactId, contact };
   },
 );
 


### PR DESCRIPTION
## Description

* Convert the 'Add to Case' button bac to a single action to add new case when flag is off
* Validates form when adding a case if flag is off
* The close cross on the new case modal removes & deletes the case
* An explicit Cancel button with the same effect is added to the bottom bar

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- [X] Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-2396

### Verification steps

* Disable case merging for the helpline you are testing
* Refresh the browser
* Verify that the old workflow of being forced to add only a new case at the end is in place (with some cosmetic changes)
* Reenable the flag & refresh the browser
* Ensure that everything for case merging still works as expected