### PR TITLE
Potential fix for flaky E2E test failures

### DIFF
--- a/e2e-tests/agent-desktop.ts
+++ b/e2e-tests/agent-desktop.ts
@@ -29,7 +29,11 @@ export const agentDesktop = (page: Page) => {
     for (let i = 0; i < 3; i++) {
       try {
         await addOfflineContactButton.click();
-        await expect(addOfflineContactButton).not.toBeEnabled({ timeout: 2000 });
+        await expect(addOfflineContactButton).not.toBeEnabled({ timeout: 5000 });
+        const dataCallTypeButton = page.locator(
+          `//button[@data-testid='DataCallTypeButton-child']`,
+        );
+        await expect(dataCallTypeButton).toBeVisible({ timeout: 5000 });
         break;
       } catch (e) {
         if (i === 2) {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -11,6 +11,7 @@
     "test:local": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true npm run test",
     "test:development:as": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=as SKIP_DATA_UPDATE=true npm run test",
     "test:development:e2e": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=e2e npm run test",
+    "test:development:e2e:local": "cross-env LOAD_SSM_CONFIG=true HL_ENV=development HL=e2e npm run test -- --headed",
     "test:development:e2e:debug": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=development HL=e2e npm run test -- --headed --retries 0 webchat",
     "test:staging:ca": "cross-env DEBUG=pw:api LOAD_SSM_CONFIG=true HL_ENV=staging HL=ca npm run test",
     "test:staging:ca:headed": "LOAD_SSM_CONFIG=true HL_ENV=staging HL=ca SKIP_DATA_UPDATE=true PLAYWRIGHT_BROWSER_TELEMETRY_LEVEL=none npm test -- --headed",


### PR DESCRIPTION
## Description
- E2E tests have been failing and one of the issues being `Add Offline Contact` button was not getting clicked given it is disabled while loading. The test run is then skipping the check whether the button is clicked. This PR adds some time to wait and check if the tabbedForms will load.
- I also added a new script for ease of testing locally

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- E2E test is passing!!