### PR TITLE
Fix channel type on in progress contacts

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/OfflineContact/AddOfflineContactButton.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/OfflineContact/AddOfflineContactButton.test.tsx
@@ -116,12 +116,7 @@ test('click on button', async () => {
   screen.getByText('OfflineContactButtonText').click();
   await waitFor(
     () => {
-      expect(mockCreateContact).toHaveBeenCalledWith(
-        expect.anything(),
-        'mock-worker',
-        'offline-contact-task-mock-worker',
-        getOfflineContactTask(),
-      );
+      expect(mockCreateContact).toHaveBeenCalledWith(expect.anything(), 'mock-worker', getOfflineContactTask());
       expect(Actions.invokeAction).toHaveBeenCalledTimes(1);
     },
     { timeout: 1000 },

--- a/plugin-hrm-form/src/___tests__/components/OfflineContact/AddOfflineContactButton.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/OfflineContact/AddOfflineContactButton.test.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { configureAxe, toHaveNoViolations } from 'jest-axe';
 import { render, screen, waitFor } from '@testing-library/react';
 import { mount } from 'enzyme';
-import { StorelessThemeProvider, withTheme, Actions } from '@twilio/flex-ui';
+import { Actions, StorelessThemeProvider, withTheme } from '@twilio/flex-ui';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
@@ -32,6 +32,7 @@ import { Contact } from '../../../types/types';
 import { namespace } from '../../../states/storeNamespaces';
 import { RootState } from '../../../states';
 import { RecursivePartial } from '../../RecursivePartial';
+import { getOfflineContactTask } from '../../../states/contacts/offlineContactTask';
 
 let mockV1;
 
@@ -119,6 +120,7 @@ test('click on button', async () => {
         expect.anything(),
         'mock-worker',
         'offline-contact-task-mock-worker',
+        getOfflineContactTask(),
       );
       expect(Actions.invokeAction).toHaveBeenCalledTimes(1);
     },

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -119,12 +119,10 @@ type SaveContactToHrmResponse = {
   externalRecordingInfo?: ExternalRecordingInfoSuccess;
 };
 
-export const createContact = async (
-  contact: Contact,
-  twilioWorkerId: string,
-  taskSid: string,
-  task: CustomITask,
-): Promise<Contact> => {
+export const createContact = async (contact: Contact, twilioWorkerId: string, task: CustomITask): Promise<Contact> => {
+  const taskSid = isOfflineContactTask(task)
+    ? task.taskSid
+    : task.attributes?.transferMeta?.originalTask ?? task.taskSid;
   const { definitionVersion } = getHrmConfig();
   const contactForApi: Contact = {
     ...contact,

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -22,7 +22,7 @@ import { fillEndMillis, getConversationDuration } from '../utils/conversationDur
 import { fetchHrmApi } from './fetchHrmApi';
 import { getDateTime } from '../utils/helpers';
 import { getDefinitionVersions, getHrmConfig } from '../hrmConfig';
-import { ConversationMedia, Contact, isOfflineContactTask, isTwilioTask } from '../types/types';
+import { Contact, ConversationMedia, CustomITask, isOfflineContactTask, isTwilioTask } from '../types/types';
 import { saveContactToExternalBackend } from '../dualWrite';
 import { getNumberFromTask } from '../utils';
 import { ContactMetadata } from '../states/contacts/types';
@@ -119,10 +119,16 @@ type SaveContactToHrmResponse = {
   externalRecordingInfo?: ExternalRecordingInfoSuccess;
 };
 
-export const createContact = async (contact: Contact, twilioWorkerId: string, taskSid: string): Promise<Contact> => {
+export const createContact = async (
+  contact: Contact,
+  twilioWorkerId: string,
+  taskSid: string,
+  task: CustomITask,
+): Promise<Contact> => {
   const { definitionVersion } = getHrmConfig();
-  const contactForApi = {
+  const contactForApi: Contact = {
     ...contact,
+    channel: task.channelType as Contact['channel'],
     rawJson: {
       definitionVersion,
       ...contact.rawJson,
@@ -209,7 +215,6 @@ const saveContactToHrm = async (
     rawJson: form,
     twilioWorkerId,
     queueName: task.queueName,
-    channel: task.channelType,
     number,
     conversationDuration,
     timeOfContact,

--- a/plugin-hrm-form/src/states/contacts/contactState.ts
+++ b/plugin-hrm-form/src/states/contacts/contactState.ts
@@ -68,6 +68,7 @@ export const newContact = (definitions: DefinitionVersion, task?: ITask | Offlin
     createdOnBehalfOf: '',
     ...Object.fromEntries(initialContactlessTaskTabDefinition.map(d => [d.name, getInitialValue(d)])),
   };
+  const channel = (task?.channelType ?? 'default') as Contact['channel'];
   const chatSids =
     task && !isOfflineContactTask(task) && TaskHelper.isChatBasedTask(task)
       ? {
@@ -92,12 +93,12 @@ export const newContact = (definitions: DefinitionVersion, task?: ITask | Offlin
       categories: {},
     },
     ...chatSids,
+    channel,
     createdBy: '',
     createdAt: '',
     updatedBy: '',
     updatedAt: '',
     queueName: '',
-    channel: 'web',
     number: '',
     conversationDuration: 0,
     profileId: null,

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -51,7 +51,7 @@ export const createContactAsyncAction = createAsyncAction(
     let contact: Contact;
     const { taskSid } = task;
     if (isOfflineContactTask(task)) {
-      contact = await createContact(contactToCreate, workerSid, taskSid, task);
+      contact = await createContact(contactToCreate, workerSid, task);
     } else {
       const attributes = task.attributes ?? {};
       const { contactId } = attributes;
@@ -59,12 +59,7 @@ export const createContactAsyncAction = createAsyncAction(
         // Setting the task id and worker id on the contact will be a noop in most cases, but when receiving a transfer it will move the contact to the new worker & task
         contact = await updateContactInHrm(contactId, { taskId: taskSid, twilioWorkerId: workerSid }, false);
       } else {
-        contact = await createContact(
-          contactToCreate,
-          workerSid,
-          attributes.transferMeta?.originalTask ?? taskSid,
-          task,
-        );
+        contact = await createContact(contactToCreate, workerSid, task);
         if (contact.taskId! !== taskSid || contact.twilioWorkerId !== workerSid) {
           // If the contact is being transferred from a client that doesn't set the contactId on the task, we need to update the contact with the task id and worker id
           contact = await updateContactInHrm(contact.id, { taskId: taskSid, twilioWorkerId: workerSid }, false);

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -51,7 +51,7 @@ export const createContactAsyncAction = createAsyncAction(
     let contact: Contact;
     const { taskSid } = task;
     if (isOfflineContactTask(task)) {
-      contact = await createContact(contactToCreate, workerSid, taskSid);
+      contact = await createContact(contactToCreate, workerSid, taskSid, task);
     } else {
       const attributes = task.attributes ?? {};
       const { contactId } = attributes;
@@ -59,7 +59,12 @@ export const createContactAsyncAction = createAsyncAction(
         // Setting the task id and worker id on the contact will be a noop in most cases, but when receiving a transfer it will move the contact to the new worker & task
         contact = await updateContactInHrm(contactId, { taskId: taskSid, twilioWorkerId: workerSid }, false);
       } else {
-        contact = await createContact(contactToCreate, workerSid, attributes.transferMeta?.originalTask ?? taskSid);
+        contact = await createContact(
+          contactToCreate,
+          workerSid,
+          attributes.transferMeta?.originalTask ?? taskSid,
+          task,
+        );
         if (contact.taskId! !== taskSid || contact.twilioWorkerId !== workerSid) {
           // If the contact is being transferred from a client that doesn't set the contactId on the task, we need to update the contact with the task id and worker id
           contact = await updateContactInHrm(contact.id, { taskId: taskSid, twilioWorkerId: workerSid }, false);


### PR DESCRIPTION
## Description

Sets the channel type for a contact based on task info when creating them, rather than defaulting to 'web'. This means that the channel type will be correct for draft contacts

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
CHI-2252

### Verification steps

See ticket