### PR TITLE
chore: Service Configuration Manager role based access improvements

### DIFF
--- a/twilio-iac/scripts/python_tools/src/service_configuration/config.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/config.py
@@ -4,7 +4,7 @@ import os
 from typing import NotRequired, TypedDict, Unpack
 from ..aws import SSMClient
 from ..twilio import Twilio
-from .constants import AWS_ROLE_ARN
+from .constants import AWS_ROLE_ARNS, get_aws_role_arn
 from .service_configuration import ServiceConfiguration
 from .remote_syncer import RemoteSyncer
 
@@ -190,8 +190,9 @@ class Config():
         except KeyError:
             raise AttributeError(f'No such attribute: {name}')
 
-    def get_ssm_client(self):
-        return SSMClient(AWS_ROLE_ARN)
+    def get_ssm_client(self, environment: str):
+        aws_role_arn = get_aws_role_arn(environment)
+        return SSMClient(aws_role_arn)
 
     def init_arg_parser(self) -> None:
         self._arg_parser = ArgumentParser()
@@ -250,7 +251,8 @@ class Config():
         self._config['helplines'][helpline_code_lower][environment] = service_config
 
     def init_service_config(self, **kwargs: Unpack[InitServiceConfigurationArgsDict]):
-        ssm_client = None if self.auth_token else self.get_ssm_client()
+        environment = kwargs['environment']
+        ssm_client = None if self.auth_token else self.get_ssm_client(environment)
         twilio_client = Twilio(ssm_client=ssm_client,  **kwargs)
         service_config = ServiceConfiguration(
             twilio_client=twilio_client,
@@ -281,7 +283,7 @@ class Config():
                 'Could not find helpline code or environment. Please provide helpline code and environment')
 
         if not account_sid:
-            account_sid, _ = self.get_ssm_client().get_twilio_creds_from_ssm(
+            account_sid, _ = self.get_ssm_client(environment).get_twilio_creds_from_ssm(
                 environment, helpline_code)
 
         self.init_service_config(
@@ -307,7 +309,7 @@ class Config():
 
     def init_service_configs_for_environment(self, environment: str):
         print(f'Initializing service configurations for {environment}')
-        for hl in self.get_ssm_client().get_helplines_for_env(environment):
+        for hl in self.get_ssm_client(environment).get_helplines_for_env(environment):
             # if helpline_code is set, only initialize service configs for that helpline across all environments
             if (self.helpline_code and hl['helpline_code'].lower() != self.helpline_code.lower()):
                 continue

--- a/twilio-iac/scripts/python_tools/src/service_configuration/config.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/config.py
@@ -149,6 +149,7 @@ class ConfigDict(TypedDict):
     skip_lock: bool
     sync_action: bool
     argument: str
+    aws_role_arn: str
 
 
 class InitServiceConfigurationArgsDict(TypedDict):
@@ -174,6 +175,7 @@ class Config():
             'json_available': False,
             'sync_action': False,
             'syncers': [],
+            'aws_role_arn': None
         }
 
         self.init_arg_parser()

--- a/twilio-iac/scripts/python_tools/src/service_configuration/constants.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/constants.py
@@ -3,3 +3,8 @@ AWS_ROLE_ARNS: dict[str, str] = {
     'developer': 'arn:aws:iam::712893914485:role/twilio-iac-service-config-developer',
     'manager': 'arn:aws:iam::712893914485:role/twilio-iac-service-config-manager',
 }
+
+def get_aws_role_arn(environment: str):
+    role_key = "manager" if environment == "production" else "developer"
+    aws_role_arn = AWS_ROLE_ARNS.get(role_key)
+    return aws_role_arn

--- a/twilio-iac/scripts/python_tools/src/service_configuration/constants.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/constants.py
@@ -1,2 +1,5 @@
 """ Constants for the service configuration manager """
-AWS_ROLE_ARN: str = 'arn:aws:iam::712893914485:role/twilio-iac-service-config-manager'
+AWS_ROLE_ARNS: dict[str, str] = {
+    'developer': 'arn:aws:iam::712893914485:role/twilio-iac-service-config-developer',
+    'manager': 'arn:aws:iam::712893914485:role/twilio-iac-service-config-manager',
+}

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -6,7 +6,7 @@ from os.path import exists as path_exists
 from typing import TypedDict, Unpack
 from ..aws import SSMClient
 from ..twilio import Twilio
-from .constants import AWS_ROLE_ARN
+from .constants import AWS_ROLE_ARNS, get_aws_role_arn
 from .version import Version
 
 JSON_PATH_ROOT = "/app/twilio-iac/helplines"
@@ -142,7 +142,7 @@ class LocalConfigsDict(TypedDict):
 
 
 class ServiceConfiguration():
-
+    
     def __init__(self, **kwargs: Unpack[InitArgsDict]) -> None:
         self.local_state: dict[str, object] = {}
         self.new_state: dict[str, object] = {}
@@ -156,6 +156,7 @@ class ServiceConfiguration():
         self.account_sid = self._twilio_client.account_sid
         self.helpline_code = self._twilio_client.helpline_code
         self.environment = self._twilio_client.environment
+        self.aws_role_arn = get_aws_role_arn(self.environment)
         self.remote_state: dict[str,
                                 object] = self._twilio_client.get_flex_configuration()
         self.init_version()
@@ -165,11 +166,11 @@ class ServiceConfiguration():
         self.init_plan()
 
     def get_ssm_client(self):
-        return SSMClient(AWS_ROLE_ARN)
+        return SSMClient(self.aws_role_arn)
 
     def init_region(self):
         try:
-            self.region = self.get_ssm_client().get_parameter(
+            self.region = self.get_ssm_client(self.environment).get_parameter(
                 f"/{self.environment}/aws/{self.account_sid}/region"
             )
         except Exception:
@@ -249,7 +250,7 @@ class ServiceConfiguration():
                 account_sid=self.account_sid,
                 helpline_code=self.helpline_code
             )
-            ssm_value = self.get_ssm_client().get_parameter(ssm_key_name)
+            ssm_value = self.get_ssm_client(self.environment).get_parameter(ssm_key_name)
             set_nested_key(self.new_state, key, ssm_value)
 
     def init_plan(self):
@@ -270,6 +271,7 @@ class ServiceConfiguration():
             helpline_code=self.helpline_code,
             state=self.remote_state,
             skip_lock=self.skip_lock,
+            aws_role_arn=self.aws_role_arn
         )
 
     def get_config_path(self, type: str) -> str:
@@ -294,6 +296,7 @@ class ServiceConfiguration():
             helpline_code=self.helpline_code,
             state=self.new_state,
             skip_lock=True,
+            aws_role_arn=self.aws_role_arn
         )
 
     def cleanup(self):

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -170,7 +170,7 @@ class ServiceConfiguration():
 
     def init_region(self):
         try:
-            self.region = self.get_ssm_client(self.environment).get_parameter(
+            self.region = self.get_ssm_client().get_parameter(
                 f"/{self.environment}/aws/{self.account_sid}/region"
             )
         except Exception:
@@ -250,7 +250,7 @@ class ServiceConfiguration():
                 account_sid=self.account_sid,
                 helpline_code=self.helpline_code
             )
-            ssm_value = self.get_ssm_client(self.environment).get_parameter(ssm_key_name)
+            ssm_value = self.get_ssm_client().get_parameter(ssm_key_name)
             set_nested_key(self.new_state, key, ssm_value)
 
     def init_plan(self):

--- a/twilio-iac/scripts/python_tools/src/service_configuration/version.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/version.py
@@ -4,7 +4,6 @@ import requests
 from datetime import datetime
 from typing import NotRequired, TypedDict, Unpack
 from ..aws import S3Client
-from .constants import AWS_ROLE_ARN
 
 """
 We keep track of every version of the service configuration in S3 so we have a change log.

--- a/twilio-iac/scripts/python_tools/src/service_configuration/version.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/version.py
@@ -25,6 +25,7 @@ class InitArgsDict(TypedDict):
     helpline_code: str
     state: dict[str, str]
     skip_lock: NotRequired[bool | None]
+    aws_role_arn: str
 
 
 class Version():
@@ -33,7 +34,7 @@ class Version():
         self.helpline_code = kwargs['helpline_code']
         self.state = kwargs['state']
         self.skip_lock = kwargs.get('skip_lock') or False
-        self.s3_client = S3Client(AWS_ROLE_ARN)
+        self.s3_client = S3Client(kwargs.get('aws_role_arn'))
         self.init_ip()
         self.init_sha()
         self.init_s3_paths()


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/infrastructure-config/pull/305.

## Description
This PR
- Changes the constant `AWS_ROLE_ARN` for `AWS_ROLE_ARNS`, a dictionary of the different arns that can be used within the service config scripts.
- Refactors the code to decide which one to use depending on the environment for which the service config is being executed:
  - If the environment is `production`, `manager` role is used.
  - In any other case `developer` role is used.

This changes attempt to:
- Tighten security constraints around service configs.
- Allow product team and developers to run service configs updates locally for `development` and `staging` environments.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2387)
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts