### PR TITLE
Turn on Case Merging for all staging and production helplines

### DIFF
--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -4,10 +4,7 @@
             "enable_case_merging": true
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
-        "resources_base_url": "https://hrm-staging.tl.techmatters.org",
-        "feature_flags": {
-            "enable_case_merging": true
-        }
+        "resources_base_url": "https://hrm-staging.tl.techmatters.org"
     },
     "ui_attributes": {
         "theme": null

--- a/twilio-iac/helplines/cl/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/common.json
@@ -16,7 +16,6 @@
             "enable_resources": false,
             "enable_lex": true,
             "enable_voice_recordings": true,
-            "enable_case_merging":true,
             "enable_client_profiles":true
         },
         "helplineLanguage": "es-CL",

--- a/twilio-iac/helplines/cl/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/staging.json
@@ -2,8 +2,7 @@
     "attributes": {
         "feature_flags": {
             "enable_fullstory_monitoring": true,
-            "enable_client_profiles": true,
-            "enable_case_merging": true
+            "enable_client_profiles": true
         },
         "helpline_code": "cl",
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/"

--- a/twilio-iac/helplines/configs/service-configuration/defaults.json
+++ b/twilio-iac/helplines/configs/service-configuration/defaults.json
@@ -72,7 +72,7 @@
             "post_survey_serverless_handled": true,
             "backend_handled_chat_janitor": true,
             "enable_client_profiles": false,
-            "enable_case_merging": false,
+            "enable_case_merging": true,
             "enable_confirm_on_browser_close": true
         },
         "multipleOfficeSupport": false,

--- a/twilio-iac/helplines/in/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/in/configs/service-configuration/staging.json
@@ -1,8 +1,5 @@
 {
     "attributes": {
-        "feature_flags": {
-            "enable_case_merging": true
-        },
         "helplineLanguage": "en-IN",
         "hrm_base_url": "https://hrm-staging.tl.techmatters.org",
         "pdfImagesSource": "https://tl-public-chat-in-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/jm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/jm/configs/service-configuration/staging.json
@@ -4,8 +4,7 @@
             "enable_manual_pulling": false,
             "enable_transcripts": true,
             "enable_twilio_transcripts": false,
-            "enable_voice_recordings": true,
-            "enable_case_merging": true
+            "enable_voice_recordings": true
         },
         "hrm_base_url": "https://hrm-test.tl.techmatters.org",
         "pdfImagesSource": "https://tl-public-chat-jm-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/mt/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mt/configs/service-configuration/staging.json
@@ -2,8 +2,7 @@
     "attributes": {
         "feature_flags": {
             "enable_manual_pulling": false,
-            "enable_twilio_transcripts": false,
-            "enable_case_merging": true
+            "enable_twilio_transcripts": false
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
         "helplineLanguage": ""

--- a/twilio-iac/helplines/nz/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/nz/configs/service-configuration/staging.json
@@ -2,8 +2,7 @@
     "attributes": {
         "feature_flags": {
             "enable_save_insights": true,
-            "enable_client_profiles": true,
-            "enable_case_merging": true
+            "enable_client_profiles": true
         },
         "definitionVersion": "nz-v1"
     }

--- a/twilio-iac/helplines/th/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/th/configs/service-configuration/staging.json
@@ -4,8 +4,7 @@
             "enable_aselo_messaging_ui": false,
             "enable_csam_clc_report": false,
             "enable_csam_report": true,
-            "enable_voice_recordings": false,
-            "enable_case_merging": true
+            "enable_voice_recordings": false
         }
     }
 }

--- a/twilio-iac/helplines/uk/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/uk/configs/service-configuration/common.json
@@ -11,8 +11,7 @@
             "enable_transcripts": true,
             "enable_twilio_transcripts": false,
             "enable_voice_recordings": false,
-            "post_survey_serverless_handled": false,
-            "enable_case_merging": true
+            "post_survey_serverless_handled": false
         },
         "hrm_base_url": "https://hrm-test.tl.techmatters.org",
         "multipleOfficeSupport": true,


### PR DESCRIPTION
Turn on Case Merging for all staging and production helplines

I changed the default for all helplines to be `"enable_case_merging: true"` and then removed the case merging feature flag from all other common, staging, and production json files.