### PR TITLE
CHI-2614: "Added on/by..." in case sections not displaying correctly

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/case/caseActivities.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/caseActivities.test.ts
@@ -74,7 +74,7 @@ describe('getActivitiesFromCase', () => {
       note: [
         {
           sectionId: 'NOTE_ID',
-          twilioWorkerId: noteWorker,
+          createdBy: noteWorker,
           createdAt,
           sectionTypeSpecificData: {
             note: 'content',
@@ -105,7 +105,7 @@ describe('getActivitiesFromCase', () => {
       note: [
         {
           sectionId: 'NOTE_ID',
-          twilioWorkerId: 'WK-note-twilio-worker-id',
+          createdBy: 'WK-note-twilio-worker-id',
           createdAt,
           sectionTypeSpecificData: {
             customProperty1: 'customProperty1 content',
@@ -144,7 +144,7 @@ describe('getActivitiesFromCase', () => {
       note: [
         {
           sectionId: 'NOTE_ID',
-          twilioWorkerId: noteWorker,
+          createdBy: noteWorker,
           createdAt,
           sectionTypeSpecificData: {
             customProperty1: 'customProperty1 content',
@@ -192,7 +192,7 @@ describe('getActivitiesFromCase', () => {
       note: [
         {
           sectionId: 'NOTE_ID_1',
-          twilioWorkerId: noteWorker,
+          createdBy: noteWorker,
           createdAt,
           sectionTypeSpecificData: {
             note: 'content',
@@ -200,7 +200,7 @@ describe('getActivitiesFromCase', () => {
         },
         {
           sectionId: 'NOTE_ID_2',
-          twilioWorkerId: noteWorker,
+          createdBy: noteWorker,
           createdAt,
           sectionTypeSpecificData: {
             note: 'moar content',
@@ -251,12 +251,12 @@ describe('getActivitiesFromCase', () => {
         comments: 'comment',
       },
       createdAt,
-      twilioWorkerId: referralWorker,
+      createdBy: referralWorker,
     } as const;
     const fakeCase = createFakeCase({
       referral: [referral],
     });
-    const { createdAt: referralCreatedAt, twilioWorkerId, sectionId, sectionTypeSpecificData } = referral;
+    const { createdAt: referralCreatedAt, createdBy, sectionId, sectionTypeSpecificData } = referral;
     const activities = getActivitiesFromCase(fakeCase, formDefinition);
     const expectedActivity: ReferralActivity = {
       id: sectionId,
@@ -265,7 +265,7 @@ describe('getActivitiesFromCase', () => {
       type: 'referral',
       text: sectionTypeSpecificData.referredTo,
       referral: sectionTypeSpecificData,
-      twilioWorkerId,
+      twilioWorkerId: createdBy,
       updatedBy: undefined,
       updatedAt: undefined,
     };
@@ -287,7 +287,7 @@ describe('getActivitiesFromCase', () => {
         comments: 'comment',
       },
       createdAt: referralCreatedAt,
-      twilioWorkerId: referralWorker,
+      createdBy: referralWorker,
     } as const;
 
     const fakeCase = createFakeCase(
@@ -296,7 +296,7 @@ describe('getActivitiesFromCase', () => {
         note: [
           {
             sectionId: 'NOTE_ID',
-            twilioWorkerId: noteWorker,
+            createdBy: noteWorker,
             createdAt: noteCreatedAt,
             sectionTypeSpecificData: {
               note: 'content',

--- a/plugin-hrm-form/src/___tests__/states/case/sections/selectCaseItemHistory.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/sections/selectCaseItemHistory.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
           sectionId: 'this one',
           sectionTypeSpecificData: { note: 'this is the note you are looking for' },
           createdAt: BASELINE_DATE.toISOString(),
-          twilioWorkerId: 'WK-1',
+          createdBy: 'WK-1',
           updatedAt: addDays(BASELINE_DATE, 1).toISOString(),
           updatedBy: 'WK-2',
         },

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -314,11 +314,12 @@ AddEditCaseItem.displayName = 'AddEditCaseItem';
 const mapStateToProps = (state: RootState, { task, sectionApi }: AddEditCaseItemProps) => {
   const { workerSid } = getHrmConfig();
   const currentRoute = selectCurrentTopmostRouteForTask(state, task.taskSid);
+
   if (isCaseRoute(currentRoute)) {
     const sectionId = isEditCaseSectionRoute(currentRoute) ? currentRoute.id : undefined;
     const { connectedCase, caseWorkingCopy } = selectCaseByCaseId(state, currentRoute.caseId);
     const caseItemHistory = sectionId
-      ? selectCaseItemHistory(state, connectedCase, sectionApi, currentRoute.caseId)
+      ? selectCaseItemHistory(state, connectedCase, sectionApi, sectionId)
       : {
           added: new Date(),
           addingCounsellorName: selectCounselorName(state, workerSid),

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintNotes.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintNotes.tsx
@@ -43,11 +43,11 @@ const CasePrintNotes: React.FC<Props> = ({ notes, counselorsHash }) => {
       </View>
       {notes &&
         notes.length > 0 &&
-        notes.map(({ twilioWorkerId, sectionTypeSpecificData: note, createdAt }, i) => {
+        notes.map(({ createdBy, sectionTypeSpecificData: note, createdAt }, i) => {
           return (
             <View key={i} style={{ ...styles['sectionBody'], ...styles['caseSummaryText'] }}>
               <View style={{ ...styles.flexRow, justifyContent: 'space-between' }}>
-                <Text style={{ fontWeight: 600 }}>{formatName(counselorsHash[twilioWorkerId])}</Text>
+                <Text style={{ fontWeight: 600 }}>{formatName(counselorsHash[createdBy])}</Text>
                 <Text style={{ fontStyle: 'italic' }}>{formatStringToDateAndTime(createdAt)}</Text>
               </View>
               <View>

--- a/plugin-hrm-form/src/services/caseSectionService.ts
+++ b/plugin-hrm-form/src/services/caseSectionService.ts
@@ -26,7 +26,7 @@ export type ApiCaseSection = {
   sectionTypeSpecificData: CaseSectionTypeSpecificData;
   sectionId: string;
   createdAt: string;
-  twilioWorkerId: WorkerSID;
+  createdBy: WorkerSID;
   updatedBy?: WorkerSID;
   updatedAt?: string;
 };

--- a/plugin-hrm-form/src/states/case/caseActivities.ts
+++ b/plugin-hrm-form/src/states/case/caseActivities.ts
@@ -48,7 +48,7 @@ const getNoteActivities = (counsellorNotes: ApiCaseSection[], formDefs: Definiti
   return (counsellorNotes || [])
     .map(n => {
       try {
-        const { sectionId: id, createdAt: date, updatedAt, updatedBy, twilioWorkerId, sectionTypeSpecificData } = n;
+        const { sectionId: id, createdAt: date, updatedAt, updatedBy, createdBy, sectionTypeSpecificData } = n;
         const text =
           previewFields
             .map(pf => sectionTypeSpecificData[pf])
@@ -60,7 +60,7 @@ const getNoteActivities = (counsellorNotes: ApiCaseSection[], formDefs: Definiti
           updatedBy,
           text,
           date,
-          twilioWorkerId,
+          twilioWorkerId: createdBy,
           type: ActivityTypes.addNote,
           note: sectionTypeSpecificData,
         };
@@ -75,14 +75,14 @@ const getNoteActivities = (counsellorNotes: ApiCaseSection[], formDefs: Definiti
 const referralActivities = (referrals: ApiCaseSection[]): Activity[] =>
   (referrals || [])
     .map(referral => {
-      const { sectionId: id, createdAt, updatedAt, updatedBy, twilioWorkerId, sectionTypeSpecificData } = referral;
+      const { sectionId: id, createdAt, updatedAt, updatedBy, createdBy, sectionTypeSpecificData } = referral;
       const { referredTo, date } = sectionTypeSpecificData;
       try {
         return {
           id,
           date: date?.toString(),
           createdAt,
-          twilioWorkerId,
+          twilioWorkerId: createdBy,
           updatedAt,
           updatedBy,
           type: ActivityTypes.addReferral,

--- a/plugin-hrm-form/src/states/case/sections/selectCaseItemHistory.ts
+++ b/plugin-hrm-form/src/states/case/sections/selectCaseItemHistory.ts
@@ -20,8 +20,7 @@ import { Case } from '../../../types/types';
 import { selectCounselorName } from '../../configuration/selectCounselorsHash';
 
 const selectCaseItemHistory = (state: RootState, caseObj: Case, caseSectionApi: CaseSectionApi, caseItemId: string) => {
-  const { createdBy, createdAt, updatedAt, updatedBy } =
-    caseSectionApi.getSectionItemById(caseObj, caseItemId) ?? {};
+  const { createdBy, createdAt, updatedAt, updatedBy } = caseSectionApi.getSectionItemById(caseObj, caseItemId) ?? {};
 
   const addingCounsellorName = selectCounselorName(state, createdBy);
   const added = new Date(createdAt);

--- a/plugin-hrm-form/src/states/case/sections/selectCaseItemHistory.ts
+++ b/plugin-hrm-form/src/states/case/sections/selectCaseItemHistory.ts
@@ -20,12 +20,14 @@ import { Case } from '../../../types/types';
 import { selectCounselorName } from '../../configuration/selectCounselorsHash';
 
 const selectCaseItemHistory = (state: RootState, caseObj: Case, caseSectionApi: CaseSectionApi, caseItemId: string) => {
-  const { twilioWorkerId, createdAt, updatedAt, updatedBy } =
+  const { createdBy, createdAt, updatedAt, updatedBy } =
     caseSectionApi.getSectionItemById(caseObj, caseItemId) ?? {};
-  const addingCounsellorName = selectCounselorName(state, twilioWorkerId);
+
+  const addingCounsellorName = selectCounselorName(state, createdBy);
   const added = new Date(createdAt);
   const updatingCounsellorName = selectCounselorName(state, updatedBy);
   const updated = updatedAt ? new Date(updatedAt) : undefined;
+
   return { addingCounsellorName, added, updatingCounsellorName, updated };
 };
 


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Bug fix: This PR fixes the bug that affects the display of the counsellor's name as well as `Added on` and `Updated on` in the case items view and edit case items view

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

- Navigate to the Case list
- Select a case that you have permission to edit
- View a case section (incidents, household members, or perpetrators)
- Verify that you can see the name of the counselor who added/updated the item
- Click to Edit item
- Verify that you can see the name of the counselor who added/updated the item