### PR TITLE
CHI-2653: Add hidden TabbedFormsTabs to TabbedFormsCase for RHF validation

### DIFF
--- a/e2e-tests/contactForm.ts
+++ b/e2e-tests/contactForm.ts
@@ -112,7 +112,7 @@ export function contactForm(page: Page) {
         await responsePromise;
       }
 
-      await selectors.tabButton(tab).waitFor({ state: 'detached' });
+      await selectors.tabButton(tab).waitFor({ state: 'hidden' });
     },
     fillCategoriesTab,
     fillStandardTab,

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedFormsCase.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedFormsCase.tsx
@@ -29,6 +29,7 @@ import Case from '../case/Case';
 import { useTabbedFormContext } from './hooks/useTabbedForm';
 import { TabbedFormsCommonProps } from './types';
 import { getTemplateStrings } from '../../hrmConfig';
+import TabbedFormsTabs from './TabbedFormsTabs';
 
 type OwnProps = TabbedFormsCommonProps;
 
@@ -50,7 +51,8 @@ const mapDispatchToProps = (dispatch: Dispatch<any>, { task }: OwnProps) => ({
 const connector = connect(mapStateToProps, mapDispatchToProps);
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const TabbedFormsCase: React.FC<Props> = ({ task, metadata, savedContact, closeModal, finaliseContact }) => {
+const TabbedFormsCase: React.FC<Props> = props => {
+  const { task, metadata, savedContact, closeModal, finaliseContact } = props;
   const strings = getTemplateStrings();
   const { newSubmitHandler } = useTabbedFormContext();
 
@@ -75,6 +77,12 @@ const TabbedFormsCase: React.FC<Props> = ({ task, metadata, savedContact, closeM
   return (
     <CaseLayout>
       <Case task={task} onNewCaseSaved={onNewCaseSaved} handleClose={closeModal} />
+      <div style={{ display: 'none' }}>
+        {
+          // Hack in order for RHF to validate the complete form on a save from the case form.
+        }
+        <TabbedFormsTabs {...props} />
+      </div>
     </CaseLayout>
   );
 };


### PR DESCRIPTION
## Description

CHI-2653 was caused because when a user clicks 'Save And End' on a case, they are in the <TabbedFormsCase> component.

This component does not actually render the forms for the contact, so there is nothing to validate when validation runs - but they have already been saved to redux so the data is saved.

To fix this in a quick & dirty way for the release, I'm adding a hidden <TabbedFormsTabs> component to <TabbedFormsCase> alongside the case component, so the forms are present and populated for RHF to run their validations on.

Analysis of how this bug was introduced.

This is actually a holdover from a previous bug that was only partially fixed. Initially when the tabbed forms components were restructured to introduce the <TabbedFormsRouter> all validation broke because we were not keeping all the form data in a single RHF. I fixed this by having a single RHF for all the contact data in the <TabbedFormsRouter> and delegating the context to subcomponents. However this fix missed the 'Save and End' from a case scenario where those sub elements of the contact forms were not rendered at all.

2 thoughts:

* The 'Save and End' button on the case is the source of a lot of bugs. Also I'd question how much it still makes sense from a UX standpoint in the case merging world, it's a holdover from the old linear workflow. In the new UI, a case is more of a 'breakout' activity, like a CSAM report, where you do it and go back to the contact, rather than some extra steps on a linear workflow. I'd like us to give consideration to whether replacing it with a 'Save' button which just goes back to the contact would make more sense. It would certainly be easier to maintain technically.
* I'm starting to question whether RHF are giving us as much value vs the cost of making them work as they once did. Back when we did a lot of logic in components they made sense, but now our logic is heavily concentrated in the redux layer, I wonder if they are still the right solution. We are in the situation where we are pushing stuff back up to the component layer just for RHF to validate it, when validating it in the redux layer ourselves might be simpler & more robust. Add in the fact that they have a fair few odd non-intuitive behaviours and have been the source of several hard to diagnose issues that required brittle non intuitive fixes recently and I think it's fair we should at least ask the question. Perhaps there is a different 3rd party lib that integrates better with our 'redux all the things' approach?

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->