### PR TITLE
refactor: align permissions framework with HRM + UX for time-based permissions

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -29,7 +29,7 @@ import * as Components from './utils/setUpComponents';
 import * as Channels from './channels/setUpChannels';
 import setUpMonitoring from './utils/setUpMonitoring';
 import { changeLanguage } from './states/configuration/actions';
-import { getPermissionsForViewingIdentifiers, PermissionActions } from './permissions';
+import { getInitializedCan, PermissionActions } from './permissions';
 import {
   getAseloFeatureFlags,
   getHrmConfig,
@@ -77,8 +77,8 @@ const setUpComponents = (
   setupObject: ReturnType<typeof getHrmConfig>,
   translateUI: (language: string) => Promise<void>,
 ) => {
-  const { canView } = getPermissionsForViewingIdentifiers();
-  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
+  const can = getInitializedCan();
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
 
   // setUp (add) dynamic components
   Components.setUpQueuesStatusWriter(setupObject);

--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -28,7 +28,7 @@ import { PreviousContactCounts } from '../../states/search/types';
 jest.mock('../../components/CSAMReport/CSAMReportFormDefinition');
 
 jest.mock('../../permissions', () => ({
-  getInitializedCan: jest.fn(() => true),
+  getInitializedCan: jest.fn(() => () => true),
   PermissionActions: {},
 }));
 

--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -28,9 +28,7 @@ import { PreviousContactCounts } from '../../states/search/types';
 jest.mock('../../components/CSAMReport/CSAMReportFormDefinition');
 
 jest.mock('../../permissions', () => ({
-  getPermissionsForViewingIdentifiers: jest.fn(() => ({
-    canView: () => true,
-  })),
+  getInitializedCan: jest.fn(() => true),
   PermissionActions: {},
 }));
 

--- a/plugin-hrm-form/src/___tests__/components/case/Case.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/Case.test.tsx
@@ -38,12 +38,7 @@ import { CaseStateEntry } from '../../../states/case/types';
 
 jest.mock('../../../services/CaseService', () => ({ getActivities: jest.fn(() => []), cancelCase: jest.fn() }));
 jest.mock('../../../permissions', () => ({
-  getPermissionsForCase: jest.fn(() => ({
-    can: () => true,
-  })),
-  getPermissionsForContact: jest.fn(() => ({
-    can: () => true,
-  })),
+  getInitializedCan: jest.fn(() => true),
   PermissionActions: {},
 }));
 

--- a/plugin-hrm-form/src/___tests__/components/case/Case.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/Case.test.tsx
@@ -38,7 +38,7 @@ import { CaseStateEntry } from '../../../states/case/types';
 
 jest.mock('../../../services/CaseService', () => ({ getActivities: jest.fn(() => []), cancelCase: jest.fn() }));
 jest.mock('../../../permissions', () => ({
-  getInitializedCan: jest.fn(() => true),
+  getInitializedCan: jest.fn(() => () => true),
   PermissionActions: {},
 }));
 

--- a/plugin-hrm-form/src/___tests__/components/case/CaseHome.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/CaseHome.test.tsx
@@ -36,8 +36,7 @@ import { RootState } from '../../../states';
 
 jest.mock('../../../permissions', () => ({
   ...jest.requireActual('../../../permissions'),
-  getPermissionsForCase: jest.fn(() => ({ can: () => true })),
-  getPermissionsForContact: jest.fn(() => ({ can: () => true })),
+  getInitializedCan: jest.fn(() => true),
 }));
 
 // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/plugin-hrm-form/src/___tests__/components/case/CaseHome.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/case/CaseHome.test.tsx
@@ -36,7 +36,7 @@ import { RootState } from '../../../states';
 
 jest.mock('../../../permissions', () => ({
   ...jest.requireActual('../../../permissions'),
-  getInitializedCan: jest.fn(() => true),
+  getInitializedCan: jest.fn(() => () => true),
 }));
 
 // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/plugin-hrm-form/src/___tests__/permissions/index.test.ts
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.ts
@@ -18,9 +18,7 @@ import each from 'jest-each';
 
 import * as fetchRulesModule from '../../permissions/fetchRules';
 import {
-  getPermissionsForCase,
-  getPermissionsForContact,
-  getPermissionsForViewingIdentifiers,
+  getInitializedCan,
   PermissionActions,
   CaseActions,
   ContactActions,
@@ -47,14 +45,15 @@ describe('Test that all actions work fine (everyone)', () => {
     permissionConfig: 'wareva',
   });
 
-  const { can } = getPermissionsForCase('notCreator', 'open');
+  // const can = getInitializedCan('notCreator', 'open');
+  const can = getInitializedCan();
 
   each(
     Object.values(PermissionActions).map(action => ({
       action,
     })),
   ).test(`Action $action should return true`, ({ action }) => {
-    expect(can(action)).toBeTruthy();
+    expect(can(action, { status: 'open', twilioWorkerId: 'some one' })).toBeTruthy();
   });
 });
 
@@ -151,9 +150,9 @@ describe('Test different scenarios (all CasesActions)', () => {
         permissionConfig: 'wareva',
       });
 
-      const { can } = getPermissionsForCase('creator', status);
+      const can = getInitializedCan();
 
-      expect(can(action)).toBe(expectedResult);
+      expect(can(action, { status, twilioWorkerSid: workerSid })).toBe(expectedResult);
     },
   );
 });
@@ -240,9 +239,9 @@ describe('Test different scenarios (all ContactActions)', () => {
         permissionConfig: 'wareva',
       });
 
-      const { can } = getPermissionsForContact('owner');
+      const can = getInitializedCan();
 
-      expect(can(action)).toBe(expectedResult);
+      expect(can(action, { twilioWorkerId: 'owner' })).toBe(expectedResult);
     },
   );
 });
@@ -298,9 +297,9 @@ describe('Test different scenarios for ViewIdentifiersAction', () => {
         permissionConfig: 'wareva',
       });
 
-      const { canView } = getPermissionsForViewingIdentifiers();
+      const can = getInitializedCan();
 
-      expect(canView(action)).toBe(expectedResult);
+      expect(can(action)).toBe(expectedResult);
     },
   );
 });

--- a/plugin-hrm-form/src/___tests__/permissions/index.test.ts
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.ts
@@ -28,6 +28,7 @@ import {
   cleanupInitializedCan,
   actionsMaps,
   TargetKind,
+  ConditionsSets,
 } from '../../permissions';
 import { getHrmConfig } from '../../hrmConfig';
 
@@ -49,6 +50,13 @@ const buildRules = (conditionsSets, kind: TargetKind | 'all') => {
 
 afterEach(() => {
   jest.resetAllMocks();
+});
+
+const addPrettyPrintConditions = (testCase: { conditionsSets: ConditionsSets }) => ({
+  ...testCase,
+  prettyConditionsSets: testCase.conditionsSets
+    .map(arr => arr.map(e => (typeof e === 'string' ? e : JSON.stringify(e))))
+    .map(arr => `[${arr.join(',')}]`),
 });
 
 describe('Test that all actions work fine (everyone)', () => {
@@ -192,12 +200,7 @@ describe('Test different scenarios (all CasesActions)', () => {
           createdAt: subDays(new Date(), 2).toISOString(),
         },
       ])
-      .map(t => ({
-        ...t,
-        prettyConditionsSets: t.conditionsSets
-          .map(arr => arr.map(e => (typeof e === 'string' ? e : JSON.stringify(e))))
-          .map(arr => `[${arr.join(',')}]`),
-      })),
+      .map(addPrettyPrintConditions),
   ).test(
     `Should return $expectedResult for action $action when $expectedDescription and conditionsSets are $prettyConditionsSets`,
     ({ action, conditionsSets, workerSid, isSupervisor, status = 'open', expectedResult, createdAt }) => {
@@ -326,12 +329,7 @@ describe('Test different scenarios (all ContactActions)', () => {
           createdAt: subDays(new Date(), 2).toISOString(),
         },
       ])
-      .map(t => ({
-        ...t,
-        prettyConditionsSets: t.conditionsSets
-          .map(arr => arr.map(e => (typeof e === 'string' ? e : JSON.stringify(e))))
-          .map(arr => `[${arr.join(',')}]`),
-      })),
+      .map(addPrettyPrintConditions),
   ).test(
     `Should return $expectedResult for action $action when $expectedDescription and conditionsSets are $prettyConditionsSets`,
     ({ action, conditionsSets, workerSid, isSupervisor, expectedResult, createdAt }) => {
@@ -394,12 +392,7 @@ describe('Test different scenarios for ViewIdentifiersAction', () => {
           expectedDescription: 'user is not a supervisor',
         },
       ])
-      .map(t => ({
-        ...t,
-        prettyConditionsSets: t.conditionsSets
-          .map(arr => arr.map(e => (typeof e === 'string' ? e : JSON.stringify(e))))
-          .map(arr => `[${arr.join(',')}]`),
-      })),
+      .map(addPrettyPrintConditions),
   ).test(
     `Should return $expectedResult for action $action when $expectedDescription and conditionsSets are $prettyConditionsSets`,
     ({ action, conditionsSets, isSupervisor, expectedResult }) => {

--- a/plugin-hrm-form/src/___tests__/search/SearchResults.test.tsx
+++ b/plugin-hrm-form/src/___tests__/search/SearchResults.test.tsx
@@ -31,15 +31,7 @@ import { RecursivePartial } from '../RecursivePartial';
 import { VALID_EMPTY_METADATA } from '../testContacts';
 
 jest.mock('../../permissions', () => ({
-  getPermissionsForCase: jest.fn(() => ({
-    can: () => true,
-  })),
-  getPermissionsForContact: jest.fn(() => ({
-    can: () => true,
-  })),
-  getPermissionsForViewingIdentifiers: jest.fn(() => ({
-    canView: () => true,
-  })),
+  getInitializedCan: jest.fn(() => true),
   PermissionActions: {},
 }));
 

--- a/plugin-hrm-form/src/___tests__/search/SearchResults.test.tsx
+++ b/plugin-hrm-form/src/___tests__/search/SearchResults.test.tsx
@@ -31,7 +31,7 @@ import { RecursivePartial } from '../RecursivePartial';
 import { VALID_EMPTY_METADATA } from '../testContacts';
 
 jest.mock('../../permissions', () => ({
-  getInitializedCan: jest.fn(() => true),
+  getInitializedCan: jest.fn(() => () => true),
   PermissionActions: {},
 }));
 

--- a/plugin-hrm-form/src/___tests__/states/case/caseStatus.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/caseStatus.test.ts
@@ -22,7 +22,7 @@ import {
   useFetchDefinitions,
 } from 'hrm-form-definitions';
 
-import { getPermissionsForCase, PermissionActions } from '../../../permissions';
+import { getInitializedCan, PermissionActions } from '../../../permissions';
 import { Case } from '../../../types/types';
 import { getAvailableCaseStatusTransitions } from '../../../states/case/caseStatus';
 
@@ -33,7 +33,7 @@ jest.mock('../../../permissions', () => ({
     REOPEN_CASE: 'reopenCase',
     CASE_STATUS_TRANSITION: 'caseStatusTransition',
   },
-  getPermissionsForCase: jest.fn(),
+  getInitializedCan: jest.fn(),
 }));
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -82,13 +82,13 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
   describe('Given open permissions', () => {
     beforeEach(() => {
-      (<jest.Mock>getPermissionsForCase).mockReturnValue({
+      (<jest.Mock>getInitializedCan).mockReturnValue({
         can: () => true,
       });
     });
     test('Looks up case permissions using worker and current status', () => {
       getAvailableCaseStatusTransitions(createCase('mulching', 'a worker'), createDefinition([]));
-      expect(getPermissionsForCase).toHaveBeenCalledWith('a worker', 'mulching');
+      expect(getInitializedCan).toHaveBeenCalledWith('a worker', 'mulching');
     });
     test('Status exists with valid transitions - returns current status and transitions', () => {
       const result = getAvailableCaseStatusTransitions(
@@ -155,7 +155,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   ]);
 
   test('Can close case and open status that can transition to closed - closed option available', () => {
-    (<jest.Mock>getPermissionsForCase).mockReturnValue({
+    (<jest.Mock>getInitializedCan).mockReturnValue({
       can: () => true,
     });
     const result = getAvailableCaseStatusTransitions(createCase('compost', ''), permissionableDefinition);
@@ -167,7 +167,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Cannot close case and open status that can transition to closed - closed option not available', () => {
-    (<jest.Mock>getPermissionsForCase).mockReturnValue({
+    (<jest.Mock>getInitializedCan).mockReturnValue({
       can: action => action !== PermissionActions.CLOSE_CASE,
     });
     const result = getAvailableCaseStatusTransitions(createCase('compost', ''), permissionableDefinition);
@@ -178,7 +178,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Can reopen case and closed status that can transition to open - open option available', () => {
-    (<jest.Mock>getPermissionsForCase).mockReturnValue({
+    (<jest.Mock>getInitializedCan).mockReturnValue({
       can: action => action === PermissionActions.REOPEN_CASE,
     });
     const result = getAvailableCaseStatusTransitions(createCase('closed', ''), permissionableDefinition);
@@ -190,7 +190,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Cannot reopen case and closed status that can transition to open - open option not available', () => {
-    (<jest.Mock>getPermissionsForCase).mockReturnValue({
+    (<jest.Mock>getInitializedCan).mockReturnValue({
       can: action => action !== PermissionActions.REOPEN_CASE,
     });
     const result = getAvailableCaseStatusTransitions(createCase('closed', ''), permissionableDefinition);
@@ -198,7 +198,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Can transition case and open status that can transition to another open status - transition options available', () => {
-    (<jest.Mock>getPermissionsForCase).mockReturnValue({
+    (<jest.Mock>getInitializedCan).mockReturnValue({
       can: action => action === PermissionActions.CASE_STATUS_TRANSITION,
     });
     const result = getAvailableCaseStatusTransitions(createCase('compost', ''), permissionableDefinition);
@@ -209,7 +209,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Cannot transition case and open status that to another open status - transition options not available', () => {
-    (<jest.Mock>getPermissionsForCase).mockReturnValue({
+    (<jest.Mock>getInitializedCan).mockReturnValue({
       can: action => action !== PermissionActions.CASE_STATUS_TRANSITION,
     });
     const result = getAvailableCaseStatusTransitions(createCase('compost', ''), permissionableDefinition);

--- a/plugin-hrm-form/src/___tests__/states/case/caseStatus.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/caseStatus.test.ts
@@ -82,13 +82,10 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
   describe('Given open permissions', () => {
     beforeEach(() => {
-      (<jest.Mock>getInitializedCan).mockReturnValue({
-        can: () => true,
-      });
+      (<jest.Mock>getInitializedCan).mockReturnValue(() => true);
     });
     test('Looks up case permissions using worker and current status', () => {
       getAvailableCaseStatusTransitions(createCase('mulching', 'a worker'), createDefinition([]));
-      expect(getInitializedCan).toHaveBeenCalledWith('a worker', 'mulching');
     });
     test('Status exists with valid transitions - returns current status and transitions', () => {
       const result = getAvailableCaseStatusTransitions(
@@ -155,9 +152,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   ]);
 
   test('Can close case and open status that can transition to closed - closed option available', () => {
-    (<jest.Mock>getInitializedCan).mockReturnValue({
-      can: () => true,
-    });
+    (<jest.Mock>getInitializedCan).mockReturnValue(() => true);
     const result = getAvailableCaseStatusTransitions(createCase('compost', ''), permissionableDefinition);
     expect(result).toStrictEqual([
       createCaseStatus('mulching', ['compost']),
@@ -167,9 +162,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Cannot close case and open status that can transition to closed - closed option not available', () => {
-    (<jest.Mock>getInitializedCan).mockReturnValue({
-      can: action => action !== PermissionActions.CLOSE_CASE,
-    });
+    (<jest.Mock>getInitializedCan).mockReturnValue(action => action !== PermissionActions.CLOSE_CASE);
     const result = getAvailableCaseStatusTransitions(createCase('compost', ''), permissionableDefinition);
     expect(result).toStrictEqual([
       createCaseStatus('mulching', ['compost']),
@@ -178,9 +171,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Can reopen case and closed status that can transition to open - open option available', () => {
-    (<jest.Mock>getInitializedCan).mockReturnValue({
-      can: action => action === PermissionActions.REOPEN_CASE,
-    });
+    (<jest.Mock>getInitializedCan).mockReturnValue(action => action === PermissionActions.REOPEN_CASE);
     const result = getAvailableCaseStatusTransitions(createCase('closed', ''), permissionableDefinition);
     expect(result).toStrictEqual([
       createCaseStatus('spaghettifying', ['mulching', 'compost']),
@@ -190,17 +181,13 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Cannot reopen case and closed status that can transition to open - open option not available', () => {
-    (<jest.Mock>getInitializedCan).mockReturnValue({
-      can: action => action !== PermissionActions.REOPEN_CASE,
-    });
+    (<jest.Mock>getInitializedCan).mockReturnValue(action => action !== PermissionActions.REOPEN_CASE);
     const result = getAvailableCaseStatusTransitions(createCase('closed', ''), permissionableDefinition);
     expect(result).toStrictEqual([createCaseStatus('closed', ['spaghettifying', 'mulching'])]);
   });
 
   test('Can transition case and open status that can transition to another open status - transition options available', () => {
-    (<jest.Mock>getInitializedCan).mockReturnValue({
-      can: action => action === PermissionActions.CASE_STATUS_TRANSITION,
-    });
+    (<jest.Mock>getInitializedCan).mockReturnValue(action => action === PermissionActions.CASE_STATUS_TRANSITION);
     const result = getAvailableCaseStatusTransitions(createCase('compost', ''), permissionableDefinition);
     expect(result).toStrictEqual([
       createCaseStatus('mulching', ['compost']),
@@ -209,9 +196,7 @@ describe('getAvailableCaseStatusTransitions', () => {
   });
 
   test('Cannot transition case and open status that to another open status - transition options not available', () => {
-    (<jest.Mock>getInitializedCan).mockReturnValue({
-      can: action => action !== PermissionActions.CASE_STATUS_TRANSITION,
-    });
+    (<jest.Mock>getInitializedCan).mockReturnValue(action => action !== PermissionActions.CASE_STATUS_TRANSITION);
     const result = getAvailableCaseStatusTransitions(createCase('compost', ''), permissionableDefinition);
     expect(result).toStrictEqual([
       createCaseStatus('compost', ['mulching', 'closed']),

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -43,7 +43,7 @@ import AddEditCaseItem, { AddEditCaseItemProps } from './AddEditCaseItem';
 import ViewCaseItem from './ViewCaseItem';
 import { bindFileUploadCustomHandlers } from './documentUploadHandler';
 import { recordBackendError } from '../../fullStory';
-import { getPermissionsForCase, PermissionActions } from '../../permissions';
+import { getInitializedCan, PermissionActions } from '../../permissions';
 import { CenteredContainer } from './styles';
 import EditCaseSummary from './EditCaseSummary';
 import { documentSectionApi } from '../../states/case/sections/document';
@@ -105,6 +105,10 @@ const Case: React.FC<Props> = ({
   const [loadedContactIds, setLoadedContactIds] = useState([]);
   const { connectedCase } = props?.connectedCaseState ?? {};
 
+  const can = React.useMemo(() => {
+    return action => getInitializedCan()(action, connectedCase);
+  }, [connectedCase]);
+
   const { workerSid } = getHrmConfig();
   const strings = getTemplateStrings();
   const { enable_case_merging: enableCaseMerging } = getAseloFeatureFlags();
@@ -149,8 +153,6 @@ const Case: React.FC<Props> = ({
   const getCategories = (firstConnectedContact: Contact): Record<string, string[]> => {
     return firstConnectedContact?.rawJson.categories ?? {};
   };
-
-  const { can } = getPermissionsForCase(connectedCase.twilioWorkerId, connectedCase.status);
 
   const firstConnectedContact = savedContacts && savedContacts[0];
 

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintContact.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintContact.tsx
@@ -24,7 +24,7 @@ import { Text, View } from '@react-pdf/renderer';
 
 import styles from './styles';
 import { mapChannel, mapChannelForInsights, formatStringToDateAndTime } from '../../../utils';
-import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
+import { getInitializedCan, PermissionActions } from '../../../permissions';
 import { presentValueFromStrings } from './presentValuesFromStrings';
 import { getTemplateStrings } from '../../../hrmConfig';
 
@@ -38,14 +38,16 @@ type Props = OwnProps;
 
 const CasePrintContact: React.FC<Props> = ({ sectionName, contact, counselor }) => {
   const strings = getTemplateStrings();
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
 
   const { rawJson, channel, number, conversationDuration, timeOfContact } = contact;
 
   const formattedChannel =
     channel === 'default' ? mapChannelForInsights(rawJson.contactlessTask?.channel) : mapChannel(channel);
 
-  const { canView } = getPermissionsForViewingIdentifiers();
-  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
   return (
     <View>
       <View style={styles['sectionHeader']}>

--- a/plugin-hrm-form/src/components/case/timeline/Timeline.tsx
+++ b/plugin-hrm-form/src/components/case/timeline/Timeline.tsx
@@ -30,7 +30,7 @@ import CaseAddButton from '../CaseAddButton';
 import { CustomITask } from '../../../types/types';
 import { isContactActivity } from '../../../states/case/caseActivities';
 import { ContactActivity, NoteActivity, ReferralActivity } from '../../../states/case/types';
-import { getPermissionsForCase, getPermissionsForContact, PermissionActions } from '../../../permissions';
+import { getInitializedCan, PermissionActions } from '../../../permissions';
 import { CaseItemAction, CaseSectionSubroute, NewCaseSubroutes } from '../../../states/routing/types';
 import { newOpenModalAction } from '../../../states/routing/actions';
 import { RootState } from '../../../states';
@@ -78,11 +78,9 @@ const Timeline: React.FC<Props> = ({
 }) => {
   const [mockedMessage, setMockedMessage] = useState(null);
 
-  const { can } = useMemo(
-    () =>
-      connectedCase ? getPermissionsForCase(connectedCase.twilioWorkerId, connectedCase.status) : { can: () => false },
-    [connectedCase],
-  );
+  const can = useMemo(() => {
+    return getInitializedCan();
+  }, []);
 
   if (!connectedCase || !timelineActivities) {
     return null;
@@ -135,12 +133,12 @@ const Timeline: React.FC<Props> = ({
             <CaseAddButton
               templateCode="Case-Note"
               onClick={handleAddNoteClick}
-              disabled={!can(PermissionActions.ADD_NOTE)}
+              disabled={!can(PermissionActions.ADD_NOTE, connectedCase)}
             />
             <CaseAddButton
               templateCode="Case-Referral"
               onClick={handleAddReferralClick}
-              disabled={!can(PermissionActions.ADD_REFERRAL)}
+              disabled={!can(PermissionActions.ADD_REFERRAL, connectedCase)}
               withDivider
             />
           </Box>
@@ -155,8 +153,7 @@ const Timeline: React.FC<Props> = ({
             if (activity.isDraft) {
               canViewActivity = false;
             } else {
-              const { can } = getPermissionsForContact(activity.twilioWorkerId);
-              canViewActivity = can(PermissionActions.VIEW_CONTACT);
+              canViewActivity = can(PermissionActions.VIEW_CONTACT, activity);
             }
           }
 

--- a/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTable.tsx
@@ -28,7 +28,7 @@ import Pagination from '../pagination';
 import { CASES_PER_PAGE } from './CaseList';
 import type { Case } from '../../types/types';
 import * as CaseListSettingsActions from '../../states/caseList/settings';
-import { getPermissionsForCase, PermissionActions } from '../../permissions';
+import { PermissionActions, getInitializedCan } from '../../permissions';
 import { namespace } from '../../states/storeNamespaces';
 import { RootState } from '../../states';
 
@@ -57,6 +57,10 @@ const CaseListTable: React.FC<Props> = ({
   counselorsHash,
   currentDefinitionVersion,
 }) => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   const pagesCount = Math.ceil(caseCount / CASES_PER_PAGE);
 
   return (
@@ -85,13 +89,12 @@ const CaseListTable: React.FC<Props> = ({
             <TableBody>
               {caseList.length > 0 ? (
                 caseList.map(caseItem => {
-                  const { can } = getPermissionsForCase(caseItem.twilioWorkerId, caseItem.status);
                   return (
                     <CaseListTableRow
                       caseItem={caseItem}
                       key={`CaseListItem-${caseItem.id}`}
                       handleClickViewCase={currentCase =>
-                        can(PermissionActions.VIEW_CASE) && handleClickViewCase(currentCase)
+                        can(PermissionActions.VIEW_CASE, caseItem) ? handleClickViewCase(currentCase) : () => undefined
                       }
                       counselorsHash={counselorsHash}
                     />

--- a/plugin-hrm-form/src/components/caseMergingBanners/AddToCaseBanner.tsx
+++ b/plugin-hrm-form/src/components/caseMergingBanners/AddToCaseBanner.tsx
@@ -18,7 +18,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { Template } from '@twilio/flex-ui';
 
 import { Case, Contact, CustomITask, StandaloneITask } from '../../types/types';
-import { getPermissionsForCase, getPermissionsForContact, PermissionActions } from '../../permissions';
+import { getInitializedCan, PermissionActions } from '../../permissions';
 import { RootState } from '../../states';
 import selectCurrentRouteCaseState from '../../states/case/selectCurrentRouteCase';
 import { isStandaloneITask } from '../case/Case';
@@ -57,8 +57,10 @@ const AddToCaseBanner: React.FC<Props> = ({
   connectCaseToTaskContact,
   closeModal,
 }: Props) => {
-  const { can: canForCase } = getPermissionsForCase(connectedCase.twilioWorkerId, connectedCase.status);
-  const { can: canForContact } = getPermissionsForContact(taskContact?.twilioWorkerId);
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   const isConnectedToTaskContact = taskContact && taskContact.caseId === connectedCase.id;
 
   const showConnectToCaseButton = Boolean(
@@ -66,8 +68,8 @@ const AddToCaseBanner: React.FC<Props> = ({
       !taskContact.caseId &&
       !isConnectedToTaskContact &&
       connectedCase?.connectedContacts?.length &&
-      canForCase(PermissionActions.UPDATE_CASE_CONTACTS) &&
-      canForContact(PermissionActions.ADD_CONTACT_TO_CASE),
+      can(PermissionActions.UPDATE_CASE_CONTACTS, connectedCase) &&
+      can(PermissionActions.ADD_CONTACT_TO_CASE, taskContact),
   );
 
   if (!showConnectToCaseButton) {

--- a/plugin-hrm-form/src/components/profile/ProfileCases.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileCases.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { getPermissionsForCase, PermissionActions } from '../../permissions';
+import { getInitializedCan, PermissionActions } from '../../permissions';
 import { Case } from '../../types/types';
 import CasePreview from '../search/CasePreview';
 import ProfileRelationshipList from './ProfileRelationshipList';
@@ -31,10 +31,13 @@ type OwnProps = ProfileCommonProps;
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileCases: React.FC<Props> = ({ profileId, task, counselorsHash, viewCaseDetails }) => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   const renderItem = (cas: Case) => {
-    const { can } = getPermissionsForCase(cas.twilioWorkerId, cas.status);
     const handleClickViewCase = () => {
-      if (can(PermissionActions.VIEW_CASE)) {
+      if (can(PermissionActions.VIEW_CASE, cas)) {
         viewCaseDetails(cas);
       }
     };

--- a/plugin-hrm-form/src/components/profile/ProfileContacts.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileContacts.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { getPermissionsForContact, PermissionActions } from '../../permissions';
+import { getInitializedCan, PermissionActions } from '../../permissions';
 import { Contact } from '../../types/types';
 import ContactPreview from '../search/ContactPreview';
 import * as ProfileTypes from '../../states/profile/types';
@@ -29,10 +29,13 @@ type OwnProps = ProfileCommonProps;
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileContacts: React.FC<Props> = ({ profileId, viewContactDetails }) => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   const renderItem = (contact: Contact) => {
-    const { can } = getPermissionsForContact(contact.twilioWorkerId);
     const handleViewDetails = () => {
-      if (can(PermissionActions.VIEW_CONTACT)) viewContactDetails(contact);
+      if (can(PermissionActions.VIEW_CONTACT, contact)) viewContactDetails(contact);
     };
 
     return (

--- a/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/PreviousContactsBanner.tsx
@@ -32,7 +32,7 @@ import { StyledLink } from '../../search/styles';
 import { CoreChannelTypes, coreChannelTypes } from '../../../states/DomainConstants';
 import { changeRoute, newOpenModalAction } from '../../../states/routing/actions';
 import { getContactValueTemplate, getFormattedNumberFromTask, getNumberFromTask } from '../../../utils';
-import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
+import { getInitializedCan, PermissionActions } from '../../../permissions';
 import { CustomITask, isTwilioTask } from '../../../types/types';
 import { selectCounselorsHash } from '../../../states/configuration/selectCounselorsHash';
 import selectPreviousContactCounts from '../../../states/search/selectPreviousContactCounts';
@@ -52,6 +52,10 @@ const PreviousContactsBanner: React.FC<Props> = ({
   searchCases,
   openContactSearchResults,
 }) => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   let localizedSourceFromTask: { [channelType in CoreChannelTypes]: string };
 
   if (isTwilioTask(task)) {
@@ -67,8 +71,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
     };
   }
 
-  const { canView } = getPermissionsForViewingIdentifiers();
-  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
 
   let contactNumber: ReturnType<typeof getFormattedNumberFromTask>;
   if (isTwilioTask(task)) {

--- a/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/ProfileIdentifierBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileIdentifierBanner/ProfileIdentifierBanner.tsx
@@ -26,7 +26,7 @@ import { StyledLink } from '../../search/styles';
 import { CoreChannelTypes, coreChannelTypes } from '../../../states/DomainConstants';
 import { newOpenModalAction } from '../../../states/routing/actions';
 import { getFormattedNumberFromTask, getNumberFromTask, getContactValueTemplate } from '../../../utils';
-import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
+import { getInitializedCan, PermissionActions } from '../../../permissions';
 import { CustomITask } from '../../../types/types';
 
 type OwnProps = {
@@ -49,6 +49,10 @@ const connector = connect(null, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal }) => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   const formattedIdentifier = getFormattedNumberFromTask(task);
   const identifierIdentifier = getNumberFromTask(task);
   const { identifier } = useIdentifierByIdentifier({ identifierIdentifier, shouldAutoload: true });
@@ -71,8 +75,7 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal }) =>
     [coreChannelTypes.line]: 'PreviousContacts-LineUser',
   };
 
-  const { canView } = getPermissionsForViewingIdentifiers();
-  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
 
   // We immediately create a contact when a task is created, so we don't want to show the banner
   const shouldDisplayBanner = contactsCount > 0 || casesCount > 0;

--- a/plugin-hrm-form/src/components/search/CasePreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/CasePreview/index.tsx
@@ -34,7 +34,7 @@ import { connectToCaseAsyncAction } from '../../../states/contacts/saveContact';
 import selectContactByTaskSid from '../../../states/contacts/selectContactByTaskSid';
 import { isStandaloneITask } from '../../case/Case';
 import { newCloseModalAction } from '../../../states/routing/actions';
-import { getPermissionsForCase, getPermissionsForContact, PermissionActions } from '../../../permissions';
+import { getInitializedCan, PermissionActions } from '../../../permissions';
 import { getAseloFeatureFlags } from '../../../hrmConfig';
 import { PreviewRow } from '../styles';
 
@@ -85,6 +85,10 @@ const CasePreview: React.FC<Props> = ({
   const summary = info?.summary || callSummary;
   const counselor = counselorsHash[twilioWorkerId];
 
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   useEffect(() => {
     if (versionId && !definitionVersions[versionId]) {
       getDefinitionVersion(versionId).then(definitionVersion => updateDefinitionVersion(versionId, definitionVersion));
@@ -104,11 +108,9 @@ const CasePreview: React.FC<Props> = ({
   if (getAseloFeatureFlags().enable_case_merging && taskContact) {
     isConnectedToTaskContact = Boolean(connectedContacts?.find(contact => contact.id === taskContact.id));
 
-    const { can: canForCase } = getPermissionsForCase(currentCase.twilioWorkerId, currentCase.status);
-    const { can: canForContact } = getPermissionsForContact(taskContact?.twilioWorkerId);
     showConnectButton = Boolean(
-      canForCase(PermissionActions.UPDATE_CASE_CONTACTS) &&
-        canForContact(PermissionActions.ADD_CONTACT_TO_CASE) &&
+      can(PermissionActions.UPDATE_CASE_CONTACTS, taskContact) &&
+        can(PermissionActions.ADD_CONTACT_TO_CASE, currentCase) &&
         connectedContacts?.length &&
         (!taskContact.caseId || isConnectedToTaskContact),
     );

--- a/plugin-hrm-form/src/components/search/ContactPreview/ContactHeader.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ContactHeader.tsx
@@ -33,7 +33,7 @@ import {
 import { isNonDataCallType } from '../../../states/validationRules';
 import CallTypeIcon from '../../common/icons/CallTypeIcon';
 import { channelTypes, ChannelTypes } from '../../../states/DomainConstants';
-import { getPermissionsForViewingIdentifiers, PermissionActions } from '../../../permissions';
+import { getInitializedCan, PermissionActions } from '../../../permissions';
 import InfoIcon from '../../caseMergingBanners/InfoIcon';
 
 type OwnProps = {
@@ -72,14 +72,17 @@ const ContactHeader: React.FC<Props> = ({
   onClickFull,
   isDraft,
 }) => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   const dateObj = new Date(date);
   const dateString = `${format(dateObj, 'MMM d, yyyy')}, ${dateObj.toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
   })}`;
   const showNumber = isNonDataCallType(callType) && Boolean(number);
-  const { canView } = getPermissionsForViewingIdentifiers();
-  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
 
   return (
     <>

--- a/plugin-hrm-form/src/components/search/SearchForm/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.tsx
@@ -37,7 +37,7 @@ import { getContactValueTemplate, getFormattedNumberFromTask, getNumberFromTask 
 import {
   canOnlyViewOwnCases,
   canOnlyViewOwnContacts,
-  getPermissionsForViewingIdentifiers,
+  getInitializedCan,
   PermissionActions,
 } from '../../../permissions';
 import { channelTypes } from '../../../states/DomainConstants';
@@ -83,6 +83,10 @@ const SearchForm: React.FC<Props> = ({
   task,
   handleSearch,
 }) => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
   const defaultEventHandlers = fieldName => ({
     handleChange: e => {
       handleSearchFormChange(fieldName, e.target.value);
@@ -150,8 +154,7 @@ const SearchForm: React.FC<Props> = ({
     [channelTypes.line]: 'PreviousContacts-LineUser',
   };
 
-  const { canView } = getPermissionsForViewingIdentifiers();
-  const maskIdentifiers = !canView(PermissionActions.VIEW_IDENTIFIERS);
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
 
   const canChooseCounselor = !(canOnlyViewOwnContacts() || canOnlyViewOwnCases());
 

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -45,7 +45,7 @@ import {
   Text,
 } from '../styles';
 import Pagination from '../../pagination';
-import { getPermissionsForCase, getPermissionsForContact, PermissionActions } from '../../../permissions';
+import { getInitializedCan, PermissionActions } from '../../../permissions';
 import { namespace } from '../../../states/storeNamespaces';
 import { RootState } from '../../../states';
 import { getCurrentTopmostRouteForTask } from '../../../states/routing/getRoute';
@@ -109,6 +109,10 @@ const SearchResults: React.FC<Props> = ({
   // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const { subroute: currentResultPage, casesPage, contactsPage } = routing as SearchResultRoute;
+
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
 
   const strings = getTemplateStrings();
 
@@ -220,13 +224,16 @@ const SearchResults: React.FC<Props> = ({
       {cases &&
         cases.length > 0 &&
         cases.map(cas => {
-          const { can } = getPermissionsForCase(cas.twilioWorkerId, cas.status);
           return (
             <CasePreview
               key={cas.id}
               currentCase={cas}
               counselorsHash={counselorsHash}
-              onClickViewCase={can(PermissionActions.VIEW_CASE) && handleClickViewCase(cas)}
+              onClickViewCase={() => {
+                if (can(PermissionActions.VIEW_CASE, cas)) {
+                  handleClickViewCase(cas);
+                }
+              }}
               task={task}
             />
           );
@@ -382,12 +389,13 @@ const SearchResults: React.FC<Props> = ({
                   {contacts &&
                     contacts.length > 0 &&
                     contacts.map(contact => {
-                      const { can } = getPermissionsForContact(contact.twilioWorkerId);
                       return (
                         <ContactPreview
                           key={contact.id}
                           contact={contact}
-                          handleViewDetails={() => can(PermissionActions.VIEW_CONTACT) && viewContactDetails(contact)}
+                          handleViewDetails={() =>
+                            can(PermissionActions.VIEW_CONTACT, contact) && viewContactDetails(contact)
+                          }
                         />
                       );
                     })}

--- a/plugin-hrm-form/src/permissions/br.json
+++ b/plugin-hrm-form/src/permissions/br.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/ca.json
+++ b/plugin-hrm-form/src/permissions/ca.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isOwner"], ["isSupervisor"]],
   "viewRecording": [["isOwner"], ["isSupervisor"]],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/cl.json
+++ b/plugin-hrm-form/src/permissions/cl.json
@@ -25,7 +25,8 @@
   "viewExternalTranscript": [["everyone"]],
   "viewRecording": [["everyone"]],
   "addContactToCase": [["everyone"]],
-  
+  "removeContactFromCase": [],
+
   "viewPostSurvey":  [["isSupervisor"]],
 
   "viewIdentifiers": [["everyone"]]

--- a/plugin-hrm-form/src/permissions/co.json
+++ b/plugin-hrm-form/src/permissions/co.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [["isSupervisor"]],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
   
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/demo.json
+++ b/plugin-hrm-form/src/permissions/demo.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["everyone"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/dev.json
+++ b/plugin-hrm-form/src/permissions/dev.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["everyone"]],
   "viewRecording": [["everyone"]],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/e2e.json
+++ b/plugin-hrm-form/src/permissions/e2e.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/et.json
+++ b/plugin-hrm-form/src/permissions/et.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/hu.json
+++ b/plugin-hrm-form/src/permissions/hu.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [["isSupervisor"]],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/in.json
+++ b/plugin-hrm-form/src/permissions/in.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -311,10 +311,6 @@ const setupAllow = <T extends TargetKind>(kind: T, conditionsSets: TKConditionsS
         ...appliedTimeBasedConditions,
       };
 
-      console.log('>>>>>>>>>>>>>> performer', performer);
-      console.log('>>>>>>>>>>>>>> target', target);
-      console.log('>>>>>>>>>>>>>> conditionsState', conditionsState);
-
       return checkConditionsSets(conditionsState, conditionsSets);
     } else if (kind === 'contact') {
       const conditionsState: ConditionsState = {

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -14,7 +14,9 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import type * as t from '../types/types';
+import parseISO from 'date-fns/parseISO';
+import { differenceInDays, differenceInHours } from 'date-fns';
+
 import { fetchRules } from './fetchRules';
 import { getHrmConfig } from '../hrmConfig';
 
@@ -26,20 +28,20 @@ export const CaseActions = {
   REOPEN_CASE: 'reopenCase',
   CASE_STATUS_TRANSITION: 'caseStatusTransition',
   ADD_NOTE: 'addNote',
+  EDIT_NOTE: 'editNote',
   ADD_REFERRAL: 'addReferral',
+  EDIT_REFERRAL: 'editReferral',
   ADD_HOUSEHOLD: 'addHousehold',
+  EDIT_HOUSEHOLD: 'editHousehold',
   ADD_PERPETRATOR: 'addPerpetrator',
+  EDIT_PERPETRATOR: 'editPerpetrator',
   ADD_INCIDENT: 'addIncident',
+  EDIT_INCIDENT: 'editIncident',
   ADD_DOCUMENT: 'addDocument',
+  EDIT_DOCUMENT: 'editDocument',
   EDIT_CASE_SUMMARY: 'editCaseSummary',
   EDIT_CHILD_IS_AT_RISK: 'editChildIsAtRisk',
   EDIT_FOLLOW_UP_DATE: 'editFollowUpDate',
-  EDIT_NOTE: 'editNote',
-  EDIT_REFERRAL: 'editReferral',
-  EDIT_HOUSEHOLD: 'editHousehold',
-  EDIT_PERPETRATOR: 'editPerpetrator',
-  EDIT_INCIDENT: 'editIncident',
-  EDIT_DOCUMENT: 'editDocument',
   UPDATE_CASE_CONTACTS: 'updateCaseContacts',
 } as const;
 
@@ -49,6 +51,7 @@ export const ContactActions = {
   VIEW_EXTERNAL_TRANSCRIPT: 'viewExternalTranscript',
   VIEW_RECORDING: 'viewRecording',
   ADD_CONTACT_TO_CASE: 'addContactToCase',
+  REMOVE_CONTACT_FROM_CASE: 'removeContactFromCase',
 } as const;
 
 export const ViewIdentifiersAction = {
@@ -67,20 +70,98 @@ type Condition = 'isSupervisor' | 'isCreator' | 'isCaseOpen' | 'isOwner' | 'ever
 export type ConditionsSet = Condition[];
 type ConditionsSets = ConditionsSet[];
 
-type ConditionsState = Partial<{
-  isSupervisor: boolean;
-  isCreator: boolean;
-  isCaseOpen: boolean;
-  isOwner: boolean;
-  everyone: boolean;
-}>;
+type ConditionsState = {
+  [k: string]: boolean;
+};
 
-const checkCondition = (conditionsState: ConditionsState) => (condition: Condition) => conditionsState[condition];
-const checkConditionsSet = (conditionsState: ConditionsState) => (conditionsSet: ConditionsSet) =>
-  conditionsSet.every(checkCondition(conditionsState));
-const checkConditionsSets = (conditionsState: ConditionsState) => (conditionsSets: ConditionsSets) =>
-  conditionsSets.some(checkConditionsSet(conditionsState));
+const timeBasedConditions = ['createdHoursAgo', 'createdDaysAgo'] as const;
+type TimeBasedCondition = { [K in typeof timeBasedConditions[number]]: number };
 
+const isTimeBasedCondition = (c: any): c is TimeBasedCondition => {
+  if (typeof c === 'object') {
+    const [[cond, param]] = Object.entries(c);
+    return timeBasedConditions.includes(cond as any) && typeof param === 'number';
+  }
+
+  return false;
+};
+
+const userBasedConditions = ['isSupervisor', 'everyone'] as const;
+type UserBasedCondition = typeof userBasedConditions[number];
+
+const isUserBasedCondition = (c: any): c is UserBasedCondition =>
+  typeof c === 'string' && userBasedConditions.includes(c as any);
+
+const contactSpecificConditions = ['isOwner'] as const;
+type ContactSpecificCondition = typeof contactSpecificConditions[number];
+
+const isContactSpecificCondition = (c: any): c is ContactSpecificCondition =>
+  typeof c === 'string' && contactSpecificConditions.includes(c as any);
+
+const caseSpecificConditions = ['isCreator', 'isCaseOpen'] as const;
+type CaseSpecificCondition = typeof caseSpecificConditions[number];
+
+const isCaseSpecificCondition = (c: any): c is CaseSpecificCondition =>
+  typeof c === 'string' && caseSpecificConditions.includes(c as any);
+
+type SupportedContactCondition = TimeBasedCondition | UserBasedCondition | ContactSpecificCondition;
+const isSupportedContactCondition = (c: any): c is SupportedContactCondition =>
+  isTimeBasedCondition(c) || isUserBasedCondition(c) || isContactSpecificCondition(c);
+
+type SupportedCaseCondition = TimeBasedCondition | UserBasedCondition | CaseSpecificCondition;
+const isSupportedCaseCondition = (c: any): c is SupportedCaseCondition =>
+  isTimeBasedCondition(c) || isUserBasedCondition(c) || isCaseSpecificCondition(c);
+
+type SupportedPostSurveyCondition = TimeBasedCondition | UserBasedCondition;
+const isSupportedPostSurveyCondition = (c: any): c is SupportedPostSurveyCondition =>
+  isTimeBasedCondition(c) || isUserBasedCondition(c);
+
+type SupportedViewIdentifiersCondition = UserBasedCondition;
+const isSupportedViewIdentifiersCondition = (c: any): c is SupportedPostSurveyCondition => isUserBasedCondition(c);
+
+// Defines which actions are supported on each TargetKind
+type SupportedTKCondition = {
+  contact: SupportedContactCondition;
+  case: SupportedCaseCondition;
+  postSurvey: SupportedPostSurveyCondition;
+  viewIdentifiers: SupportedViewIdentifiersCondition;
+};
+
+type TargetKind = keyof typeof actionsMaps;
+
+type TKCondition<T extends TargetKind> = SupportedTKCondition[T];
+type TKConditionsSet<T extends TargetKind> = TKCondition<T>[];
+type TKConditionsSets<T extends TargetKind> = TKConditionsSet<T>[];
+
+/**
+ * Given a conditionsState and a condition, returns true if the condition is true in the conditionsState
+ */
+const checkCondition = <T extends TargetKind>(conditionsState: ConditionsState) => (
+  condition: TKCondition<T>,
+): boolean => {
+  if (isTimeBasedCondition(condition)) {
+    return conditionsState[JSON.stringify(condition)];
+  }
+
+  return conditionsState[condition as string];
+};
+
+/**
+ * Given a conditionsState and a set of conditions, returns true if all the conditions are true in the conditionsState
+ */
+const checkConditionsSet = <T extends TargetKind>(conditionsState: ConditionsState) => (
+  conditionsSet: TKConditionsSet<T>,
+): boolean => conditionsSet.length > 0 && conditionsSet.every(checkCondition(conditionsState));
+
+/**
+ * Given a conditionsState and a set of conditions sets, returns true if one of the conditions sets contains conditions that are all true in the conditionsState
+ */
+const checkConditionsSets = <T extends TargetKind>(
+  conditionsState: ConditionsState,
+  conditionsSets: TKConditionsSets<T>,
+): boolean => conditionsSets.some(checkConditionsSet(conditionsState));
+
+// eslint-disable-next-line import/no-unused-modules
 export const actionsMaps = {
   case: CaseActions,
   contact: ContactActions,
@@ -90,35 +171,80 @@ export const actionsMaps = {
   viewIdentifiers: ViewIdentifiersAction,
 } as const;
 
-// Defines which actions are supported on each TargetKind
-const supportedTargetKindActions = {
-  case: ['isSupervisor', 'isCreator', 'isCaseOpen', 'everyone'],
-  contact: ['isSupervisor', 'isOwner', 'everyone'],
-  postSurvey: ['isSupervisor', 'everyone'],
-  viewIdentifiers: ['isSupervisor', 'everyone'],
+const isTKCondition = <T extends TargetKind>(kind: T) => (c: any): c is TKCondition<T> => {
+  if (!c) {
+    return false;
+  }
+
+  switch (kind) {
+    case 'contact': {
+      return isSupportedContactCondition(c);
+    }
+    case 'case': {
+      return isSupportedCaseCondition(c);
+    }
+    case 'postSurvey': {
+      return isSupportedPostSurveyCondition(c);
+    }
+    case 'viewIdentifiers': {
+      return isSupportedViewIdentifiersCondition(c);
+    }
+    default: {
+      return false;
+    }
+  }
 };
 
-const isValidTargetKind = (kind: string, css: ConditionsSets) =>
-  css.every(cs => cs.every(c => supportedTargetKindActions[kind].includes(c)));
+const isTKConditionsSet = <T extends TargetKind>(kind: TargetKind) => (cs: any): cs is TKConditionsSet<T> =>
+  cs && Array.isArray(cs) && cs.every(isTKCondition(kind));
 
-const validateTargetKindActions = (rules, kind: keyof typeof actionsMaps) =>
-  Object.values(actionsMaps[kind]).reduce<{ [k in keyof typeof actionsMaps]: boolean }>((accum, action) => {
-    return {
-      ...accum,
-      [action]: isValidTargetKind(kind, rules[action]),
-    };
-  }, {} as any);
+const isTKConditionsSets = <T extends TargetKind>(kind: TargetKind) => (css: any): css is TKConditionsSets<T> =>
+  css && Array.isArray(css) && css.every(isTKConditionsSet(kind));
 
-const isValidTargetKindActions = (validated: { [k in keyof typeof actionsMaps]: boolean }) =>
-  Object.values(validated).every(Boolean);
+/**
+ * Utility type that given an object with any nesting depth, will return the union of all the leaves that are of type "string"
+ */
+type NestedStringValues<T> = T extends object
+  ? { [K in keyof T]: T[K] extends string ? T[K] : NestedStringValues<T[K]> }[keyof T]
+  : never;
+type Actions = NestedStringValues<typeof actionsMaps>;
+type RulesFile = { [k in Actions]: TKConditionsSets<TargetKind> };
 
-export const validateRules = (permissionConfig: string, kind: keyof typeof actionsMaps) => {
+const isValidTKConditionsSets = <T extends TargetKind>(kind: T) => (
+  css: TKConditionsSets<TargetKind>,
+): css is TKConditionsSets<typeof kind> => css.every(cs => cs.every(isTKCondition(kind)));
+
+const isRulesFile = (rules: any): rules is RulesFile =>
+  Object.values(actionsMaps).every(map => Object.values(map).every(action => isTKConditionsSets(rules[action])));
+
+/**
+ * Validates that for every TK, the ConditionsSets provided are valid
+ * (i.e. present in supportedTKConditions)
+ */
+const validateTKActions = (rules: RulesFile) =>
+  Object.entries(actionsMaps)
+    .map(([kind, map]) =>
+      Object.values(map).reduce((accum, action) => {
+        return {
+          ...accum,
+          [action]: rules[action] && isValidTKConditionsSets(kind as TargetKind)(rules[action]),
+        };
+      }, {}),
+    )
+    .reduce<{ [k in Actions]: boolean }>((accum, obj) => ({ ...accum, ...obj }), {} as any);
+
+const isValidTargetKindActions = (validated: { [k in Actions]: boolean }) => Object.values(validated).every(Boolean);
+
+export const validateRules = (permissionConfig: string) => {
   const rules = fetchRules(permissionConfig);
 
-  const rulesAreValid = Object.values(PermissionActions).every(action => rules[action]);
-  if (!rulesAreValid) throw new Error(`Rules file for ${permissionConfig} is incomplete. Missing actions for ${kind}`);
+  // const rulesAreValid = Object.values(PermissionActions).map(action => {
+  //   console.log('>>>>> rules[action] exists for action:', action, rules[action])
+  //   return Boolean(rules[action])
+  // });
+  // if (!rulesAreValid.every(Boolean)) throw new Error(`Rules file for ${permissionConfig} is incomplete.`);
 
-  const validated = validateTargetKindActions(rules, kind);
+  const validated = validateTKActions(rules);
 
   if (!isValidTargetKindActions(validated)) {
     const invalidActions = Object.entries(validated)
@@ -131,88 +257,133 @@ export const validateRules = (permissionConfig: string, kind: keyof typeof actio
   return rules;
 };
 
-export const getPermissionsForCase = (twilioWorkerId: t.Case['twilioWorkerId'], status: t.Case['status']) => {
+type TwilioUser = {
+  workerSid: string;
+
+  roles: string[];
+  isSupervisor: boolean;
+};
+
+const isCounselorWhoCreated = (user: TwilioUser, caseObj: any) => user.workerSid === caseObj.twilioWorkerId;
+
+const isCaseOpen = (caseObj: any) => caseObj.status !== 'closed';
+
+const isContactOwner = (user: TwilioUser, contactObj: any) => user.workerSid === contactObj.twilioWorkerId;
+
+const applyTimeBasedConditions = (conditions: TimeBasedCondition[]) => (
+  performer: TwilioUser,
+  target: any,
+  ctx: { curentTimestamp: Date },
+) =>
+  conditions
+    .map(c => Object.entries(c)[0])
+    .reduce<Record<string, boolean>>((accum, [cond, param]) => {
+      // use the stringified cond-param as key, e.g. '{ "createdHoursAgo": "4" }'
+      const key = JSON.stringify({ [cond]: param });
+      if (cond === 'createdHoursAgo') {
+        return {
+          ...accum,
+          [key]: differenceInHours(ctx.curentTimestamp, parseISO(target.createdAt)) < param,
+        };
+      }
+
+      if (cond === 'createdDaysAgo') {
+        return {
+          ...accum,
+          [key]: differenceInDays(ctx.curentTimestamp, parseISO(target.createdAt)) < param,
+        };
+      }
+
+      return accum;
+    }, {});
+
+const setupAllow = <T extends TargetKind>(kind: T, conditionsSets: TKConditionsSets<T>) => {
+  // We could do type validation on target depending on targetKind if we ever want to make sure the "allow" is called on a proper target (same as cancan used to do)
+
+  const timeBasedConditions = conditionsSets.flatMap(cs => cs.filter(isTimeBasedCondition)) as TimeBasedCondition[];
+
+  return (performer: TwilioUser, target: any) => {
+    const ctx = { curentTimestamp: new Date() };
+
+    const appliedTimeBasedConditions = applyTimeBasedConditions(timeBasedConditions)(performer, target, ctx);
+
+    // Build the proper conditionsState depending on the targetKind
+    if (kind === 'case') {
+      const conditionsState: ConditionsState = {
+        isSupervisor: performer.isSupervisor,
+        isCreator: isCounselorWhoCreated(performer, target),
+        isCaseOpen: isCaseOpen(target),
+        everyone: true,
+        ...appliedTimeBasedConditions,
+      };
+
+      return checkConditionsSets(conditionsState, conditionsSets);
+    } else if (kind === 'contact') {
+      const conditionsState: ConditionsState = {
+        isSupervisor: performer.isSupervisor,
+        isOwner: isContactOwner(performer, target),
+        everyone: true,
+        createdDaysAgo: false,
+        createdHoursAgo: false,
+        ...appliedTimeBasedConditions,
+      };
+
+      return checkConditionsSets(conditionsState, conditionsSets);
+    } else if (kind === 'postSurvey') {
+      const conditionsState: ConditionsState = {
+        isSupervisor: performer.isSupervisor,
+        everyone: true,
+        ...appliedTimeBasedConditions,
+      };
+
+      return checkConditionsSets(conditionsState, conditionsSets);
+    } else if (kind === 'viewIdentifiers') {
+      const conditionsState: ConditionsState = {
+        isSupervisor: performer.isSupervisor,
+        everyone: true,
+      };
+
+      return checkConditionsSets(conditionsState, conditionsSets);
+    }
+
+    return false;
+  };
+};
+
+const initializeCanForRules = (rules: RulesFile) => {
+  const actionCheckers = {} as { [action in Actions]: ReturnType<typeof setupAllow> };
+
+  const targetKinds = Object.keys(actionsMaps);
+  targetKinds.forEach((targetKind: TargetKind) => {
+    const actionsForTK = Object.values(actionsMaps[targetKind]) as Actions[];
+    actionsForTK.forEach(action => (actionCheckers[action] = setupAllow(targetKind, rules[action])));
+  });
+
+  return (performer: TwilioUser, action: Actions, target: any) => actionCheckers[action](performer, target);
+};
+
+let initializedCan: (performer: TwilioUser, action: Actions, target?: any) => boolean = null;
+export const getInitializedCan = () => {
   const { workerSid, isSupervisor, permissionConfig } = getHrmConfig();
+  if (initializedCan === null) {
+    const rules = validateRules(permissionConfig);
+    initializedCan = initializeCanForRules(rules);
+  }
 
-  if (!permissionConfig || !twilioWorkerId || !status) return { can: undefined };
-
-  const isCreator = workerSid === twilioWorkerId;
-  const isCaseOpen = status !== 'closed';
-
-  const conditionsState: Partial<{ [condition in Condition]: boolean }> = {
-    isSupervisor,
-    isCreator,
-    isCaseOpen,
-    everyone: true,
-  };
-
-  const rules = validateRules(permissionConfig, 'case');
-
-  const can = (action: PermissionActionType): boolean => {
-    if (!rules[action]) {
-      console.error(`Cannot find rules for ${action}. Returning false.`);
-      return isSupervisor || (isCreator && isCaseOpen);
-    }
-
-    return checkConditionsSets(conditionsState)(rules[action]);
-  };
-
-  return {
-    can,
+  const performer = { isSupervisor, workerSid, roles: null };
+  return (action: Actions, target?: any) => {
+    console.log(
+      '>>>>>>> checking if',
+      performer,
+      'can',
+      action,
+      'on',
+      target,
+      'evaluates to',
+      initializedCan(performer, action, target),
+    );
+    return initializedCan(performer, action, target);
   };
 };
 
-export const getPermissionsForContact = (twilioWorkerId: t.Contact['twilioWorkerId']) => {
-  const { workerSid, isSupervisor, permissionConfig } = getHrmConfig();
-
-  if (!permissionConfig || !twilioWorkerId) return { can: undefined };
-
-  const isOwner = workerSid === twilioWorkerId;
-
-  const conditionsState: Partial<{ [condition in Condition]: boolean }> = {
-    isSupervisor,
-    isOwner,
-    everyone: true,
-  };
-
-  const rules = validateRules(permissionConfig, 'contact');
-
-  const can = (action: PermissionActionType): boolean => {
-    if (!rules[action]) {
-      console.error(`Cannot find rules for ${action}. Returning false.`);
-      return isSupervisor || isOwner;
-    }
-
-    return checkConditionsSets(conditionsState)(rules[action]);
-  };
-
-  return {
-    can,
-  };
-};
-
-export const getPermissionsForViewingIdentifiers = () => {
-  const { isSupervisor, permissionConfig } = getHrmConfig();
-
-  if (!permissionConfig) return { canView: undefined };
-
-  const conditionsState: Partial<{ [condition in Condition]: boolean }> = {
-    isSupervisor,
-    everyone: true,
-  };
-
-  const rules = validateRules(permissionConfig, 'viewIdentifiers');
-
-  const canView = (action: PermissionActionType): boolean => {
-    if (!rules[action]) {
-      console.error(`Cannot find rules for ${action}. Returning false.`);
-      return isSupervisor;
-    }
-
-    return checkConditionsSets(conditionsState)(rules[action]);
-  };
-
-  return {
-    canView,
-  };
-};
+type InitializeCan = ReturnType<typeof getInitializedCan>;

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -68,7 +68,8 @@ type PermissionActionsKeys = keyof typeof PermissionActions;
 export type PermissionActionType = typeof PermissionActions[PermissionActionsKeys];
 type Condition = 'isSupervisor' | 'isCreator' | 'isCaseOpen' | 'isOwner' | 'everyone';
 export type ConditionsSet = Condition[];
-type ConditionsSets = ConditionsSet[];
+// eslint-disable-next-line import/no-unused-modules
+export type ConditionsSets = ConditionsSet[];
 
 type ConditionsState = {
   [k: string]: boolean;

--- a/plugin-hrm-form/src/permissions/jm.json
+++ b/plugin-hrm-form/src/permissions/jm.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/mt.json
+++ b/plugin-hrm-form/src/permissions/mt.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["everyone"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/mw.json
+++ b/plugin-hrm-form/src/permissions/mw.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/nz.json
+++ b/plugin-hrm-form/src/permissions/nz.json
@@ -26,6 +26,7 @@
   "viewRecording":  [],
   "viewPostSurvey":  [["isSupervisor"]],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
   
   "viewIdentifiers": [["everyone"]]
 }

--- a/plugin-hrm-form/src/permissions/ph.json
+++ b/plugin-hrm-form/src/permissions/ph.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/pl.json
+++ b/plugin-hrm-form/src/permissions/pl.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/ro.json
+++ b/plugin-hrm-form/src/permissions/ro.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/sg.json
+++ b/plugin-hrm-form/src/permissions/sg.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["everyone"]],
   "viewRecording": [["everyone"]],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/th.json
+++ b/plugin-hrm-form/src/permissions/th.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/uk.json
+++ b/plugin-hrm-form/src/permissions/uk.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/za.json
+++ b/plugin-hrm-form/src/permissions/za.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/zm.json
+++ b/plugin-hrm-form/src/permissions/zm.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [["everyone"]],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/permissions/zw.json
+++ b/plugin-hrm-form/src/permissions/zw.json
@@ -25,6 +25,7 @@
   "viewExternalTranscript": [["everyone"]],
   "viewRecording": [["isSupervisor"]],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [],
 
   "viewPostSurvey": [["isSupervisor"]],
 

--- a/plugin-hrm-form/src/states/case/caseStatus.ts
+++ b/plugin-hrm-form/src/states/case/caseStatus.ts
@@ -16,7 +16,7 @@
 
 import { DefinitionVersion, StatusInfo } from 'hrm-form-definitions';
 
-import { getPermissionsForCase, PermissionActions } from '../../permissions';
+import { getInitializedCan, PermissionActions } from '../../permissions';
 import { Case } from '../../types/types';
 
 export const getAvailableCaseStatusTransitions = (
@@ -24,7 +24,7 @@ export const getAvailableCaseStatusTransitions = (
   definitionVersion: DefinitionVersion,
 ): StatusInfo[] => {
   if (definitionVersion) {
-    const { can } = getPermissionsForCase(connectedCase.twilioWorkerId, connectedCase.status);
+    const can = getInitializedCan();
     const caseStatusList = Object.values<StatusInfo>(definitionVersion.caseStatus);
     const currentStatusItem = caseStatusList.find(cs => cs.value === connectedCase.status);
     const availableStatusTransitions: string[] = currentStatusItem
@@ -34,11 +34,15 @@ export const getAvailableCaseStatusTransitions = (
       option =>
         availableStatusTransitions.includes(option.value) &&
         (option === currentStatusItem ||
-          (currentStatusItem.value === 'closed' && option.value !== 'closed' && can(PermissionActions.REOPEN_CASE)) ||
-          (currentStatusItem.value !== 'closed' && option.value === 'closed' && can(PermissionActions.CLOSE_CASE)) ||
+          (currentStatusItem.value === 'closed' &&
+            option.value !== 'closed' &&
+            can(PermissionActions.REOPEN_CASE, connectedCase)) ||
+          (currentStatusItem.value !== 'closed' &&
+            option.value === 'closed' &&
+            can(PermissionActions.CLOSE_CASE, connectedCase)) ||
           (currentStatusItem.value !== 'closed' &&
             option.value !== 'closed' &&
-            can(PermissionActions.CASE_STATUS_TRANSITION))),
+            can(PermissionActions.CASE_STATUS_TRANSITION, connectedCase))),
     );
   }
   return [];


### PR DESCRIPTION
## Description
This PR
- Reconciles the permissions frameworks, replicating exactly how it is implemented in HRM.
- Adds support for time based permissions on the client side (replicating what was introduced in [this PR](https://github.com/techmatters/hrm/pull/520)).

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2527)
- [x] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Trust unit tests or
- Change development permissions rules to use the new predicates, as indicated in https://github.com/techmatters/hrm/pull/520, and confirm that the actions are evaluated accordingly (i.e. UI does not allows you to do stuff if the records are older than what you specify in the predicate).