### PR TITLE
CHI-2394 - Map Household Fields into Insight

### DIFF
--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -199,6 +199,7 @@ type InsightsCaseForm = {
   perpetrator?: { [key: string]: string };
   incident?: { [key: string]: string | boolean };
   referral?: { [key: string]: string };
+  household?: { [key: string]: string };
 };
 
 /*
@@ -212,6 +213,7 @@ const convertCaseFormForInsights = (caseForm: Case): InsightsCaseForm => {
   let perpetrator: { [key: string]: string } = undefined;
   let incident: { [key: string]: string | boolean } = undefined;
   let referral: { [key: string]: string } = undefined;
+  let household: { [key: string]: string } = undefined;
   const topLevel = {
     id: caseForm.id.toString(),
   };
@@ -243,6 +245,17 @@ const convertCaseFormForInsights = (caseForm: Case): InsightsCaseForm => {
       ...untypedIncident,
     };
   }
+  if (caseForm.info?.households && caseForm.info.households.length > 0) {
+    const theHousehold = caseForm.info.households[0];
+    const untypedHousehold: any = {
+      ...theHousehold,
+      ...theHousehold.household,
+    };
+    delete untypedHousehold.household;
+    household = {
+      ...untypedHousehold,
+    };
+  }
   if (caseForm.info?.referrals && caseForm.info.referrals.length > 0) {
     referral = {
       ...caseForm.info.referrals[0],
@@ -254,6 +267,7 @@ const convertCaseFormForInsights = (caseForm: Case): InsightsCaseForm => {
     topLevel,
     perpetrator,
     incident,
+    household,
     referral,
   };
 };


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer: @murilovmachado

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- This task maps household fields into Insights in the case section of Insight.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes [CHI-2394](https://tech-matters.atlassian.net/browse/CHI-2394)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
- Create a task
- Navigate to Twilio console to confirm that the task was created
- Add a household object within the caseForm object in the oneToOneConfigSpec.json file in the insight folder in hrm-form-definition. E.g:
`"household": [
      {
          "name": "relationshipToChild",
          "insights": [
            "conversations", "campaign"
          ]
      }
  ]
`
- Add a new household member to the newly created task
- Save and end the task
- Navigate to the Twilio console
-  Click on the task and verify that the household member exist in the atrribute


[CHI-2394]: https://tech-matters.atlassian.net/browse/CHI-2394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ