### PR TITLE
CHI-2546: Ensure the tabbed form subcomponents use the parent RHF context 

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/TabbedFormsCase.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedFormsCase.tsx
@@ -26,8 +26,9 @@ import { newCloseModalAction } from '../../states/routing/actions';
 import { CaseLayout } from '../case/styles';
 import { Case as CaseForm, Contact, CustomITask } from '../../types/types';
 import Case from '../case/Case';
-import useTabbedForm from './hooks/useTabbedForm';
+import { useTabbedFormContext } from './hooks/useTabbedForm';
 import { TabbedFormsCommonProps } from './types';
+import { getTemplateStrings } from '../../hrmConfig';
 
 type OwnProps = TabbedFormsCommonProps;
 
@@ -50,7 +51,8 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const TabbedFormsCase: React.FC<Props> = ({ task, metadata, savedContact, closeModal, finaliseContact }) => {
-  const { newSubmitHandler, strings } = useTabbedForm();
+  const strings = getTemplateStrings();
+  const { newSubmitHandler } = useTabbedFormContext();
 
   const submit = async (caseForm: CaseForm) => {
     try {

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedFormsRouter.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedFormsRouter.tsx
@@ -15,10 +15,11 @@
  */
 
 import React from 'react';
+import { FormProvider } from 'react-hook-form';
 
 import { AppRoutes } from '../../states/routing/types';
 import Router, { RouteConfig, shouldHandleRoute } from '../router/Router';
-import useTabbedForm from './hooks/useTabbedForm';
+import { useTabbedForm } from './hooks/useTabbedForm';
 import TabbedFormsCase from './TabbedFormsCase';
 import TabbedFormsContact from './TabbedFormsContact';
 import TabbedFormsTabs from './TabbedFormsTabs';
@@ -49,7 +50,7 @@ const TABBED_FORMS_ROUTES: RouteConfig<Props> = [
 export const isTabbedFormsRoute = (routing: AppRoutes) => shouldHandleRoute(routing, TABBED_FORMS_ROUTES);
 
 const TabbedFormsRouter: React.FC<Props> = props => {
-  const { methods, FormProvider } = useTabbedForm();
+  const { methods } = useTabbedForm();
 
   return (
     <FormProvider {...methods}>

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedFormsTabs.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedFormsTabs.tsx
@@ -53,7 +53,7 @@ import ContactlessTaskTab from './ContactlessTaskTab';
 import CSAMAttachments from './CSAMAttachments';
 import CSAMReportButton from './CSAMReportButton';
 import { TabbedFormsCommonProps } from './types';
-import useTabbedForm from './hooks/useTabbedForm';
+import { useTabbedFormContext } from './hooks/useTabbedForm';
 // Ensure we import any custom components that might be used in a form
 import '../contact/ResourceReferralList';
 
@@ -178,7 +178,7 @@ const TabbedFormsTabs: React.FC<Props> = ({
   const { contactSaveFrequency } = getHrmConfig();
   const { subroute, autoFocus } = currentRoute as TabbedFormRoute;
 
-  const { methods, newSubmitHandler } = useTabbedForm();
+  const { methods, newSubmitHandler } = useTabbedFormContext();
   const { setValue } = methods;
 
   const isMounted = React.useRef(false); // mutable value to avoid reseting the state in the first render.

--- a/plugin-hrm-form/src/components/tabbedForms/hooks/useTabbedForm.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/hooks/useTabbedForm.ts
@@ -13,28 +13,30 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { FormProvider, useForm } from 'react-hook-form';
+import { useForm, useFormContext } from 'react-hook-form';
 
 import { recordingErrorHandler } from '../../../fullStory';
 import { getTemplateStrings } from '../../../hrmConfig';
 
-const useTabbedForm = () => {
-  const strings = getTemplateStrings();
+const newSubmitHandlerFactory = (methods: ReturnType<typeof useFormContext>) => {
+  const onError = recordingErrorHandler('Tabbed HRM Form', () => {
+    window.alert(getTemplateStrings()['Error-Form']);
+  });
 
+  return (successHandler: () => Promise<void>) => {
+    return methods.handleSubmit(successHandler, onError);
+  };
+};
+
+export const useTabbedFormContext = () => {
+  const methods = useFormContext();
+  return { methods, newSubmitHandler: newSubmitHandlerFactory(methods) };
+};
+
+export const useTabbedForm = () => {
   const methods = useForm({
     shouldFocusError: false,
     mode: 'onChange',
   });
-
-  const onError = recordingErrorHandler('Tabbed HRM Form', () => {
-    window.alert(strings['Error-Form']);
-  });
-
-  const newSubmitHandler = (successHandler: () => Promise<void>) => {
-    return methods.handleSubmit(successHandler, onError);
-  };
-
-  return { methods, strings, FormProvider, onError, newSubmitHandler };
+  return { methods, newSubmitHandler: newSubmitHandlerFactory(methods) };
 };
-
-export default useTabbedForm;


### PR DESCRIPTION
## Description

The refactored forms were creating new RHFs when trying to validate, rather than using the parent context that was being used in other scenarios - so the RHF used in validation was always blank so always passed validation

This change adds a useTabbedFormContext method for subcomponents to use that will share context as intended, restoring the form validation behaviour

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Related Issues
Fixes CHI-2546

### Verification steps

See ticket