### PR TITLE
[Modica POC] Add support for Modica

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -89,6 +89,7 @@ const setUpComponents = (
   Channels.setupTwitterChatChannel(maskIdentifiers);
   Channels.setupInstagramChatChannel(maskIdentifiers);
   Channels.setupLineChatChannel(maskIdentifiers);
+  Channels.expandSMSChannel();
 
   if (maskIdentifiers) {
     // Masks TaskInfoPanelContent - TODO: refactor to use a react component

--- a/plugin-hrm-form/src/channels/setUpChannels.tsx
+++ b/plugin-hrm-form/src/channels/setUpChannels.tsx
@@ -28,6 +28,7 @@ import SmsIcon from '../components/common/icons/SmsIcon';
 import * as TransferHelpers from '../utils/transfer';
 import { colors, mainChannelColor } from './colors';
 import { getTemplateStrings } from '../hrmConfig';
+import { smsChannelTypes } from '../states/DomainConstants';
 
 const isIncomingTransfer = task => TransferHelpers.hasTransferStarted(task) && task.status === 'pending';
 
@@ -81,6 +82,10 @@ export const customiseDefaultChatChannels = () => {
   Flex.DefaultTaskChannels.ChatSms.icons = allIcons(smsIcon);
   const callIcon = <CallIcon width="24px" height="24px" color={colors.voice} />;
   Flex.DefaultTaskChannels.Call.icons = allIcons(callIcon);
+};
+
+export const expandSMSChannel = () => {
+  Flex.DefaultTaskChannels.ChatSms.isApplicable = task => smsChannelTypes.includes(task.channelType);
 };
 
 export const setupTwitterChatChannel = maskIdentifiers => {

--- a/plugin-hrm-form/src/components/queuesStatus/helpers.ts
+++ b/plugin-hrm-form/src/components/queuesStatus/helpers.ts
@@ -15,7 +15,7 @@
  */
 
 import type { QueuesStatus } from '../../states/queuesStatus/types';
-import type { ChannelTypes } from '../../states/DomainConstants';
+import { ChannelTypes, smsChannelTypes } from '../../states/DomainConstants';
 
 type QueueEntry = { [K in ChannelTypes]: number } & { longestWaitingDate: string; isChatPending: boolean };
 
@@ -45,6 +45,16 @@ export const isWaiting = (status: string) => isPending(status) || isReserved(sta
 const subscribedToQueue = (queue: string, queues: QueuesStatus) => Boolean(queues[queue]);
 
 /**
+ * This function is used to determine the channel of a task.
+ * It handles additional SMS channels, such as Modica.
+ */
+const getChannel = (task: any): ChannelTypes => {
+  if (task.channel_type === 'voice') return 'voice';
+
+  return smsChannelTypes.includes(task.attributes.channelType) ? 'sms' : task.attributes.channelType;
+};
+
+/**
  * Adds each waiting tasks to the appropiate queue and channel, recording which is the oldest.
  * If counselor is not subscribed to a queue, acc[queue] will be undefined
  */
@@ -54,7 +64,7 @@ export const addPendingTasks = (acc: QueuesStatus, task: any): QueuesStatus => {
 
   const created = task.date_created;
   const isChatBasedTask = task.channel_type !== 'voice';
-  const channel = isChatBasedTask ? task.attributes.channelType : 'voice';
+  const channel = getChannel(task);
   const queue = task.queue_name;
   const currentOldest = acc[queue].longestWaitingDate;
   const longestWaitingDate = currentOldest !== null && currentOldest < created ? currentOldest : created;

--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -28,6 +28,8 @@ export const customChannelTypes = {
   line: 'line',
 } as const;
 
+export const smsChannelTypes = ['sms', 'modica'];
+
 export const channelTypes = {
   ...defaultChannelTypes,
   ...customChannelTypes,


### PR DESCRIPTION
## Description
- This PR adds support for Modica-SMS on the front-end
- Modica's SMS will show up on Aselo as if it's a regular SMS

This PR can be merged with no harm.

TODO: 
- [IMPORTANT]: modify `getNumberFromTask` so the contact number is saved correctly in the backend
  - see whatsapp and facebook channels
- Offline contacts: When the user chooses SMS, should we change behind the scenes to be Modica-SMS? 
- Verify on other screens: cases, contact details, etc,  if Modica's contacts still shows up as SMS or if any additional work is necessary.

Serverless related PR: https://github.com/techmatters/serverless/pull/559