### PR TITLE
CHI-2359: Added case transition rules to terragrunt config, with the …

### DIFF
--- a/plugin-hrm-form/src/___tests__/search/ContactPreview.test.tsx
+++ b/plugin-hrm-form/src/___tests__/search/ContactPreview.test.tsx
@@ -30,6 +30,7 @@ import { getDefinitionVersions } from '../../hrmConfig';
 import { Contact } from '../../types/types';
 import { RootState } from '../../states';
 import { configurationBase, namespace } from '../../states/storeNamespaces';
+import { VALID_EMPTY_CONTACT } from '../testContacts';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 const { mockFetchImplementation, mockReset, buildBaseURL } = useFetchDefinitions();
@@ -67,6 +68,7 @@ test('<ContactPreview> should mount', async () => {
     },
   };
   const contact: Contact = {
+    ...VALID_EMPTY_CONTACT,
     id: '123',
     accountSid: '',
     timeOfContact: '2019-01-01T00:00:00.000Z',
@@ -75,16 +77,7 @@ test('<ContactPreview> should mount', async () => {
     twilioWorkerId: 'WKxxxx',
     helpline: 'test helpline',
     conversationDuration: 0,
-    createdBy: '',
-    createdAt: '',
-    updatedBy: '',
-    updatedAt: '',
-    queueName: '',
-    channelSid: '',
-    serviceSid: '',
     taskId: 'TASK_ID',
-    conversationMedia: [],
-    csamReports: [],
     rawJson: {
       definitionVersion: DefinitionVersionId.v1,
       callType: 'Child calling about self',
@@ -111,22 +104,17 @@ test('<ContactPreview> should mount', async () => {
         wouldTheChildRecommendUsToAFriend: false,
       },
       callerInformation: {},
-      contactlessTask: { channel: 'voice' },
+      contactlessTask: { ...VALID_EMPTY_CONTACT.rawJson.contactlessTask, channel: 'voice' },
     },
   };
 
-  const handleOpenConnectDialog = jest.fn();
   const handleViewDetails = jest.fn();
   const store = mockStore(initialState);
 
   const wrapper = renderer.create(
     <StorelessThemeProvider themeConf={{}}>
       <Provider store={store}>
-        <ContactPreview
-          contact={contact}
-          handleOpenConnectDialog={handleOpenConnectDialog}
-          handleViewDetails={handleViewDetails}
-        />
+        <ContactPreview contact={contact} handleViewDetails={handleViewDetails} />
       </Provider>
     </StorelessThemeProvider>,
   ).root;

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -251,7 +251,6 @@ const Case: React.FC<Props> = ({
     const addScreenProps = {
       task,
       counselor: currentCounselor,
-      counselorsHash,
       definitionVersion,
     };
 

--- a/plugin-hrm-form/src/components/case/CaseSummaryEditHistory.tsx
+++ b/plugin-hrm-form/src/components/case/CaseSummaryEditHistory.tsx
@@ -22,9 +22,9 @@ import { Row } from '../../styles';
 import { CaseActionDetailFont } from './styles';
 import ActionHeader from './ActionHeader';
 import { getAseloFeatureFlags } from '../../hrmConfig';
-import { CaseAuditDetails } from '../../states/case/selectCaseStateByCaseId';
+import { CaseHistoryDetails } from '../../states/case/selectCaseStateByCaseId';
 
-type OwnProps = CaseAuditDetails;
+type OwnProps = CaseHistoryDetails;
 
 type Props = OwnProps;
 

--- a/plugin-hrm-form/src/components/case/CaseSummaryEditHistory.tsx
+++ b/plugin-hrm-form/src/components/case/CaseSummaryEditHistory.tsx
@@ -39,8 +39,8 @@ const CaseSummaryEditHistory: React.FC<Props> = ({ sourceCase, counselorsHash, d
   const previousStatusLabel = previousStatus
     ? definitionVersion.caseStatus[previousStatus]?.label || 'Unknown'
     : 'None';
-  const statusLabel = previousStatus ? definitionVersion.caseStatus[status]?.label || 'Unknown' : undefined;
-  const statusUpdatingCounsellorName = statusUpdatedBy ? counselorsHash[statusUpdatedBy] || 'Unknown' : undefined;
+  const statusLabel = previousStatus ? definitionVersion.caseStatus[status]?.label || `Unknown (${status})` : 'None'; // Shouldn't ever be 'None'
+  const statusUpdatingCounsellorName = statusUpdatedBy ? counselorsHash[statusUpdatedBy] || 'Unknown' : statusUpdatedBy;
   const statusUpdated = statusUpdatedAt ? new Date(statusUpdatedAt) : undefined;
   const { enable_last_case_status_update_info: enableLastCaseStatusUpdateInfo } = getAseloFeatureFlags();
   const { added, addingCounsellorName, updated, updatingCounsellorName } = caseItemHistory(sourceCase, counselorsHash);

--- a/plugin-hrm-form/src/components/case/CaseSummaryEditHistory.tsx
+++ b/plugin-hrm-form/src/components/case/CaseSummaryEditHistory.tsx
@@ -17,51 +17,41 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Template } from '@twilio/flex-ui';
-import { DefinitionVersion } from 'hrm-form-definitions';
 
 import { Row } from '../../styles';
 import { CaseActionDetailFont } from './styles';
-import { Case } from '../../types/types';
 import ActionHeader from './ActionHeader';
-import { caseItemHistory } from '../../states/case/types';
 import { getAseloFeatureFlags } from '../../hrmConfig';
+import { CaseAuditDetails } from '../../states/case/selectCaseStateByCaseId';
 
-type OwnProps = {
-  sourceCase: Case;
-  counselorsHash: { [key: string]: string };
-  definitionVersion: DefinitionVersion;
-};
+type OwnProps = CaseAuditDetails;
 
 type Props = OwnProps;
 
-const CaseSummaryEditHistory: React.FC<Props> = ({ sourceCase, counselorsHash, definitionVersion }) => {
-  const { status, previousStatus, statusUpdatedAt, statusUpdatedBy } = sourceCase;
-  const previousStatusLabel = previousStatus
-    ? definitionVersion.caseStatus[previousStatus]?.label || 'Unknown'
-    : 'None';
-  const statusLabel = previousStatus ? definitionVersion.caseStatus[status]?.label || `Unknown (${status})` : 'None'; // Shouldn't ever be 'None'
-  const statusUpdatingCounsellorName = statusUpdatedBy ? counselorsHash[statusUpdatedBy] || 'Unknown' : statusUpdatedBy;
-  const statusUpdated = statusUpdatedAt ? new Date(statusUpdatedAt) : undefined;
+const CaseSummaryEditHistory: React.FC<Props> = ({
+  createdAt,
+  createdBy,
+  updatedBy,
+  updatedAt,
+  statusUpdatedAt,
+  statusUpdatedBy,
+  previousStatusLabel,
+  statusLabel,
+}) => {
   const { enable_last_case_status_update_info: enableLastCaseStatusUpdateInfo } = getAseloFeatureFlags();
-  const { added, addingCounsellorName, updated, updatingCounsellorName } = caseItemHistory(sourceCase, counselorsHash);
 
   return (
     <>
-      <ActionHeader
-        added={added}
-        addingCounsellor={addingCounsellorName}
-        updated={updated}
-        updatingCounsellor={updatingCounsellorName}
-      />
+      <ActionHeader added={createdAt} addingCounsellor={updatedBy} updated={updatedAt} updatingCounsellor={createdBy} />
 
-      {enableLastCaseStatusUpdateInfo && status && statusUpdated && (
+      {enableLastCaseStatusUpdateInfo && statusUpdatedAt && (
         <Row style={{ width: '100%' }}>
           <CaseActionDetailFont style={{ marginRight: 20 }} data-testid="Case-EditSummary-EditHistory-StatusUpdated">
             <Template
               code="Case-EditSummary-EditHistory-StatusUpdated"
-              date={statusUpdated.toLocaleDateString()}
-              time={statusUpdated.toLocaleTimeString(undefined, { minute: '2-digit', hour: '2-digit' })}
-              counsellor={statusUpdatingCounsellorName}
+              date={statusUpdatedAt.toLocaleDateString()}
+              time={statusUpdatedAt.toLocaleTimeString(undefined, { minute: '2-digit', hour: '2-digit' })}
+              counsellor={statusUpdatedBy}
               previousStatus={previousStatusLabel}
               updatedStatus={statusLabel}
             />

--- a/plugin-hrm-form/src/components/case/CaseSummaryEditHistory.tsx
+++ b/plugin-hrm-form/src/components/case/CaseSummaryEditHistory.tsx
@@ -42,7 +42,7 @@ const CaseSummaryEditHistory: React.FC<Props> = ({
 
   return (
     <>
-      <ActionHeader added={createdAt} addingCounsellor={updatedBy} updated={updatedAt} updatingCounsellor={createdBy} />
+      <ActionHeader added={createdAt} addingCounsellor={createdBy} updated={updatedAt} updatingCounsellor={updatedBy} />
 
       {enableLastCaseStatusUpdateInfo && statusUpdatedAt && (
         <Row style={{ width: '100%' }}>

--- a/plugin-hrm-form/src/components/caseMergingBanners/CaseCreatedBanner.tsx
+++ b/plugin-hrm-form/src/components/caseMergingBanners/CaseCreatedBanner.tsx
@@ -24,7 +24,7 @@ import { removeFromCaseAsyncAction } from '../../states/contacts/saveContact';
 import { newGoBackAction } from '../../states/routing/actions';
 import { getOfflineContactTaskSid } from '../../states/contacts/offlineContactTask';
 import { cancelCaseAsyncAction } from '../../states/case/saveCase';
-import selectCaseStateByCaseId from '../../states/case/selectCaseStateByCaseId';
+import { selectCaseByCaseId } from '../../states/case/selectCaseStateByCaseId';
 import { showRemovedFromCaseBannerAction } from '../../states/case/caseBanners';
 import { CustomITask, StandaloneITask } from '../../types/types';
 import { BannerActionLink, BannerContainer, Text } from '../../styles/banners';
@@ -39,7 +39,7 @@ type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const mapStateToProps = (state, { task, caseId }: OwnProps) => {
   const taskSid = task ? task.taskSid : getOfflineContactTaskSid();
-  const cas = selectCaseStateByCaseId(state, caseId)?.connectedCase;
+  const cas = selectCaseByCaseId(state, caseId)?.connectedCase;
   return {
     cas,
     taskSid,

--- a/plugin-hrm-form/src/components/caseMergingBanners/ContactAddedToCaseBanner.tsx
+++ b/plugin-hrm-form/src/components/caseMergingBanners/ContactAddedToCaseBanner.tsx
@@ -25,7 +25,7 @@ import { newOpenModalAction } from '../../states/routing/actions';
 import type { Case } from '../../types/types';
 import InfoIcon from './InfoIcon';
 import { showRemovedFromCaseBannerAction } from '../../states/case/caseBanners';
-import selectCaseByCaseId from '../../states/case/selectCaseStateByCaseId';
+import { selectCaseByCaseId } from '../../states/case/selectCaseStateByCaseId';
 import { RootState } from '../../states';
 import { BannerActionLink, BannerContainer, CaseLink, Text } from '../../styles/banners';
 import selectContactStateByContactId from '../../states/contacts/selectContactStateByContactId';

--- a/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
@@ -39,7 +39,7 @@ type ContactPreviewProps = {
 
 const mapStateToProps = (state: RootState, { contact }: ContactPreviewProps) => ({
   definitionVersions: selectDefinitionVersions(state),
-  counselorName: selectCounselorName(state, contact.id),
+  counselorName: selectCounselorName(state, contact.twilioWorkerId),
 });
 
 const connector = connect(mapStateToProps);

--- a/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
@@ -28,17 +28,18 @@ import { getDefinitionVersion } from '../../../services/ServerlessService';
 import { updateDefinitionVersion } from '../../../states/configuration/actions';
 import { RootState } from '../../../states';
 import { contactLabelFromHrmContact } from '../../../states/contacts/contactIdentifier';
-import { configurationBase, namespace } from '../../../states/storeNamespaces';
 import { PreviewRow } from '../styles';
+import { selectDefinitionVersions } from '../../../states/configuration/selectDefinitions';
+import { selectCounselorName } from '../../../states/configuration/selectCounselorsHash';
 
 type ContactPreviewProps = {
   contact: Contact;
   handleViewDetails: () => void;
 };
 
-const mapStateToProps = (state: RootState) => ({
-  definitionVersions: state[namespace][configurationBase].definitionVersions,
-  counselorsHash: state[namespace][configurationBase].counselors.hash,
+const mapStateToProps = (state: RootState, { contact }: ContactPreviewProps) => ({
+  definitionVersions: selectDefinitionVersions(state),
+  counselorName: selectCounselorName(state, contact.id),
 });
 
 const connector = connect(mapStateToProps);
@@ -79,10 +80,9 @@ const getCallerName = (rawJson: ContactRawJson) => {
   return undefined;
 };
 
-const ContactPreview: React.FC<Props> = ({ contact, handleViewDetails, definitionVersions, counselorsHash }) => {
+const ContactPreview: React.FC<Props> = ({ contact, handleViewDetails, definitionVersions, counselorName }) => {
   const { callType } = contact.rawJson;
   const callerName = getCallerName(contact.rawJson);
-  const counselorName = counselorsHash[contact.twilioWorkerId] || 'Unknown';
   const { definitionVersion: versionId, caseInformation } = contact.rawJson;
   const { callSummary } = caseInformation;
   const definition = definitionVersions[versionId];

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.tsx
@@ -21,9 +21,8 @@ import { CircularProgress } from '@material-ui/core';
 import FolderIcon from '@material-ui/icons/CreateNewFolderOutlined';
 import { DefinitionVersionId } from 'hrm-form-definitions';
 
-import { Box, BottomButtonBar } from '../../styles';
+import { BottomButtonBar, Box, SaveAndEndButton, StyledNextStepButton } from '../../styles';
 import { AddedToCaseButton } from './styles';
-import { StyledNextStepButton, SaveAndEndButton } from '../../styles/buttons';
 import * as RoutingActions from '../../states/routing/actions';
 import { completeTask } from '../../services/formSubmissionHelpers';
 import { hasTaskControl } from '../../transfer/transferTaskState';
@@ -39,7 +38,7 @@ import { ContactMetadata, LoadingStatus } from '../../states/contacts/types';
 import { AppRoutes } from '../../states/routing/types';
 import AddCaseButton from './AddCaseButton';
 import asyncDispatch from '../../states/asyncDispatch';
-import selectCaseByCaseId from '../../states/case/selectCaseStateByCaseId';
+import { selectCaseByCaseId } from '../../states/case/selectCaseStateByCaseId';
 import selectContactStateByContactId from '../../states/contacts/selectContactStateByContactId';
 import { SuccessReportIcon } from '../CSAMReport/styles';
 

--- a/plugin-hrm-form/src/states/case/sections/selectCaseItemHistory.ts
+++ b/plugin-hrm-form/src/states/case/sections/selectCaseItemHistory.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { CaseSectionApi } from './api';
+import { RootState } from '../..';
+import { Case } from '../../../types/types';
+import { selectCounselorName } from '../../configuration/selectCounselorsHash';
+
+const selectCaseItemHistory = (
+  state: RootState,
+  caseObj: Case,
+  caseSectionApi: CaseSectionApi<unknown>,
+  caseItemId: string,
+) => {
+  const { twilioWorkerId, createdAt, updatedAt, updatedBy } =
+    caseSectionApi.toForm(caseSectionApi.getSectionItemById(caseObj.info, caseItemId)) ?? {};
+  const addingCounsellorName = selectCounselorName(state, twilioWorkerId);
+  const added = new Date(createdAt);
+  const updatingCounsellorName = selectCounselorName(state, updatedBy);
+  const updated = updatedAt ? new Date(updatedAt) : undefined;
+  return { addingCounsellorName, added, updatingCounsellorName, updated };
+};
+
+export default selectCaseItemHistory;

--- a/plugin-hrm-form/src/states/case/selectCaseStateByCaseId.ts
+++ b/plugin-hrm-form/src/states/case/selectCaseStateByCaseId.ts
@@ -17,8 +17,48 @@
 import { RootState } from '..';
 import { connectedCaseBase, namespace } from '../storeNamespaces';
 import { CaseStateEntry } from './types';
+import { selectCounselorName } from '../configuration/selectCounselorsHash';
+import { selectDefinitionVersionForCase } from '../configuration/selectDefinitions';
+import { Case } from '../../types/types';
 
-const selectCaseByCaseId = (state: RootState, caseId: string): CaseStateEntry | undefined =>
+export const selectCaseByCaseId = (state: RootState, caseId: string): CaseStateEntry | undefined =>
   state[namespace][connectedCaseBase].cases[caseId];
 
-export default selectCaseByCaseId;
+export type CaseAuditDetails = {
+  createdAt: Date;
+  createdBy: string;
+  updatedAt?: Date;
+  updatedBy?: string;
+  statusUpdatedAt?: Date;
+  statusUpdatedBy?: string;
+  previousStatusLabel?: string;
+  statusLabel: string;
+};
+
+export const selectCaseHistoryDetails = (state: RootState, caseObj: Case): CaseAuditDetails => {
+  const definitionVersion = selectDefinitionVersionForCase(state, caseObj);
+  const {
+    previousStatus,
+    status,
+    statusUpdatedBy,
+    statusUpdatedAt,
+    twilioWorkerId,
+    createdAt,
+    updatedAt,
+    updatedBy,
+  } = caseObj;
+  const statusLabel = status ? definitionVersion.caseStatus[status]?.label || `Unknown (${status})` : 'None'; // Shouldn't ever be 'None'
+  const previousStatusLabel = previousStatus
+    ? definitionVersion.caseStatus[previousStatus]?.label || `Unknown (${previousStatus})`
+    : 'None';
+  return {
+    createdAt: new Date(createdAt),
+    createdBy: selectCounselorName(state, twilioWorkerId),
+    updatedAt: updatedAt ? new Date(updatedAt) : undefined,
+    updatedBy: selectCounselorName(state, updatedBy),
+    statusUpdatedAt: statusUpdatedAt ? new Date(statusUpdatedAt) : undefined,
+    statusUpdatedBy: selectCounselorName(state, statusUpdatedBy),
+    previousStatusLabel,
+    statusLabel,
+  };
+};

--- a/plugin-hrm-form/src/states/case/selectCaseStateByCaseId.ts
+++ b/plugin-hrm-form/src/states/case/selectCaseStateByCaseId.ts
@@ -24,7 +24,7 @@ import { Case } from '../../types/types';
 export const selectCaseByCaseId = (state: RootState, caseId: string): CaseStateEntry | undefined =>
   state[namespace][connectedCaseBase].cases[caseId];
 
-export type CaseAuditDetails = {
+export type CaseHistoryDetails = {
   createdAt: Date;
   createdBy: string;
   updatedAt?: Date;
@@ -35,7 +35,7 @@ export type CaseAuditDetails = {
   statusLabel: string;
 };
 
-export const selectCaseHistoryDetails = (state: RootState, caseObj: Case): CaseAuditDetails => {
+export const selectCaseHistoryDetails = (state: RootState, caseObj: Case): CaseHistoryDetails => {
   const definitionVersion = selectDefinitionVersionForCase(state, caseObj);
   const {
     previousStatus,

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -114,22 +114,6 @@ export type CaseDetails = {
   contacts: any[];
 };
 
-export const caseItemHistory = (
-  info: {
-    updatedAt?: string;
-    updatedBy?: string;
-    createdAt: string;
-    twilioWorkerId: string;
-  },
-  counselorsHash: Record<string, string>,
-) => {
-  const addingCounsellorName = counselorsHash[info.twilioWorkerId] || 'Unknown';
-  const added = new Date(info.createdAt);
-  const updatingCounsellorName = info.updatedBy ? counselorsHash[info.updatedBy] || 'Unknown' : undefined;
-  const updated = info.updatedAt ? new Date(info.updatedAt) : undefined;
-  return { addingCounsellorName, added, updatingCounsellorName, updated };
-};
-
 export type CaseSummaryWorkingCopy = {
   status: string;
   followUpDate: string;

--- a/plugin-hrm-form/src/states/configuration/selectCounselorsHash.ts
+++ b/plugin-hrm-form/src/states/configuration/selectCounselorsHash.ts
@@ -22,3 +22,16 @@ export const selectCounselorsHash = (state: RootState) => state[namespace].confi
 
 export const selectCounselorsList = (state: RootState): CounselorsList =>
   state[namespace].configuration.counselors.list;
+
+export const selectCounselorName = (state: RootState, counselorId: string): string => {
+  if (counselorId) {
+    const counselor = state[namespace].configuration.counselors.hash[counselorId];
+    if (counselor) {
+      return counselor;
+    } else if (counselorId.startsWith('WK')) {
+      return 'Unknown';
+    }
+    return counselorId;
+  }
+  return undefined;
+};

--- a/twilio-iac/helplines/as/staging.hcl
+++ b/twilio-iac/helplines/as/staging.hcl
@@ -25,5 +25,15 @@ locals {
         chatbot_unique_names = []
       }
     }
+
+    # HRM
+    case_status_transition_rules = [
+      {
+        startingStatus: "inProgress",
+        targetStatus: "closed",
+        timeInStatusInterval: "5 minutes",
+        description: "system - 'In Progress' cases are closed after 5 minutes"
+      }
+    ]
   }
 }

--- a/twilio-iac/helplines/nz/common.hcl
+++ b/twilio-iac/helplines/nz/common.hcl
@@ -55,7 +55,15 @@ locals {
       en_NZ : ["pre_survey"]
     }
 
-
+    # HRM
+    case_status_transition_rules = [
+      {
+        startingStatus: "submitted",
+        targetStatus: "closed",
+        timeInStatusInterval: '28 days',
+        description: "rule to close submitted cases after 28 days"
+      }
+    ]
 
   }
 }

--- a/twilio-iac/helplines/nz/common.hcl
+++ b/twilio-iac/helplines/nz/common.hcl
@@ -60,7 +60,7 @@ locals {
       {
         startingStatus: "submitted",
         targetStatus: "closed",
-        timeInStatusInterval: '28 days',
+        timeInStatusInterval: "28 days",
         description: "rule to close submitted cases after 28 days"
       }
     ]

--- a/twilio-iac/stages/README.md
+++ b/twilio-iac/stages/README.md
@@ -12,7 +12,7 @@ The terragrunt.hcl includes `./terragrunt.root.hcl` which handles shared configu
 
 To run a terraform command for a single stage, navigate into the stage directory use the makesystem to run the command. Specify the helpline short code (`HL`) and the environment (`HL_ENV`) when you run the command.
 
-example plan action for the aselop helpline in the production environment:
+example plan action for the aselo helpline in the production environment:
 
 ```bash
 

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -73,7 +73,7 @@ resource "aws_ssm_parameter" "case_status_transition" {
   name        = "/${lower(var.environment)}/${var.helpline_region}/hrm/scheduled-task/case-status-transitionrules/${nonsensitive(local.secrets.twilio_account_sid)}"
   type        = "SecureString"
   value       = jsonencode(var.case_status_transition_rules)
-  description = "Twilio account - External Recordings Enabled"
+  description = "Automated case status transition rules configuration"
 
   tags = {
     environment = var.environment

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -65,3 +65,20 @@ resource "aws_ssm_parameter" "transcript_retention_override" {
   type  = "String"
   value = var.hrm_transcript_retention_days_override
 }
+
+
+
+resource "aws_ssm_parameter" "case_status_transition" {
+  count       = var.case_status_transition_rules != null ? 1 : 0
+  name        = "/${lower(var.environment)}/${var.helpline_region}/hrm/scheduled-task/case-status-transitionrules/${nonsensitive(local.secrets.twilio_account_sid)}"
+  type        = "SecureString"
+  value       = jsonencode(var.case_status_transition_rules)
+  description = "Twilio account - External Recordings Enabled"
+
+  tags = {
+    environment = var.environment
+    helpline    = var.short_helpline
+    env         = var.environment
+    Terraform   = true
+  }
+}

--- a/twilio-iac/terraform-modules/stages/configure/variables.tf
+++ b/twilio-iac/terraform-modules/stages/configure/variables.tf
@@ -162,5 +162,5 @@ variable "case_status_transition_rules" {
     description = string
     timeInStatusInterval = string
   }))
-  required = false
+  default = null
 }

--- a/twilio-iac/terraform-modules/stages/configure/variables.tf
+++ b/twilio-iac/terraform-modules/stages/configure/variables.tf
@@ -153,3 +153,14 @@ variable "hrm_transcript_retention_days_override" {
   type        = number
   default     = -1
 }
+
+variable "case_status_transition_rules" {
+  description = "List of case status transition rules, specifying the starting status, how long it has to have been in that status to qualify for the transition, and the target status. A description is also required."
+  type = list(object({
+    startingStatus = string
+    targetStatus = string
+    description = string
+    timeInStatusInterval = string
+  }))
+  required = false
+}


### PR DESCRIPTION
## Description

* Added case transition rules config SSM parameter to terragrunt config,
* Added required NZ rule & a test rule in AS_STG
* Updated the 'Status last updated' line to show the rule description if the status was updated by a rule
* Refactored case & case item history state lookups to be redux selectors rather than component code

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
CHI-2359

### Verification steps

* The correct version of HRM needs to be deployed so us-east-1 staging, and the terraform updates in infrastructure_config need to be applied to set up the test
* Set a case to 'In Progress' in AS_STG
* Wait 3 hours (the test rule says 5 minutes but the task to check only runs every 3 hours
* Check the case, the status should be 'closed' and the EditCaseSummary.tsx page should say it was updated by the rule