### PR TITLE
bg: fix caseId inconsistency on the callout banner

### DIFF
--- a/plugin-hrm-form/src/components/caseMergingBanners/ContactAddedToCaseBanner.tsx
+++ b/plugin-hrm-form/src/components/caseMergingBanners/ContactAddedToCaseBanner.tsx
@@ -28,19 +28,24 @@ import type { Case } from '../../types/types';
 import { BannerContainer, Text, CaseLink, BannerActionLink } from './styles';
 import InfoIcon from './InfoIcon';
 import { showRemovedFromCaseBannerAction } from '../../states/case/caseBanners';
+import { contactFormsBase, namespace } from '../../states/storeNamespaces';
+import { RootState } from '../../states';
 
 type OwnProps = {
   taskId: string;
+  contactId: string;
 };
 
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
-const mapStateToProps = (state, { taskId }: OwnProps) => {
+const mapStateToProps = (state: RootState, { taskId, contactId }: OwnProps) => {
   const contact = selectContactByTaskSid(state, taskId);
   const connectedCase = selectCaseByTaskSid(state, taskId);
+  const caseId = state[namespace][contactFormsBase].existingContacts[contactId].savedContact?.caseId;
   return {
     contact: contact.savedContact,
     connectedCase,
+    caseId,
   };
 };
 
@@ -60,6 +65,7 @@ const ContactAddedToCaseBanner: React.FC<Props> = ({
   contact,
   viewCaseDetails,
   removeContactFromCase,
+  caseId,
 }) => {
   if (connectedCase === undefined) return null;
 
@@ -71,7 +77,7 @@ const ContactAddedToCaseBanner: React.FC<Props> = ({
       </Text>
       <CaseLink type="button" onClick={() => viewCaseDetails(connectedCase)}>
         <Template code="Case-CaseNumber" />
-        {connectedCase.id}
+        {caseId}
       </CaseLink>
       <BannerActionLink type="button" onClick={() => removeContactFromCase(contact.id)}>
         <Template code="CaseMerging-RemoveFromCase" />

--- a/plugin-hrm-form/src/components/caseMergingBanners/ContactAddedToCaseBanner.tsx
+++ b/plugin-hrm-form/src/components/caseMergingBanners/ContactAddedToCaseBanner.tsx
@@ -33,15 +33,14 @@ import { RootState } from '../../states';
 
 type OwnProps = {
   taskId: string;
-  contactId: string;
 };
 
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
-const mapStateToProps = (state: RootState, { taskId, contactId }: OwnProps) => {
+const mapStateToProps = (state: RootState, { taskId }: OwnProps) => {
   const contact = selectContactByTaskSid(state, taskId);
   const connectedCase = selectCaseByTaskSid(state, taskId);
-  const caseId = state[namespace][contactFormsBase].existingContacts[contactId].savedContact?.caseId;
+  const caseId = contact?.savedContact?.caseId;
   return {
     contact: contact.savedContact,
     connectedCase,

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -366,7 +366,9 @@ const TabbedForms: React.FC<Props> = ({
           {/* eslint-disable-next-line camelcase */}
           {enable_case_merging && (
             <>
-              {showConnectedToCaseBanner && <ContactAddedToCaseBanner taskId={task.taskSid} />}
+              {showConnectedToCaseBanner && (
+                <ContactAddedToCaseBanner taskId={task.taskSid} contactId={savedContact.id} />
+              )}
               {showRemovedFromCaseBanner && <ContactRemovedFromCaseBanner taskId={task.taskSid} />}
             </>
           )}

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -366,9 +366,7 @@ const TabbedForms: React.FC<Props> = ({
           {/* eslint-disable-next-line camelcase */}
           {enable_case_merging && (
             <>
-              {showConnectedToCaseBanner && (
-                <ContactAddedToCaseBanner taskId={task.taskSid} contactId={savedContact.id} />
-              )}
+              {showConnectedToCaseBanner && <ContactAddedToCaseBanner taskId={task.taskSid} />}
               {showRemovedFromCaseBanner && <ContactRemovedFromCaseBanner taskId={task.taskSid} />}
             </>
           )}


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Bug fix: This handles the inconsistency with the case ID displayed on the blue banner when contact is added to existing case.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes [CHI-2451](https://tech-matters.atlassian.net/browse/CHI-2451)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
- Add a contact to an existing case 
- Find another case through Search and click on it (but do not select “add to case”):
- Go back to the summary tab
- Verify that the blue confirmation banner still have the case ID of the connected case

[CHI-2451]: https://tech-matters.atlassian.net/browse/CHI-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ