### PR TITLE
fix: align webchat e2e specs for CA to the new studio flows 

### DIFF
--- a/e2e-tests/chatScripts.ts
+++ b/e2e-tests/chatScripts.ts
@@ -40,9 +40,9 @@ export const defaultScript: ChatStatement[] = [
 
 export const commonScripts: Record<string, ChatStatement[]> = {
   ca: [
-    botStatement(
-      'You are number 1 in line. To keep your chat active, please do not leave/refresh this window or hit the back button.',
-    ),
+    // botStatement(
+    //   'You are number 1 in line. To keep your chat active, please do not leave/refresh this window or hit the back button.',
+    // ),
     counselorAutoStatement("Hi, you've reached a counsellor. What would you like to talk about?"),
     callerStatement('CALLER TEST CHAT MESSAGE'),
     counselorStatement('COUNSELLOR TEST CHAT MESSAGE'),


### PR DESCRIPTION
## Description
This PR fixes e2e webchat test for `ca` accounts. The tests are currently failing because a message that was being expected by the tests has been removed from the test path from Studio flows.

### Checklist
- [ ] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Set env vars to match the e2e tests for `ca staging` (aselo alerts production Okta user and `ca staging` Twilio credentials).
- Run the tests like `npm run test:staging:ca:headed -- -- webchat`