### PR TITLE
CHI-1974: Aligned search results page with mocks

### DIFF
--- a/plugin-hrm-form/src/components/search/CasePreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/CasePreview/index.tsx
@@ -121,7 +121,7 @@ const CasePreview: React.FC<Props> = ({
     );
   }
   return (
-    <Flex>
+    <Flex width="100%">
       <PreviewWrapper>
         <CaseHeader
           caseId={id}

--- a/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
@@ -98,7 +98,7 @@ const ContactPreview: React.FC<Props> = ({ contact, handleViewDetails, definitio
   }, [versionId, definitionVersions]);
 
   return (
-    <Flex>
+    <Flex width="100%">
       <PreviewWrapper key={contact.id}>
         <ContactHeader
           id={contact.id}

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -23,7 +23,7 @@ import { Template, Tab as TwilioTab } from '@twilio/flex-ui';
 import ContactPreview from '../ContactPreview';
 import CasePreview from '../CasePreview';
 import { SearchContactResult, SearchCaseResult, Contact, Case, CustomITask } from '../../../types/types';
-import { Row } from '../../../styles/HrmStyles';
+import { Box, Row } from '../../../styles/HrmStyles';
 import {
   ResultsHeader,
   ListContainer,
@@ -35,8 +35,6 @@ import {
   StyledTabs,
   StyledResultsContainer,
   StyledResultsText,
-  StyledTabLabel,
-  StyledFolderIcon,
   StyledResultsHeader,
   EmphasisedText,
   StyledCount,
@@ -94,7 +92,6 @@ const SearchResults: React.FC<Props> = ({
   isRequestingContacts,
   caseRefreshRequired,
   contactRefreshRequired,
-  searchCase,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const [contactsPage, setContactsPage] = useState(0);
@@ -211,35 +208,36 @@ const SearchResults: React.FC<Props> = ({
   return (
     <>
       <ResultsHeader>
-        <Row style={{ justifyContent: 'center' }}>
-          <div style={{ width: '300px' }}>
-            <StyledTabs
-              selectedTabName={currentResultPage}
-              onTabSelected={tabSelected}
-              alignment="left"
-              keepTabsMounted={false}
+        <Row style={{ justifyContent: 'center', width: '100%' }}>
+          <StyledTabs
+            selectedTabName={currentResultPage}
+            onTabSelected={tabSelected}
+            alignment="center"
+            keepTabsMounted={false}
+          >
+            <TwilioTab
+              key="SearchResultsIndex-Contacts"
+              label={
+                <Box style={{ minWidth: '340px' }}>
+                  <Template code="SearchResultsIndex-Contacts" />
+                </Box>
+              }
+              uniqueName="contact-results"
             >
-              <TwilioTab
-                key="SearchResultsIndex-Contacts"
-                label={<Template code="SearchResultsIndex-Contacts" />}
-                uniqueName="contact-results"
-              >
-                {[]}
-              </TwilioTab>
-              <TwilioTab
-                key="SearchResultsIndex-Cases"
-                label={
-                  <StyledTabLabel>
-                    <StyledFolderIcon />
-                    <Template code="SearchResultsIndex-Cases" />
-                  </StyledTabLabel>
-                }
-                uniqueName="case-results"
-              >
-                {[]}
-              </TwilioTab>
-            </StyledTabs>
-          </div>
+              {[]}
+            </TwilioTab>
+            <TwilioTab
+              key="SearchResultsIndex-Cases"
+              label={
+                <Box style={{ minWidth: '340px' }}>
+                  <Template code="SearchResultsIndex-Cases" />
+                </Box>
+              }
+              uniqueName="case-results"
+            >
+              {[]}
+            </TwilioTab>
+          </StyledTabs>
         </Row>
       </ResultsHeader>
       <ListContainer>

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -32,7 +32,8 @@ export const PreviewWrapper = styled('div')`
   justify-content: space-between;
   margin-top: 10px;
   padding: 5px 20px 10px 20px;
-  width: 600px;
+  width: 100%;
+  max-width: 100%;
   box-sizing: border-box;
   background-color: #ffffff;
   border-color: #d8d8d8;
@@ -162,6 +163,10 @@ export const StyledTabs = styled((props: Partial<TabsProps> & { children?: any }
   .Twilio-TabHeader-StateIndicator-Active {
     background-color: #0064e1;
     height: 1px;
+    padding: 0;
+  }
+  .Twilio-Tabs-Labels {
+    padding: 0;
   }
 `;
 StyledTabs.displayName = 'StyledTabs';
@@ -169,31 +174,16 @@ StyledTabs.displayName = 'StyledTabs';
 export const StyledResultsContainer = styled('div')`
   display: flex;
   align-items: center;
-  width: 600px;
+  width: 100%;
   margin-top: 10px;
 `;
 StyledResultsContainer.displayName = 'StyledResultsContainer';
-
-export const StyledTabLabel = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-`;
-StyledTabLabel.displayName = 'StyledTabLabel';
 
 export const StyledResultsText = styled('div')`
   display: flex;
   padding-right: 5px;
 `;
 StyledResultsText.displayName = 'StyledResultsText';
-
-export const StyledFolderIcon = styled(Folder)`
-  font-size: 18px !important;
-  padding: -1px 10px 0 6px;
-  margin-right: 10px;
-`;
-
-StyledFolderIcon.displayName = 'StyledFolderIcon';
 
 export const EmphasisedText = styled('div')`
   font-weight: 600;
@@ -404,10 +394,14 @@ export const ResultsHeader = styled('div')`
 `;
 
 export const ListContainer = styled(BottomButtonBar)`
+  box-shadow: none;
   background-color: #ffffff;
   flex-basis: 0;
   flex-grow: 1;
-  padding: 10px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 0;
+  padding-right: 0;
   margin: 2px 5px 0 5px;
 `;
 


### PR DESCRIPTION
## Description

* Removed chrome from search results page
* Updated styling to match mocks more closely

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-1974

### Verification steps

Review styling on search results page in tabbed form & standalone