### PR TITLE
CHI-2466: Use selector to get contact in ContactlessTaskTab.ts, fixing undefined ref error

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
@@ -24,15 +24,16 @@ import type { DefinitionVersion } from 'hrm-form-definitions';
 
 import { disperseInputs } from '../common/forms/formGenerators';
 import { useCreateFormFromDefinition } from '../forms';
-import { Container, ColumnarBlock, TwoColumnLayout, ColumnarContent } from '../../styles/HrmStyles';
+import { ColumnarBlock, ColumnarContent, Container, TwoColumnLayout } from '../../styles/HrmStyles';
 import { RootState } from '../../states';
 import { selectWorkerSid } from '../../states/selectors/flexSelectors';
 import { createContactlessTaskTabDefinition } from './ContactlessTaskTabDefinition';
 import { splitDate, splitTime } from '../../utils/helpers';
 import type { ContactRawJson, OfflineContactTask } from '../../types/types';
 import { updateDraft } from '../../states/contacts/existingContacts';
-import { configurationBase, contactFormsBase, namespace } from '../../states/storeNamespaces';
+import { configurationBase, namespace } from '../../states/storeNamespaces';
 import { getUnsavedContact } from '../../states/contacts/getUnsavedContact';
+import selectContactByTaskSid from '../../states/contacts/selectContactByTaskSid';
 
 type OwnProps = {
   task: OfflineContactTask;
@@ -44,10 +45,7 @@ type OwnProps = {
 };
 
 const mapStateToProps = (state: RootState, { task }: OwnProps) => {
-  const { savedContact, draftContact } =
-    Object.values(state[namespace][contactFormsBase].existingContacts).find(
-      cs => cs.savedContact.taskId === task.taskSid,
-    ) ?? {};
+  const { savedContact, draftContact } = selectContactByTaskSid(state, task.taskSid) ?? {};
   return {
     counselorsList: state[namespace][configurationBase].counselors.list,
     unsavedContact: getUnsavedContact(savedContact, draftContact),


### PR DESCRIPTION
## Description

* Use standard selector to get contact in ContactlessTaskTab.tsx, fixing an undefined ref error

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-2466

### Verification steps

See ticket