### PR TITLE
Fix contact summary preview wrap into contact card

### DIFF
--- a/plugin-hrm-form/src/components/search/PreviewDescription.tsx
+++ b/plugin-hrm-form/src/components/search/PreviewDescription.tsx
@@ -26,6 +26,7 @@ export const PreviewDescription = styled(ExpandableTextBlock)<ExpandableTextBloc
   font-family: Open Sans, serif;
   text-align: left;
   padding-top: 5px;
+  width: 100%;
 `;
 
 PreviewDescription.displayName = 'PreviewDescription';


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- This PR fixes the width of the expandable block for Contact Summary in preview mode
[
![Screenshot 2024-02-05 at 3 47 30 PM](https://github.com/techmatters/flex-plugins/assets/102122005/8e483cba-1ef5-40e6-a4bd-aa81f6ea20ee)
](url)

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes #(https://tech-matters.atlassian.net/browse/CHI-2545)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->