### PR TITLE
CHI-1976: Fix view button on timeline for some contacts

### DIFF
--- a/plugin-hrm-form/src/components/case/timeline/Timeline.tsx
+++ b/plugin-hrm-form/src/components/case/timeline/Timeline.tsx
@@ -28,8 +28,8 @@ import { CaseSectionFont, TimelineCallTypeIcon, TimelineDate, TimelineRow, Timel
 import { Box, Row } from '../../../styles';
 import CaseAddButton from '../CaseAddButton';
 import { CustomITask } from '../../../types/types';
-import { isConnectedCaseActivity } from '../../../states/case/caseActivities';
-import { ConnectedCaseActivity, NoteActivity, ReferralActivity } from '../../../states/case/types';
+import { isContactActivity } from '../../../states/case/caseActivities';
+import { ContactActivity, NoteActivity, ReferralActivity } from '../../../states/case/types';
 import { getPermissionsForCase, getPermissionsForContact, PermissionActions } from '../../../permissions';
 import { CaseItemAction, CaseSectionSubroute, NewCaseSubroutes } from '../../../states/routing/types';
 import { newOpenModalAction } from '../../../states/routing/actions';
@@ -97,7 +97,7 @@ const Timeline: React.FC<Props> = ({
     openViewCaseSectionModal(caseId, NewCaseSubroutes.Referral, id);
   };
 
-  const handleViewConnectedCaseActivityClick = ({ contactId }: ConnectedCaseActivity) => {
+  const handleViewConnectedCaseActivityClick = ({ contactId }: ContactActivity) => {
     openContactModal(contactId);
   };
 
@@ -114,7 +114,7 @@ const Timeline: React.FC<Props> = ({
       handleViewNoteClick(activity);
     } else if (activity.type === 'referral') {
       handleViewReferralClick(activity);
-    } else if (isConnectedCaseActivity(activity)) {
+    } else if (isContactActivity(activity)) {
       handleViewConnectedCaseActivityClick(activity);
     } else {
       setMockedMessage(<Template code="NotImplemented" />);
@@ -151,7 +151,7 @@ const Timeline: React.FC<Props> = ({
         timelineActivities.map((activity, index) => {
           const date = parseISO(activity.date).toLocaleDateString(navigator.language);
           let canViewActivity = true;
-          if (isConnectedCaseActivity(activity)) {
+          if (isContactActivity(activity)) {
             if (activity.isDraft) {
               canViewActivity = false;
             } else {
@@ -164,13 +164,12 @@ const Timeline: React.FC<Props> = ({
             <TimelineRow
               key={index}
               style={{
-                backgroundColor:
-                  isConnectedCaseActivity(activity) && activity.isDraft ? colors.background.yellow : undefined,
+                backgroundColor: isContactActivity(activity) && activity.isDraft ? colors.background.yellow : undefined,
               }}
             >
               <TimelineDate>{date}</TimelineDate>
-              <TimelineIcon type={isConnectedCaseActivity(activity) ? activity.channel : activity.type} />
-              {isConnectedCaseActivity(activity) && (
+              <TimelineIcon type={isContactActivity(activity) ? activity.channel : activity.type} />
+              {isContactActivity(activity) && (
                 <TimelineCallTypeIcon>
                   <CallTypeIcon callType={activity.callType} fontSize="18px" />
                 </TimelineCallTypeIcon>
@@ -185,7 +184,7 @@ const Timeline: React.FC<Props> = ({
                   </Box>
                 </Box>
               )}
-              {isConnectedCaseActivity(activity) && activity.isDraft && (
+              {isContactActivity(activity) && activity.isDraft && (
                 <Box marginLeft="auto">
                   <Box marginLeft="auto">
                     <InfoIcon color="#fed44b" />

--- a/plugin-hrm-form/src/states/case/caseActivities.ts
+++ b/plugin-hrm-form/src/states/case/caseActivities.ts
@@ -16,7 +16,7 @@
 
 import { DefinitionVersion } from 'hrm-form-definitions';
 
-import { Activity, ConnectedCaseActivity, NoteActivity } from './types';
+import { Activity, ContactActivity, NoteActivity } from './types';
 import { Case, Contact, NoteEntry, ReferralEntry } from '../../types/types';
 import { channelTypes } from '../DomainConstants';
 import { getTemplateStrings } from '../../hrmConfig';
@@ -33,11 +33,11 @@ const ActivityTypes = {
 } as const;
 
 /**
- * Returns true if the activity provided is a connected case activity (included in channelsAndDefault const object)
+ * Returns true if the activity provided represents a contact that was connected to the case
  * @param activity Timeline Activity
  */
-export const isConnectedCaseActivity = (activity): activity is ConnectedCaseActivity =>
-  Boolean(ActivityTypes.connectContact[activity.type]);
+export const isContactActivity = (activity: Activity): activity is ContactActivity =>
+  Boolean((activity as ContactActivity).contactId);
 
 export const getNoteActivities = (counsellorNotes: NoteEntry[], formDefs: DefinitionVersion): NoteActivity[] => {
   let { previewFields } = formDefs.layoutVersion.case.notes ?? {};
@@ -105,7 +105,7 @@ const getContactActivityText = (contact: Contact, strings: Record<string, string
   return '';
 };
 
-const connectedContactActivities = (caseContacts: Contact[]): ConnectedCaseActivity[] => {
+const connectedContactActivities = (caseContacts: Contact[]): ContactActivity[] => {
   const strings = getTemplateStrings();
   return (caseContacts || [])
     .map(cc => {

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -76,9 +76,9 @@ export type ReferralActivity = CoreActivity & {
   updatedBy?: string;
 };
 
-export type ConnectedCaseActivity = CoreActivity & {
+export type ContactActivity = CoreActivity & {
   callType: string;
-  contactId?: string;
+  contactId: string;
   date: string;
   createdAt: string;
   type: string;
@@ -86,7 +86,7 @@ export type ConnectedCaseActivity = CoreActivity & {
   isDraft: boolean;
 };
 
-export type Activity = NoteActivity | ReferralActivity | ConnectedCaseActivity;
+export type Activity = NoteActivity | ReferralActivity | ContactActivity;
 
 export type CaseDetails = {
   id: string;


### PR DESCRIPTION
## Description

Renamed ConnectedCaseActivities -> ContactActivities. 
Updated check for contact activity just to check for a contact ID

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-1976

### Verification steps

* Start creating an offline contact with a type that doesn't map to a standard channel type, like 'email' or 'Bulletin Board'
* Add it to a case
* Save the contact
* Open the case timeline and ensure you can view the contact from the timeline