### PR TITLE
CHI-2654: Move 'copy to perpetrator' logic to redux

### DIFF
--- a/hrm-form-definitions/form-definitions/as/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/as/v1/caseForms/HouseholdForm.json
@@ -166,7 +166,6 @@
     "name": "copyToPerpetrator",
     "label": "This household member is also a perpetrator",
     "type": "copy-to",
-    "target": "perpetrators",
-    "saveable": false
+    "target": "perpetrators"
   }
 ]

--- a/hrm-form-definitions/form-definitions/as/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/as/v1/caseForms/PerpetratorForm.json
@@ -200,7 +200,6 @@
     "name": "copyToHousehold",
     "label": "This perpetrator is also a household member",
     "type": "copy-to",
-    "target": "households",
-    "saveable": false
+    "target": "households"
   }
 ]

--- a/hrm-form-definitions/form-definitions/e2e/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/e2e/v1/caseForms/HouseholdForm.json
@@ -166,7 +166,6 @@
     "name": "copyToPerpetrator",
     "label": "This household member is also a perpetrator",
     "type": "copy-to",
-    "target": "perpetrators",
-    "saveable": false
+    "target": "perpetrators"
   }
 ]

--- a/hrm-form-definitions/form-definitions/e2e/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/e2e/v1/caseForms/PerpetratorForm.json
@@ -200,7 +200,6 @@
     "name": "copyToHousehold",
     "label": "This perpetrator is also a household member",
     "type": "copy-to",
-    "target": "households",
-    "saveable": false
+    "target": "households"
   }
 ]

--- a/hrm-form-definitions/form-definitions/f2/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/f2/v1/caseForms/HouseholdForm.json
@@ -166,7 +166,6 @@
     "name": "copyToPerpetrator",
     "label": "This household member is also a perpetrator",
     "type": "copy-to",
-    "target": "perpetrators",
-    "saveable": false
+    "target": "perpetrators"
   }
 ]

--- a/hrm-form-definitions/form-definitions/f2/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/f2/v1/caseForms/PerpetratorForm.json
@@ -200,7 +200,6 @@
     "name": "copyToHousehold",
     "label": "This perpetrator is also a household member",
     "type": "copy-to",
-    "target": "households",
-    "saveable": false
+    "target": "households"
   }
 ]

--- a/hrm-form-definitions/form-definitions/in/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/in/v1/caseForms/HouseholdForm.json
@@ -1064,8 +1064,7 @@
       "name": "copyToPerpetrator",
       "label": "This household member is also a perpetrator",
       "type": "copy-to",
-      "target": "perpetrators",
-      "saveable": false
+      "target": "perpetrators"
     },
     {
       "name": "additionalInfo",

--- a/hrm-form-definitions/form-definitions/in/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/in/v1/caseForms/PerpetratorForm.json
@@ -1092,8 +1092,7 @@
       "name": "copyToHousehold",
       "label": "This perpetrator is also a household member",
       "type": "copy-to",
-      "target": "households",
-      "saveable": false
+      "target": "households"
     },  
     {
       "name": "additionalInfo",

--- a/hrm-form-definitions/form-definitions/ph/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/ph/v1/caseForms/HouseholdForm.json
@@ -127,8 +127,7 @@
     "name": "copyToPerpetrator",
     "label": "This household member is also a perpetrator/facilitator",
     "type": "copy-to",
-    "target": "perpetrators",
-    "saveable": false
+    "target": "perpetrators"
   },
   {
     "name": "gender",

--- a/hrm-form-definitions/form-definitions/ph/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/ph/v1/caseForms/PerpetratorForm.json
@@ -26,8 +26,7 @@
       "name": "copyToHousehold",
       "label": "This perpetrator is also a household member",
       "type": "copy-to",
-      "target": "households",
-      "saveable": false
+      "target": "households"
     },
     {
       "name": "firstName",

--- a/hrm-form-definitions/form-definitions/sg/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/sg/v1/caseForms/HouseholdForm.json
@@ -201,7 +201,6 @@
     "name": "copyToPerpetrator",
     "label": "This household member is also a perpetrator/facilitator",
     "type": "copy-to",
-    "target": "perpetrators",
-    "saveable": false
+    "target": "perpetrators"
   }
 ]

--- a/hrm-form-definitions/form-definitions/sg/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/sg/v1/caseForms/PerpetratorForm.json
@@ -185,7 +185,6 @@
     "name": "copyToHousehold",
     "label": "This perpetrator is also a household member",
     "type": "copy-to",
-    "target": "households",
-    "saveable": false
+    "target": "households"
   }
 ]

--- a/hrm-form-definitions/form-definitions/za/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/za/v1/caseForms/HouseholdForm.json
@@ -1271,7 +1271,6 @@
     "name": "copyToPerpetrator",
     "label": "This household member is also a perpetrator",
     "type": "copy-to",
-    "target": "perpetrators",
-    "saveable": false
+    "target": "perpetrators"
   }
 ]

--- a/hrm-form-definitions/form-definitions/za/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/za/v1/caseForms/PerpetratorForm.json
@@ -1266,7 +1266,6 @@
     "name": "copyToHousehold",
     "label": "This perpetrator is also a household member",
     "type": "copy-to",
-    "target": "households",
-    "saveable": false
+    "target": "households"
   }
 ]

--- a/hrm-form-definitions/form-definitions/zw/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/zw/v1/caseForms/HouseholdForm.json
@@ -539,7 +539,6 @@
     "name": "copyToPerpetrator",
     "label": "This household member is also a perpetrator",
     "type": "copy-to",
-    "target": "perpetrators",
-    "saveable": false
+    "target": "perpetrators"
   }
 ]

--- a/hrm-form-definitions/form-definitions/zw/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/zw/v1/caseForms/PerpetratorForm.json
@@ -535,7 +535,6 @@
     "name": "copyToHousehold",
     "label": "This perpetrator is also a household member",
     "type": "copy-to",
-    "target": "households",
-    "saveable": false
+    "target": "households"
   }
 ]

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -17,7 +17,7 @@
 /* eslint-disable import/no-unused-modules */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { RegisterOptions } from 'react-hook-form';
-import { OneToOneConfigSpec, OneToManyConfigSpecs } from './insightsConfig';
+import { OneToManyConfigSpecs, OneToOneConfigSpec } from './insightsConfig';
 import { CallTypeKeys } from './callTypes';
 
 export enum CaseSectionApiName {
@@ -174,12 +174,11 @@ type CallTypeButtonInputDefinition = {
   category: 'data' | 'non-data';
 } & ItemBase;
 
-type CopyToDefinition = ItemBase &
-  NonSaveable & {
-    type: FormInputType.CopyTo;
-    initialChecked: false;
-    target: CaseSectionApiName;
-  };
+type CopyToDefinition = ItemBase & {
+  type: FormInputType.CopyTo;
+  initialChecked: false;
+  target: CaseSectionApiName;
+};
 
 type CustomContactComponentDefinition = ItemBase &
   NonSaveable & {

--- a/plugin-hrm-form/src/___tests__/states/case/sections/caseSectionUpdates.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/sections/caseSectionUpdates.test.ts
@@ -16,6 +16,13 @@
 
 import promiseMiddleware from 'redux-promise-middleware';
 import { configureStore } from '@reduxjs/toolkit';
+import {
+  CaseSectionApiName,
+  DefinitionVersion,
+  DefinitionVersionId,
+  loadDefinition,
+  useFetchDefinitions,
+} from 'hrm-form-definitions';
 
 import { HrmState } from '../../../../states';
 import { RecursivePartial } from '../../../RecursivePartial';
@@ -26,11 +33,14 @@ import {
   updateCaseSectionAsyncAction,
 } from '../../../../states/case/sections/caseSectionUpdates';
 import { VALID_EMPTY_CASE } from '../../../testCases';
+import { lookupApi } from '../../../../states/case/sections/lookupApi';
 
 jest.mock('../../../../services/caseSectionService', () => ({
   createCaseSection: jest.fn(),
   updateCaseSection: jest.fn(),
 }));
+// eslint-disable-next-line react-hooks/rules-of-hooks
+const { mockFetchImplementation, buildBaseURL } = useFetchDefinitions();
 
 let state: HrmState;
 const initialState: HrmState = {
@@ -43,6 +53,10 @@ const BASELINE_DATE = new Date('2000-01-01T00:00:00Z');
 const mockCreateSection = createCaseSection as jest.Mock<ReturnType<typeof createCaseSection>>;
 const mockUpdateSection = updateCaseSection as jest.Mock<ReturnType<typeof updateCaseSection>>;
 
+const noteApi = lookupApi(CaseSectionApiName.Notes);
+const referralApi = lookupApi(CaseSectionApiName.Referrals);
+let definitionVersion: DefinitionVersion;
+
 const testStore = (stateChanges: Partial<HrmState> = {}) =>
   configureStore({
     preloadedState: { ...state, ...stateChanges },
@@ -52,6 +66,13 @@ const testStore = (stateChanges: Partial<HrmState> = {}) =>
       promiseMiddleware(),
     ],
   });
+
+beforeAll(async () => {
+  const formDefinitionsBaseUrl = buildBaseURL(DefinitionVersionId.demoV1);
+  await mockFetchImplementation(formDefinitionsBaseUrl);
+
+  definitionVersion = await loadDefinition(formDefinitionsBaseUrl);
+});
 
 beforeEach(() => {
   const partial: RecursivePartial<HrmState> = {
@@ -65,7 +86,7 @@ beforeEach(() => {
                 {
                   sectionTypeSpecificData: { text: 'existing note' },
                   sectionId: 'EXISTING_NOTE_ID',
-                  twilioWorkerId: 'WK-WORKER_ID',
+                  createdBy: 'WK-WORKER_ID',
                   createdAt: BASELINE_DATE.toISOString(),
                 },
               ],
@@ -87,24 +108,28 @@ describe('createCaseSectionAsyncAction', () => {
     mockCreateSection.mockResolvedValue({
       sectionTypeSpecificData: payload,
       sectionId: 'SECTION_ID',
-      twilioWorkerId: 'WK-WORKER_ID',
+      createdBy: 'WK-WORKER_ID',
       createdAt: BASELINE_DATE.toISOString(),
     });
   });
 
   test('calls createCaseSection with parameters taken form the action', async () => {
-    const res = createCaseSectionAsyncAction(CASE_ID, 'note', payload);
+    const res = createCaseSectionAsyncAction(CASE_ID, payload, definitionVersion, noteApi);
     expect(mockCreateSection).toHaveBeenCalledWith(CASE_ID, 'note', payload);
     const result = await res.payload;
     expect(result).toEqual({
       caseId: CASE_ID,
-      section: {
-        sectionTypeSpecificData: payload,
-        sectionId: 'SECTION_ID',
-        twilioWorkerId: 'WK-WORKER_ID',
-        createdAt: BASELINE_DATE.toISOString(),
-      },
-      sectionType: 'note',
+      sections: [
+        {
+          section: {
+            sectionTypeSpecificData: payload,
+            sectionId: 'SECTION_ID',
+            createdBy: 'WK-WORKER_ID',
+            createdAt: BASELINE_DATE.toISOString(),
+          },
+          sectionType: 'note',
+        },
+      ],
     });
   });
 
@@ -112,14 +137,16 @@ describe('createCaseSectionAsyncAction', () => {
     const EXPECTED_CASE_SECTION = {
       sectionTypeSpecificData: payload,
       sectionId: 'SECTION_ID',
-      twilioWorkerId: 'WK-WORKER_ID',
+      createdBy: 'WK-WORKER_ID',
       createdAt: BASELINE_DATE.toISOString(),
     };
 
     test(`case already has sections of the same type - appends section to the appropriate section type list`, async () => {
       const { dispatch, getState } = testStore({});
 
-      await ((dispatch(createCaseSectionAsyncAction(CASE_ID, 'note', payload)) as unknown) as PromiseLike<unknown>);
+      await ((dispatch(
+        createCaseSectionAsyncAction(CASE_ID, payload, definitionVersion, noteApi),
+      ) as unknown) as PromiseLike<unknown>);
       const state = getState();
       expect(state.connectedCase.cases[CASE_ID].connectedCase.sections.note).toHaveLength(2);
       expect(state.connectedCase.cases[CASE_ID].connectedCase.sections.note[1]).toEqual(EXPECTED_CASE_SECTION);
@@ -127,7 +154,9 @@ describe('createCaseSectionAsyncAction', () => {
     test(`case has no existing sections of the same type - adds an appropriate section type list with the new item as its element`, async () => {
       const { dispatch, getState } = testStore({});
 
-      await ((dispatch(createCaseSectionAsyncAction(CASE_ID, 'referral', payload)) as unknown) as PromiseLike<unknown>);
+      await ((dispatch(
+        createCaseSectionAsyncAction(CASE_ID, payload, definitionVersion, referralApi),
+      ) as unknown) as PromiseLike<unknown>);
       const state = getState();
       expect(state.connectedCase.cases[CASE_ID].connectedCase.sections.note).toHaveLength(1);
       expect(state.connectedCase.cases[CASE_ID].connectedCase.sections.referral).toHaveLength(1);
@@ -147,7 +176,9 @@ describe('createCaseSectionAsyncAction', () => {
         },
       });
 
-      await ((dispatch(createCaseSectionAsyncAction(CASE_ID, 'note', payload)) as unknown) as PromiseLike<unknown>);
+      await ((dispatch(
+        createCaseSectionAsyncAction(CASE_ID, payload, definitionVersion, noteApi),
+      ) as unknown) as PromiseLike<unknown>);
       const state = getState();
       expect(state.connectedCase.cases[CASE_ID].connectedCase.sections).toBeDefined();
       expect(state.connectedCase.cases[CASE_ID].connectedCase.sections.note).toHaveLength(1);
@@ -159,7 +190,7 @@ describe('createCaseSectionAsyncAction', () => {
       const { dispatch, getState } = testStore({});
       const oldState = getState();
       await ((dispatch(
-        createCaseSectionAsyncAction('not existing case', 'referral', payload),
+        createCaseSectionAsyncAction('not existing case', payload, definitionVersion, referralApi),
       ) as unknown) as PromiseLike<unknown>);
       const state = getState();
       expect(state).toStrictEqual(oldState);
@@ -171,9 +202,9 @@ describe('createCaseSectionAsyncAction', () => {
       const oldState = getState();
 
       try {
-        await ((dispatch(createCaseSectionAsyncAction(CASE_ID, 'referral', payload)) as unknown) as PromiseLike<
-          unknown
-        >);
+        await ((dispatch(
+          createCaseSectionAsyncAction(CASE_ID, payload, definitionVersion, referralApi),
+        ) as unknown) as PromiseLike<unknown>);
       } catch (e) {
         // Error still bubbles up so need to swallow it
       }
@@ -191,7 +222,7 @@ describe('updateCaseSectionAsyncAction', () => {
     mockUpdateSection.mockImplementation(async (caseId, sectionType, sectionId, sectionData) => ({
       sectionTypeSpecificData: sectionData,
       sectionId,
-      twilioWorkerId: 'WK-WORKER_ID',
+      createdBy: 'WK-WORKER_ID',
       createdAt: BASELINE_DATE.toISOString(),
     }));
   });
@@ -202,13 +233,17 @@ describe('updateCaseSectionAsyncAction', () => {
     const result = await res.payload;
     expect(result).toEqual({
       caseId: CASE_ID,
-      section: {
-        sectionTypeSpecificData: payload,
-        sectionId: 'EXISTING_NOTE_ID',
-        twilioWorkerId: 'WK-WORKER_ID',
-        createdAt: BASELINE_DATE.toISOString(),
-      },
-      sectionType: 'note',
+      sections: [
+        {
+          section: {
+            sectionTypeSpecificData: payload,
+            sectionId: 'EXISTING_NOTE_ID',
+            createdBy: 'WK-WORKER_ID',
+            createdAt: BASELINE_DATE.toISOString(),
+          },
+          sectionType: 'note',
+        },
+      ],
     });
   });
 
@@ -216,7 +251,7 @@ describe('updateCaseSectionAsyncAction', () => {
     const EXPECTED_CASE_SECTION = {
       sectionTypeSpecificData: payload,
       sectionId: 'EXISTING_NOTE_ID',
-      twilioWorkerId: 'WK-WORKER_ID',
+      createdBy: 'WK-WORKER_ID',
       createdAt: BASELINE_DATE.toISOString(),
     };
 

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -39,13 +39,11 @@ import ActionHeader from './ActionHeader';
 import { RootState } from '../../states';
 import { createStateItem, CustomHandlers, disperseInputs, splitAt, splitInHalf } from '../common/forms/formGenerators';
 import { useCreateFormFromDefinition } from '../forms';
-import type { Case, CustomITask, StandaloneITask, WellKnownCaseSection } from '../../types/types';
+import type { Case, CustomITask, StandaloneITask } from '../../types/types';
 import { CaseItemAction, isAddCaseSectionRoute, isCaseRoute, isEditCaseSectionRoute } from '../../states/routing/types';
 import { recordingErrorHandler } from '../../fullStory';
 import CloseCaseDialog from './CloseCaseDialog';
 import { CaseSectionApi } from '../../states/case/sections/api';
-import { lookupApi } from '../../states/case/sections/lookupApi';
-import { copyCaseSectionItem } from '../../states/case/sections/update';
 import { newCloseModalAction, newGoBackAction } from '../../states/routing/actions';
 import {
   initialiseExistingCaseSectionWorkingCopy,
@@ -99,19 +97,13 @@ const AddEditCaseItem: React.FC<Props> = ({
   sectionId,
   updateCaseSection,
   createCaseSection,
-  createCaseSectionCopy,
 }) => {
-  const formDefinition = React.useMemo(
-    () =>
-      sectionApi
-        .getSectionFormDefinition(definitionVersion)
-        // If more 'when adding only' form item types are implemented, we should create a specific property, but there is only one so just check the type for now
-        .filter(fd => !sectionId || fd.type !== 'copy-to'),
-    [definitionVersion, sectionId, sectionApi],
-  );
+  const formDefinition = React.useMemo(() => sectionApi.getSectionFormDefinition(definitionVersion), [
+    definitionVersion,
+    sectionApi,
+  ]);
   const layout = sectionApi.getSectionLayoutDefinition(definitionVersion);
 
-  // Grab initial values in first render only. If getTemporaryFormContent(temporaryCaseInfo), cherrypick the values using formDefinition, if not build the object with getInitialValue
   const savedForm = React.useMemo(() => {
     if (sectionId && connectedCase) {
       const { sectionTypeSpecificData: form } = sectionApi.getSectionItemById(connectedCase, sectionId);
@@ -188,22 +180,6 @@ const AddEditCaseItem: React.FC<Props> = ({
       await updateCaseSection(caseId, sectionId, workingCopy);
     } else {
       await createCaseSection(caseId, workingCopy);
-      await Promise.all(
-        formDefinition.map(fd => {
-          // A preceding 'filter' call looks nicer but TS type narrowing isn't smart enough to work with that.
-          if (fd.type === 'copy-to' && getValues()[fd.name]) {
-            const toApi = lookupApi(fd.target);
-            const copied = copyCaseSectionItem({
-              definition: definitionVersion,
-              fromSection: workingCopy,
-              fromApi: sectionApi,
-              toApi,
-            });
-            return createCaseSectionCopy(caseId, toApi.type, copied);
-          }
-          return Promise.resolve();
-        }),
-      );
     }
   };
 
@@ -340,7 +316,7 @@ const mapStateToProps = (state: RootState, { task, sectionApi }: AddEditCaseItem
   };
 };
 
-const mapDispatchToProps = (dispatch, { sectionApi, task }: AddEditCaseItemProps) => {
+const mapDispatchToProps = (dispatch, { sectionApi, task, definitionVersion }: AddEditCaseItemProps) => {
   const searchAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
   return {
     updateCaseSectionWorkingCopy: bindActionCreators(updateCaseSectionWorkingCopy, dispatch),
@@ -356,13 +332,7 @@ const mapDispatchToProps = (dispatch, { sectionApi, task }: AddEditCaseItemProps
     },
 
     createCaseSection: (caseId: Case['id'], newSection: CaseSectionTypeSpecificData) =>
-      searchAsyncDispatch(createCaseSectionAsyncAction(caseId, sectionApi.type, newSection)),
-
-    createCaseSectionCopy: (
-      caseId: Case['id'],
-      targetSectionType: WellKnownCaseSection,
-      newSection: CaseSectionTypeSpecificData,
-    ) => searchAsyncDispatch(createCaseSectionAsyncAction(caseId, targetSectionType, newSection)),
+      searchAsyncDispatch(createCaseSectionAsyncAction(caseId, newSection, definitionVersion, sectionApi)),
     updateCaseSection: (caseId: Case['id'], sectionId, update: CaseSectionTypeSpecificData) =>
       searchAsyncDispatch(updateCaseSectionAsyncAction(caseId, sectionApi.type, sectionId, update)),
   };

--- a/plugin-hrm-form/src/states/case/sections/caseSectionUpdates.ts
+++ b/plugin-hrm-form/src/states/case/sections/caseSectionUpdates.ts
@@ -15,6 +15,7 @@
  */
 
 import { createAsyncAction, createReducer } from 'redux-promise-middleware-actions';
+import { DefinitionVersion } from 'hrm-form-definitions';
 
 import { Case, WellKnownCaseSection } from '../../../types/types';
 import {
@@ -24,11 +25,13 @@ import {
   updateCaseSection,
 } from '../../../services/caseSectionService';
 import { HrmState } from '../..';
+import { CaseSectionApi } from './api';
+import { lookupApi } from './lookupApi';
+import { copyCaseSectionItem } from './update';
 
 type CaseSectionUpdatePayload = {
   caseId: Case['id'];
-  sectionType: WellKnownCaseSection;
-  section: ApiCaseSection;
+  sections: { section: ApiCaseSection; sectionType: WellKnownCaseSection }[];
 };
 
 const ADD_CASE_SECTION_ACTION = 'case/section/ADD';
@@ -37,19 +40,49 @@ export const createCaseSectionAsyncAction = createAsyncAction(
   ADD_CASE_SECTION_ACTION,
   async (
     caseId: Case['id'],
-    sectionType: WellKnownCaseSection,
     newSection: CaseSectionTypeSpecificData,
+    formDefinition: DefinitionVersion,
+    sectionApi: CaseSectionApi,
   ): Promise<CaseSectionUpdatePayload> => {
+    const copyToFields = sectionApi.getSectionFormDefinition(formDefinition).filter(fd => fd.type === 'copy-to');
+    const filteredEntries = Object.entries(newSection).filter(([key]) => !copyToFields.some(fd => fd.name === key));
+    const filteredSection = Object.fromEntries(filteredEntries);
+
+    const createTargetSection: Promise<CaseSectionUpdatePayload['sections'][number]> = (async () => ({
+      section: await createCaseSection(caseId, sectionApi.type, filteredSection),
+      sectionType: sectionApi.type,
+    }))();
+
+    const createCopySections: Promise<CaseSectionUpdatePayload['sections'][number]>[] = copyToFields.map(async fd => {
+      if (fd.type === 'copy-to' && newSection[fd.name] === true) {
+        const toApi = lookupApi(fd.target);
+        const copied = copyCaseSectionItem({
+          definition: formDefinition,
+          fromSection: filteredSection,
+          fromApi: sectionApi,
+          toApi,
+        });
+        return {
+          section: await createCaseSection(caseId, toApi.type, copied),
+          sectionType: toApi.type,
+        };
+      }
+      return undefined; // should never hit here because the items are already filtered, the if check is just for TS
+    });
     return {
-      section: await createCaseSection(caseId, sectionType, newSection),
+      sections: await Promise.all([createTargetSection, ...createCopySections]),
       caseId,
-      sectionType,
     };
   },
-  (caseId: Case['id'], sectionType: string) =>
+  (
+    caseId: Case['id'],
+    newSection: CaseSectionTypeSpecificData,
+    formDefinition: DefinitionVersion,
+    sectionApi: CaseSectionApi,
+  ) =>
     ({
       caseId,
-      sectionType,
+      sectionType: sectionApi.type,
     } as const),
 );
 
@@ -64,9 +97,8 @@ export const updateCaseSectionAsyncAction = createAsyncAction(
     update: CaseSectionTypeSpecificData,
   ): Promise<CaseSectionUpdatePayload> => {
     return {
-      section: await updateCaseSection(caseId, sectionType, sectionId, update),
+      sections: [{ sectionType, section: await updateCaseSection(caseId, sectionType, sectionId, update) }],
       caseId,
-      sectionType,
     };
   },
   (caseId: Case['id'], sectionType: string) => ({
@@ -78,40 +110,38 @@ export const updateCaseSectionAsyncAction = createAsyncAction(
 const updateCaseSections = (
   state: HrmState,
   caseId: Case['id'],
-  sectionType: WellKnownCaseSection,
-  updatedCaseSection: ApiCaseSection,
+  updatedCaseSections: CaseSectionUpdatePayload['sections'],
 ): HrmState => {
   const caseState = state.connectedCase.cases[caseId];
   if (!caseState) {
-    console.warn(
-      `Tried to update case section of type '${sectionType}' for missing case state (id: ${caseId})`,
-      updatedCaseSection,
-    );
+    console.warn(`Tried to update case sections for missing case state (id: ${caseId})`, updatedCaseSections);
     return state;
   }
   const { connectedCase: existingCase, caseWorkingCopy } = caseState;
   existingCase.sections = existingCase.sections || {};
-  existingCase.sections[sectionType] = existingCase.sections[sectionType] || [];
-  const list = existingCase.sections[sectionType];
-  const index = list.findIndex(section => section.sectionId === updatedCaseSection.sectionId);
-  if (index === -1) {
-    list.push(updatedCaseSection);
-    delete caseWorkingCopy?.sections?.[sectionType]?.new;
-  } else {
-    list[index] = updatedCaseSection;
-    delete caseWorkingCopy?.sections?.[sectionType]?.existing?.[updatedCaseSection.sectionId];
-  }
+  updatedCaseSections.forEach(({ section: updatedCaseSection, sectionType }) => {
+    existingCase.sections[sectionType] = existingCase.sections[sectionType] || [];
+    const list = existingCase.sections[sectionType];
+    const index = list.findIndex(section => section.sectionId === updatedCaseSection.sectionId);
+    if (index === -1) {
+      list.push(updatedCaseSection);
+      delete caseWorkingCopy?.sections?.[sectionType]?.new;
+    } else {
+      list[index] = updatedCaseSection;
+      delete caseWorkingCopy?.sections?.[sectionType]?.existing?.[updatedCaseSection.sectionId];
+    }
+  });
   return state;
 };
 
 export const caseSectionUpdateReducer = (initialState: HrmState): ((state: HrmState, action) => HrmState) =>
   createReducer(initialState, handleAction => [
     handleAction(createCaseSectionAsyncAction.fulfilled, (state: HrmState, action) => {
-      const { caseId, sectionType, section } = action.payload;
-      return updateCaseSections(state, caseId, sectionType, section);
+      const { caseId, sections } = action.payload;
+      return updateCaseSections(state, caseId, sections);
     }),
     handleAction(updateCaseSectionAsyncAction.fulfilled, (state: HrmState, action) => {
-      const { caseId, sectionType, section } = action.payload;
-      return updateCaseSections(state, caseId, sectionType, section);
+      const { caseId, sections } = action.payload;
+      return updateCaseSections(state, caseId, sections);
     }),
   ]);


### PR DESCRIPTION
## Description

The root cause of this issue was another 'weird values being returned by RHF for some reason' issue. These issues have proven tricky to fully diagnose in the past and usually result in less than satisfactory non intuitive fixes that are easy to break in future work.

Because of this, I decided to undertake a small piece of refactoring that is already on our 'TODO list', which is to move the 'copy to' logic in the redux layer.

This way the copy logic can all be run against the redux case 'workingCopy' which we know has correct sanitized values

As part of this work, I changed 'copyTo' fields in form definitions to be standard fields, rather than 'non saveable' fields so that they are persisted to the redux working copy. In their only current usage, in case sections, the redux layer strips the field from the data sent to HRM. 

The only effect would be if 'copyTo' fields were used in other Aselo forms where there is no specific handling for them, they will be persisted as a regular field. I think this is a feature rather than a bug. If this form item type is used in a form where it isn't properly supported, at least we record that somebody intended to copy something in the saved data. We could potentially use this later to fix up the data, unlike if we just dropped that value on the floor like we did previously.

This is probably a 'revealed attack' scenario, the bug existed for a while but until recently the feature wasn't working at all, so was only shown when the first issue was fixed. I think the initial issue was fixed as part of the work to migrate case sections to be updated via their own HRM endpoints rather than the old general endpoint

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

TODO: unit test coverage for the copy-to case in the redux state would be good, but the component level logic it replaces has no test coverage either, so not PR blocking I think :-P

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket