### PR TITLE
CHI-1971: Added To Case banner state inferred from contact state

### DIFF
--- a/plugin-hrm-form/src/components/caseMergingBanners/state.ts
+++ b/plugin-hrm-form/src/components/caseMergingBanners/state.ts
@@ -19,15 +19,7 @@ import { createAction, createReducer } from 'redux-promise-middleware-actions';
 import { RootState } from '../../states';
 import { namespace } from '../../states/storeNamespaces';
 
-const SHOW_CONNECTED_TO_CASE_BANNER = 'case-merging-banners/show-connected-to-case-banner';
 const SHOW_REMOVED_FROM_CASE_BANNER = 'case-merging-banners/show-removed-from-case-banner';
-
-export const showConnectedToCaseBannerAction = createAction(SHOW_CONNECTED_TO_CASE_BANNER, (contactId: string) => ({
-  contactId,
-  banners: {
-    showConnectedToCaseBanner: true,
-  },
-}));
 
 export const showRemovedFromCaseBannerAction = createAction(SHOW_REMOVED_FROM_CASE_BANNER, (contactId: string) => ({
   contactId,
@@ -45,24 +37,24 @@ export const closeRemovedFromCaseBannerAction = createAction(SHOW_REMOVED_FROM_C
 }));
 
 type CaseMergingBannersAction =
-  | ReturnType<typeof showConnectedToCaseBannerAction>
   | ReturnType<typeof showRemovedFromCaseBannerAction>
   | ReturnType<typeof closeRemovedFromCaseBannerAction>;
 
 type CaseMergingBannersState = {
   [contactId: string]: {
-    showConnectedToCaseBanner: boolean;
     showRemovedFromCaseBanner: boolean;
   };
 };
 
 const initialState: CaseMergingBannersState = {};
 
-export const selectCaseMergingBanners = (state: RootState, contactId: string): CaseMergingBannersState['contactId'] =>
-  state[namespace].caseMergingBanners[contactId] || {
-    showConnectedToCaseBanner: true,
-    showRemovedFromCaseBanner: false,
-  };
+export const selectCaseMergingBanners = (
+  state: RootState,
+  contactId: string,
+): CaseMergingBannersState['contactId'] & { showConnectedToCaseBanner: boolean } => ({
+  showConnectedToCaseBanner: Boolean(state[namespace].activeContacts.existingContacts[contactId]?.savedContact.caseId),
+  showRemovedFromCaseBanner: state[namespace].caseMergingBanners[contactId]?.showRemovedFromCaseBanner ?? false,
+});
 
 const mergeResultPayloadIntoState = (state, action: CaseMergingBannersAction) => {
   const { contactId, banners } = action.payload;
@@ -77,7 +69,6 @@ const mergeResultPayloadIntoState = (state, action: CaseMergingBannersAction) =>
 };
 
 const caseMergingBannersReducer = createReducer(initialState, handleAction => [
-  handleAction(showConnectedToCaseBannerAction, mergeResultPayloadIntoState),
   handleAction(showRemovedFromCaseBannerAction, mergeResultPayloadIntoState),
   handleAction(closeRemovedFromCaseBannerAction, mergeResultPayloadIntoState),
 ]);

--- a/plugin-hrm-form/src/components/search/CasePreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/CasePreview/index.tsx
@@ -38,7 +38,6 @@ import { newCloseModalAction } from '../../../states/routing/actions';
 import { getPermissionsForCase, getPermissionsForContact, PermissionActions } from '../../../permissions';
 import { getAseloFeatureFlags } from '../../../hrmConfig';
 import { isNonDataCallType } from '../../../states/validationRules';
-import { showConnectedToCaseBannerAction } from '../../caseMergingBanners/state';
 
 type OwnProps = {
   currentCase: Case;
@@ -58,8 +57,6 @@ const mapStateToProps = (state: RootState, { task }: OwnProps) => {
 const mapDispatchToProps = (dispatch: Dispatch<any>, { task, currentCase }: OwnProps) => ({
   connectCaseToTaskContact: async (taskContact: Contact) => {
     await asyncDispatch(dispatch)(connectToCaseAsyncAction(taskContact.id, currentCase.id));
-    // TODO: maybe should change asyncDispatch to throw error instead of handling?
-    dispatch(showConnectedToCaseBannerAction(taskContact.id));
   },
   closeModal: () => dispatch(newCloseModalAction(task.taskSid)),
 });

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -46,7 +46,6 @@ import { connectedCaseBase, contactFormsBase, namespace } from '../../states/sto
 import { AppRoutes } from '../../states/routing/types';
 import AddNewCaseDropdown from './AddNewCaseDropdown';
 import asyncDispatch from '../../states/asyncDispatch';
-import { showConnectedToCaseBannerAction } from '../caseMergingBanners/state';
 
 type BottomBarProps = {
   handleSubmitIfValid: (handleSubmit: () => Promise<void>) => () => void;
@@ -246,7 +245,6 @@ const mapDispatchToProps = (dispatch, { task }: BottomBarProps) => {
       // Deliberately using dispatch rather than asyncDispatch here, because we still handle the error from where the action is dispatched.
       // TODO: Rework error handling to be based on redux state set by the _REJECTED action
       await asyncDispatch(dispatch)(createCaseAsyncAction(contact, task.taskSid, workerSid, definitionVersion));
-      dispatch(showConnectedToCaseBannerAction(contact.id));
     },
     submitContactFormAsyncAction: (task: CustomITask, contact: Contact, metadata: ContactMetadata, caseForm: Case) =>
       // Deliberately using dispatch rather than asyncDispatch here, because we still handle the error from where the action is dispatched.


### PR DESCRIPTION
## Description

Since we now know we always want to show the 'Added To Case' banner when a contact is part of a case, we can infer whether to show it from the state of the contact rather than a separate state. This should address some inconsistencies in the banner state that are arising in QA

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1971

### Verification steps

Try to reproduce point 1 in https://tech-matters.slack.com/archives/C05HT9K8602/p1700585180670849