### PR TITLE
CHI-2224: Child at risk checkbox status not kept while editing

### DIFF
--- a/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
+++ b/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
@@ -124,7 +124,6 @@ const EditCaseSummary: React.FC<Props> = ({
           name: 'childIsAtRisk',
           label: 'Case-ChildIsAtRisk',
           type: FormInputType.Checkbox,
-          initialChecked: Boolean(workingCopy?.childIsAtRisk),
         },
         {
           name: 'summary',
@@ -136,7 +135,7 @@ const EditCaseSummary: React.FC<Props> = ({
       console.error('Failed to render edit case summary form', e);
       return [];
     }
-  }, [availableStatusTransitions, workingCopy?.childIsAtRisk]);
+  }, [availableStatusTransitions]);
 
   const savedForm = React.useMemo(() => {
     const {

--- a/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
+++ b/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
@@ -124,6 +124,7 @@ const EditCaseSummary: React.FC<Props> = ({
           name: 'childIsAtRisk',
           label: 'Case-ChildIsAtRisk',
           type: FormInputType.Checkbox,
+          initialChecked: Boolean(workingCopy?.childIsAtRisk),
         },
         {
           name: 'summary',
@@ -135,7 +136,7 @@ const EditCaseSummary: React.FC<Props> = ({
       console.error('Failed to render edit case summary form', e);
       return [];
     }
-  }, [availableStatusTransitions]);
+  }, [availableStatusTransitions, workingCopy?.childIsAtRisk]);
 
   const savedForm = React.useMemo(() => {
     const {

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -67,7 +67,6 @@ export const getInitialValue = (def: FormItemDefinition) => {
       if (def.initializeWithCurrent) {
         return format(startOfDay(new Date()), 'yyyy-MM-dd');
       }
-
       return '';
     }
     case FormInputType.TimeInput: {

--- a/plugin-hrm-form/src/components/forms/hooks/useCreateFormFromDefinition.tsx
+++ b/plugin-hrm-form/src/components/forms/hooks/useCreateFormFromDefinition.tsx
@@ -49,6 +49,9 @@ const useCreateFormFromDefinition = ({
   context = {},
 }: UseFormFromDefinition) => {
   const firstElementRef = useFocus(shouldFocusFirstElement);
+
+  if (!initialValues) return [];
+
   return definition.map((e: FormItemDefinition, index: number) => {
     const elementRef = index === 0 ? firstElementRef : null;
     const maybeValue = get(initialValues, e.name);


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Bug fix: This PR fixes the issue that affects the `childAtRisk` checkbox not being checked when the edit button is clicked even when the checkbox has a true (checked) value.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
[CHI-2224](https://tech-matters.atlassian.net/browse/CHI-2224)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
1. Check the “Child is at risk” checkbox in the Case Overview section and save it.
2. Close the case and reopen it (this part is important, if you click the Edit button right away the checkbox will work properly)
3. Click on Edit. Verify that the “Child is at risk” checkbox is still checked.

[CHI-2224]: https://tech-matters.atlassian.net/browse/CHI-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ