### PR TITLE
Fix flaky test Allow slight difference in startMillis in test

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
@@ -185,16 +185,16 @@ describe('actions', () => {
       // Not sure why the extra cast to any is needed here but not for the other actions?
       await (dispatch(submitContactFormAsyncAction(task, baseContact, baseMetadata, baseCase) as any) as unknown);
       const { metadata, savedContact } = getState().existingContacts[baseContact.id];
-
       // Check that the difference in startMillis is still insignificant
       expect(Math.abs(metadata.startMillis - newContactMetaData(false).startMillis)).toBeLessThanOrEqual(1);
+      expect(metadata).toStrictEqual(
+        expect.objectContaining({
+          ...newContactMetaData(false),
+          loadingStatus: LoadingStatus.LOADED,
+          startMillis: expect.any(Number),
+        }),
+      );
 
-      expect(metadata).toStrictEqual(expect.objectContaining({
-        ...newContactMetaData(false),
-        loadingStatus: LoadingStatus.LOADED,
-        startMillis: expect.any(Number) 
-      }));
-      
       expect(savedContact).toStrictEqual(updatedContact);
     });
   });

--- a/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
@@ -185,11 +185,16 @@ describe('actions', () => {
       // Not sure why the extra cast to any is needed here but not for the other actions?
       await (dispatch(submitContactFormAsyncAction(task, baseContact, baseMetadata, baseCase) as any) as unknown);
       const { metadata, savedContact } = getState().existingContacts[baseContact.id];
-      expect(metadata).toStrictEqual({
+
+      // Check that the difference in startMillis is still insignificant
+      expect(Math.abs(metadata.startMillis - newContactMetaData(false).startMillis)).toBeLessThanOrEqual(1);
+
+      expect(metadata).toStrictEqual(expect.objectContaining({
         ...newContactMetaData(false),
-        startMillis: expect.any(Number),
         loadingStatus: LoadingStatus.LOADED,
-      });
+        startMillis: expect.any(Number) 
+      }));
+      
       expect(savedContact).toStrictEqual(updatedContact);
     });
   });

--- a/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
@@ -186,7 +186,7 @@ describe('actions', () => {
       await (dispatch(submitContactFormAsyncAction(task, baseContact, baseMetadata, baseCase) as any) as unknown);
       const { metadata, savedContact } = getState().existingContacts[baseContact.id];
       // Check that the difference in startMillis is still insignificant
-      expect(Math.abs(metadata.startMillis - newContactMetaData(false).startMillis)).toBeLessThanOrEqual(1);
+      expect(Math.abs(metadata.startMillis - newContactMetaData(false).startMillis)).toBeLessThanOrEqual(100);
       expect(metadata).toStrictEqual(
         expect.objectContaining({
           ...newContactMetaData(false),


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- This PR modifies the `Updates contact in redux and sets metadata` test in `saveContact.test.ts` to allow for a slight difference in `startMillis`. The test was intermittently failing because it was comparing timestamps (`startMillis`) based on the current time, and they are failing even though it is insignificant

![Screenshot 2024-01-22 at 2 45 05 PM](https://github.com/techmatters/flex-plugins/assets/102122005/7716dc2f-68ef-4284-8dc4-4aad050a2f65)


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->