### PR TITLE
fix: Add safeguard before reading participantsLabels in conference components

### DIFF
--- a/plugin-hrm-form/src/components/Conference/ParticipantLabel/index.tsx
+++ b/plugin-hrm-form/src/components/Conference/ParticipantLabel/index.tsx
@@ -29,7 +29,7 @@ type Props = ParticipantCanvasChildrenProps;
 const ParticipantLabel: React.FC<Props> = ({ participant, task }) => {
   const participantLabel = useSelector(
     (state: RootState) =>
-      state[namespace][conferencingBase].tasks[task?.taskSid].participantsLabels[participant?.participantSid],
+      state[namespace][conferencingBase].tasks[task?.taskSid]?.participantsLabels[participant?.participantSid],
   );
   const dispatch = useDispatch();
 

--- a/plugin-hrm-form/src/states/conferencing/index.ts
+++ b/plugin-hrm-form/src/states/conferencing/index.ts
@@ -168,7 +168,7 @@ const conferencingReducer = createReducer(initialState, handleAction => [
       [payload.taskId]: {
         ...state.tasks[payload.taskId],
         participantsLabels: {
-          ...state.tasks[payload.taskId].participantsLabels,
+          ...state.tasks[payload.taskId]?.participantsLabels,
           [payload.participantSid]: payload.participantLabel,
         },
       },


### PR DESCRIPTION
## Description
This PR fixes the bug where supervisors are "Unable to live monitor 3-way conference call". The cause of this bug is that the Redux state for conference is not mounted when the supervisor tries to initially monitor the conference, so accessing `.participantsLabels` property in participant label component and Redux action cause two different errors. To prevent this I'm adding a `?` operator so it defers to a null value initially, until the conference is actually fetched and loaded into the state. 

[Screencast from 04-01-24 13:57:20.webm](https://github.com/techmatters/flex-plugins/assets/15805319/e333bc77-c261-49ac-93c0-83d2f9ccfb39)

### Checklist
- [ ] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2445)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Verification steps
See attached video or try repro steps in the linked bug ticket.