### PR TITLE
CHI-2616: llow save without media

### DIFF
--- a/plugin-hrm-form/src/___tests__/permissions/index.test.ts
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.ts
@@ -20,18 +20,20 @@ import { subDays } from 'date-fns';
 
 import * as fetchRulesModule from '../../permissions/fetchRules';
 import {
+  actionsMaps,
+  CaseActions,
+  cleanupInitializedCan,
+  ContactActions,
   getInitializedCan,
   PermissionActions,
-  CaseActions,
-  ContactActions,
-  ViewIdentifiersAction,
-  cleanupInitializedCan,
-  actionsMaps,
-  TargetKind,
   ProfileActions,
   ProfileSectionActions,
+  TargetKind,
+  ViewIdentifiersAction,
 } from '../../permissions';
 import { getHrmConfig } from '../../hrmConfig';
+
+const NOT_CREATOR_WORKER_SID = 'WK-not creator';
 
 const fetchRulesSpy = jest.spyOn(fetchRulesModule, 'fetchRules').mockImplementation(() => {
   throw new Error('fetchRules not mocked!');
@@ -65,7 +67,7 @@ describe('Test that all actions work fine (everyone)', () => {
   fetchRulesSpy.mockReturnValue(rules);
 
   mockGetHrmConfig.mockReturnValue({
-    workerSid: 'not creator',
+    workerSid: NOT_CREATOR_WORKER_SID,
     isSupervisor: false,
     permissionConfig: 'wareva',
   });
@@ -92,7 +94,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [['everyone']],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: false,
           expectedResult: true,
           expectedDescription: 'is not creator nor supervisor, case is open',
@@ -100,7 +102,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [['everyone']],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: false,
           expectedResult: true,
           expectedDescription: 'is not creator nor supervisor, case is close',
@@ -117,7 +119,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: true,
           expectedResult: true,
           expectedDescription: 'user is supervisor but not creator, case open',
@@ -125,7 +127,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: true,
           expectedResult: true,
           expectedDescription: 'user is supervisor but not creator, case closed',
@@ -134,7 +136,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: false,
           expectedResult: false,
           expectedDescription: 'user is not supervisor nor creator',
@@ -159,7 +161,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [['isSupervisor'], ['isCreator', 'isCaseOpen']],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: false,
           expectedResult: false,
           expectedDescription: 'case is open but user is not creator',
@@ -167,7 +169,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [[{ createdHoursAgo: 1 }]],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: false,
           expectedResult: true,
           expectedDescription: 'created less than 1 hour ago',
@@ -176,7 +178,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [[{ createdHoursAgo: 1 }]],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: false,
           expectedResult: false,
           expectedDescription: 'created less than 1 hour ago',
@@ -185,7 +187,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [[{ createdDaysAgo: 1 }]],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: false,
           expectedResult: true,
           expectedDescription: 'created less than 1 day ago',
@@ -194,7 +196,7 @@ describe('CasesActions', () => {
         {
           action,
           conditionsSets: [[{ createdDaysAgo: 1 }]],
-          workerSid: 'not creator',
+          workerSid: NOT_CREATOR_WORKER_SID,
           isSupervisor: false,
           expectedResult: false,
           expectedDescription: 'created less than 1 day ago',
@@ -511,7 +513,7 @@ describe('ProfileSectionActions', () => {
         },
       ])
       .map(addPrettyPrintConditions),
-  ).test.only(
+  ).test(
     `Should return $expectedResult for action $action when $expectedDescription and conditionsSets are $prettyConditionsSets`,
     ({ action, conditionsSets, workerSid = 'workerSid', isSupervisor, expectedResult, createdAt, sectionType }) => {
       const rules = buildRules(conditionsSets, 'profileSection');

--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -441,8 +441,9 @@ describe('handleTwilioTask() (externalRecording)', () => {
       attributes: {},
     };
 
-    await expect(handleTwilioTask(task)).rejects.toThrow(
-      'Error getting external recording info: Could not find call sid',
-    );
+    const returnData = await handleTwilioTask(task);
+    expect(returnData).toStrictEqual({
+      conversationMedia: [{ storeType: 'twilio', storeTypeSpecificData: { reservationSid: undefined } }],
+    });
   });
 });

--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -128,8 +128,8 @@ describe('saveContact()', () => {
     defaultFrom: 'Anonymous',
     attributes: { isContactlessTask: false, preEngagementData: { contactType: 'ip', contactIdentifier: 'ip-address' } },
   };
-  const workerSid = 'worker-sid';
-  const uniqueIdentifier = 'uniqueIdentifier';
+  const workerSid = 'WK-worker-sid';
+  const uniqueIdentifier = 'WT-uniqueIdentifier';
   const fetchSuccess = Promise.resolve(<any>{ ok: true, json: jest.fn(), text: jest.fn() });
 
   test('data calltype saves form data', async () => {
@@ -166,8 +166,8 @@ describe('saveContact() (isContactlessTask)', () => {
     defaultFrom: 'Anonymous',
     attributes: { isContactlessTask: true },
   };
-  const workerSid = 'worker-sid';
-  const uniqueIdentifier = 'uniqueIdentifier';
+  const workerSid = 'WK-worker-sid';
+  const uniqueIdentifier = 'WT-uniqueIdentifier';
   const fetchJson = jest.fn();
   const fetchSuccess = Promise.resolve(<any>{
     ok: true,
@@ -326,7 +326,7 @@ describe('saveContact() (externalRecording)', () => {
     };
 
     const { savedContact, metadata } = createContactState({ callType: callTypes.child, childFirstName: 'Jill' });
-    await saveContact(task, savedContact, metadata, 'workerSid', 'uniqueIdentifier');
+    await saveContact(task, savedContact, metadata, 'WK-workerSid', 'WT-uniqueIdentifier');
 
     const formFromPOST = getFormFromMediaPOST(mockedFetch);
     expect(formFromPOST).toStrictEqual([

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -78,47 +78,65 @@ export const handleTwilioTask = async (task): Promise<HandleTwilioTaskResponse> 
     return returnData;
   }
 
-  if (TaskHelper.isChatBasedTask(task)) {
-    // Store a pending transcript
+  try {
+    if (TaskHelper.isChatBasedTask(task)) {
+      // Store a pending transcript
+      returnData.conversationMedia.push({
+        storeType: 'S3',
+        storeTypeSpecificData: {
+          type: 'transcript',
+          location: undefined,
+        },
+      });
+    }
+
+    if (TaskHelper.isChatBasedTask(task) || TaskHelper.isCallTask(task)) {
+      // Store reservation sid to use Twilio insights overlay (recordings/transcript)
+      returnData.conversationMedia.push({
+        storeType: 'twilio',
+        storeTypeSpecificData: {
+          reservationSid: task.sid,
+        },
+      });
+    }
+
+    if (!shouldGetExternalRecordingInfo(task)) return returnData;
+
+    const externalRecordingInfo = await getExternalRecordingInfo(task);
+    if (isFailureExternalRecordingInfo(externalRecordingInfo)) {
+      console.error(
+        'Failed to get external recording info',
+        externalRecordingInfo.error,
+        'Task:',
+        task,
+        'Return data captured so far:',
+        returnData,
+      );
+      return returnData;
+    }
+
+    returnData.externalRecordingInfo = externalRecordingInfo;
+    const { bucket, key } = externalRecordingInfo;
     returnData.conversationMedia.push({
       storeType: 'S3',
       storeTypeSpecificData: {
-        type: 'transcript',
-        location: undefined,
+        type: 'recording',
+        location: {
+          bucket,
+          key,
+        },
       },
     });
+  } catch (err) {
+    console.error(
+      'Error processing contact media during finalization:',
+      err,
+      'Task:',
+      task,
+      'Return data captured so far:',
+      returnData,
+    );
   }
-
-  if (TaskHelper.isChatBasedTask(task) || TaskHelper.isCallTask(task)) {
-    // Store reservation sid to use Twilio insights overlay (recordings/transcript)
-    returnData.conversationMedia.push({
-      storeType: 'twilio',
-      storeTypeSpecificData: {
-        reservationSid: task.sid,
-      },
-    });
-  }
-
-  if (!shouldGetExternalRecordingInfo(task)) return returnData;
-
-  const externalRecordingInfo = await getExternalRecordingInfo(task);
-  if (isFailureExternalRecordingInfo(externalRecordingInfo)) {
-    throw new Error(`Error getting external recording info: ${externalRecordingInfo.error}`);
-  }
-
-  returnData.externalRecordingInfo = externalRecordingInfo;
-  const { bucket, key } = externalRecordingInfo;
-  returnData.conversationMedia.push({
-    storeType: 'S3',
-    storeTypeSpecificData: {
-      type: 'recording',
-      location: {
-        bucket,
-        key,
-      },
-    },
-  });
-
   return returnData;
 };
 
@@ -210,16 +228,9 @@ const saveContactToHrm = async (
 
   // This might change if isNonDataCallType, that's why we use rawForm
   const timeOfContact = new Date(getDateTime(form.contactlessTask)).toISOString();
-  let channelSid;
-  let serviceSid;
-  let externalRecordingInfo = null;
-  try {
-    const twilioTaskResult = await handleTwilioTask(task);
-    ({ channelSid, serviceSid, externalRecordingInfo } = twilioTaskResult);
-    await saveConversationMedia(contact.id, twilioTaskResult.conversationMedia);
-  } catch (error) {
-    console.error(`Error saving conversation media, continuing to save to HRM: `, error);
-  }
+  const twilioTaskResult = await handleTwilioTask(task);
+  const { channelSid, serviceSid, externalRecordingInfo } = twilioTaskResult;
+  await saveConversationMedia(contact.id, twilioTaskResult.conversationMedia);
 
   /*
    * We do a transform from the original and then add things.
@@ -244,7 +255,7 @@ const saveContactToHrm = async (
 
   return {
     response,
-    externalRecordingInfo,
+    externalRecordingInfo: externalRecordingInfo ?? null,
   };
 };
 

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -210,10 +210,16 @@ const saveContactToHrm = async (
 
   // This might change if isNonDataCallType, that's why we use rawForm
   const timeOfContact = new Date(getDateTime(form.contactlessTask)).toISOString();
-
-  const { conversationMedia, channelSid, serviceSid, externalRecordingInfo } = await handleTwilioTask(task);
-
-  await saveConversationMedia(contact.id, conversationMedia);
+  let channelSid;
+  let serviceSid;
+  let externalRecordingInfo = null;
+  try {
+    const twilioTaskResult = await handleTwilioTask(task);
+    ({ channelSid, serviceSid, externalRecordingInfo } = twilioTaskResult);
+    await saveConversationMedia(contact.id, twilioTaskResult.conversationMedia);
+  } catch (error) {
+    console.error(`Error saving conversation media, continuing to save to HRM: `, error);
+  }
 
   /*
    * We do a transform from the original and then add things.

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -44,6 +44,7 @@ import { ContactDraftChanges } from '../states/contacts/existingContacts';
 import { newContactState } from '../states/contacts/contactState';
 import { ApiError, FetchOptions } from './fetchApi';
 import { TaskSID, WorkerSID } from '../types/twilio';
+import { recordEvent } from '../fullStory';
 
 export async function searchContacts(
   searchParams: SearchParams,
@@ -112,6 +113,13 @@ export const handleTwilioTask = async (task): Promise<HandleTwilioTaskResponse> 
         'Return data captured so far:',
         returnData,
       );
+      recordEvent('Backend Error: Get External Recording Info', {
+        taskSid: task.taskSid,
+        reservationSid: task.sid,
+        recordingError: externalRecordingInfo.error,
+        isCallTask: TaskHelper.isCallTask(task),
+        isChatBasedTask: TaskHelper.isChatBasedTask(task),
+      });
       return returnData;
     }
 


### PR DESCRIPTION
## Description

* Allows contacts to continue saving & finalizing even when the media saving portion of the process fails
* Logs out more info about the issue & context
* 

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Test happy path by saving call & chat contacts
To test the error case you need to run broken code locally
The real test will be when the intermittent 'no call SID' occurs, and the contact still finalizes, but this is not reproducible RN