### PR TITLE
CHI-2430: Fix issue with contact selector in TaskView. 

### DIFF
--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -33,15 +33,17 @@ import { getAseloFeatureFlags, getHrmConfig } from '../hrmConfig';
 import { rerenderAgentDesktop } from '../rerenderView';
 import { updateDraft } from '../states/contacts/existingContacts';
 import { createContactAsyncAction, loadContactFromHrmByTaskSidAsyncAction } from '../states/contacts/saveContact';
-import { namespace } from '../states/storeNamespaces';
 import { isRouteModal } from '../states/routing/types';
-import { getCurrentBaseRoute } from '../states/routing/getRoute';
+import { selectCurrentBaseRoute } from '../states/routing/getRoute';
 import { getUnsavedContact } from '../states/contacts/getUnsavedContact';
 import ContactNotLoaded from './ContactNotLoaded';
 import { completeTask } from '../services/formSubmissionHelpers';
 import { newContact } from '../states/contacts/contactState';
 import asyncDispatch from '../states/asyncDispatch';
 import { selectIsContactCreating } from '../states/contacts/selectContactSaveStatus';
+import selectContactByTaskSid from '../states/contacts/selectContactByTaskSid';
+import { selectCurrentDefinitionVersion } from '../states/configuration/selectDefinitions';
+import selectSearchStateForTask from '../states/search/selectSearchStateForTask';
 
 type OwnProps = {
   task: CustomITask;
@@ -158,28 +160,24 @@ const TaskView: React.FC<Props> = props => {
 TaskView.displayName = 'TaskView';
 
 const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
-  const {
-    [namespace]: { configuration, activeContacts, routing, searchContacts },
-  } = state;
   const { task } = ownProps;
-  const { currentDefinitionVersion } = configuration;
+  const currentDefinitionVersion = selectCurrentDefinitionVersion(state);
   // Check if the entry for this task exists in each reducer
-  const { savedContact, draftContact } =
-    (task && Object.values(activeContacts.existingContacts).find(c => c.savedContact?.taskId)) ?? {};
+  const { savedContact, draftContact } = selectContactByTaskSid(state, task?.taskSid) ?? {};
   const unsavedContact = getUnsavedContact(savedContact, draftContact);
   const contactFormStateExists = Boolean(savedContact);
-  const routingStateExists = Boolean(task && routing.tasks[task.taskSid]);
-  const searchStateExists = Boolean(task && searchContacts.tasks[task.taskSid]);
-  const contactIsCreating = selectIsContactCreating(state, task.taskSid);
+  const currentRoute = selectCurrentBaseRoute(state, task?.taskSid);
+  const searchStateExists = Boolean(selectSearchStateForTask(state, task?.taskSid));
+  const contactIsCreating = selectIsContactCreating(state, task?.taskSid);
 
   const shouldRecreateState =
-    currentDefinitionVersion && (!contactFormStateExists || !routingStateExists || !searchStateExists);
+    currentDefinitionVersion && (!contactFormStateExists || !currentRoute || !searchStateExists);
 
   return {
     unsavedContact,
     shouldRecreateState,
     currentDefinitionVersion,
-    isModalOpen: routingStateExists && isRouteModal(getCurrentBaseRoute(routing, task.taskSid)),
+    isModalOpen: currentRoute && isRouteModal(currentRoute),
     contactIsCreating,
   };
 };

--- a/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.tsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.tsx
@@ -99,7 +99,8 @@ const CallTypeButtons: React.FC<Props> = ({
 
     handleClick(callTypeEntry);
     await saveContactChangesInHrm(savedContact, {
-      rawJson: { callType: callTypes[callTypeEntry.name] || callTypeEntry.label },
+      ...draftContact,
+      rawJson: { ...draftContact?.rawJson, callType: callTypes[callTypeEntry.name] || callTypeEntry.label },
     });
     changeRoute({ route: 'tabbed-forms', subroute, autoFocus: true });
   };

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -73,7 +73,7 @@ export const isStandaloneITask = (task): task is StandaloneITask => {
   return task && task.taskSid === 'standalone-task-sid';
 };
 
-export type OwnProps = {
+type OwnProps = {
   task: CustomITask | StandaloneITask;
   handleClose?: () => void;
   onNewCaseSaved?: (caseForm: CaseType) => Promise<void>;

--- a/plugin-hrm-form/src/components/contact/EditContactSection.tsx
+++ b/plugin-hrm-form/src/components/contact/EditContactSection.tsx
@@ -22,12 +22,16 @@ import { CircularProgress } from '@material-ui/core';
 import { AnyAction } from 'redux';
 
 import { RootState } from '../../states';
-import { Box, BottomButtonBar } from '../../styles';
-import { StyledNextStepButton } from '../../styles/buttons';
+import { BottomButtonBar, Box, StyledNextStepButton } from '../../styles';
 import { EditContactContainer } from '../case/styles';
 import { recordBackendError, recordingErrorHandler } from '../../fullStory';
 import { DetailsContext } from '../../states/contacts/contactDetails';
-import { clearDraft, newSetContactDialogStateAction, refreshContact } from '../../states/contacts/existingContacts';
+import {
+  clearDraft,
+  ContactDraftChanges,
+  newSetContactDialogStateAction,
+  refreshContact,
+} from '../../states/contacts/existingContacts';
 import CloseCaseDialog from '../case/CloseCaseDialog';
 import { getTemplateStrings } from '../../hrmConfig';
 import { Contact, ContactRawJson, CustomITask, StandaloneITask } from '../../types/types';
@@ -77,12 +81,8 @@ const EditContactSection: React.FC<Props> = ({
 
   const onSubmitValidForm = async (closeAction: () => void) => {
     setSubmitting(true);
-    const payload: Partial<Pick<
-      ContactRawJson,
-      'categories' | 'callerInformation' | 'caseInformation' | 'childInformation'
-    >> = draftContact.rawJson;
     try {
-      updateContactsFormInHrmAsyncAction(savedContact, payload);
+      updateContactsFormInHrmAsyncAction(savedContact, draftContact);
       closeAction();
     } catch (error) {
       setSubmitting(false);
@@ -151,8 +151,8 @@ const mapDispatchToProps = (
   return {
     refreshContact: contact => dispatch(refreshContact(contact)),
     goBack: () => dispatch(newGoBackAction(task.taskSid)),
-    updateContactsFormInHrmAsyncAction: async (contact: Contact, body: Partial<ContactRawJson>) => {
-      await updateContactAsyncDispatch(updateContactInHrmAsyncAction(contact, { rawJson: body }));
+    updateContactsFormInHrmAsyncAction: async (contact: Contact, changes: ContactDraftChanges) => {
+      await updateContactAsyncDispatch(updateContactInHrmAsyncAction(contact, changes));
     },
     closeDialog: (dismissAction: 'close' | 'back') =>
       dispatch(newSetContactDialogStateAction(contactId, `${tabPath}-confirm-${dismissAction}`, false)),

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -61,7 +61,7 @@ import { namespace } from '../../states/storeNamespaces';
 import Search from '../search';
 import { getCurrentBaseRoute, getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
 import { CaseLayout } from '../case/styles';
-import Case, { OwnProps as CaseProps } from '../case/Case';
+import Case from '../case/Case';
 import { ContactMetadata } from '../../states/contacts/types';
 import SearchResultsBackButton from '../search/SearchResults/SearchResultsBackButton';
 import ContactAddedToCaseBanner from '../caseMergingBanners/ContactAddedToCaseBanner';
@@ -268,11 +268,11 @@ const TabbedForms: React.FC<Props> = ({
 
   const handleBackButton = async () => {
     if (!hasTaskControl(task)) return;
-    await clearCallType(savedContact);
+    await clearCallType(savedContact, draftContact);
     backToCallTypeSelect();
   };
 
-  const tabsToIndex = mapTabsToIndex(savedContact, getUnsavedContact(savedContact, draftContact).rawJson);
+  const tabsToIndex = mapTabsToIndex(savedContact, updatedContact.rawJson);
   const tabs = tabsToIndex.map(mapTabsComponents(methods.errors));
 
   const handleTabsChange = async (t: number) => {
@@ -468,8 +468,14 @@ const mapDispatchToProps = (dispatch: Dispatch<any>, { contactId, task }: OwnPro
   updateDraftForm: (form: Partial<ContactRawJson>) => dispatch(updateDraft(contactId, { rawJson: form })),
   saveDraft: (savedContact: Contact, draftContact: ContactDraftChanges) =>
     asyncDispatch(dispatch)(updateContactInHrmAsyncAction(savedContact, draftContact, task.taskSid)),
-  clearCallType: (savedContact: Contact) =>
-    asyncDispatch(dispatch)(updateContactInHrmAsyncAction(savedContact, { rawJson: { callType: '' } }, task.taskSid)),
+  clearCallType: (savedContact: Contact, otherChanges: ContactDraftChanges) =>
+    asyncDispatch(dispatch)(
+      updateContactInHrmAsyncAction(
+        savedContact,
+        { ...otherChanges, rawJson: { ...otherChanges?.rawJson, callType: '' } },
+        task.taskSid,
+      ),
+    ),
   newCSAMReport: (csamReportType: CSAMReportType) =>
     dispatch(newCSAMReportActionForContact(contactId, csamReportType, true)),
   openCSAMReport: (previousRoute: AppRoutes) =>

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -15,22 +15,22 @@
  */
 
 /* eslint-disable camelcase */
-import { get, cloneDeep } from 'lodash';
+import { cloneDeep, get } from 'lodash';
 import {
-  DefinitionVersion,
   callTypes,
+  DefinitionVersion,
   FieldType,
   InsightsFieldSpec,
   InsightsFormSpec,
-  OneToOneConfigSpec,
   OneToManyConfigSpec,
   OneToManyConfigSpecs,
+  OneToOneConfigSpec,
 } from 'hrm-form-definitions';
 
 import { isNonDataCallType } from '../states/validationRules';
-import { mapChannelForInsights, formatCategories } from '../utils';
+import { formatCategories, mapChannelForInsights } from '../utils';
 import { getDateTime } from '../utils/helpers';
-import { Case, CustomITask, Contact, ContactRawJson } from '../types/types';
+import { Case, Contact, ContactRawJson, CustomITask } from '../types/types';
 import { getDefinitionVersions, getHrmConfig } from '../hrmConfig';
 import {
   ExternalRecordingInfo,
@@ -203,7 +203,7 @@ type InsightsCaseForm = {
 
 /*
  * This takes a Case and turns it into a format more like the subforms
- * for a TaskEntry (contact form) so it can be consumed in the same manner.
+ * for a SearchStateTaskEntry (contact form) so it can be consumed in the same manner.
  * As of January 2, 2021, Case has not been moved over to use the
  * customization framework.  When it is, we will need to change this function.
  */

--- a/plugin-hrm-form/src/states/search/reducer.ts
+++ b/plugin-hrm-form/src/states/search/reducer.ts
@@ -31,7 +31,7 @@ import {
 } from '../contacts/types';
 import { CaseUpdatingAction, CREATE_CASE_ACTION_FULFILLED, UPDATE_CASE_ACTION_FULFILLED } from '../case/types';
 
-type TaskEntry = {
+export type SearchStateTaskEntry = {
   form: t.SearchFormValues;
   detailsExpanded: {
     [key in ContactDetailsSectionsType]: boolean;
@@ -50,11 +50,11 @@ type TaskEntry = {
 
 type SearchState = {
   tasks: {
-    [taskId: string]: TaskEntry;
+    [taskId: string]: SearchStateTaskEntry;
   };
 };
 
-export const newTaskEntry: TaskEntry = {
+export const newTaskEntry: SearchStateTaskEntry = {
   form: newSearchFormEntry,
   detailsExpanded: {
     [ContactDetailsSections.GENERAL_DETAILS]: true,

--- a/plugin-hrm-form/src/states/search/selectContactsForSearchResults.ts
+++ b/plugin-hrm-form/src/states/search/selectContactsForSearchResults.ts
@@ -17,9 +17,10 @@
 import { SearchContactResult } from '../../types/types';
 import { RootState } from '..';
 import { namespace } from '../storeNamespaces';
+import selectSearchStateForTask from './selectSearchStateForTask';
 
 const selectContactsForSearchResults = (state: RootState, taskSid: string): SearchContactResult => {
-  const resultReferences = state[namespace].searchContacts.tasks[taskSid]?.searchContactsResult;
+  const resultReferences = selectSearchStateForTask(state, taskSid)?.searchContactsResult;
   if (!resultReferences) {
     return {
       count: 0,

--- a/plugin-hrm-form/src/states/search/selectPreviousContactCounts.ts
+++ b/plugin-hrm-form/src/states/search/selectPreviousContactCounts.ts
@@ -15,10 +15,10 @@
  */
 
 import { RootState } from '..';
-import { namespace } from '../storeNamespaces';
 import { PreviousContactCounts } from './types';
+import selectSearchStateForTask from './selectSearchStateForTask';
 
 const selectPreviousContactCounts = (state: RootState, taskId: string): PreviousContactCounts | undefined =>
-  state[namespace].searchContacts.tasks[taskId]?.previousContactCounts;
+  selectSearchStateForTask(state, taskId)?.previousContactCounts;
 
 export default selectPreviousContactCounts;

--- a/plugin-hrm-form/src/states/search/selectSearchStateForTask.ts
+++ b/plugin-hrm-form/src/states/search/selectSearchStateForTask.ts
@@ -14,25 +14,11 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { SearchCaseResult } from '../../types/types';
 import { RootState } from '..';
 import { namespace } from '../storeNamespaces';
-import selectSearchStateForTask from './selectSearchStateForTask';
+import { SearchStateTaskEntry } from './reducer';
 
-const selectCasesForSearchResults = (state: RootState, taskSid: string): SearchCaseResult => {
-  const resultReferences = selectSearchStateForTask(state, taskSid)?.searchCasesResult;
-  if (!resultReferences) {
-    return {
-      count: 0,
-      cases: [],
-    };
-  }
-  return {
-    count: resultReferences.count,
-    cases: resultReferences.ids
-      .map(id => state[namespace].connectedCase.cases[id]?.connectedCase)
-      .filter(c => Boolean(c)),
-  };
-};
+const selectSearchStateForTask = (state: RootState, taskId: string): SearchStateTaskEntry | undefined =>
+  taskId ? state[namespace].searchContacts.tasks[taskId] : undefined;
 
-export default selectCasesForSearchResults;
+export default selectSearchStateForTask;


### PR DESCRIPTION
## Description

- Fix issue with contact selector in TaskView, where the wrong contact could be selected from redux
- Ensure that all outstanding edits are included in active contacts, not just the ones from the current form (the helpline was being dropped from omitted from the draft changes sent to the backend in some cases previously)

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-2430

### Verification steps

* Deploy to a staging account with multiple helplines / offices configured
* Take a contact using a worker who has a specific helpline assigned
* The same worker should be able to see the contact in the search results
* To be sure, you can check that the 'helpline' field is set to the worker's helpline in the record on the Contacts database table