### PR TITLE
[Bug Fix] No error message appears if contact isn't categorized

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/contact/IssueCategorizationSectionForm.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/contact/IssueCategorizationSectionForm.test.tsx
@@ -34,7 +34,7 @@ jest.mock('react-hook-form', () => ({
   useFormContext: () => ({
     clearErrors: jest.fn(),
     register: jest.fn(),
-  })
+  }),
 }));
 jest.mock('../../../components/CSAMReport/CSAMReportFormDefinition');
 jest.mock('../../../hrmConfig');

--- a/plugin-hrm-form/src/___tests__/components/contact/IssueCategorizationSectionForm.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/contact/IssueCategorizationSectionForm.test.tsx
@@ -30,6 +30,12 @@ import { VALID_EMPTY_CONTACT } from '../../testContacts';
 import { FeatureFlags } from '../../../types/types';
 import { contactFormsBase, namespace } from '../../../states/storeNamespaces';
 
+jest.mock('react-hook-form', () => ({
+  useFormContext: () => ({
+    clearErrors: jest.fn(),
+    register: jest.fn(),
+  })
+}));
 jest.mock('../../../components/CSAMReport/CSAMReportFormDefinition');
 jest.mock('../../../hrmConfig');
 

--- a/plugin-hrm-form/src/components/contact/IssueCategorizationSectionForm.tsx
+++ b/plugin-hrm-form/src/components/contact/IssueCategorizationSectionForm.tsx
@@ -21,6 +21,7 @@ import type { CategoriesDefinition } from 'hrm-form-definitions';
 import { Template } from '@twilio/flex-ui';
 import GridIcon from '@material-ui/icons/GridOn';
 import ListIcon from '@material-ui/icons/List';
+import { useFormContext } from 'react-hook-form';
 
 import { RootState } from '../../states';
 import useFocus from '../../utils/useFocus';
@@ -62,6 +63,28 @@ const IssueCategorizationSectionForm: React.FC<Props> = ({
   const shouldFocusFirstElement = display && autoFocus;
   const firstElementRef = useFocus(shouldFocusFirstElement);
   const selectedCount = Object.values(selectedCategories).reduce((acc, curr) => acc + curr.length, 0);
+
+  const { register, setError } = useFormContext();
+
+  // Add invisible field that errors if no category is selected (triggered by validaiton)
+  React.useEffect(() => {
+    register('categories.categorySelected', {
+      validate: () => {
+        if (selectedCount < 1) {
+          return 'Error';
+        }
+
+        return null;
+      },
+    });
+  }, [register, selectedCount]);
+
+  // Clear the error state once the count is non-zero
+  React.useEffect(() => {
+    if (selectedCount) {
+      setError('categories.categorySelected', null);
+    }
+  }, [selectedCount, setError]);
 
   return (
     <Container formContainer={true}>

--- a/plugin-hrm-form/src/components/contact/IssueCategorizationSectionForm.tsx
+++ b/plugin-hrm-form/src/components/contact/IssueCategorizationSectionForm.tsx
@@ -64,7 +64,7 @@ const IssueCategorizationSectionForm: React.FC<Props> = ({
   const firstElementRef = useFocus(shouldFocusFirstElement);
   const selectedCount = Object.values(selectedCategories).reduce((acc, curr) => acc + curr.length, 0);
 
-  const { register, setError } = useFormContext();
+  const { clearErrors, register } = useFormContext();
 
   // Add invisible field that errors if no category is selected (triggered by validaiton)
   React.useEffect(() => {
@@ -82,9 +82,9 @@ const IssueCategorizationSectionForm: React.FC<Props> = ({
   // Clear the error state once the count is non-zero
   React.useEffect(() => {
     if (selectedCount) {
-      setError('categories.categorySelected', null);
+      clearErrors('categories.categorySelected');
     }
-  }, [selectedCount, setError]);
+  }, [clearErrors, selectedCount]);
 
   return (
     <Container formContainer={true}>


### PR DESCRIPTION
## Description
>Users are not prompted with an error message if they don't choose a category for the contact, even though it says at least one is required. They are still able to save and end the contact successfully without it.

This PR fixes the bug cited above. This bug is caused because when the categories forms were refactored, they were unplugged from RHF, that's where the validation occurs.
To fix this, I'm introducing an invisible input that holds no value, and that is never used. It's only purpose is to run it's `validate` function on submission-attempts, and error if there are no categories selected.

![Screenshot from 2023-12-06 18-30-15](https://github.com/techmatters/flex-plugins/assets/15805319/4e767f87-6027-42c7-9389-8a4222b19440)


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2455)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Verification steps
- Start development server (`npm run dev`).
- Start a new contact.
- Fill all the required values but the categories.
- Try saving the contact, confirm that the Categories tab shows an error as expected. Also confirm that you can't save the contact under this conditions.
- Select 1 category, retry submitting and confirm now it's fine to so.