### PR TITLE
CHI-1976: Fixed tags layout on search preview items

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
@@ -185,7 +185,11 @@ describe('actions', () => {
       // Not sure why the extra cast to any is needed here but not for the other actions?
       await (dispatch(submitContactFormAsyncAction(task, baseContact, baseMetadata, baseCase) as any) as unknown);
       const { metadata, savedContact } = getState().existingContacts[baseContact.id];
-      expect(metadata).toStrictEqual({ ...newContactMetaData(false), loadingStatus: LoadingStatus.LOADED });
+      expect(metadata).toStrictEqual({
+        ...newContactMetaData(false),
+        startMillis: expect.any(Number),
+        loadingStatus: LoadingStatus.LOADED,
+      });
       expect(savedContact).toStrictEqual(updatedContact);
     });
   });

--- a/plugin-hrm-form/src/components/search/CasePreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/CasePreview/index.tsx
@@ -139,9 +139,8 @@ const CasePreview: React.FC<Props> = ({
               {summary}
             </PreviewDescription>
           )}
-
-          <TagsAndCounselor counselor={counselor} categories={categories} definitionVersion={definitionVersion} />
         </PreviewRow>
+        <TagsAndCounselor counselor={counselor} categories={categories} definitionVersion={definitionVersion} />
       </PreviewWrapper>
     </Flex>
   );

--- a/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
@@ -111,22 +111,22 @@ const ContactPreview: React.FC<Props> = ({ contact, handleViewDetails, definitio
           onClickFull={handleViewDetails}
           isDraft={!contact.finalizedAt}
         />
-        <PreviewRow>
-          {callSummary && (
+        {callSummary && (
+          <PreviewRow>
             <PreviewDescription expandLinkText="ReadMore" collapseLinkText="ReadLess">
               {callSummary}
             </PreviewDescription>
-          )}
-          {isNonDataCallType(callType) ? (
-            <TagsAndCounselor counselor={counselorName} nonDataCallType={callType} definitionVersion={definition} />
-          ) : (
-            <TagsAndCounselor
-              counselor={counselorName}
-              categories={contact.rawJson.categories}
-              definitionVersion={definition}
-            />
-          )}
-        </PreviewRow>
+          </PreviewRow>
+        )}
+        {isNonDataCallType(callType) ? (
+          <TagsAndCounselor counselor={counselorName} nonDataCallType={callType} definitionVersion={definition} />
+        ) : (
+          <TagsAndCounselor
+            counselor={counselorName}
+            categories={contact.rawJson.categories}
+            definitionVersion={definition}
+          />
+        )}
       </PreviewWrapper>
     </Flex>
   );

--- a/plugin-hrm-form/src/components/search/TagsAndCounselor.tsx
+++ b/plugin-hrm-form/src/components/search/TagsAndCounselor.tsx
@@ -20,7 +20,7 @@ import { Template } from '@twilio/flex-ui';
 import { DefinitionVersion } from 'hrm-form-definitions';
 
 import { Flex } from '../../styles';
-import { TagText, SummaryText, TagsWrapper, SilentText, SubtitleLabel } from './styles';
+import { SilentText, SubtitleLabel, SummaryText, TagsWrapper, TagText } from './styles';
 import CategoryWithTooltip from '../common/CategoryWithTooltip';
 import { getContactTags } from '../../utils/categories';
 
@@ -67,7 +67,15 @@ const TagsAndCounselor: React.FC<Props> = props => {
   };
 
   return (
-    <Flex justifyContent="space-between" height="23px" marginTop="10px">
+    <Flex
+      style={{
+        justifyContent: 'space-between',
+        height: '23px',
+        marginTop: '10px',
+        padding: '0 20px 0px 20px',
+        display: 'flex', // Not sure why but display is set to 'block' without this
+      }}
+    >
       {leftTags()}
       <Flex style={{ minWidth: 'fit-content' }}>
         <SubtitleLabel>


### PR DESCRIPTION
## Description

* Restore layouts of the bottom part of search results that were broken in a previous commit

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-1976

### Verification steps

See ticket