### PR TITLE
CHI-2461:  Show 'Add to Case' button for nondata contacts in search results

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -43,7 +43,7 @@ import { setUpReferrableResources } from './components/resources/setUpReferrable
 import { subscribeNewMessageAlertOnPluginInit } from './notifications/newMessage';
 import { subscribeReservedTaskAlert } from './notifications/reservedTask';
 import { setUpCounselorToolkits } from './components/toolkits/setUpCounselorToolkits';
-import { setupConferenceComponents, setUpConferenceActions } from './conference';
+import { setUpConferenceActions, setupConferenceComponents } from './conference';
 import { setUpTransferActions } from './transfer/setUpTransferActions';
 import { playNotification } from './notifications/playNotification';
 import { namespace } from './states/storeNamespaces';
@@ -114,7 +114,7 @@ const setUpComponents = (
     Channels.setUpIncomingTransferMessage();
   }
 
-  if (featureFlags.enable_case_management) Components.setUpCaseList();
+  Components.setUpCaseList();
 
   if (!Boolean(setupObject.helpline)) Components.setUpDeveloperComponents(translateUI); // utilities for developers only
 

--- a/plugin-hrm-form/src/components/search/CasePreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/CasePreview/index.tsx
@@ -99,11 +99,8 @@ const CasePreview: React.FC<Props> = ({
   });
   let isConnectedToTaskContact = false;
   let showConnectButton = false;
-  const {
-    enable_case_management: enableCaseManagement,
-    enable_case_merging: enableCaseMerging,
-  } = getAseloFeatureFlags();
-  if (enableCaseManagement && enableCaseMerging && taskContact) {
+
+  if (getAseloFeatureFlags().enable_case_merging && taskContact) {
     isConnectedToTaskContact = Boolean(connectedContacts?.find(contact => contact.id === taskContact.id));
 
     const { can: canForCase } = getPermissionsForCase(currentCase.twilioWorkerId, currentCase.status);

--- a/plugin-hrm-form/src/components/search/CasePreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/CasePreview/index.tsx
@@ -36,7 +36,6 @@ import { isStandaloneITask } from '../../case/Case';
 import { newCloseModalAction } from '../../../states/routing/actions';
 import { getPermissionsForCase, getPermissionsForContact, PermissionActions } from '../../../permissions';
 import { getAseloFeatureFlags } from '../../../hrmConfig';
-import { isNonDataCallType } from '../../../states/validationRules';
 
 type OwnProps = {
   currentCase: Case;
@@ -104,7 +103,7 @@ const CasePreview: React.FC<Props> = ({
     enable_case_management: enableCaseManagement,
     enable_case_merging: enableCaseMerging,
   } = getAseloFeatureFlags();
-  if (enableCaseManagement && enableCaseMerging && taskContact && !isNonDataCallType(taskContact.rawJson?.callType)) {
+  if (enableCaseManagement && enableCaseMerging && taskContact) {
     isConnectedToTaskContact = Boolean(connectedContacts?.find(contact => contact.id === taskContact.id));
 
     const { can: canForCase } = getPermissionsForCase(currentCase.twilioWorkerId, currentCase.status);

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -22,11 +22,11 @@ import FolderIcon from '@material-ui/icons/CreateNewFolderOutlined';
 import { DefinitionVersionId } from 'hrm-form-definitions';
 
 import {
-  Box,
-  BottomButtonBar,
-  StyledNextStepButton,
   AddedToCaseButton,
+  BottomButtonBar,
+  Box,
   SaveAndEndContactButton,
+  StyledNextStepButton,
 } from '../../styles/HrmStyles';
 import * as RoutingActions from '../../states/routing/actions';
 import { completeTask } from '../../services/formSubmissionHelpers';
@@ -34,7 +34,7 @@ import { hasTaskControl } from '../../utils/transfer';
 import { RootState } from '../../states';
 import { isNonDataCallType } from '../../states/validationRules';
 import { recordBackendError } from '../../fullStory';
-import { Case, CustomITask, Contact } from '../../types/types';
+import { Case, Contact, CustomITask } from '../../types/types';
 import { getAseloFeatureFlags, getHrmConfig, getTemplateStrings } from '../../hrmConfig';
 import { createCaseAsyncAction } from '../../states/case/saveCase';
 import { getUnsavedContact } from '../../states/contacts/getUnsavedContact';
@@ -183,7 +183,7 @@ const BottomBar: React.FC<
       )}
       {showSubmitButton && (
         <>
-          {featureFlags.enable_case_management && renderCaseButton()}
+          {renderCaseButton()}
 
           <SaveAndEndContactButton
             roundCorners={true}

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -254,7 +254,6 @@ export type FeatureFlags = {
   enable_upload_documents: boolean; // Enables Case Documents
   enable_post_survey: boolean; // Enables Post-Survey
   enable_contact_editing: boolean; // Enables Editing Contacts
-  enable_case_management: boolean; // Enables Creating Cases and Viewing the Case List
   enable_offline_contact: boolean; // Enables Creating Offline Contacts
   enable_filter_cases: boolean; // Enables Filters at Case List
   enable_sort_cases: boolean; // Enables Sorting at Case List

--- a/twilio-iac/helplines/configs/service-configuration/defaults.json
+++ b/twilio-iac/helplines/configs/service-configuration/defaults.json
@@ -48,7 +48,6 @@
         "feature_flags": {
             "enable_aselo_messaging_ui": false,
             "enable_canned_responses": true,
-            "enable_case_management": true,
             "enable_conferencing": true,
             "enable_contact_editing": true,
             "enable_counselor_toolkits": false,

--- a/twilio-iac/helplines/mt/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mt/configs/service-configuration/staging.json
@@ -3,7 +3,6 @@
         "feature_flags": {
             "enable_manual_pulling": false,
             "enable_twilio_transcripts": false,
-            "enable_case_management": true,
             "enable_case_merging": true
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",


### PR DESCRIPTION
## Description

* Adding non data contacts to cases should be permitted from the case search results, so the condition excluding those has been removed
* enable_case_management feature flag has been removed (not applied)

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- [X] Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-2461

### Verification steps

See ticket