### PR TITLE
Make Modica tasks look like SMS throughout Aselo

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.tsx
@@ -25,7 +25,7 @@ import each from 'jest-each';
 
 import HrmTheme from '../../../styles/HrmTheme';
 import QueuesStatus from '../../../components/queuesStatus';
-import { channelTypes } from '../../../states/DomainConstants';
+import { coreChannelTypes } from '../../../states/DomainConstants';
 
 jest.mock('../../../components/CSAMReport/CSAMReportFormDefinition');
 
@@ -178,7 +178,7 @@ test('Test <QueuesStatus> after update', () => {
   expect(screen.getAllByText('QueueCard-Name')).toHaveLength(5);
 
   const expectAllChannelsRendersInQ = ([qName, qStatus]) =>
-    Object.values(channelTypes).forEach(c => {
+    Object.values(coreChannelTypes).forEach(c => {
       // Check that the UI renders for this channel
       const channelInQ = screen.getByTestId(`${qName}-${c}`);
       expect(channelInQ).toBeInTheDocument();
@@ -196,12 +196,12 @@ test('Test <QueuesStatus> after update', () => {
 });
 
 each([
-  ...Object.values(channelTypes).map(c => ({ contactsWaitingChannels: [c], expectedChannelsCount: 1 })),
+  ...Object.values(coreChannelTypes).map(c => ({ contactsWaitingChannels: [c], expectedChannelsCount: 1 })),
   {
-    contactsWaitingChannels: [channelTypes.voice, channelTypes.whatsapp, channelTypes.instagram],
+    contactsWaitingChannels: [coreChannelTypes.voice, coreChannelTypes.whatsapp, coreChannelTypes.instagram],
     expectedChannelsCount: 3,
   },
-  ...Object.values(channelTypes).map((c1, _, arr) => ({
+  ...Object.values(coreChannelTypes).map((c1, _, arr) => ({
     contactsWaitingChannels: arr.filter(c2 => c2 !== c1),
     expectedChannelsCount: arr.length - 1,
   })),
@@ -249,7 +249,7 @@ each([
     expect(screen.getAllByTestId('channel-box-inner-value')).toHaveLength(expectedChannelsCount);
 
     const expectAllChannelsRendersInQ = ([qName, qStatus]) =>
-      Object.values(channelTypes).forEach(c => {
+      Object.values(coreChannelTypes).forEach(c => {
         if (ownProps.contactsWaitingChannels.includes(c as any)) {
           // Check that the UI renders for this channel (if it's defined in contactsWaitingChannels)
           const channelInQ = screen.getByTestId(`${qName}-${c}`);

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/helpers.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/helpers.test.js
@@ -23,10 +23,10 @@ import {
   addPendingTasks,
   getNewQueuesStatus,
 } from '../../../components/queuesStatus/helpers';
-import { channelTypes } from '../../../states/DomainConstants';
+import { coreChannelTypes } from '../../../states/DomainConstants';
 
 test('Test newQueueEntry', () => {
-  Object.keys(channelTypes).forEach(key => expect(newQueueEntry[key]).toEqual(0));
+  Object.keys(coreChannelTypes).forEach(key => expect(newQueueEntry[key]).toEqual(0));
   expect(newQueueEntry.longestWaitingDate).toBeNull();
 });
 
@@ -50,21 +50,21 @@ const tasks = {
     task_sid: 'T1',
     status: 'pending',
     date_created: '2020-04-14T21:36:28.045Z',
-    attributes: { channelType: channelTypes.facebook },
+    attributes: { channelType: coreChannelTypes.facebook },
     queue_name: queuesNames[0],
   },
   T2: {
     task_sid: 'T2',
     status: 'pending',
     date_created: '2020-04-14T21:36:26.033Z',
-    attributes: { channelType: channelTypes.web },
+    attributes: { channelType: coreChannelTypes.web },
     queue_name: queuesNames[1],
   },
   T3: {
     task_sid: 'T3',
     status: 'reserved',
     date_created: '2020-04-14T21:25:00.012Z',
-    attributes: { channelType: channelTypes.facebook },
+    attributes: { channelType: coreChannelTypes.facebook },
     queue_name: queuesNames[0],
   },
   T4: {
@@ -80,21 +80,21 @@ const tasks = {
     status: 'pending',
     channel_type: 'voice',
     date_created: '2020-04-14T21:36:00.012Z',
-    attributes: { channelType: channelTypes.facebook }, // this should be ignored
+    attributes: { channelType: coreChannelTypes.facebook }, // this should be ignored
     queue_name: queuesNames[0],
   },
   T7: {
     task_sid: 'T7',
     status: 'pending',
     date_created: '2020-04-14T21:36:00.012Z',
-    attributes: { channelType: channelTypes.sms },
+    attributes: { channelType: coreChannelTypes.sms },
     queue_name: queuesNames[0],
   },
   T8: {
     task_sid: 'T8',
     status: 'pending',
     date_created: '2020-04-14T21:36:00.012Z',
-    attributes: { channelType: channelTypes.whatsapp },
+    attributes: { channelType: coreChannelTypes.whatsapp },
     queue_name: queuesNames[0],
   },
 };
@@ -144,7 +144,7 @@ const tasks2 = {
     task_sid: 'T9',
     status: 'pending',
     date_created: '2020-03-14T21:25:00.012Z',
-    attributes: { channelType: channelTypes.facebook },
+    attributes: { channelType: coreChannelTypes.facebook },
     queue_name: queuesNames[0],
   },
 };
@@ -168,7 +168,7 @@ const tasks3 = {
     task_sid: 'T10',
     status: 'pending',
     date_created: '2020-03-14T21:25:00.013Z',
-    attributes: { channelType: channelTypes.facebook },
+    attributes: { channelType: coreChannelTypes.facebook },
     queue_name: queuesNames[0],
   },
 };

--- a/plugin-hrm-form/src/channels/setUpChannels.tsx
+++ b/plugin-hrm-form/src/channels/setUpChannels.tsx
@@ -28,7 +28,7 @@ import SmsIcon from '../components/common/icons/SmsIcon';
 import * as TransferHelpers from '../transfer/transferTaskState';
 import { colors, mainChannelColor } from './colors';
 import { getTemplateStrings } from '../hrmConfig';
-import { smsChannelTypes } from '../states/DomainConstants';
+import { isSmsChannelType } from '../utils/smsChannels';
 
 const isIncomingTransfer = task => TransferHelpers.hasTransferStarted(task) && task.status === 'pending';
 
@@ -85,7 +85,7 @@ export const customiseDefaultChatChannels = () => {
 };
 
 export const expandSMSChannel = () => {
-  Flex.DefaultTaskChannels.ChatSms.isApplicable = task => smsChannelTypes.includes(task.channelType);
+  Flex.DefaultTaskChannels.ChatSms.isApplicable = task => isSmsChannelType(task.channelType);
 };
 
 export const setupTwitterChatChannel = maskIdentifiers => {

--- a/plugin-hrm-form/src/components/case/timeline/TimelineIcon.tsx
+++ b/plugin-hrm-form/src/components/case/timeline/TimelineIcon.tsx
@@ -45,6 +45,7 @@ const getIcon = (type: IconType) => {
     case channelTypes.web:
       return <DefaultIcon defaultTaskChannel={Flex.DefaultTaskChannels.Chat} color={colors.web} />;
     case channelTypes.sms:
+    case channelTypes.modica:
       return <SmsIcon width="24px" height="24px" color={colors.sms} />;
     case channelTypes.voice:
       return <CallIcon width="24px" height="24px" color={colors.voice} />;

--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -57,6 +57,7 @@ import ContactRemovedFromCaseBanner from '../caseMergingBanners/ContactRemovedFr
 import { selectCaseMergingBanners } from '../../states/case/caseBanners';
 import InfoIcon from '../caseMergingBanners/InfoIcon';
 import { BannerContainer, Text } from '../../styles/banners';
+import { isSmsChannelType } from '../../utils/smsChannels';
 
 const formatResourceReferral = (referral: ResourceReferral) => {
   return (
@@ -195,7 +196,7 @@ const ContactDetailsHome: React.FC<Props> = function ({
   const formattedDuration = formatDuration(conversationDuration);
 
   const isPhoneContact =
-    channel === channelTypes.voice || channel === channelTypes.sms || channel === channelTypes.whatsapp;
+    channel === channelTypes.voice || channel === channelTypes.whatsapp || isSmsChannelType(channel);
 
   const formattedCategories = formatCategories(categories);
 

--- a/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/PreviousContactsBanner.tsx
@@ -29,7 +29,7 @@ import { CASES_PER_PAGE, CONTACTS_PER_PAGE } from '../../search/SearchResults';
 import { YellowBanner } from '../styles';
 import { Bold } from '../../../styles';
 import { StyledLink } from '../../search/styles';
-import { ChannelTypes, channelTypes } from '../../../states/DomainConstants';
+import { CoreChannelTypes, coreChannelTypes } from '../../../states/DomainConstants';
 import { changeRoute, newOpenModalAction } from '../../../states/routing/actions';
 import { getContactValueTemplate, getFormattedNumberFromTask, getNumberFromTask } from '../../../utils';
 import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
@@ -52,18 +52,18 @@ const PreviousContactsBanner: React.FC<Props> = ({
   searchCases,
   openContactSearchResults,
 }) => {
-  let localizedSourceFromTask: { [channelType in ChannelTypes]: string };
+  let localizedSourceFromTask: { [channelType in CoreChannelTypes]: string };
 
   if (isTwilioTask(task)) {
     localizedSourceFromTask = {
-      [channelTypes.web]: `${getContactValueTemplate(task)}`,
-      [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
-      [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
-      [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
-      [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
-      [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
-      [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
-      [channelTypes.line]: 'PreviousContacts-LineUser',
+      [coreChannelTypes.web]: `${getContactValueTemplate(task)}`,
+      [coreChannelTypes.voice]: 'PreviousContacts-PhoneNumber',
+      [coreChannelTypes.sms]: 'PreviousContacts-PhoneNumber',
+      [coreChannelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
+      [coreChannelTypes.facebook]: 'PreviousContacts-FacebookUser',
+      [coreChannelTypes.twitter]: 'PreviousContacts-TwitterUser',
+      [coreChannelTypes.instagram]: 'PreviousContacts-InstagramUser',
+      [coreChannelTypes.line]: 'PreviousContacts-LineUser',
     };
   }
 

--- a/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/ProfileIdentifierBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/ProfileIdentifierBanner.tsx
@@ -23,7 +23,7 @@ import { useIdentifierByIdentifier, useProfileProperty } from '../../../states/p
 import { YellowBanner } from '../styles';
 import { Bold } from '../../../styles';
 import { StyledLink } from '../../search/styles';
-import { ChannelTypes, channelTypes } from '../../../states/DomainConstants';
+import { CoreChannelTypes, coreChannelTypes } from '../../../states/DomainConstants';
 import { newOpenModalAction } from '../../../states/routing/actions';
 import { getFormattedNumberFromTask, getNumberFromTask, getContactValueTemplate } from '../../../utils';
 import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
@@ -60,15 +60,15 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal }) =>
   const contactsCount = contactsCountState ? contactsCountState - 1 : 0;
   const casesCount = useProfileProperty(profileId, 'casesCount') || 0;
 
-  const localizedSourceFromTask: { [channelType in ChannelTypes]: string } = {
-    [channelTypes.web]: `${getContactValueTemplate(task)}`,
-    [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
-    [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
-    [channelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
-    [channelTypes.facebook]: 'PreviousContacts-FacebookUser',
-    [channelTypes.twitter]: 'PreviousContacts-TwitterUser',
-    [channelTypes.instagram]: 'PreviousContacts-InstagramUser',
-    [channelTypes.line]: 'PreviousContacts-LineUser',
+  const localizedSourceFromTask: { [channelType in CoreChannelTypes]: string } = {
+    [coreChannelTypes.web]: `${getContactValueTemplate(task)}`,
+    [coreChannelTypes.voice]: 'PreviousContacts-PhoneNumber',
+    [coreChannelTypes.sms]: 'PreviousContacts-PhoneNumber',
+    [coreChannelTypes.whatsapp]: 'PreviousContacts-WhatsappNumber',
+    [coreChannelTypes.facebook]: 'PreviousContacts-FacebookUser',
+    [coreChannelTypes.twitter]: 'PreviousContacts-TwitterUser',
+    [coreChannelTypes.instagram]: 'PreviousContacts-InstagramUser',
+    [coreChannelTypes.line]: 'PreviousContacts-LineUser',
   };
 
   const { canView } = getPermissionsForViewingIdentifiers();

--- a/plugin-hrm-form/src/components/queuesStatus/QueueCard.tsx
+++ b/plugin-hrm-form/src/components/queuesStatus/QueueCard.tsx
@@ -21,11 +21,11 @@ import { Template } from '@twilio/flex-ui';
 
 import { Box, Row, HiddenText } from '../../styles';
 import { QueueName, ChannelColumn, ChannelBox, ChannelLabel, WaitTimeLabel, WaitTimeValue } from './styles';
-import { channelTypes, ChannelTypes, ChannelColors } from '../../states/DomainConstants';
+import { coreChannelTypes, CoreChannelTypes, ChannelColors } from '../../states/DomainConstants';
 
 const getChannelUI = (
   shortChannel: string,
-  color: ChannelColors[ChannelTypes],
+  color: ChannelColors[CoreChannelTypes],
   value: number,
   marginLeft: boolean,
   channelAria: string = undefined,
@@ -49,25 +49,25 @@ const renderChannel = ({
 }: {
   colors: ChannelColors;
   contactsWaiting: number;
-}): ((channel: ChannelTypes) => JSX.Element) => channel => {
+}): ((channel: CoreChannelTypes) => JSX.Element) => channel => {
   const channelColor = colors[channel];
 
   switch (channel) {
-    case channelTypes.voice:
+    case coreChannelTypes.voice:
       return getChannelUI('Calls', channelColor, contactsWaiting, false);
-    case channelTypes.sms:
+    case coreChannelTypes.sms:
       return getChannelUI('SMS', channelColor, contactsWaiting, true);
-    case channelTypes.facebook:
+    case coreChannelTypes.facebook:
       return getChannelUI('FB', channelColor, contactsWaiting, true, 'Facebook');
-    case channelTypes.whatsapp:
+    case coreChannelTypes.whatsapp:
       return getChannelUI('WA', channelColor, contactsWaiting, true, 'Whatsapp');
-    case channelTypes.web:
+    case coreChannelTypes.web:
       return getChannelUI('Chat', channelColor, contactsWaiting, true);
-    case channelTypes.twitter:
+    case coreChannelTypes.twitter:
       return getChannelUI('Twtr', channelColor, contactsWaiting, true);
-    case channelTypes.instagram:
+    case coreChannelTypes.instagram:
       return getChannelUI('IG', channelColor, contactsWaiting, true);
-    case channelTypes.line:
+    case coreChannelTypes.line:
       return getChannelUI('LN', channelColor, contactsWaiting, true);
     default:
       return null;
@@ -86,7 +86,7 @@ type Props = {
   line: number;
   longestWaitingDate: string | null;
   colors: ChannelColors;
-  contactsWaitingChannels?: ChannelTypes[];
+  contactsWaitingChannels?: CoreChannelTypes[];
 };
 
 const QueuesCard: React.FC<Props> = props => {
@@ -145,10 +145,10 @@ const QueuesCard: React.FC<Props> = props => {
         <Box marginTop="7px" marginBottom="14px">
           <Row>
             {contactsWaitingChannels && Array.isArray(contactsWaitingChannels)
-              ? Object.values(channelTypes)
+              ? Object.values(coreChannelTypes)
                   .filter(c => contactsWaitingChannels.includes(c))
                   .map(renderFun)
-              : Object.values(channelTypes).map(renderFun)}
+              : Object.values(coreChannelTypes).map(renderFun)}
           </Row>
         </Box>
         <Row>

--- a/plugin-hrm-form/src/components/queuesStatus/helpers.ts
+++ b/plugin-hrm-form/src/components/queuesStatus/helpers.ts
@@ -15,9 +15,10 @@
  */
 
 import type { QueuesStatus } from '../../states/queuesStatus/types';
-import { ChannelTypes, smsChannelTypes } from '../../states/DomainConstants';
+import { CoreChannelTypes } from '../../states/DomainConstants';
+import { isSmsChannelType } from '../../utils/smsChannels';
 
-type QueueEntry = { [K in ChannelTypes]: number } & { longestWaitingDate: string; isChatPending: boolean };
+type QueueEntry = { [K in CoreChannelTypes]: number } & { longestWaitingDate: string; isChatPending: boolean };
 
 export const newQueueEntry: QueueEntry = {
   facebook: 0,
@@ -48,10 +49,10 @@ const subscribedToQueue = (queue: string, queues: QueuesStatus) => Boolean(queue
  * This function is used to determine the channel of a task.
  * It handles additional SMS channels, such as Modica.
  */
-const getChannel = (task: any): ChannelTypes => {
+const getChannel = (task: any): CoreChannelTypes => {
   if (task.channel_type === 'voice') return 'voice';
 
-  return smsChannelTypes.includes(task.attributes.channelType) ? 'sms' : task.attributes.channelType;
+  return isSmsChannelType(task.attributes.channelType) ? 'sms' : task.attributes.channelType;
 };
 
 /**

--- a/plugin-hrm-form/src/components/queuesStatus/index.tsx
+++ b/plugin-hrm-form/src/components/queuesStatus/index.tsx
@@ -24,13 +24,13 @@ import QueueCard from './QueueCard';
 import { Container, QueuesContainer } from './styles';
 import { Box, ErrorText, HeaderContainer } from '../../styles';
 import { TLHPaddingLeft } from '../../styles/GlobalOverrides';
-import type { ChannelTypes, ChannelColors } from '../../states/DomainConstants';
+import type { CoreChannelTypes, ChannelColors } from '../../states/DomainConstants';
 import { namespace, queuesStatusBase } from '../../states/storeNamespaces';
 
 type OwnProps = {
   colors: ChannelColors;
   paddingRight: boolean;
-  contactsWaitingChannels?: ChannelTypes[];
+  contactsWaitingChannels?: CoreChannelTypes[];
 };
 
 const mapStateToProps = (state: RootState) => {

--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -46,8 +46,7 @@ export const coreChannelTypes = {
  * This is the complete list of channels.
  */
 export const channelTypes = {
-  ...defaultChannelTypes,
-  ...customChannelTypes,
+  ...coreChannelTypes,
   ...customSmsChannelTypes,
 };
 

--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -14,6 +14,8 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import { customSmsChannelTypes } from '../utils/smsChannels';
+
 const defaultChannelTypes = {
   voice: 'voice',
   sms: 'sms',
@@ -28,19 +30,35 @@ export const customChannelTypes = {
   line: 'line',
 } as const;
 
-export const smsChannelTypes = ['sms', 'modica'];
-
-export const channelTypes = {
+/**
+ * These are the channels without the custom SMS channels.
+ *
+ * Since the custom SMS channels are going to behave like the default SMS channel,
+ * some components should not be aware of them, like the QueueStatus or
+ * the PreviousContactsBanner.
+ */
+export const coreChannelTypes = {
   ...defaultChannelTypes,
   ...customChannelTypes,
 };
 
+/**
+ * This is the complete list of channels.
+ */
+export const channelTypes = {
+  ...defaultChannelTypes,
+  ...customChannelTypes,
+  ...customSmsChannelTypes,
+};
+
 export type ChannelTypes = typeof channelTypes[keyof typeof channelTypes];
+export type CoreChannelTypes = typeof coreChannelTypes[keyof typeof coreChannelTypes];
 
 const chatChannels = [
   channelTypes.whatsapp,
   channelTypes.facebook,
   channelTypes.web,
+  channelTypes.modica,
   channelTypes.sms,
   channelTypes.twitter,
   channelTypes.instagram,
@@ -51,7 +69,7 @@ export const isVoiceChannel = (channel: string) => channel === channelTypes.voic
 export const isChatChannel = (channel: string) => chatChannels.includes(channel as any);
 
 export type ChannelColors = {
-  [C in ChannelTypes]: string;
+  [C in CoreChannelTypes]: string;
 };
 
 export const transferModes = {

--- a/plugin-hrm-form/src/utils/mappers.ts
+++ b/plugin-hrm-form/src/utils/mappers.ts
@@ -43,6 +43,7 @@ export const mapChannel = (channel: string) => {
     case channelTypes.voice:
       return 'Voice';
     case channelTypes.sms:
+    case channelTypes.modica:
       return 'SMS';
     case channelTypes.whatsapp:
       return 'WhatsApp';

--- a/plugin-hrm-form/src/utils/smsChannels.ts
+++ b/plugin-hrm-form/src/utils/smsChannels.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export const customSmsChannelTypes = {
+  modica: 'modica',
+} as const;
+
+const smsChannelTypes = ['sms', ...Object.values(customSmsChannelTypes)] as const;
+
+export const isSmsChannelType = channelType =>
+  Boolean(smsChannelTypes.find(smsChannelType => smsChannelType === channelType));

--- a/plugin-hrm-form/src/utils/task.ts
+++ b/plugin-hrm-form/src/utils/task.ts
@@ -31,6 +31,8 @@ export const getNumberFromTask = (task: CustomITask) => {
     return task.defaultFrom.replace('messenger:', '');
   } else if (task.channelType === channelTypes.whatsapp) {
     return task.defaultFrom.replace('whatsapp:', '');
+  } else if (task.channelType === channelTypes.modica) {
+    return task.defaultFrom.replace('modica:', '');
   } else if (task.channelType === channelTypes.web) {
     return getContactValueFromWebchat(task);
   }


### PR DESCRIPTION
## Description
The goal of this PR is to make Modica tasks look like SMS throughout Aselo, at places like:
- Case Timeline
- Contact Details
- QueueStatus
- PreviousContactsBanner

Because of this specific behavior, just adding `modica` channel to `channelTypes` in our `DomainConstants` is not enough, we needed a way to differentiate these kinds of channels. So, we have two kinds of channel types now:
- `ChannelTypes`: just like before, it includes all channel types
- `CoreChannelTypes`: it doesn't include channels like Modica, because for this matter `modica` = `sms`

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes https://tech-matters.atlassian.net/browse/CHI-2393

### Verification steps
Send an SMS from a NZ device, and verify it show looks like an SMS throughout Aselo.
I'm fine with just code reviewing this, cause testing will be tricky.
