### PR TITLE
CHI-2627 bg: fix bug with viewing contact

### DIFF
--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -315,14 +315,14 @@ const applyTimeBasedConditions = (conditions: TimeBasedCondition[]) => (
       if (cond === 'createdHoursAgo') {
         return {
           ...accum,
-          [key]: differenceInHours(ctx.curentTimestamp, target && parseISO(target.createdAt)) < param,
+          [key]: target && differenceInHours(ctx.curentTimestamp, parseISO(target.createdAt)) < param,
         };
       }
 
       if (cond === 'createdDaysAgo') {
         return {
           ...accum,
-          [key]: differenceInDays(ctx.curentTimestamp, target && parseISO(target.createdAt)) < param,
+          [key]: target && differenceInDays(ctx.curentTimestamp, parseISO(target.createdAt)) < param,
         };
       }
 

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -315,14 +315,14 @@ const applyTimeBasedConditions = (conditions: TimeBasedCondition[]) => (
       if (cond === 'createdHoursAgo') {
         return {
           ...accum,
-          [key]: differenceInHours(ctx.curentTimestamp, parseISO(target.createdAt)) < param,
+          [key]: differenceInHours(ctx.curentTimestamp, parseISO(target?.createdAt)) < param,
         };
       }
 
       if (cond === 'createdDaysAgo') {
         return {
           ...accum,
-          [key]: differenceInDays(ctx.curentTimestamp, parseISO(target.createdAt)) < param,
+          [key]: differenceInDays(ctx.curentTimestamp, parseISO(target?.createdAt)) < param,
         };
       }
 

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -315,14 +315,14 @@ const applyTimeBasedConditions = (conditions: TimeBasedCondition[]) => (
       if (cond === 'createdHoursAgo') {
         return {
           ...accum,
-          [key]: differenceInHours(ctx.curentTimestamp, parseISO(target?.createdAt)) < param,
+          [key]: differenceInHours(ctx.curentTimestamp, target && parseISO(target.createdAt)) < param,
         };
       }
 
       if (cond === 'createdDaysAgo') {
         return {
           ...accum,
-          [key]: differenceInDays(ctx.curentTimestamp, parseISO(target?.createdAt)) < param,
+          [key]: differenceInDays(ctx.curentTimestamp, target && parseISO(target.createdAt)) < param,
         };
       }
 


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

- Bug fix: Opening contact linked to closed case brings a white screen.
- From the contact search view, while trying to open a contact linked to a closed case, the system brings a white screen.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
This should be replicated with NZ
- Search for contact with close case
- Click on the contact
- Verify that the contact details are displayed