### PR TITLE
refactor: use dedicate endpoints to fetch case and contact counts [CHI-2624]

### DIFF
--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -19,7 +19,6 @@ import React, { useEffect, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { CircularProgress } from '@material-ui/core';
 import { AnyAction, bindActionCreators } from 'redux';
-import { parseISO } from 'date-fns';
 
 import { RootState } from '../../states';
 import { getDefinitionVersion } from '../../services/ServerlessService';

--- a/plugin-hrm-form/src/components/profile/IdentifierBanner/ProfileIdentifierBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/IdentifierBanner/ProfileIdentifierBanner.tsx
@@ -18,7 +18,12 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { Template } from '@twilio/flex-ui';
 
-import { useIdentifierByIdentifier, useProfileProperty, useProfile } from '../../../states/profile/hooks';
+import {
+  useIdentifierByIdentifier,
+  useProfileProperty,
+  useProfile,
+  useProfileRelationshipsByType,
+} from '../../../states/profile/hooks';
 import { YellowBannerContainer, IconContainer, IdentifierContainer, BannerLink } from './styles';
 import { Bold } from '../../../styles';
 import { newOpenModalAction } from '../../../states/routing/actions';
@@ -60,17 +65,33 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal, open
   const formattedIdentifier = getFormattedNumberFromTask(task);
   const identifierIdentifier = getNumberFromTask(task);
   const { identifier } = useIdentifierByIdentifier({ identifierIdentifier, shouldAutoload: true });
+
+  /**
+   * This is a known hack that is OK as long as we ensure that there is only exactly 1 Profile for each Identifier.
+   * When the time comes that's no longer true, below logic should accoutn for all the Profiles related to the Identifier.
+   */
   const profileId = identifier?.profiles?.[0]?.id;
   const { canView } = useProfile({ profileId });
 
-  const contactsCount = useProfileProperty(profileId, 'contactsCount') || 0;
-  const casesCount = useProfileProperty(profileId, 'casesCount') || 0;
+  const { total: contactsCount, loading: contactsLoading } = useProfileRelationshipsByType({
+    profileId,
+    page: 0,
+    type: 'contacts',
+  });
+  const { total: casesCount, loading: casesLoading } = useProfileRelationshipsByType({
+    profileId,
+    page: 0,
+    type: 'cases',
+  });
+
+  // const contactsCount = useProfileProperty(profileId, 'contactsCount') || 0;
+  // const casesCount = useProfileProperty(profileId, 'casesCount') || 0;
 
   const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
 
   // We immediately create a contact when a task is created, so we don't want to show the banner
   const shouldDisplayBanner = contactsCount > 0 || casesCount > 0;
-  if (!shouldDisplayBanner) return null;
+  if (!shouldDisplayBanner || contactsLoading || casesLoading) return null;
 
   const handleViewClients = () => {
     openProfileModal(profileId);

--- a/plugin-hrm-form/src/components/profile/ProfileTabs.tsx
+++ b/plugin-hrm-form/src/components/profile/ProfileTabs.tsx
@@ -17,8 +17,9 @@
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { Tab as TwilioTab, Template } from '@twilio/flex-ui';
+import { CircularProgress } from '@material-ui/core';
 
-import { useProfile, useProfileLoader } from '../../states/profile/hooks';
+import { useProfile, useProfileRelationshipsByType } from '../../states/profile/hooks';
 import * as RoutingTypes from '../../states/routing/types';
 import { getCurrentTopmostRouteForTask } from '../../states/routing/getRoute';
 import * as RoutingActions from '../../states/routing/actions';
@@ -59,10 +60,17 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ProfileTabs: React.FC<Props> = ({ profileId, task, currentTab, changeProfileTab }) => {
-  const { profile, canView } = useProfile({ profileId });
-  const { contactsCount, casesCount } = profile;
-
-  useProfileLoader({ profileId });
+  const { canView } = useProfile({ profileId });
+  const { total: contactsCount, loading: contactsLoading } = useProfileRelationshipsByType({
+    profileId,
+    page: 0,
+    type: 'contacts',
+  });
+  const { total: casesCount, loading: casesLoading } = useProfileRelationshipsByType({
+    profileId,
+    page: 0,
+    type: 'cases',
+  });
 
   const tabs = [
     {
@@ -73,7 +81,8 @@ const ProfileTabs: React.FC<Props> = ({ profileId, task, currentTab, changeProfi
     {
       label: (
         <>
-          <Template code="SearchResultsIndex-Contacts" /> ({contactsCount})
+          <Template code="SearchResultsIndex-Contacts" /> (
+          {contactsLoading ? <CircularProgress size={10} /> : contactsCount})
         </>
       ),
       key: 'contacts',
@@ -82,7 +91,7 @@ const ProfileTabs: React.FC<Props> = ({ profileId, task, currentTab, changeProfi
     {
       label: (
         <>
-          <Template code="SearchResultsIndex-Cases" /> ({casesCount})
+          <Template code="SearchResultsIndex-Cases" /> ({casesLoading ? <CircularProgress size={10} /> : casesCount})
         </>
       ),
       key: 'cases',

--- a/plugin-hrm-form/src/states/profile/hooks/index.ts
+++ b/plugin-hrm-form/src/states/profile/hooks/index.ts
@@ -22,3 +22,4 @@ export * from './useProfileProperty';
 export * from './useProfileSection';
 export * from './useProfilesList';
 export * from './useProfilesListLoader';
+export * from './useProfileRelationshipsBytype';

--- a/plugin-hrm-form/src/states/profile/hooks/useProfile.ts
+++ b/plugin-hrm-form/src/states/profile/hooks/useProfile.ts
@@ -21,8 +21,9 @@ import * as ProfileSelectors from '../selectors';
 import { RootState } from '../..';
 import { UseProfileCommonParams } from './types';
 import { PermissionActions, getInitializedCan } from '../../../permissions';
+import { useProfileLoader } from './useProfileLoader';
 
-export type UseProfileParams = UseProfileCommonParams;
+export type UseProfileParams = UseProfileCommonParams & { autoload?: boolean; refresh?: boolean };
 
 export type UseProfileReturn = {
   profile: Profile | undefined;
@@ -39,11 +40,14 @@ export type UseProfileReturn = {
  * @returns {UseProfile} - State and actions for the profile
  */
 export const useProfile = (params: UseProfileParams): UseProfileReturn => {
+  const { profileId } = params;
+
+  useProfileLoader({ profileId, autoload: true });
+
   const can = useMemo(() => {
     return getInitializedCan();
   }, []);
 
-  const { profileId } = params;
   const profile = useSelector((state: RootState) => ProfileSelectors.selectProfileById(state, profileId)?.data);
   const loading = useSelector((state: RootState) => ProfileSelectors.selectProfileById(state, profileId)?.loading);
 

--- a/plugin-hrm-form/src/states/profile/hooks/useProfileLoader.ts
+++ b/plugin-hrm-form/src/states/profile/hooks/useProfileLoader.ts
@@ -54,11 +54,12 @@ export const useProfileLoader = ({
   const firstFetch = autoload && !loading && !data;
 
   useEffect(() => {
+    if (!profileId) return;
+
     if (firstFetch || refresh) {
       loadProfile();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profileId, autoload, loadProfile]);
+  }, [firstFetch, loadProfile, profileId, refresh]);
 
   return {
     error,

--- a/plugin-hrm-form/src/states/profile/hooks/useProfileLoader.ts
+++ b/plugin-hrm-form/src/states/profile/hooks/useProfileLoader.ts
@@ -22,9 +22,7 @@ import * as ProfileActions from '../profiles';
 import * as ProfileSelectors from '../selectors';
 import { UseProfileCommonParams } from './types';
 
-type UseProfileLoaderParams = UseProfileCommonParams & {
-  skipAutoload?: boolean;
-};
+type UseProfileLoaderParams = UseProfileCommonParams & { autoload?: boolean; refresh?: boolean };
 
 type UseProfileLoaderReturn = {
   error?: any;
@@ -41,21 +39,26 @@ type UseProfileLoaderReturn = {
  */
 export const useProfileLoader = ({
   profileId,
-  skipAutoload = false,
+  autoload = true,
+  refresh = false,
 }: UseProfileLoaderParams): UseProfileLoaderReturn => {
   const dispatch = useDispatch();
   const error = useSelector((state: RootState) => ProfileSelectors.selectProfileById(state, profileId)?.error);
   const loading = useSelector((state: RootState) => ProfileSelectors.selectProfileById(state, profileId)?.loading);
+  const data = useSelector((state: RootState) => ProfileSelectors.selectProfileById(state, profileId)?.data);
+
   const loadProfile = useCallback(() => {
     asyncDispatch(dispatch)(ProfileActions.loadProfileAsync(profileId));
   }, [dispatch, profileId]);
 
+  const firstFetch = autoload && !loading && !data;
+
   useEffect(() => {
-    if (!skipAutoload && !loading) {
+    if (firstFetch || refresh) {
       loadProfile();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profileId, skipAutoload, loadProfile]);
+  }, [profileId, autoload, loadProfile]);
 
   return {
     error,

--- a/plugin-hrm-form/src/states/profile/hooks/useProfileRelationshipsBytype.ts
+++ b/plugin-hrm-form/src/states/profile/hooks/useProfileRelationshipsBytype.ts
@@ -1,0 +1,76 @@
+/* eslint-disable import/no-unused-modules */
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { selectProfileRelationshipsByType } from '../selectors';
+import asyncDispatch from '../../asyncDispatch';
+import { ProfileRelationships } from '../types';
+import * as ProfileActions from '../profiles';
+import { RootState } from '../..';
+import { UseProfileCommonParams } from './types';
+
+export type UseProfileRelationsByType = UseProfileCommonParams & {
+  type: ProfileRelationships;
+  page: number;
+};
+
+export const useProfileRelationshipsLoaderByType = ({ profileId, type, page }: UseProfileRelationsByType) => {
+  const dispatch = useDispatch();
+
+  const loadProfileRelationshipsByTypeAsync = useCallback(
+    (params: ProfileActions.LoadRelationshipAsyncParams) => {
+      asyncDispatch(dispatch)(ProfileActions.loadRelationshipAsync(params));
+    },
+    [dispatch],
+  );
+
+  useEffect(() => {
+    if (!profileId) return;
+
+    loadProfileRelationshipsByTypeAsync({ profileId, type, page });
+  }, [profileId, loadProfileRelationshipsByTypeAsync, type, page]);
+
+  const error = useSelector((state: RootState) => selectProfileRelationshipsByType(state, profileId, type))?.error;
+  const loading = useSelector((state: RootState) => selectProfileRelationshipsByType(state, profileId, type))?.loading;
+
+  return {
+    error,
+    loading,
+    loadProfileRelationshipsByTypeAsync,
+  };
+};
+
+export const useProfileRelationshipsByType = ({ profileId, type, page }: UseProfileRelationsByType) => {
+  // Triggerr a load on the profile relationships
+  useProfileRelationshipsLoaderByType({ profileId, type, page });
+
+  const data = useSelector((state: RootState) => selectProfileRelationshipsByType(state, profileId, type))?.data;
+  const error = useSelector((state: RootState) => selectProfileRelationshipsByType(state, profileId, type))?.error;
+  const loading = useSelector((state: RootState) => selectProfileRelationshipsByType(state, profileId, type))?.loading;
+  const currentPage = useSelector((state: RootState) => selectProfileRelationshipsByType(state, profileId, type))?.page;
+  const total = useSelector((state: RootState) => selectProfileRelationshipsByType(state, profileId, type))?.total;
+
+  return {
+    data,
+    error,
+    loading,
+    page: currentPage,
+    total,
+  };
+};

--- a/plugin-hrm-form/src/states/profile/profiles.ts
+++ b/plugin-hrm-form/src/states/profile/profiles.ts
@@ -31,7 +31,7 @@ type CommonRelationshipParams = {
   type: t.ProfileRelationships;
 };
 
-type LoadRelationshipAsyncParams = CommonRelationshipParams & {
+export type LoadRelationshipAsyncParams = CommonRelationshipParams & {
   page?: number;
 };
 
@@ -197,14 +197,6 @@ const handleProfileFlagUpdateFulfilledAction = (state: t.ProfilesState, action: 
 
   const profileUpdate = {
     loading: false,
-    cases: {
-      ...state[profileId].cases,
-      total: action.payload.casesCount,
-    },
-    contacts: {
-      ...state[profileId].contacts,
-      total: action.payload.contactsCount,
-    },
     data: {
       ...t.newProfileEntry,
       ...state[profileId].data,

--- a/plugin-hrm-form/src/states/profile/types.ts
+++ b/plugin-hrm-form/src/states/profile/types.ts
@@ -14,6 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import { getProfileContacts, getProfileCases } from '../../services/ProfileService';
 import {
   Case,
   Contact,
@@ -26,8 +27,8 @@ import {
   ProfilesListSortBy,
   SortDirection,
 } from '../../types/types';
-import { getProfileContacts, getProfileCases } from '../../services/ProfileService';
-import { ParseFetchErrorResult } from '../parseFetchError';
+import type { ParseFetchErrorResult } from '../parseFetchError';
+import type { AsyncCommon } from '../types';
 
 export type { Case, Contact, Identifier, Profile, ProfileFlag, ProfileSection };
 
@@ -111,27 +112,22 @@ export const PROFILE_RELATIONSHIPS = {
 export type ProfileRelationships = keyof typeof PROFILE_RELATIONSHIPS;
 export type ProfileRelationshipTypes = Case | Contact;
 
-export type ProfileAsyncCommon<t> = {
-  loading: boolean;
-  error?: ParseFetchErrorResult;
-  data?: t;
+type ProfileRelationshipsCommon<T> = AsyncCommon<T> & {
+  page: number;
+  total?: number;
+};
+type ProfileAsyncRelationships = {
+  contacts: ProfileRelationshipsCommon<Contact[]>;
+  cases: ProfileRelationshipsCommon<Case[]>;
 };
 
-export type ProfileAsyncRelationships = {
-  [type in ProfileRelationships]: ProfileAsyncCommon<ProfileRelationshipTypes[]> & {
-    page: number;
-    total?: number;
+export type ProfileEntry = AsyncCommon<Profile> & {
+  sections?: {
+    [sectionType: ProfileSection['sectionType']]: AsyncCommon<ProfileSection>;
   };
-};
+} & ProfileAsyncRelationships;
 
-export type ProfileEntry = ProfileAsyncRelationships &
-  ProfileAsyncCommon<Profile> & {
-    sections?: {
-      [sectionType: ProfileSection['sectionType']]: ProfileAsyncCommon<ProfileSection>;
-    };
-  };
-
-export type ProfileSectionsState = ProfileAsyncCommon<ProfileSection>;
+export type ProfileSectionsState = AsyncCommon<ProfileSection>;
 
 export type ProfileState = {
   identifiers: IdentifiersState;
@@ -145,10 +141,16 @@ export const newProfileEntry: ProfileEntry = {
   loading: false,
   data: undefined,
   contacts: {
+    data: null,
+    error: null,
+    total: null,
     loading: false,
     page: 0,
   },
   cases: {
+    data: null,
+    error: null,
+    total: null,
     loading: false,
     page: 0,
   },

--- a/plugin-hrm-form/src/states/types.ts
+++ b/plugin-hrm-form/src/states/types.ts
@@ -16,8 +16,7 @@
 
 import type { DefinitionVersion } from 'hrm-form-definitions';
 
-import { Contact } from '../types/types';
-import { ContactMetadata } from './contacts/types';
+import { ParseFetchErrorResult } from './parseFetchError';
 
 export type { DefinitionVersion };
 
@@ -28,4 +27,10 @@ export type RemoveContactStateAction = {
   type: typeof REMOVE_CONTACT_STATE;
   taskId: string;
   contactId: string;
+};
+
+export type AsyncCommon<T> = {
+  loading: boolean;
+  error: ParseFetchErrorResult;
+  data: T;
 };

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -397,8 +397,6 @@ export type ProfileSection = {
 export type Profile = {
   id: number;
   name: string;
-  contactsCount: number;
-  casesCount: number;
   createdAt?: string;
   updatedAt?: string;
   identifiers?: Identifier[];


### PR DESCRIPTION
## Description
This PR fixes the bug ticket linked below, where "Contact/Case count (number within parenthesis) doesn't match results". To solve this issue, we decouple the case and contacts count and instead we fetch the first page using the case and contact dedicated endpoints. This solves the missmatches in the counts as permissions are taken into consideration that way.
For more information about the root cause of this bug, refer to https://github.com/techmatters/hrm/pull/587.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2624)
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- Configure HRM permissions in such a way that `everyone` can see contacts and cases.
- Start HRM local server (`npm run start:light`), start Flex server pointing to the local HRM (`npm start dev:local`)
- Confirm that the case and contact count works as expected - count matches the lists views.
- Configure HRM permissions in such a way that no one can see contacts and cases.
- Confirm that the case and contact count works as expected - count matches the lists views.