### PR TITLE
fix: profiles filter translation [CHI-2631]

### DIFF
--- a/plugin-hrm-form/src/components/caseList/filters/MultiSelectFilter.tsx
+++ b/plugin-hrm-form/src/components/caseList/filters/MultiSelectFilter.tsx
@@ -51,11 +51,12 @@ type ReactHookFormValues = {
 
 type OwnProps = {
   name: string;
-  text: string;
+  text: string | React.ReactElement;
   defaultValues: Item[];
   withSearch?: boolean;
   openedFilter: string;
   searchable?: boolean;
+  capitalizeOptions?: boolean;
   searchDescription?: string;
   applyFilter: (values: Item[]) => void;
   setOpenedFilter: (name: string) => void;
@@ -70,6 +71,7 @@ const MultiSelectFilter: React.FC<Props> = ({
   defaultValues,
   openedFilter,
   searchable,
+  capitalizeOptions,
   searchDescription,
   applyFilter,
   setOpenedFilter,
@@ -177,7 +179,11 @@ const MultiSelectFilter: React.FC<Props> = ({
   const drawCount = () => (selectedCount === 0 ? '' : ` (${selectedCount})`);
 
   const highlightLabel = (label: string) => {
-    if (!searchable || searchTerm.length === 0) {
+    if (!searchable) {
+      return <Template code={label} />;
+    }
+
+    if (searchTerm.length === 0) {
       return <span>{label}</span>;
     }
 
@@ -257,7 +263,9 @@ const MultiSelectFilter: React.FC<Props> = ({
                         }}
                         onKeyDown={isFirstFocusableElement ? handleShiftTabForFirstElement : null}
                       />
-                      <MultiSelectCheckboxLabel>{highlightLabel(item.label)}</MultiSelectCheckboxLabel>
+                      <MultiSelectCheckboxLabel capitalize={capitalizeOptions}>
+                        {highlightLabel(item.label)}
+                      </MultiSelectCheckboxLabel>
                     </FormLabel>
                   </MultiSelectListItem>
                 );

--- a/plugin-hrm-form/src/components/profile/profileFlag/ProfileFlagPill.tsx
+++ b/plugin-hrm-form/src/components/profile/profileFlag/ProfileFlagPill.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import { format } from 'date-fns';
 import { Template } from '@twilio/flex-ui';
 
-import { getTemplateStrings } from '../../../hrmConfig';
 import { ProfileFlag } from '../../../types/types';
 import { FlagPill, ProfileFlagsListItem, StyledBlockOutlinedIcon, FlagPillTime } from '../styles';
 
@@ -33,13 +32,18 @@ const ProfileFlagPill: React.FC<Props> = ({ flag, renderDisassociate }) => {
     formattedDate = `${format(new Date(flag.validUntil), 'MMMM d, yyyy, h:mma')}`;
   }
 
-  const strings = getTemplateStrings();
   return (
     <ProfileFlagsListItem key={flag.name}>
       <FlagPill title={`${flag.name} Status`} key={flag.name} fillColor="#F5EEF4" isBlocked={flag.name === 'blocked'}>
         {flag.name === 'blocked' && <StyledBlockOutlinedIcon />}
         <Template code={flag.name} />
-        <FlagPillTime>{flag.validUntil && `${strings['Profile-ValidUntil']} ${formattedDate}`}</FlagPillTime>
+        <FlagPillTime>
+          {flag.validUntil && (
+            <>
+              <Template code="Profile-ValidUntil" /> {formattedDate}
+            </>
+          )}
+        </FlagPillTime>
         {renderDisassociate && renderDisassociate(flag)}
       </FlagPill>
     </ProfileFlagsListItem>

--- a/plugin-hrm-form/src/components/profileList/filters/ProfileFilters.tsx
+++ b/plugin-hrm-form/src/components/profileList/filters/ProfileFilters.tsx
@@ -40,7 +40,7 @@ const ProfileFilters: React.FC = () => {
     (flags: ProfileFlag[]) => {
       return flags.map(flag => ({
         value: `_${flag.id}`,
-        label: flag.name.charAt(0).toUpperCase() + flag.name.slice(1),
+        label: flag.name,
         checked: filter.statuses.includes(flag.id.toString()),
       }));
     },
@@ -59,8 +59,6 @@ const ProfileFilters: React.FC = () => {
     }
   }, [allProfileFlags, flagsLoading, computeStatusValues]);
 
-  const strings = getTemplateStrings();
-
   const handleApplyStatusFilter = useCallback(
     (values: Item[]) => {
       const checkedItems = filterCheckedItems(values).map(item => item.replace('_', ''));
@@ -76,11 +74,12 @@ const ProfileFilters: React.FC = () => {
     return (
       <MultiSelectFilter
         name="status"
-        text={strings['ProfileList-THStatus']}
+        text={<Template code="ProfileList-THStatus" />}
         defaultValues={statusValues}
         openedFilter={openedFilter}
         applyFilter={handleApplyStatusFilter}
         setOpenedFilter={setOpenedFilter}
+        capitalizeOptions
       />
     );
   };

--- a/plugin-hrm-form/src/styles/filters.ts
+++ b/plugin-hrm-form/src/styles/filters.ts
@@ -198,11 +198,13 @@ export const MultiSelectListItem = styled('li')<MultiSelectListItemProps>`
 `;
 MultiSelectListItem.displayName = 'MultiSelectListItem';
 
-export const MultiSelectCheckboxLabel = styled('span')`
+export const MultiSelectCheckboxLabel = styled('span')<{ capitalize?: boolean }>`
   font-family: 'Open Sans';
   font-size: 13px;
   color: #192b33;
   margin-left: 2px;
+
+  ${({ capitalize }) => (capitalize ? 'text-transform: capitalize;' : '')}
 
   strong {
     font-weight: 700;


### PR DESCRIPTION
## Description
This PR fixes the bug described in the Jira ticket linked below
> Client profile tags like Abusive and Blocked are translatable, but not the filters labels on the client profiles page are not.

The bug was caused because in order to render the list of flags uppercased, a string manipulation was used. This caused that the filters, for a value like `abusive`, ended up receiving a string like `Abusive`. Since the translations are assumed to be on the `name` of the flags, this caused a missmatch between the value being passed to the filters and the translations. This bug has been present since this component was implemented ([see](https://github.com/techmatters/flex-plugins/blame/92102fcb862e34e102a87a904c686c4b247d8ae8/plugin-hrm-form/src/components/profileList/filters/ProfileFilters.tsx#L39)).

To fix this issue, the filters now receive the profile flag `name` without any string manipulation, and instead the UI components will capitalize the strings being passed on. 
In order to achieve this behavior, I also needed to do some small tweaks to the `src/components/caseList/filters/MultiSelectFilter` component: when the filter is not searchable, the string rendered can now be translated (via `Template` component). This would be harder to implement if we allow this behavior in "searchable" variants, but doable. I'm skipping that for now since it's not really related to the bug this PR intends to fix.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2631)
- [ ] New tests added
- [n/a] Feature flags added
- [x] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Verification steps
- Start local server (`npm run dev`).
- Confirm that the flags are displayed in the UI as intended.
  ![Screenshot from 2024-03-04 17-02-19](https://github.com/techmatters/flex-plugins/assets/15805319/052b687f-2c94-4254-8f73-e837927ea7dd)
- Change `src/translations/en-US/flexUI.json` adding an entry like:
  `"abusive": "Verbally Abusive"`.
- Confirm that the flags are now translated according to the above changes.
  ![image](https://github.com/techmatters/flex-plugins/assets/15805319/1842e809-38cc-4452-b07c-3a0836205c5c)
