### PR TITLE
fix: make tg stage var validation check using shell instead of pre-pr…

### DIFF
--- a/twilio-iac/makefiles/terragrunt/terragrunt.make
+++ b/twilio-iac/makefiles/terragrunt/terragrunt.make
@@ -3,13 +3,14 @@ tg_args ?= $(tf_args)     # --terragrunt-log-level debug --terragrunt-debug
 TG_ENV = -e TERRAGRUNT_DOWNLOAD=".terragrunt-cache/$(HL)/$(HL_ENV)"
 
 verify-env:
-	ifeq ($(HL),)
-	$(error No helpline specified. please be sure to set HL=<helpline> before running make)
-	endif
-
-	ifeq ($(HL_ENV),)
-	$(error No environment specified. please be sure to set HL_ENV=<environment> before running make)
-	endif
+	@if [ -z "$(HL)" ]; then \
+		echo "No helpline specified. Please be sure to set HL=<helpline> before running make"; \
+		exit 1; \
+	fi
+	@if [ -z "$(HL_ENV)" ]; then \
+		echo "No environment specified. Please be sure to set HL_ENV=<environment> before running make"; \
+		exit 1; \
+	fi
 
 apply-tg: verify-env
 	docker run -it --rm $(DEFAULT_ARGS) $(TG_ENV) $(DOCKER_IMAGE):$(TF_VER) terragrunt apply $(tg_args)


### PR DESCRIPTION
…occesor logic

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This fixes a regression introduced in the make system cleanup/help system pr where make vars required for terragrunt commands were being checked using make preprocessor commands `ifeq` instead of runtime shell commands.

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

Try running a `make plan`