### PR TITLE
fix: refactor profiles to control their own relationship details pages

### DIFF
--- a/plugin-hrm-form/src/components/HrmForm.tsx
+++ b/plugin-hrm-form/src/components/HrmForm.tsx
@@ -20,7 +20,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { DefinitionVersion } from 'hrm-form-definitions';
 
 import CallTypeButtons from './callTypeButtons';
-import ProfileRouter, { ALL_PROFILE_ROUTES } from './profile/ProfileRouter';
+import ProfileRouter, { isProfileRoute } from './profile/ProfileRouter';
 import TabbedForms from './tabbedForms';
 import CSAMReport from './CSAMReport/CSAMReport';
 import { RootState } from '../states';
@@ -49,12 +49,12 @@ const HrmForm: React.FC<Props> = ({ routing, task, featureFlags, savedContact })
 
   const routes = [
     {
-      routes: ALL_PROFILE_ROUTES,
+      shouldHandleRoute: () => isProfileRoute(routing),
       renderComponent: () => <ProfileRouter task={task} />,
     },
     // TODO: move hrm form search into it's own component and use it here so all routes are in one place
     {
-      routes: ['tabbed-forms', 'search', 'contact', 'case'],
+      shouldHandleRoute: () => ['tabbed-forms', 'search', 'contact', 'case'].includes(route),
       renderComponent: () => (
         <TabbedForms
           task={task}
@@ -65,17 +65,20 @@ const HrmForm: React.FC<Props> = ({ routing, task, featureFlags, savedContact })
       ),
     },
     {
-      routes: ['csam-report'],
+      shouldHandleRoute: () => ['csam-report'].includes(route),
       renderComponent: () => (
         <CSAMReport
           api={newContactCSAMApi(savedContact.id, task.taskSid, (routing as CSAMReportRoute).previousRoute)}
         />
       ),
     },
-    { routes: ['select-call-type'], renderComponent: () => <CallTypeButtons task={task} /> },
+    {
+      shouldHandleRoute: () => ['select-call-type'].includes(route),
+      renderComponent: () => <CallTypeButtons task={task} />,
+    },
   ];
 
-  return routes.find(r => r.routes?.includes(route))?.renderComponent() || null;
+  return routes.find(r => r.shouldHandleRoute())?.renderComponent() || null;
 };
 
 HrmForm.displayName = 'HrmForm';

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -70,7 +70,6 @@ export const isStandaloneITask = (task): task is StandaloneITask => {
 
 export type OwnProps = {
   task: CustomITask | StandaloneITask;
-  isCreating?: boolean;
   handleClose?: () => void;
   onNewCaseSaved?: (caseForm: CaseType) => Promise<void>;
 };
@@ -330,12 +329,15 @@ const mapStateToProps = (state: RootState, { task }: OwnProps) => {
   const caseState = state[namespace][connectedCaseBase].tasks[task.taskSid];
   const { connectedCase } = caseState ?? {};
   const { definitionVersions, currentDefinitionVersion } = state[namespace][configurationBase];
+  const routing = getCurrentTopmostRouteForTask(state[namespace].routing, task.taskSid) as CaseRoute;
+  const isCreating = routing.route === 'case' && routing.isCreating;
 
   return {
     connectedCaseState: caseState,
     connectedCaseId: connectedCase?.id,
     counselorsHash: state[namespace][configurationBase].counselors.hash,
-    routing: getCurrentTopmostRouteForTask(state[namespace].routing, task.taskSid) as CaseRoute,
+    isCreating,
+    routing,
     definitionVersions,
     currentDefinitionVersion,
     savedContacts: selectSavedContacts(state, connectedCase),

--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -80,7 +80,7 @@ const CaseHome: React.FC<Props> = ({
   can,
   connectedCaseState,
   taskContact,
-  routing,
+  isCreating,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   if (!connectedCaseState) return null; // narrow type before deconstructing
@@ -106,8 +106,6 @@ const CaseHome: React.FC<Props> = ({
 
   const { caseForms } = definitionVersion;
   const caseLayouts = definitionVersion.layoutVersion.case;
-
-  const isCreating = routing.route === 'case' && routing.isCreating;
 
   const {
     incidents,
@@ -344,8 +342,9 @@ const mapStateToProps = (state: RootState, { task }: CaseHomeProps) => {
   const connectedCaseState = caseState.tasks[task.taskSid];
   const taskContact = isStandaloneITask(task) ? undefined : selectContactByTaskSid(state, task.taskSid)?.savedContact;
   const routing = getCurrentTopmostRouteForTask(state[namespace].routing, task.taskSid);
+  const isCreating = routing.route === 'case' && routing.isCreating;
 
-  return { connectedCaseState, taskContact, routing };
+  return { isCreating, connectedCaseState, taskContact };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch<any>, { task }: CaseHomeProps) => ({

--- a/plugin-hrm-form/src/components/caseList/CaseList.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseList.tsx
@@ -135,7 +135,7 @@ const CaseList: React.FC<Props> = ({
     return (
       <StandaloneSearchContainer>
         <CaseLayout>
-          <Case task={standaloneTask} isCreating={false} handleClose={closeCaseView} />
+          <Case task={standaloneTask} handleClose={closeCaseView} />
         </CaseLayout>
       </StandaloneSearchContainer>
     );

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -50,6 +50,7 @@ import type { ResourceReferral } from '../../states/contacts/resourceReferral';
 import { getAseloFeatureFlags, getTemplateStrings } from '../../hrmConfig';
 import { configurationBase, contactFormsBase, namespace } from '../../states/storeNamespaces';
 import { changeRoute, newOpenModalAction } from '../../states/routing/actions';
+import { getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
 
 const formatResourceReferral = (referral: ResourceReferral) => {
   return (
@@ -111,6 +112,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
   toggleSectionExpandedForContext,
   navigate,
   openProfileModal,
+  isProfileRoute,
   enableEditing,
   canViewTwilioTranscript,
   createDraftCsamReport,
@@ -249,7 +251,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
   const { canView } = getPermissionsForViewingIdentifiers();
   const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
-  const profileLink = featureFlags.enable_client_profiles && savedContact.profileId && (
+  const profileLink = featureFlags.enable_client_profiles && !isProfileRoute && savedContact.profileId && (
     <SectionActionButton padding="0" type="button" onClick={() => openProfileModal(savedContact.profileId)}>
       <Icon icon="DefaultAvatar" />
       View Client
@@ -446,6 +448,8 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
   canViewTwilioTranscript: (state.flex.worker.attributes.roles as string[]).some(
     role => role.toLowerCase().startsWith('wfo') && role !== 'wfo.quality_process_manager',
   ),
+  isProfileRoute:
+    getCurrentTopmostRouteForTask(state[namespace].routing, ownProps.task.taskSid)?.route === 'profile-contact',
 });
 
 const mapDispatchToProps = (dispatch, { contactId, context, task }: OwnProps) => ({

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -51,6 +51,7 @@ import { getAseloFeatureFlags, getTemplateStrings } from '../../hrmConfig';
 import { configurationBase, contactFormsBase, namespace } from '../../states/storeNamespaces';
 import { changeRoute, newOpenModalAction } from '../../states/routing/actions';
 import { getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
+import { isRouteWithContext } from '../../states/routing/types';
 
 const formatResourceReferral = (referral: ResourceReferral) => {
   return (
@@ -439,18 +440,20 @@ ContactDetailsHome.defaultProps = {
   showActionIcons: false,
 };
 
-const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
-  definitionVersions: state[namespace][configurationBase].definitionVersions,
-  counselorsHash: state[namespace][configurationBase].counselors.hash,
-  savedContact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.savedContact,
-  draftContact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.draftContact,
-  detailsExpanded: state[namespace][contactFormsBase].contactDetails[ownProps.context].detailsExpanded,
-  canViewTwilioTranscript: (state.flex.worker.attributes.roles as string[]).some(
-    role => role.toLowerCase().startsWith('wfo') && role !== 'wfo.quality_process_manager',
-  ),
-  isProfileRoute:
-    getCurrentTopmostRouteForTask(state[namespace].routing, ownProps.task.taskSid)?.route === 'profile-contact',
-});
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
+  const currentRoute = getCurrentTopmostRouteForTask(state[namespace].routing, ownProps.task.taskSid);
+  return {
+    definitionVersions: state[namespace][configurationBase].definitionVersions,
+    counselorsHash: state[namespace][configurationBase].counselors.hash,
+    savedContact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.savedContact,
+    draftContact: state[namespace][contactFormsBase].existingContacts[ownProps.contactId]?.draftContact,
+    detailsExpanded: state[namespace][contactFormsBase].contactDetails[ownProps.context].detailsExpanded,
+    canViewTwilioTranscript: (state.flex.worker.attributes.roles as string[]).some(
+      role => role.toLowerCase().startsWith('wfo') && role !== 'wfo.quality_process_manager',
+    ),
+    isProfileRoute: isRouteWithContext(currentRoute) && currentRoute?.context === 'profile',
+  };
+};
 
 const mapDispatchToProps = (dispatch, { contactId, context, task }: OwnProps) => ({
   toggleSectionExpandedForContext: (section: ContactDetailsSectionsType) =>

--- a/plugin-hrm-form/src/components/profile/ProfileCaseDetails.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileCaseDetails.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import React from 'react';
+
+import Case from '../case';
+import { ProfileCommonProps } from './types';
+
+type OwnProps = ProfileCommonProps;
+
+type Props = OwnProps;
+
+const ProfileCaseDetails: React.FC<Props> = (props: Props) => {
+  return <Case {...props} />;
+};
+
+export default ProfileCaseDetails;

--- a/plugin-hrm-form/src/components/profile/ProfileCases.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileCases.tsx
@@ -71,7 +71,7 @@ const mapDispatchToProps = (dispatch, { task: { taskSid } }) => {
   return {
     viewCaseDetails: (cas: Case) => {
       dispatch(CaseActions.setConnectedCase(cas, taskSid));
-      dispatch(RoutingActions.newOpenModalAction({ route: 'case', subroute: 'home', isCreating: false }, taskSid));
+      dispatch(RoutingActions.newOpenModalAction({ route: 'profile-case', subroute: 'home' }, taskSid));
     },
   };
 };

--- a/plugin-hrm-form/src/components/profile/ProfileCases.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileCases.tsx
@@ -71,7 +71,7 @@ const mapDispatchToProps = (dispatch, { task: { taskSid } }) => {
   return {
     viewCaseDetails: (cas: Case) => {
       dispatch(CaseActions.setConnectedCase(cas, taskSid));
-      dispatch(RoutingActions.newOpenModalAction({ route: 'profile-case', subroute: 'home' }, taskSid));
+      dispatch(RoutingActions.newOpenModalAction({ route: 'case', context: 'profile', subroute: 'home' }, taskSid));
     },
   };
 };

--- a/plugin-hrm-form/src/components/profile/ProfileContactDetails.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileContactDetails.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+
+import { namespace } from '../../states/storeNamespaces';
+import { RootState } from '../../states';
+import { DetailsContext } from '../../states/contacts/contactDetails';
+import { isContactRoute } from '../../states/routing/types';
+import { getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
+import ContactDetails from '../contact/ContactDetails';
+import { ProfileCommonProps } from './types';
+
+type OwnProps = ProfileCommonProps;
+
+const mapStateToProps = (state: RootState, { task: { taskSid } }) => {
+  const routingState = state[namespace].routing;
+  const currentRoute = getCurrentTopmostRouteForTask(routingState, taskSid);
+  const contactId = isContactRoute(currentRoute) && currentRoute?.id;
+
+  return {
+    contactId,
+  };
+};
+
+const connector = connect(mapStateToProps);
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+const ProfileContactDetails: React.FC<Props> = (props: Props) => {
+  return <ContactDetails {...props} context={DetailsContext.CONTACT_SEARCH} />;
+};
+
+export default connector(ProfileContactDetails);

--- a/plugin-hrm-form/src/components/profile/ProfileContacts.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileContacts.tsx
@@ -52,7 +52,9 @@ const ProfileContacts: React.FC<Props> = ({ profileId, viewContactDetails }) => 
 const mapDispatchToProps = (dispatch, { task: { taskSid } }) => {
   return {
     viewContactDetails: ({ id }: Contact) => {
-      dispatch(RoutingActions.newOpenModalAction({ route: 'contact', subroute: 'view', id: id.toString() }, taskSid));
+      dispatch(
+        RoutingActions.newOpenModalAction({ route: 'profile-contact', subroute: 'view', id: id.toString() }, taskSid),
+      );
     },
   };
 };

--- a/plugin-hrm-form/src/components/profile/ProfileContacts.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileContacts.tsx
@@ -53,7 +53,10 @@ const mapDispatchToProps = (dispatch, { task: { taskSid } }) => {
   return {
     viewContactDetails: ({ id }: Contact) => {
       dispatch(
-        RoutingActions.newOpenModalAction({ route: 'profile-contact', subroute: 'view', id: id.toString() }, taskSid),
+        RoutingActions.newOpenModalAction(
+          { route: 'contact', context: 'profile', subroute: 'view', id: id.toString() },
+          taskSid,
+        ),
       );
     },
   };

--- a/plugin-hrm-form/src/components/profile/ProfileDetails.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileDetails.tsx
@@ -36,6 +36,19 @@ import ProfileSectionView from './section/ProfileSectionView';
 
 type OwnProps = ProfileCommonProps;
 
+const mapDispatchToProps = (dispatch, ownProps: OwnProps) => {
+  const { profileId, task } = ownProps;
+  const taskId = task.taskSid;
+  return {
+    openSectionEditModal: (type: string) => {
+      dispatch(newOpenModalAction({ route: 'profileSectionEdit', type, id: profileId }, taskId));
+    },
+  };
+};
+
+const connector = connect(null, mapDispatchToProps);
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
 type Section = {
   titleCode?: string;
   title?: string;
@@ -43,9 +56,6 @@ type Section = {
   handleEdit?: () => void;
   inInlineEditMode?: boolean;
 };
-
-// eslint-disable-next-line no-use-before-define
-type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileDetails: React.FC<Props> = ({ profileId, task, openSectionEditModal }) => {
   const { profile } = useProfile({ profileId });
@@ -127,15 +137,4 @@ const ProfileDetails: React.FC<Props> = ({ profileId, task, openSectionEditModal
   );
 };
 
-const mapDispatchToProps = (dispatch, ownProps: OwnProps) => {
-  const { profileId, task } = ownProps;
-  const taskId = task.taskSid;
-  return {
-    openSectionEditModal: (type: string) => {
-      dispatch(newOpenModalAction({ route: 'profileSectionEdit', type, id: profileId }, taskId));
-    },
-  };
-};
-
-const connector = connect(null, mapDispatchToProps);
 export default connector(ProfileDetails);

--- a/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/ProfileIdentifierBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/ProfileIdentifierBanner.tsx
@@ -34,7 +34,18 @@ type OwnProps = {
   enableClientProfiles?: boolean;
 };
 
-// eslint-disable-next-line no-use-before-define
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const { task } = ownProps;
+  const taskId = task.taskSid;
+
+  return {
+    openProfileModal: id => {
+      dispatch(newOpenModalAction({ route: 'profile', id }, taskId));
+    },
+  };
+};
+
+const connector = connect(null, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal }) => {
@@ -120,17 +131,4 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal }) =>
 };
 
 ProfileIdentifierBanner.displayName = 'PreviousContactsBanner';
-
-const mapDispatchToProps = (dispatch, ownProps) => {
-  const { task } = ownProps;
-  const taskId = task.taskSid;
-
-  return {
-    openProfileModal: id => {
-      dispatch(newOpenModalAction({ route: 'profile', id }, taskId));
-    },
-  };
-};
-
-const connector = connect(null, mapDispatchToProps);
 export default connector(ProfileIdentifierBanner);

--- a/plugin-hrm-form/src/components/profile/ProfileRelationshipList.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileRelationshipList.tsx
@@ -34,7 +34,38 @@ type OwnProps = {
   renderItem: (d: ProfileTypes.ProfileRelationshipTypes) => React.ReactNode;
 };
 
-// eslint-disable-next-line no-use-before-define
+const mapStateToProps = (state: RootState, { profileId, type }) => {
+  const { data, loading, page, total } =
+    profileSelectors.selectProfileRelationshipsByType(state, profileId, type) || {};
+
+  return {
+    data,
+    loading,
+    page,
+    total,
+  };
+};
+
+const mapDispatchToProps = (dispatch, { profileId, type }: OwnProps) => ({
+  loadRelationshipAsync: (page: number) =>
+    asyncDispatch(dispatch)(
+      profileActions.loadRelationshipAsync({
+        profileId,
+        type,
+        page,
+      }),
+    ),
+  updatePage: (page: number) =>
+    dispatch(
+      profileActions.updateRelationshipsPage({
+        profileId,
+        type,
+        page,
+      }),
+    ),
+});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileRelationshipList: React.FC<Props> = ({
@@ -83,36 +114,4 @@ const ProfileRelationshipList: React.FC<Props> = ({
   );
 };
 
-const mapStateToProps = (state: RootState, { profileId, type }) => {
-  const { data, loading, page, total } =
-    profileSelectors.selectProfileRelationshipsByType(state, profileId, type) || {};
-
-  return {
-    data,
-    loading,
-    page,
-    total,
-  };
-};
-
-const mapDispatchToProps = (dispatch, { profileId, type }: OwnProps) => ({
-  loadRelationshipAsync: (page: number) =>
-    asyncDispatch(dispatch)(
-      profileActions.loadRelationshipAsync({
-        profileId,
-        type,
-        page,
-      }),
-    ),
-  updatePage: (page: number) =>
-    dispatch(
-      profileActions.updateRelationshipsPage({
-        profileId,
-        type,
-        page,
-      }),
-    ),
-});
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
 export default connector(ProfileRelationshipList);

--- a/plugin-hrm-form/src/components/profile/ProfileRouter.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileRouter.tsx
@@ -19,9 +19,9 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { RouterTask } from '../../types/types';
 import { getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
+import { AppRoutes, ProfileRoute, ProfileSectionEditRoute, isRouteWithContext } from '../../states/routing/types';
 import { namespace } from '../../states/storeNamespaces';
 import { RootState } from '../../states';
-import { ProfileRoute, ProfileSectionEditRoute } from '../../states/routing/types';
 import ProfileCaseDetails from './ProfileCaseDetails';
 import ProfileContactDetails from './ProfileContactDetails';
 import ProfileEdit from './ProfileEdit';
@@ -37,7 +37,7 @@ const mapStateToProps = (state: RootState, { task: { taskSid } }: OwnProps) => {
   const route = getCurrentTopmostRouteForTask(routingState, taskSid);
   const profileId = (route as ProfileRoute).id;
   const currentRouteStack = getCurrentTopmostRouteForTask(routingState, taskSid);
-  const currentRoute = currentRouteStack?.route.toString();
+  const currentRoute = currentRouteStack?.route.toString() as AppRoutes['route'];
   const sectionType = (currentRouteStack as ProfileSectionEditRoute)?.type;
 
   return {
@@ -50,17 +50,23 @@ const mapStateToProps = (state: RootState, { task: { taskSid } }: OwnProps) => {
 const connector = connect(mapStateToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const PROFILE_ROUTES = {
+type ProfileRouteConfig = {
+  routes?: AppRoutes['route'][];
+  contextRoutes?: AppRoutes['route'][];
+  renderComponent: (props: Props) => JSX.Element;
+};
+
+const PROFILE_ROUTES: Record<string, ProfileRouteConfig> = {
   profile: {
     routes: ['profile'],
     renderComponent: (props: Props) => <ProfileTabs {...props} />,
   },
   profileContact: {
-    routes: ['profile-contact'],
+    contextRoutes: ['contact'],
     renderComponent: (props: Props) => <ProfileContactDetails {...props} />,
   },
   profileCase: {
-    routes: ['profile-case'],
+    contextRoutes: ['case'],
     renderComponent: (props: Props) => <ProfileCaseDetails {...props} />,
   },
   profileEdit: {
@@ -73,14 +79,25 @@ const PROFILE_ROUTES = {
   },
 };
 
-export const ALL_PROFILE_ROUTES = Object.values(PROFILE_ROUTES).flatMap(({ routes }) => routes);
+const rootProfileRoutes = Object.values(PROFILE_ROUTES).flatMap(({ routes }) => routes);
+const contextProfileRoutes = Object.values(PROFILE_ROUTES).flatMap(({ contextRoutes }) => contextRoutes);
+
+export const isProfileRoute = (routing: AppRoutes) => {
+  if (rootProfileRoutes.includes(routing.route)) return true;
+
+  return (
+    isRouteWithContext(routing) &&
+    routing.context === 'profile' &&
+    contextProfileRoutes.includes(routing.route as AppRoutes['route'])
+  );
+};
 
 const ProfileRouter: React.FC<Props> = props => {
   const { currentRoute } = props;
 
   return (
     Object.values(PROFILE_ROUTES)
-      .find(({ routes }) => routes.includes(currentRoute))
+      .find(({ routes, contextRoutes }) => routes?.includes(currentRoute) || contextRoutes?.includes(currentRoute))
       ?.renderComponent(props) || null
   );
 };

--- a/plugin-hrm-form/src/components/profile/ProfileRouter.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileRouter.tsx
@@ -22,6 +22,8 @@ import { getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
 import { namespace } from '../../states/storeNamespaces';
 import { RootState } from '../../states';
 import { ProfileRoute, ProfileSectionEditRoute } from '../../states/routing/types';
+import ProfileCaseDetails from './ProfileCaseDetails';
+import ProfileContactDetails from './ProfileContactDetails';
 import ProfileEdit from './ProfileEdit';
 import ProfileTabs from './ProfileTabs';
 import ProfileSectionEdit from './section/ProfileSectionEdit';
@@ -30,13 +32,36 @@ type OwnProps = {
   task: RouterTask;
 };
 
-// eslint-disable-next-line no-use-before-define
+const mapStateToProps = (state: RootState, { task: { taskSid } }: OwnProps) => {
+  const routingState = state[namespace].routing;
+  const route = getCurrentTopmostRouteForTask(routingState, taskSid);
+  const profileId = (route as ProfileRoute).id;
+  const currentRouteStack = getCurrentTopmostRouteForTask(routingState, taskSid);
+  const currentRoute = currentRouteStack?.route.toString();
+  const sectionType = (currentRouteStack as ProfileSectionEditRoute)?.type;
+
+  return {
+    profileId,
+    currentRoute,
+    sectionType,
+  };
+};
+
+const connector = connect(mapStateToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const PROFILE_ROUTES = {
   profile: {
     routes: ['profile'],
     renderComponent: (props: Props) => <ProfileTabs {...props} />,
+  },
+  profileContact: {
+    routes: ['profile-contact'],
+    renderComponent: (props: Props) => <ProfileContactDetails {...props} />,
+  },
+  profileCase: {
+    routes: ['profile-case'],
+    renderComponent: (props: Props) => <ProfileCaseDetails {...props} />,
   },
   profileEdit: {
     routes: ['profileEdit'],
@@ -60,20 +85,4 @@ const ProfileRouter: React.FC<Props> = props => {
   );
 };
 
-const mapStateToProps = (state: RootState, { task: { taskSid } }: OwnProps) => {
-  const routingState = state[namespace].routing;
-  const route = getCurrentTopmostRouteForTask(routingState, taskSid);
-  const profileId = (route as ProfileRoute).id;
-  const currentRouteStack = getCurrentTopmostRouteForTask(routingState, taskSid);
-  const currentRoute = currentRouteStack?.route.toString();
-  const sectionType = (currentRouteStack as ProfileSectionEditRoute)?.type;
-
-  return {
-    profileId,
-    currentRoute,
-    sectionType,
-  };
-};
-
-const connector = connect(mapStateToProps);
 export default connector(ProfileRouter);

--- a/plugin-hrm-form/src/components/profile/ProfileTabs.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileTabs.tsx
@@ -35,7 +35,28 @@ import { ProfileCommonProps } from './types';
 
 type OwnProps = ProfileCommonProps;
 
-// eslint-disable-next-line no-use-before-define
+const mapStateToProps = (state: RootState, { task: { taskSid } }: OwnProps) => {
+  const routingState = state[namespace].routing;
+  const route = getCurrentTopmostRouteForTask(routingState, taskSid);
+  const currentTab = (route as ProfileRoute).subroute || 'details';
+
+  return {
+    currentTab,
+  };
+};
+
+const mapDispatchToProps = (dispatch, { task }: OwnProps) => ({
+  changeProfileTab: (id, subroute) =>
+    dispatch(
+      RoutingActions.changeRoute(
+        { route: 'profile', id, subroute },
+        task.taskSid,
+        RoutingTypes.ChangeRouteMode.Replace,
+      ),
+    ),
+});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileTabs: React.FC<Props> = ({ profileId, task, currentTab, changeProfileTab }) => {
@@ -86,26 +107,4 @@ const ProfileTabs: React.FC<Props> = ({ profileId, task, currentTab, changeProfi
   );
 };
 
-const mapStateToProps = (state: RootState, { task: { taskSid } }: OwnProps) => {
-  const routingState = state[namespace].routing;
-  const route = getCurrentTopmostRouteForTask(routingState, taskSid);
-  const currentTab = (route as ProfileRoute).subroute || 'details';
-
-  return {
-    currentTab,
-  };
-};
-
-const mapDispatchToProps = (dispatch, { task }: OwnProps) => ({
-  changeProfileTab: (id, subroute) =>
-    dispatch(
-      RoutingActions.changeRoute(
-        { route: 'profile', id, subroute },
-        task.taskSid,
-        RoutingTypes.ChangeRouteMode.Replace,
-      ),
-    ),
-});
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
 export default connector(ProfileTabs);

--- a/plugin-hrm-form/src/components/profile/section/ProfileSectionEdit.tsx
+++ b/plugin-hrm-form/src/components/profile/section/ProfileSectionEdit.tsx
@@ -38,6 +38,13 @@ type OwnProps = ProfileCommonProps & {
   sectionType: ProfileSection['sectionType'];
 };
 
+const mapDispatchToProps = (dispatch, { task }: OwnProps) => {
+  return {
+    closeModal: () => dispatch(RoutingActions.newCloseModalAction(task.taskSid)),
+  };
+};
+
+const connector = connect(null, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileSectionEdit = ({ task, profileId, sectionType, closeModal }: Props) => {
@@ -84,13 +91,4 @@ const ProfileSectionEdit = ({ task, profileId, sectionType, closeModal }: Props)
   );
 };
 
-const mapDispatchToProps = (dispatch, { task }: OwnProps) => {
-  return {
-    closeModal: () => dispatch(RoutingActions.newCloseModalAction(task.taskSid)),
-  };
-};
-
-const connector = connect(null, mapDispatchToProps);
-const connected = connector(ProfileSectionEdit);
-
-export default connected;
+export default connector(ProfileSectionEdit);

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -165,7 +165,7 @@ const Search: React.FC<Props> = ({
         break;
       }
       case 'case': {
-        return <Case task={task} isCreating={false} />;
+        return <Case task={task} />;
       }
       case 'contact':
         // Find contact in contact search results or connected to one of case search results

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -26,7 +26,7 @@ import SearchForm from './SearchForm';
 import SearchResults, { CONTACTS_PER_PAGE, CASES_PER_PAGE } from './SearchResults';
 import ContactDetails from './ContactDetails';
 import Case from '../case';
-import ProfileRouter, { ALL_PROFILE_ROUTES } from '../profile/ProfileRouter';
+import ProfileRouter, { isProfileRoute } from '../profile/ProfileRouter';
 import { SearchParams } from '../../states/search/types';
 import { CustomITask, Contact, standaloneTaskSid } from '../../types/types';
 import { handleSearchFormChange, searchContacts, searchCases } from '../../states/search/actions';
@@ -132,7 +132,7 @@ const Search: React.FC<Props> = ({
   renderMockDialog.displayName = 'MockDialog';
 
   const renderSearchPages = () => {
-    if (ALL_PROFILE_ROUTES.includes(routing.route)) return <ProfileRouter task={task} />;
+    if (isProfileRoute(routing)) return <ProfileRouter task={task} />;
 
     switch (routing.route) {
       case 'search': {

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -243,32 +243,12 @@ const TabbedForms: React.FC<Props> = ({
     );
   }
 
-  const renderCaseLayout = () => {
-    // This is a dirty hack so that case viewing works for the create case form and
-    // the profile view case form. It could use a refactor if/when we move routing
-    // into a separate component, but this *should* mostly work for now.
-    // Editing the case in the profile view case form will probably not work
-    // as expected without some additional work.
-    const isCreating = currentRoute.hasOwnProperty('isCreating') ? (currentRoute as CaseRoute).isCreating : true;
-    const caseProps: CaseProps = {
-      task,
-      isCreating,
-    };
-
-    if (isCreating) {
-      caseProps.onNewCaseSaved = onNewCaseSaved;
-      caseProps.handleClose = closeModal;
-    }
-
+  if (currentRoute.route === 'case') {
     return (
       <CaseLayout>
-        <Case {...caseProps} />
+        <Case task={task} onNewCaseSaved={onNewCaseSaved} handleClose={closeModal} />
       </CaseLayout>
     );
-  };
-
-  if (currentRoute.route === 'case') {
-    return renderCaseLayout();
   }
 
   if (currentRoute.route === 'contact') {

--- a/plugin-hrm-form/src/states/routing/types.ts
+++ b/plugin-hrm-form/src/states/routing/types.ts
@@ -88,10 +88,20 @@ type CaseListRoute = RouteWithModalSupport & {
   subroute: 'case-list';
 };
 
-const CASE_ROUTES = ['case', 'profile-case'] as const;
+const CONTEXTS = ['search', 'hrm-form', 'profile'] as const;
 
-type CaseCoreRoute = {
-  route: typeof CASE_ROUTES[number];
+export type Contexts = typeof CONTEXTS[number];
+
+export type RouteWithContext = {
+  context?: Contexts;
+};
+
+export const isRouteWithContext = (route: any): route is RouteWithContext => {
+  return CONTEXTS.includes((route as RouteWithContext).context);
+};
+
+type CaseCoreRoute = RouteWithContext & {
+  route: 'case';
   autoFocus?: boolean;
   isCreating?: boolean;
 };
@@ -172,7 +182,7 @@ export function isRouteModal(route: AppRoutes): boolean {
 }
 
 export function isCaseRoute(appRoute: AppRoutes): appRoute is CaseRoute {
-  return CASE_ROUTES.includes(appRoute?.route as CaseRoute['route']);
+  return appRoute?.route === 'case';
 }
 
 export type CSAMReportRoute = {
@@ -181,11 +191,10 @@ export type CSAMReportRoute = {
   previousRoute: AppRoutes;
 };
 
-const CONTACT_ROUTES = ['contact', 'profile-contact'] as const;
-
-type ContactCoreRoute = {
-  route: typeof CONTACT_ROUTES[number];
+type ContactCoreRoute = RouteWithContext & {
+  route: 'contact';
   id: string;
+  profileId?: Profile['id'];
 };
 
 type ContactViewRoute = ContactCoreRoute & {
@@ -200,7 +209,7 @@ export type ContactEditRoute = ContactCoreRoute & {
 type ContactRoute = ContactViewRoute | ContactEditRoute;
 
 export const isContactRoute = (route: AppRoutes): route is ContactRoute => {
-  return CONTACT_ROUTES.includes(route.route as ContactRoute['route']);
+  return route.route === 'contact';
 };
 
 type OtherRoutes =

--- a/plugin-hrm-form/src/states/routing/types.ts
+++ b/plugin-hrm-form/src/states/routing/types.ts
@@ -31,7 +31,6 @@ export type TabbedFormSubroutes =
   | 'profileEdit';
 
 export type RouteWithModalSupport = {
-  route: 'tabbed-forms' | 'case' | 'case-list' | 'search';
   activeModal?: AppRoutes[];
 };
 
@@ -89,8 +88,10 @@ type CaseListRoute = RouteWithModalSupport & {
   subroute: 'case-list';
 };
 
+const CASE_ROUTES = ['case', 'profile-case'] as const;
+
 type CaseCoreRoute = {
-  route: 'case';
+  route: typeof CASE_ROUTES[number];
   autoFocus?: boolean;
   isCreating?: boolean;
 };
@@ -137,7 +138,7 @@ export const PROFILE_TABS = {
 
 export type ProfileTabs = typeof PROFILE_TABS[keyof typeof PROFILE_TABS];
 
-export type ProfileRoute = {
+export type ProfileRoute = RouteWithModalSupport & {
   route: 'profile';
   id: Profile['id'];
   subroute?: ProfileTabs;
@@ -170,13 +171,8 @@ export function isRouteModal(route: AppRoutes): boolean {
   return isRouteWithModalSupport(route) && route.activeModal?.length > 0;
 }
 
-// Routes that may lead to Case screen (maybe we need an improvement here)
-export type AppRoutesWithCase =
-  // TODO: enum the possible subroutes on each route
-  CaseRoute;
-
-export function isCaseRoute(appRoute: AppRoutes): appRoute is AppRoutesWithCase {
-  return appRoute?.route === 'case';
+export function isCaseRoute(appRoute: AppRoutes): appRoute is CaseRoute {
+  return CASE_ROUTES.includes(appRoute?.route as CaseRoute['route']);
 }
 
 export type CSAMReportRoute = {
@@ -185,20 +181,27 @@ export type CSAMReportRoute = {
   previousRoute: AppRoutes;
 };
 
-type ContactViewRoute = {
-  route: 'contact';
-  subroute: 'view';
+const CONTACT_ROUTES = ['contact', 'profile-contact'] as const;
+
+type ContactCoreRoute = {
+  route: typeof CONTACT_ROUTES[number];
   id: string;
 };
 
-export type ContactEditRoute = {
-  route: 'contact';
+type ContactViewRoute = ContactCoreRoute & {
+  subroute: 'view';
+};
+
+export type ContactEditRoute = ContactCoreRoute & {
   subroute: 'edit';
-  id: string;
   form: keyof Pick<ContactRawJson, 'childInformation' | 'callerInformation' | 'caseInformation' | 'categories'>;
 };
 
 type ContactRoute = ContactViewRoute | ContactEditRoute;
+
+export const isContactRoute = (route: AppRoutes): route is ContactRoute => {
+  return CONTACT_ROUTES.includes(route.route as ContactRoute['route']);
+};
 
 type OtherRoutes =
   | CSAMReportRoute
@@ -212,7 +215,7 @@ type OtherRoutes =
   | ProfileSectionEditRoute;
 
 // The different routes we have in our app
-export type AppRoutes = AppRoutesWithCase | OtherRoutes;
+export type AppRoutes = CaseRoute | OtherRoutes;
 
 export function isRouteWithModalSupport(appRoute: any): appRoute is RouteWithModalSupport {
   return ['tabbed-forms', 'case', 'case-list', 'contact', 'profile', 'search', 'select-call-type'].includes(


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Trying to reuse the same case/contact route for profiles in standalone search and profiles in an active call was causing all kinds of issues.

Giving search control of its own relationship details views seemed like a pattern to remove some of that complexity, improve separation of concerns, and it definitely fixed some of the bugs we were hitting with trying to overload individual routes.

I'm, obviously, totally open to other approaches.

This also completes the migration to an `isCreating` property on the case route instead of passing through a property that was implemented [here](https://github.com/techmatters/flex-plugins/pull/1883/files#diff-a43cd9fba5ab2070d4abb775bbd93796afff5ea7c237d494e703a8edccda363eR111).

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->