### PR TITLE
Add "flex_instance_sid" to excluded fields of service config tool

### DIFF
--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -40,6 +40,7 @@ TEMPLATE_FIELDS = {
 
 # These are fields that will be excluded from the payload sent to twilio
 EXCLUDED_FIELDS = [
+    "flex_instance_sid",
     "flex_service_instance_sid",
     "runtime_domain",
     "flex_insights_hr",


### PR DESCRIPTION
For whatever reason, there is a new field in the Flex service config that we are not allowed to change, and not excluding it from our changes is breaking updates.