### PR TITLE
fix: configure aws creds so taht ssm param loader works in flex-deplo…

### DIFF
--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -64,11 +64,20 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '16.x'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
       - name: Set Twilio account SID
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "/${{inputs.environment_code}}/twilio/${{inputs.helpline_code}}/account_sid"
           env_variable_name: "TWILIO_ACCOUNT_SID"
+
       - name: Set Twilio Auth Token
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:


### PR DESCRIPTION


## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This should fix the regression in flex deployment introduced in #1893