### PR TITLE
Alphabetize default config and disable NZ confirm-on-close

### DIFF
--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -4,7 +4,6 @@
             "enable_aselo_messaging_ui": false,
             "enable_case_merging": true,
             "enable_client_profiles": true,
-            "enable_confirm_on_browser_close": true,
             "enable_conferencing": false,
             "enable_contact_editing": false,
             "enable_counselor_toolkits": false,

--- a/twilio-iac/helplines/configs/service-configuration/defaults.json
+++ b/twilio-iac/helplines/configs/service-configuration/defaults.json
@@ -46,9 +46,13 @@
             "enableUnmaskingCalls": false
         },
         "feature_flags": {
+            "backend_handled_chat_janitor": true,
             "enable_aselo_messaging_ui": false,
             "enable_canned_responses": true,
+            "enable_case_merging": false,
+            "enable_client_profiles": false,
             "enable_conferencing": true,
+            "enable_confirm_on_browser_close": true,
             "enable_contact_editing": true,
             "enable_counselor_toolkits": false,
             "enable_csam_clc_report": false,
@@ -69,11 +73,7 @@
             "enable_twilio_transcripts": true,
             "enable_upload_documents": true,
             "enable_voice_recordings": false,
-            "post_survey_serverless_handled": true,
-            "backend_handled_chat_janitor": true,
-            "enable_client_profiles": false,
-            "enable_case_merging": false,
-            "enable_confirm_on_browser_close": true
+            "post_survey_serverless_handled": true
         },
         "multipleOfficeSupport": false,
         "WARNING": "These attributes are set using a tool in the twilio-iac repo. If you are seeing this message anywhere else, please stop and use the process described here: https://github.com/techmatters/flex-plugins/blob/master/twilio-iac/docs/service_configuration.md"

--- a/twilio-iac/helplines/nz/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/nz/configs/service-configuration/common.json
@@ -9,6 +9,7 @@
         "feature_flags": {
             "enable_aselo_messaging_ui": false,
             "enable_conferencing": true,
+            "enable_confirm_on_browser_close": false,
             "enable_counselor_toolkits": true,
             "enable_fullstory_monitoring": true,
             "enable_last_case_status_update_info": false,


### PR DESCRIPTION
Alphabetize the default feature flag service config for greater readability. Disable confirm-on-close for all NZ stages.

This is applied everywhere. The only actual effect was to disable `confirm_on_browser_close` on NZ staging.

No review, but FYI @annaliseirby090 