### PR TITLE
CHI-2628: Fix case button positions

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -290,23 +290,25 @@ const CaseHome: React.FC<Props> = ({
             ),
           )}
       </CaseContainer>
-      <BottomButtonBar>
-        {!enableCaseMerging && (
-          <Box marginRight="15px">
-            <StyledNextStepButton
-              data-testid="CaseHome-CancelButton"
-              secondary="true"
-              roundCorners
-              onClick={handleClose}
-            >
-              <Template code="BottomBar-CancelNewCaseAndClose" />
-            </StyledNextStepButton>
-          </Box>
-        )}
-        <SaveAndEndButton roundCorners onClick={handleSaveAndEnd} data-testid="BottomBar-SaveCaseAndEnd">
-          <Template code="BottomBar-SaveAndEnd" />
-        </SaveAndEndButton>
-      </BottomButtonBar>
+      {isCreating && (
+        <BottomButtonBar>
+          {!enableCaseMerging && (
+            <Box marginRight="15px">
+              <StyledNextStepButton
+                data-testid="CaseHome-CancelButton"
+                secondary="true"
+                roundCorners
+                onClick={handleClose}
+              >
+                <Template code="BottomBar-CancelNewCaseAndClose" />
+              </StyledNextStepButton>
+            </Box>
+          )}
+          <SaveAndEndButton roundCorners onClick={handleSaveAndEnd} data-testid="BottomBar-SaveCaseAndEnd">
+            <Template code="BottomBar-SaveAndEnd" />
+          </SaveAndEndButton>
+        </BottomButtonBar>
+      )}
     </NavigableContainer>
   );
 };

--- a/plugin-hrm-form/src/components/case/ViewCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/ViewCaseItem.tsx
@@ -98,7 +98,7 @@ const ViewCaseItem: React.FC<Props> = ({
   return (
     <CaseLayout>
       <NavigableContainer task={task} titleCode={`Case-View${sectionApi.label}`}>
-        <Box height="100%">
+        <Box height="100%" style={{ overflowY: 'auto' }}>
           <ActionHeader
             addingCounsellor={addingCounsellorName}
             added={added}


### PR DESCRIPTION
## Description

* Fixes the issue where long case sections scroll leaving the edit button floating in the middle of the content
* Prevent the 'save and end' button rendering when viewing cases from the list / search

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A] Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->