### PR TITLE
CHI-2255: Centered preview banner text on contact search result preview

### DIFF
--- a/plugin-hrm-form/src/components/search/ContactPreview/ContactHeader.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ContactHeader.tsx
@@ -83,7 +83,10 @@ const ContactHeader: React.FC<Props> = ({
 
   return (
     <>
-      <PreviewRow color={isDraft ? 'yellow' : undefined} style={{ paddingTop: '15px', marginTop: '0px' }}>
+      <PreviewRow
+        color={isDraft ? 'yellow' : undefined}
+        style={{ paddingTop: '15px', marginTop: '0px', paddingBottom: isDraft ? '15px' : undefined }}
+      >
         {!isNonDataCallType(callType) && (
           <Flex marginRight="10px">
             <CallTypeIcon callType={callType} fontSize="18px" />


### PR DESCRIPTION
## Description

Centered preview banner text on contact search result preview

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
FixesCHI-2255

### Verification steps

See ticket comment