### PR TITLE
Skills column with real data from workers

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -15,6 +15,7 @@
  */
 
 import * as Flex from '@twilio/flex-ui';
+import React from 'react';
 import { FlexPlugin, loadCSS } from '@twilio/flex-plugin';
 
 import './styles/global-overrides.css';
@@ -48,6 +49,7 @@ import { setUpTransferActions } from './transfer/setUpTransferActions';
 import { playNotification } from './notifications/playNotification';
 import { namespace } from './states/storeNamespaces';
 import { setUpTransferComponents } from './components/transfer/setUpTransferComponents';
+import CategoryWithTooltip from './components/common/CategoryWithTooltip';
 
 const PLUGIN_NAME = 'HrmFormPlugin';
 
@@ -72,6 +74,10 @@ const setUpLocalization = (config: ReturnType<typeof getHrmConfig>) => {
   return initLocalization(localizationConfig, initialLanguage);
 };
 
+const sortFn = (first, second) => {
+  return 0;
+};
+
 const setUpComponents = (
   featureFlags: FeatureFlags,
   setupObject: ReturnType<typeof getHrmConfig>,
@@ -79,6 +85,27 @@ const setUpComponents = (
 ) => {
   const { canView } = getPermissionsForViewingIdentifiers();
   const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
+
+  Flex.WorkersDataTable.Content.add(
+    <Flex.ColumnDefinition
+      key="skills"
+      header="Skills"
+      sortingFn={sortFn}
+      style={{ width: '180px' }}
+      content={item => {
+        console.log(item);
+        const skills = item?.worker?.attributes?.disabled_skills?.skills ?? [];
+        return (
+          <>
+            {skills.map(skill => (
+              <CategoryWithTooltip key={skill} category={skill} color="#FF0000" />
+            ))}
+          </>
+        );
+      }}
+    />,
+    { sortOrder: 0 },
+  );
 
   // setUp (add) dynamic components
   Components.setUpQueuesStatusWriter(setupObject);


### PR DESCRIPTION
## Description
An extension of [Nick's POC](https://github.com/techmatters/flex-plugins/pull/1980) that:
- Uses real data from worker
- When sorting other columns, Skills get sorted accordingly

I'll keep this branch for future investigations on Teams View

<img width="916" alt="image" src="https://github.com/techmatters/flex-plugins/assets/1504544/4cb62ab5-450b-49a8-8b00-0410762a80e1">