### PR TITLE
Show only coreChannelTypes at OfflineContact

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -17,13 +17,13 @@
 import { isFuture } from 'date-fns';
 import { DefinitionVersion, FormDefinition, FormInputType } from 'hrm-form-definitions';
 
-import { channelTypes } from '../../states/DomainConstants';
+import { coreChannelTypes } from '../../states/DomainConstants';
 import { mapChannelForInsights } from '../../utils/mappers';
 import { splitDate } from '../../utils/helpers';
 import type { CounselorsList } from '../../states/configuration/types';
 
 const defaultChannelOptions = [{ value: '', label: '' }].concat(
-  Object.values(channelTypes).map(s => ({
+  Object.values(coreChannelTypes).map(s => ({
     label: mapChannelForInsights(s),
     value: s,
   })),


### PR DESCRIPTION
## Description
This PR prevents Modica integration from showing the `SMS` option duplicated when selecting a channel for Offline Contacts.


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes https://tech-matters.atlassian.net/browse/CHI-2518

### Verification steps
Create an offline contact and check that `SMS` is not duplicated on the channel options