### PR TITLE
Enable profile router in caseList page

### DIFF
--- a/plugin-hrm-form/src/components/caseList/CaseList.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseList.tsx
@@ -36,6 +36,7 @@ import selectCasesForList from '../../states/caseList/selectCasesForList';
 import selectCaseListSettings from '../../states/caseList/selectCaseListSettings';
 import { CaseListSettingsState } from '../../states/caseList/settings';
 import asyncDispatch from '../../states/asyncDispatch';
+import ProfileRouter, { isProfileRoute } from '../profile/ProfileRouter';
 
 export const CASES_PER_PAGE = 10;
 
@@ -133,6 +134,15 @@ const CaseList: React.FC<Props> = ({
       </StandaloneContainer>
     );
   }
+
+  if (isProfileRoute(routing)) {
+    return (
+      <StandaloneContainer>
+        <ProfileRouter task={standaloneTask} />
+      </StandaloneContainer>
+    );
+  }
+
   return (
     <>
       <ListContainer>


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Primary reviewer:

## Description
- In Case List page, profile-related modals were not supported. This PR ensures this profile routes are interactive within the Case List view. 

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Related Issues
Fixes # 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->