### PR TITLE
Revert "Map to long environment names for SSM parameters in flex_deploy.yml"

### DIFF
--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -72,28 +72,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      # Set ENVIRONMENT_NAME
-      - name: Production Environment
-        if: inputs.environment_code == 'PROD'
-        run: echo "ENVIRONMENT_NAME=production" >> $GITHUB_ENV
-
-      - name: Staging Environment
-        if: inputs.environment_code == 'STG'
-        run: echo "ENVIRONMENT_NAME=staging" >> $GITHUB_ENV
-
-      - name: Development Environment
-        if: inputs.environment_code == 'DEV'
-        run: echo "ENVIRONMENT_NAME=development" >> $GITHUB_ENV
       - name: Set Twilio account SID
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
-          ssm_parameter: "/${{env.ENVIRONMENT_NAME}}/twilio/${{inputs.helpline_code}}/account_sid"
+          ssm_parameter: "/${{inputs.environment_code}}/twilio/${{inputs.helpline_code}}/account_sid"
           env_variable_name: "TWILIO_ACCOUNT_SID"
 
       - name: Set Twilio Auth Token
         uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
-          ssm_parameter: "/${{env.ENVIRONMENT_NAME}}/twilio/${{env.TWILIO_ACCOUNT_SID}}/auth_token"
+          ssm_parameter: "/${{inputs.environment_code}}/twilio/${{env.TWILIO_ACCOUNT_SID}}/auth_token"
           env_variable_name: "TWILIO_AUTH_TOKEN"
 
       # Call main-action to compile and deploy secrets.AS_DEV_ACCOUNT_SID


### PR DESCRIPTION
Reverts techmatters/flex-plugins#1963

I will do a temporary revert of this to test whether removing this fixes all-stage deploys.

The changes introduced in the original PR are necessary for cutting QA releases (and possibly other workflows) so I will revert my revert once it's tested.