### PR TITLE
CHI-1993 Extend masking ids to profile related components

### DIFF
--- a/plugin-hrm-form/src/components/profile/ProfileDetails.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileDetails.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { Icon, Template } from '@twilio/flex-ui';
 
-import { Box, HiddenText, Row, HorizontalLine, Title } from '../../styles';
+import { Box, HiddenText, Row, HorizontalLine, Title, Bold } from '../../styles';
 import { newOpenModalAction } from '../../states/routing/actions';
 import { useProfile } from '../../states/profile/hooks';
 import useProfileSectionTypes from '../../states/configuration/hooks/useProfileSectionTypes';
@@ -32,6 +32,7 @@ import {
 } from './styles';
 import ProfileFlagSection from './profileFlag/ProfileFlagSection';
 import ProfileSectionView from './section/ProfileSectionView';
+import { getInitializedCan, PermissionActions } from '../../permissions';
 
 type OwnProps = ProfileCommonProps;
 
@@ -58,12 +59,27 @@ type Section = {
 const ProfileDetails: React.FC<Props> = ({ profileId, task, openSectionEditModal }) => {
   const { profile } = useProfile({ profileId });
 
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
+
   const overviewSections: Section[] = [
     {
       titleCode: 'Profile-IdentifiersHeader',
       renderComponent: () =>
         profile?.identifiers ? (
-          profile.identifiers?.map(identifier => <div key={identifier.id}>{identifier.identifier}</div>)
+          profile.identifiers?.map(identifier => (
+            <>
+              {maskIdentifiers ? (
+                <Bold>
+                  <Template code="MaskIdentifiers" />
+                </Bold>
+              ) : (
+                <div key={identifier.id}>{identifier.identifier}</div>
+              )}
+            </>
+          ))
         ) : (
           <Template code="Profile-NoIdentifiersFound" />
         ),

--- a/plugin-hrm-form/src/components/profileList/ProfileDetailsRow.tsx
+++ b/plugin-hrm-form/src/components/profileList/ProfileDetailsRow.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../styles';
 import { newOpenModalAction } from '../../states/routing/actions';
 import { useProfileFlags, useProfileSectionByType } from '../../states/profile/hooks';
+import { PermissionActions, getInitializedCan } from '../../permissions';
 
 const CHAR_LIMIT = 200;
 
@@ -53,6 +54,11 @@ const ProfileDetailsRow: React.FC<Props> = ({ profileId }) => {
   const handleViewProfile = async () => {
     dispatch(newOpenModalAction({ route: 'profile', profileId, subroute: 'details' }, 'standalone-task-sid'));
   };
+
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
 
   return (
     <DataTableRow onClick={handleViewProfile}>
@@ -78,9 +84,11 @@ const ProfileDetailsRow: React.FC<Props> = ({ profileId }) => {
           </TableBodyFont>
         </SummaryCell>
       )}
-      <DataCell>
-        <TableBodyFont>{profile?.identifiers.map(i => i.identifier).join('\n')}</TableBodyFont>
-      </DataCell>
+      {maskIdentifiers ? null : (
+        <DataCell>
+          <TableBodyFont>{profile?.identifiers.map(i => i.identifier).join('\n')}</TableBodyFont>
+        </DataCell>
+      )}
       <SummaryCell>
         {error && <ErrorText>Please try again later</ErrorText>}
         {loading ? (

--- a/plugin-hrm-form/src/components/profileList/ProfileHeader.tsx
+++ b/plugin-hrm-form/src/components/profileList/ProfileHeader.tsx
@@ -20,15 +20,21 @@ import { TableRow } from '@material-ui/core';
 import { TableHeader } from '../../styles';
 import ProfileHeaderCell from './ProfileHeaderCell';
 import { ProfilesListSortBy } from '../../types/types';
+import { PermissionActions, getInitializedCan } from '../../permissions';
 
 const ProfileHeader: React.FC = () => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+  const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
+
   return (
     <TableHeader>
       <TableRow>
         <ProfileHeaderCell column={ProfilesListSortBy.ID} localizedText="ProfileList-THClient" width="8%" />
         <ProfileHeaderCell localizedText="ProfileList-THStatus" />
-        <ProfileHeaderCell localizedText="ProfileList-THIdentifier" />
-        <ProfileHeaderCell localizedText="ProfileList-THSummary" />
+        {maskIdentifiers ? null : <ProfileHeaderCell localizedText="ProfileList-THIdentifier" />}
+        <ProfileHeaderCell localizedText="ProfileList-THSummary" width="15%" />
       </TableRow>
     </TableHeader>
   );


### PR DESCRIPTION
## Description
- This PR extends masking ids to profile related components, namely, identifier in the profile details page and the column in profile list page

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- In this branch, change `"viewIdentifiers": [["everyone"]]` in [`dev.json`](https://github.com/techmatters/flex-plugins/blob/CHI-1993-maskids/plugin-hrm-form/src/permissions/dev.json) to  `"viewIdentifiers": []`
- Check all the profile related displays for identifiers
[masked for profiles.webm](https://github.com/techmatters/flex-plugins/assets/102122005/b29347a9-70e9-4df0-9c3e-f834de4dd4d6)
