### PR TITLE
CHI-2223: Fix the nag on browser close logic

### DIFF
--- a/plugin-hrm-form/src/components/CustomCRMContainer.tsx
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.tsx
@@ -32,7 +32,7 @@ import { namespace } from '../states/storeNamespaces';
 import { getUnsavedContact } from '../states/contacts/getUnsavedContact';
 import asyncDispatch from '../states/asyncDispatch';
 import { createContactAsyncAction } from '../states/contacts/saveContact';
-import { getHrmConfig } from '../hrmConfig';
+import { getAseloFeatureFlags, getHrmConfig } from '../hrmConfig';
 import { newContact } from '../states/contacts/contactState';
 import { selectAnyContactIsSaving } from '../states/contacts/selectContactSaveStatus';
 
@@ -55,6 +55,7 @@ const CustomCRMContainer: React.FC<Props> = ({
   definitionVersion,
   loadOrCreateDraftOfflineContact,
 }) => {
+  const { enable_confirm_on_browser_close: enableConfirmOnBrowserClose } = getAseloFeatureFlags();
   useEffect(() => {
     const fetchPopulateCounselors = async () => {
       try {
@@ -76,6 +77,9 @@ const CustomCRMContainer: React.FC<Props> = ({
   }, [currentOfflineContact, definitionVersion, loadOrCreateDraftOfflineContact]);
 
   useEffect(() => {
+    if (!enableConfirmOnBrowserClose) {
+      return () => undefined;
+    }
     if (handleUnloadRef) {
       window.removeEventListener('beforeunload', handleUnloadRef);
     }
@@ -93,7 +97,7 @@ const CustomCRMContainer: React.FC<Props> = ({
         window.removeEventListener('beforeunload', handleUnloadRef);
       }
     };
-  }, [hasUnsavedChanges]);
+  }, [enableConfirmOnBrowserClose, hasUnsavedChanges]);
 
   const offlineContactTask: OfflineContactTask = {
     taskSid: getOfflineContactTaskSid(),

--- a/plugin-hrm-form/src/components/CustomCRMContainer.tsx
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.tsx
@@ -34,6 +34,7 @@ import asyncDispatch from '../states/asyncDispatch';
 import { createContactAsyncAction } from '../states/contacts/saveContact';
 import { getHrmConfig } from '../hrmConfig';
 import { newContact } from '../states/contacts/contactState';
+import { selectAnyContactIsSaving } from '../states/contacts/selectContactSaveStatus';
 
 type OwnProps = {
   task?: ITask;
@@ -115,10 +116,11 @@ const CustomCRMContainer: React.FC<Props> = ({
 
 CustomCRMContainer.displayName = 'CustomCRMContainer';
 
-const mapStateToProps = ({
-  [namespace]: { routing, activeContacts, configuration, connectedCase },
-  flex,
-}: RootState) => {
+const mapStateToProps = (state: RootState) => {
+  const {
+    [namespace]: { routing, activeContacts, configuration, connectedCase },
+    flex,
+  } = state;
   const { selectedTaskSid } = flex.view;
   const { isAddingOfflineContact } = routing;
   const currentOfflineContact = Object.values(activeContacts.existingContacts).find(
@@ -131,7 +133,8 @@ const mapStateToProps = ({
     Object.values(connectedCase.tasks).some(
       ({ caseWorkingCopy }) =>
         caseWorkingCopy.caseSummary || Object.values(caseWorkingCopy.sections).some(section => section),
-    );
+    ) ||
+    selectAnyContactIsSaving(state);
   return {
     selectedTaskSid,
     isAddingOfflineContact,

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -41,7 +41,7 @@ import ContactNotLoaded from './ContactNotLoaded';
 import { completeTask } from '../services/formSubmissionHelpers';
 import { newContact } from '../states/contacts/contactState';
 import asyncDispatch from '../states/asyncDispatch';
-import selectIsContactCreating from '../states/contacts/selectIsContactCreating';
+import { selectIsContactCreating } from '../states/contacts/selectContactSaveStatus';
 
 type OwnProps = {
   task: CustomITask;

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -48,7 +48,7 @@ import CloseCaseDialog from './CloseCaseDialog';
 import { CaseSectionApi } from '../../states/case/sections/api';
 import { lookupApi } from '../../states/case/sections/lookupApi';
 import { copyCaseSectionItem } from '../../states/case/sections/update';
-import { newGoBackAction } from '../../states/routing/actions';
+import { newCloseModalAction, newGoBackAction } from '../../states/routing/actions';
 import {
   initialiseExistingCaseSectionWorkingCopy,
   initialiseNewCaseSectionWorkingCopy,
@@ -72,6 +72,12 @@ export type AddEditCaseItemProps = {
 };
 // eslint-disable-next-line no-use-before-define
 type Props = AddEditCaseItemProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
+
+enum DismissAction {
+  NONE,
+  BACK,
+  CLOSE,
+}
 
 const AddEditCaseItem: React.FC<Props> = ({
   definitionVersion,
@@ -136,7 +142,14 @@ const AddEditCaseItem: React.FC<Props> = ({
   ]);
 
   const methods = useForm(reactHookFormOptions);
-  const [openDialog, setOpenDialog] = React.useState(false);
+
+  enum DialogState {
+    CLOSED,
+    OPEN_FOR_BACK,
+    OPEN_FOR_CLOSE,
+  }
+
+  const [dialogState, setDialogState] = React.useState(DialogState.CLOSED);
 
   const { getValues } = methods;
 
@@ -202,21 +215,21 @@ const AddEditCaseItem: React.FC<Props> = ({
     await updateCaseAsyncAction(caseId, { info: newInfo });
   };
 
-  function close() {
-    closeActions(id);
+  function close(action: DismissAction) {
+    closeActions(id, action);
   }
 
   async function saveAndStay() {
     await save();
-    closeActions(id, false);
+    closeActions(id, DismissAction.NONE);
 
     // Reset the entire form state, fields reference, and subscriptions.
     methods.reset();
   }
 
-  async function saveAndLeave() {
+  async function saveAndLeave(followingAction: DismissAction) {
     await save();
-    closeActions(id);
+    closeActions(id, followingAction);
   }
 
   const strings = getTemplateStrings();
@@ -224,7 +237,7 @@ const AddEditCaseItem: React.FC<Props> = ({
     currentRoute.action === CaseItemAction.Edit ? `Case: Edit ${sectionApi.label}` : `Case: Add ${sectionApi.label}`,
     () => {
       window.alert(strings['Error-Form']);
-      if (openDialog) setOpenDialog(false);
+      if (dialogState !== DialogState.CLOSED) setDialogState(DialogState.CLOSED);
     },
   );
 
@@ -232,10 +245,10 @@ const AddEditCaseItem: React.FC<Props> = ({
     ? caseItemHistory(workingCopy, counselorsHash)
     : { added: new Date(), addingCounsellorName: counselor, updated: undefined, updatingCounsellorName: undefined };
 
-  const checkForEdits = () => {
+  const checkForEdits = (action: DismissAction) => {
     if (isEqual(workingCopy?.form, savedForm)) {
-      close();
-    } else setOpenDialog(true);
+      close(action);
+    } else setDialogState(action === DismissAction.CLOSE ? DialogState.OPEN_FOR_CLOSE : DialogState.OPEN_FOR_BACK);
   };
   return (
     <FormProvider {...methods}>
@@ -243,7 +256,8 @@ const AddEditCaseItem: React.FC<Props> = ({
         titleCode={
           currentRoute.action === CaseItemAction.Edit ? `Case-Edit${sectionApi.label}` : `Case-Add${sectionApi.label}`
         }
-        onGoBack={checkForEdits}
+        onGoBack={() => checkForEdits(DismissAction.BACK)}
+        onCloseModal={() => checkForEdits(DismissAction.CLOSE)}
         task={task}
       >
         <CaseActionFormContainer>
@@ -283,17 +297,22 @@ const AddEditCaseItem: React.FC<Props> = ({
           <StyledNextStepButton
             data-testid="Case-AddEditItemScreen-SaveItem"
             roundCorners
-            onClick={methods.handleSubmit(saveAndLeave, onError)}
+            onClick={methods.handleSubmit(() => saveAndLeave(DismissAction.BACK), onError)}
           >
             <Template code={`BottomBar-Save${sectionApi.label}`} />
           </StyledNextStepButton>
         </BottomButtonBar>
         <CloseCaseDialog
           data-testid="CloseCaseDialog"
-          openDialog={openDialog}
-          setDialog={() => setOpenDialog(false)}
-          handleDontSaveClose={close}
-          handleSaveUpdate={methods.handleSubmit(saveAndLeave, onError)}
+          openDialog={dialogState !== DialogState.CLOSED}
+          setDialog={() => setDialogState(DialogState.CLOSED)}
+          handleDontSaveClose={() =>
+            close(dialogState === DialogState.OPEN_FOR_CLOSE ? DismissAction.CLOSE : DismissAction.BACK)
+          }
+          handleSaveUpdate={methods.handleSubmit(
+            () => saveAndLeave(dialogState === DialogState.OPEN_FOR_CLOSE ? DismissAction.CLOSE : DismissAction.BACK),
+            onError,
+          )}
         />
       </NavigableContainer>
     </FormProvider>
@@ -322,10 +341,12 @@ const mapDispatchToProps = (dispatch, props: AddEditCaseItemProps) => {
     updateCaseSectionWorkingCopy: bindActionCreators(updateCaseSectionWorkingCopy, dispatch),
     initialiseCaseSectionWorkingCopy: bindActionCreators(initialiseExistingCaseSectionWorkingCopy, dispatch),
     initialiseNewCaseSectionWorkingCopy: bindActionCreators(initialiseNewCaseSectionWorkingCopy, dispatch),
-    closeActions: (id: string, closeForm: boolean = true) => {
+    closeActions: (id: string, action: DismissAction) => {
       dispatch(removeCaseSectionWorkingCopy(task.taskSid, sectionApi, id));
-      if (closeForm) {
+      if (action === DismissAction.BACK) {
         dispatch(newGoBackAction(task.taskSid));
+      } else if (action === DismissAction.CLOSE) {
+        dispatch(newCloseModalAction(task.taskSid));
       }
     },
     updateCaseAsyncAction: (caseId: Case['id'], body: Partial<Case>) =>

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -44,7 +44,6 @@ import { connectedCaseBase, contactFormsBase, namespace } from '../../states/sto
 import { AppRoutes } from '../../states/routing/types';
 import AddCaseButton from './AddCaseButton';
 import asyncDispatch from '../../states/asyncDispatch';
-import selectIsContactCreating from '../../states/contacts/selectIsContactCreating';
 
 type BottomBarProps = {
   handleSubmitIfValid: (handleSubmit: () => Promise<void>) => () => void;
@@ -205,7 +204,7 @@ BottomBar.displayName = 'BottomBar';
 const mapStateToProps = (state: RootState, { contactId, task }: BottomBarProps) => {
   const { draftContact, savedContact, metadata } = state[namespace][contactFormsBase].existingContacts[contactId] ?? {};
   const caseForm = state[namespace][connectedCaseBase].tasks[task.taskSid]?.connectedCase || {};
-  const contactIsSaving = selectIsContactCreating(state, contactId);
+  const contactIsSaving = metadata?.saveStatus === 'saving';
   return {
     contact: getUnsavedContact(savedContact, draftContact),
     metadata,

--- a/plugin-hrm-form/src/states/case/sections/workingCopy.ts
+++ b/plugin-hrm-form/src/states/case/sections/workingCopy.ts
@@ -31,23 +31,28 @@ export const setWorkingCopy = (sectionName: string) => (
   if (!caseWorkingCopy.sections[sectionName]) {
     caseWorkingCopy.sections[sectionName] = { existing: {} };
   }
+  const section = caseWorkingCopy.sections[sectionName];
   if (id) {
     // Id specified so we are updating an existing section's working copy
     if (item) {
       // Overwriting
-      caseWorkingCopy.sections[sectionName].existing[id] = item;
+      section.existing[id] = item;
     } else {
       // Removing
-      delete caseWorkingCopy.sections[sectionName].existing[id];
+      delete section.existing[id];
     }
   }
   // Id not specified so we are updating a 'new', as yet unsaved section's working copy
   else if (item) {
     // Overwriting
-    caseWorkingCopy.sections[sectionName].new = item;
+    section.new = item;
   } else {
     // Removing
-    delete caseWorkingCopy.sections[sectionName].new;
+    delete section.new;
+  }
+  // Clean up empty sections
+  if (!section.new && Object.keys(section.existing).length === 0) {
+    delete caseWorkingCopy.sections[sectionName];
   }
   return caseWorkingCopy;
 };

--- a/plugin-hrm-form/src/states/contacts/selectContactSaveStatus.ts
+++ b/plugin-hrm-form/src/states/contacts/selectContactSaveStatus.ts
@@ -17,7 +17,7 @@
 import { RootState } from '..';
 import { namespace } from '../storeNamespaces';
 
-const selectIsContactCreating = (
+export const selectIsContactCreating = (
   {
     [namespace]: {
       activeContacts: { contactsBeingCreated },
@@ -26,4 +26,10 @@ const selectIsContactCreating = (
   taskSid: string,
 ) => contactsBeingCreated.has(taskSid);
 
-export default selectIsContactCreating;
+export const selectAnyContactIsSaving = ({
+  [namespace]: {
+    activeContacts: { contactsBeingCreated, existingContacts },
+  },
+}: RootState) =>
+  contactsBeingCreated.size > 0 ||
+  Object.values(existingContacts).some(({ metadata }) => metadata?.saveStatus === 'saving');

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -277,6 +277,7 @@ export type FeatureFlags = {
   backend_handled_chat_janitor: boolean; // [Temporary flag until all accounts are migrated] Enables handling the janitor from taskrouter event listeners
   enable_client_profiles: boolean; // Enables Client Profiles
   enable_case_merging: boolean; // Enables adding contacts to existing cases
+  enable_confirm_on_browser_close: boolean; // Enables confirmation dialog on browser close when there are unsaved changes
 };
 /* eslint-enable camelcase */
 


### PR DESCRIPTION
## Description

* The draft copy handling logic has changed, breaking the logic to display that window. To prevent this going forward, the confirm now appears if any contact is currently saving, not just if there are working copies
* The working copies for cases were not being fully cleaned up, meaning the confirm for cases kept appearing after changes were saved, this is now fixed

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- [X] Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps

* Make changes to a contact form - refreshing with unsaved changes on a tab should show the warning, after changing tabs, it should not
* Make changes to a case, saved or cancelled changes should not trigger the warning, but unsaved edits should
* Try to refresh whilst a contact is saving, it should trigger the warning, but not after save is complete