### PR TITLE
Add Skills column with category pill to teams view

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -85,6 +85,12 @@ const setUpComponents = (
   const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
   // setUp (add) dynamic components
+  // Flex.WorkersDataTable.defaultProps = {
+  //   initialCompareFunction = (worker1, worker2) => {
+  //     // see https://www.twilio.com/docs/flex/developer/ui/v1/configuration#agentsdatatable
+  //     return 0;  // -1, -0, or 1
+  //   }
+  // }
   Flex.WorkersDataTable.Content.add(
     <Flex.ColumnDefinition 
       key="skills" 

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -47,6 +47,7 @@ import { setUpConferenceActions, setupConferenceComponents } from './conference'
 import { setUpTransferActions } from './transfer/setUpTransferActions';
 import { playNotification } from './notifications/playNotification';
 import { namespace } from './states/storeNamespaces';
+import CategoryWithTooltip from './components/common/CategoryWithTooltip';
 
 const PLUGIN_NAME = 'HrmFormPlugin';
 
@@ -80,6 +81,9 @@ const setUpComponents = (
   const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
 
   // setUp (add) dynamic components
+  Flex.WorkersDataTable.Content.add(
+    <Flex.ColumnDefinition key="skills" header={"Skills"} content={<CategoryWithTooltip category="category" color="#FF0000"/>} />
+  );
   Components.setUpQueuesStatusWriter(setupObject);
   Components.setUpQueuesStatus(setupObject);
   Components.setUpAddButtons(featureFlags);
@@ -228,6 +232,8 @@ export default class HrmFormPlugin extends FlexPlugin {
     if (hrmBaseUrl === undefined) {
       console.error('HRM base URL not defined, you must provide this to save program data');
     }
+
+
   }
 
   /**

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -72,6 +72,10 @@ const setUpLocalization = (config: ReturnType<typeof getHrmConfig>) => {
   return initLocalization(localizationConfig, initialLanguage);
 };
 
+const sortFn = (first, second) => {
+  return 0;
+}
+
 const setUpComponents = (
   featureFlags: FeatureFlags,
   setupObject: ReturnType<typeof getHrmConfig>,
@@ -82,7 +86,12 @@ const setUpComponents = (
 
   // setUp (add) dynamic components
   Flex.WorkersDataTable.Content.add(
-    <Flex.ColumnDefinition key="skills" header={"Skills"} content={<CategoryWithTooltip category="category" color="#FF0000"/>} />
+    <Flex.ColumnDefinition 
+      key="skills" 
+      header={"Skills"} 
+      sortingFn={sortFn}
+      content={
+        <CategoryWithTooltip category="category" color="#FF0000"/>} />
   );
   Components.setUpQueuesStatusWriter(setupObject);
   Components.setUpQueuesStatus(setupObject);

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -96,8 +96,12 @@ const setUpComponents = (
       key="skills" 
       header={"Skills"} 
       sortingFn={sortFn}
+      style={{ width: "180px" }}
       content={
-        <CategoryWithTooltip category="category" color="#FF0000"/>} />
+        <CategoryWithTooltip category="category" color="#FF0000"/>} />,
+        {
+          sortOrder: 0,
+        }
   );
   Components.setUpQueuesStatusWriter(setupObject);
   Components.setUpQueuesStatus(setupObject);


### PR DESCRIPTION
Hack to test out some Teams View ideas:
- adds a Skills column with pill boxes after the Agent column (we can put arbitrary content inside each cell of the skills column)
- adds placeholder code (unimplemented) to modify the sort function for the Agents column
- In the image below, I've made the "Monitor Task" panel wider by editing the CSS directly via the browser. We would need to explore further... unclear if this can be set up to be dynamic

Related Twilio docs: https://www.twilio.com/docs/flex/developer/ui/v1/components#teams-view-components

<img width="1433" alt="Screenshot 2024-01-09 at 3 32 33 PM" src="https://github.com/techmatters/flex-plugins/assets/10714292/9f497d20-d305-4664-a41b-5b7d5cc2ca52">


