### PR TITLE
refactor: support translations on profile flags (pills and input)

### DIFF
--- a/plugin-hrm-form/src/components/profile/profileFlag/ProfileFlagEdit.tsx
+++ b/plugin-hrm-form/src/components/profile/profileFlag/ProfileFlagEdit.tsx
@@ -16,7 +16,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { IconButton } from '@twilio/flex-ui';
+import { IconButton, Template } from '@twilio/flex-ui';
 import { Box, Popper } from '@material-ui/core';
 import { parseISO } from 'date-fns';
 
@@ -130,13 +130,14 @@ const ProfileFlagsEdit: React.FC<Props> = (props: Props) => {
                       Date.now() + Number(customDuration.durationInHours) * 60 * 60 * 1000,
                     ).toISOString();
                     const validatedTime = parseISO(validUntil);
+
                     return (
                       <StyledMenuItem
                         key={customDuration.durationInHours}
                         onClick={() => shouldAllowAssociate && associateProfileFlag(flag.id, validatedTime)}
                         ref={index && customDurationIndex ? null : associateRef}
                       >
-                        {customDuration.label}
+                        <Template code={customDuration.label} />
                       </StyledMenuItem>
                     );
                   });
@@ -148,7 +149,7 @@ const ProfileFlagsEdit: React.FC<Props> = (props: Props) => {
                     onClick={() => shouldAllowAssociate && associateProfileFlag(flag.id)}
                     ref={index ? null : associateRef}
                   >
-                    {flag.name}
+                    <Template code={flag.name} />
                   </StyledMenuItem>
                 );
               })}

--- a/plugin-hrm-form/src/components/profile/profileFlag/ProfileFlagPill.tsx
+++ b/plugin-hrm-form/src/components/profile/profileFlag/ProfileFlagPill.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { format } from 'date-fns';
+import { Template } from '@twilio/flex-ui';
 
 import { getTemplateStrings } from '../../../hrmConfig';
 import { ProfileFlag } from '../../../types/types';
@@ -37,7 +38,7 @@ const ProfileFlagPill: React.FC<Props> = ({ flag, renderDisassociate }) => {
     <ProfileFlagsListItem key={flag.name}>
       <FlagPill title={`${flag.name} Status`} key={flag.name} fillColor="#F5EEF4" isBlocked={flag.name === 'blocked'}>
         {flag.name === 'blocked' && <StyledBlockOutlinedIcon />}
-        {flag.name.charAt(0).toUpperCase() + flag.name.slice(1)}
+        <Template code={flag.name} />
         <FlagPillTime>{flag.validUntil && `${strings['Profile-ValidUntil']} ${formattedDate}`}</FlagPillTime>
         {renderDisassociate && renderDisassociate(flag)}
       </FlagPill>

--- a/plugin-hrm-form/src/components/profile/styles.tsx
+++ b/plugin-hrm-form/src/components/profile/styles.tsx
@@ -100,6 +100,7 @@ export const FlagPill = styled('div')<ColorProps>`
   border-color: ${props => (props.isBlocked ? `#D61F1F` : 'none')};
   color: ${props => (props.isBlocked ? `#D61F1F` : '#192B33')};
   font-size: 12px;
+  text-transform: capitalize;
 `;
 FlagPill.displayName = 'FlagPill';
 


### PR DESCRIPTION
## Description
This PR adds support to translate the profile flags in the pills where they are shown and in the "associate flag" input (profile details page).

![Screenshot from 2024-02-16 12-53-15](https://github.com/techmatters/flex-plugins/assets/15805319/b552a2c3-3778-406d-8750-29bdb70e3279)
![Screenshot from 2024-02-16 12-53-08](https://github.com/techmatters/flex-plugins/assets/15805319/5628e9a9-eac4-438a-9096-c61acd67d224)
![Screenshot from 2024-02-16 12-53-02](https://github.com/techmatters/flex-plugins/assets/15805319/2c3472cf-3ba0-4292-ace1-20e536c0f947)
![Screenshot from 2024-02-16 12-52-53](https://github.com/techmatters/flex-plugins/assets/15805319/ba206d34-f39b-42a0-86f0-4d173b445c54)


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- Add an entry translating profile flags to `src/translations/en-US/flexUI.json`, like `"abusive": "abusive flag translated"`.
- Start server (`npm run dev`).
- Confirm that the translated flags work as intended.