### PR TITLE
Release 202401 service config changes STG

### DIFF
--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -17,9 +17,7 @@
             "enable_separate_timeline_view": true,
             "enable_transcripts": false,
             "enable_twilio_transcripts": false,
-            "enable_voice_recordings": false,
-            "enable_client_profiles": true,
-            "enable_case_merging": true
+            "enable_voice_recordings": false
         },
         "hrm_base_url": "https://hrm-test.tl.techmatters.org",
         "multipleOfficeSupport": true,

--- a/twilio-iac/helplines/baseline/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/baseline/configs/service-configuration/staging.json
@@ -1,10 +1,6 @@
 {
     "attributes": {
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
-        "resources_base_url": "",
-        "feature_flags": {
-          "enable_last_case_status_update_info": true,
-          "enable_separate_timeline_view": true
-        }
+        "resources_base_url": ""
     }
 }

--- a/twilio-iac/helplines/baseline/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/baseline/configs/service-configuration/staging.json
@@ -1,6 +1,10 @@
 {
     "attributes": {
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
-        "resources_base_url": ""
+        "resources_base_url": "",
+        "feature_flags": {
+          "enable_last_case_status_update_info": true,
+          "enable_separate_timeline_view": true
+        }
     }
 }

--- a/twilio-iac/helplines/br/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/br/configs/service-configuration/staging.json
@@ -2,7 +2,9 @@
     "attributes": {
         "assets_bucket_url": "https://s3.amazonaws.com/assets-staging.tl.techmatters.org",
         "feature_flags": {
-            "enable_external_transcripts": false
+            "enable_external_transcripts": false,
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true
         }
     }
 }

--- a/twilio-iac/helplines/br/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/br/configs/service-configuration/staging.json
@@ -2,6 +2,7 @@
     "attributes": {
         "assets_bucket_url": "https://s3.amazonaws.com/assets-staging.tl.techmatters.org",
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_external_transcripts": false,
             "enable_last_case_status_update_info": true,
             "enable_separate_timeline_view": true

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,13 +1,12 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_case_merging": true
+            "enable_case_merging": true,
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
-        "resources_base_url": "https://hrm-staging.tl.techmatters.org",
-        "feature_flags": {
-            "enable_case_merging": true
-        }
+        "resources_base_url": "https://hrm-staging.tl.techmatters.org"
     },
     "ui_attributes": {
         "theme": null

--- a/twilio-iac/helplines/cl/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/staging.json
@@ -1,9 +1,9 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_fullstory_monitoring": true,
             "enable_case_merging": true,
             "enable_client_profiles": true,
+            "enable_fullstory_monitoring": true,
             "enable_last_case_status_update_info": true,
             "enable_separate_timeline_view": true
         },

--- a/twilio-iac/helplines/cl/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/staging.json
@@ -2,8 +2,10 @@
     "attributes": {
         "feature_flags": {
             "enable_fullstory_monitoring": true,
+            "enable_case_merging": true,
             "enable_client_profiles": true,
-            "enable_case_merging": true
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true
         },
         "helpline_code": "cl",
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/"

--- a/twilio-iac/helplines/co/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/co/configs/service-configuration/staging.json
@@ -1,8 +1,10 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_twilio_transcripts": false,
-            "enable_lex": true
+            "enable_last_case_status_update_info": true,
+            "enable_lex": true,
+            "enable_separate_timeline_view": true,
+            "enable_twilio_transcripts": false
         }
     }
 }

--- a/twilio-iac/helplines/co/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/co/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_last_case_status_update_info": true,
             "enable_lex": true,
             "enable_separate_timeline_view": true,

--- a/twilio-iac/helplines/et/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/et/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_last_case_status_update_info": true,
             "enable_separate_timeline_view": true,
             "post_survey_serverless_handled": false

--- a/twilio-iac/helplines/et/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/et/configs/service-configuration/staging.json
@@ -1,6 +1,8 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true,
             "post_survey_serverless_handled": false
         },
         "previous_ui_version": {

--- a/twilio-iac/helplines/hu/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/hu/configs/service-configuration/staging.json
@@ -1,6 +1,8 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true,
             "enable_twilio_transcripts": false,
             "post_survey_serverless_handled": false
             

--- a/twilio-iac/helplines/hu/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/hu/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_last_case_status_update_info": true,
             "enable_separate_timeline_view": true,
             "enable_twilio_transcripts": false,

--- a/twilio-iac/helplines/in/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/in/configs/service-configuration/staging.json
@@ -1,7 +1,9 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_case_merging": true
+            "enable_case_merging": true,
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true
         },
         "helplineLanguage": "en-IN",
         "hrm_base_url": "https://hrm-staging.tl.techmatters.org",

--- a/twilio-iac/helplines/jm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/jm/configs/service-configuration/staging.json
@@ -1,11 +1,13 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_manual_pulling": false,
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true,
             "enable_transcripts": true,
             "enable_twilio_transcripts": false,
-            "enable_voice_recordings": true,
-            "enable_case_merging": true
+            "enable_voice_recordings": true
         },
         "hrm_base_url": "https://hrm-test.tl.techmatters.org",
         "pdfImagesSource": "https://tl-public-chat-jm-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/mt/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mt/configs/service-configuration/staging.json
@@ -1,9 +1,11 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
+            "enable_last_case_status_update_info": true,
             "enable_manual_pulling": false,
-            "enable_twilio_transcripts": false,
-            "enable_case_merging": true
+            "enable_separate_timeline_view": true,
+            "enable_twilio_transcripts": false
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
         "helplineLanguage": ""

--- a/twilio-iac/helplines/mw/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mw/configs/service-configuration/staging.json
@@ -2,6 +2,8 @@
     "attributes": {
         "feature_flags": {
             "enable_external_transcripts": false,
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true,
             "post_survey_serverless_handled": false
         },
         "hrm_base_url": "https://hrm-test.tl.techmatters.org",

--- a/twilio-iac/helplines/mw/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mw/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_external_transcripts": false,
             "enable_last_case_status_update_info": true,
             "enable_separate_timeline_view": true,

--- a/twilio-iac/helplines/nz/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/nz/configs/service-configuration/common.json
@@ -11,9 +11,11 @@
             "enable_conferencing": true,
             "enable_counselor_toolkits": true,
             "enable_fullstory_monitoring": true,
+            "enable_last_case_status_update_info": false,
             "enable_lex": false,
             "enable_post_survey": false,
             "enable_resources": false,
+            "enable_separate_timeline_view": false,
             "enable_transcripts": false,
             "enable_twilio_transcripts": false
         },

--- a/twilio-iac/helplines/nz/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/nz/configs/service-configuration/staging.json
@@ -1,9 +1,9 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_save_insights": true,
+            "enable_case_merging": true,
             "enable_client_profiles": true,
-            "enable_case_merging": true
+            "enable_save_insights": true
         },
         "definitionVersion": "nz-v1"
     }

--- a/twilio-iac/helplines/ph/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ph/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_counselor_toolkits": false,
             "enable_csam_clc_report": false,
             "enable_external_transcripts": false,

--- a/twilio-iac/helplines/ph/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ph/configs/service-configuration/staging.json
@@ -5,6 +5,8 @@
             "enable_csam_clc_report": false,
             "enable_external_transcripts": false,
             "enable_fullstory_monitoring": true,
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true,
             "enable_voice_recordings": false,
             "post_survey_serverless_handled": false
         }

--- a/twilio-iac/helplines/sg/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/sg/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_fullstory_monitoring": true,
             "enable_last_case_status_update_info": true,
             "enable_separate_timeline_view": true

--- a/twilio-iac/helplines/sg/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/sg/configs/service-configuration/staging.json
@@ -1,7 +1,9 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_fullstory_monitoring": true
+            "enable_fullstory_monitoring": true,
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true
         },
         "helpline_code": "sg",
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/"

--- a/twilio-iac/helplines/th/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/th/configs/service-configuration/staging.json
@@ -2,10 +2,12 @@
     "attributes": {
         "feature_flags": {
             "enable_aselo_messaging_ui": false,
+            "enable_case_merging": true,
             "enable_csam_clc_report": false,
             "enable_csam_report": true,
-            "enable_voice_recordings": false,
-            "enable_case_merging": true
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true,
+            "enable_voice_recordings": false
         }
     }
 }

--- a/twilio-iac/helplines/za/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/za/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_transcripts": true,
             "enable_twilio_transcripts": false,
             "post_survey_serverless_handled": false

--- a/twilio-iac/helplines/zm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zm/configs/service-configuration/staging.json
@@ -1,6 +1,8 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true,
             "enable_transcripts": true,
             "enable_twilio_transcripts": false
         },

--- a/twilio-iac/helplines/zm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zm/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_last_case_status_update_info": true,
             "enable_separate_timeline_view": true,
             "enable_transcripts": true,

--- a/twilio-iac/helplines/zw/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zw/configs/service-configuration/staging.json
@@ -10,6 +10,7 @@
             "line"
         ],
         "feature_flags": {
+            "enable_case_merging": true,
             "enable_last_case_status_update_info": true,
             "enable_separate_timeline_view": true
         },

--- a/twilio-iac/helplines/zw/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zw/configs/service-configuration/staging.json
@@ -9,6 +9,10 @@
             "instagram",
             "line"
         ],
+        "feature_flags": {
+            "enable_last_case_status_update_info": true,
+            "enable_separate_timeline_view": true
+        },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
         "resources_base_url": ""
     }


### PR DESCRIPTION
See notes at https://techmatters.app.box.com/notes/1411807981335

* Adds `enable_last_case_status_update_info` and `enable_separate_timeline_view` to all active helpline staging configs, while explicitly disabling those flags for all NZ accounts.
* Alphabetizes feature flags in helpline staging config for easier reading (please let's maintain this)
* @annaliseirby090 has an outstanding action to determine where to put `enable_case_merging`

@stephenhand I'd like some guidance if I'm doing this correctly. As far as I can tell, there is no way to add a flag once for all helplines in a stage, so I did them one by one.

UPDATE: `enable_case_merging` has been added to all active helplines after confirmation with Annalise