### PR TITLE
CHI-2656: Cancel existing case bug

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseDetails.tsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.tsx
@@ -23,7 +23,7 @@
 import React from 'react';
 import { Template } from '@twilio/flex-ui';
 import { DefinitionVersion, StatusInfo } from 'hrm-form-definitions';
-import { format, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 
 import CaseTags from './CaseTags';
 import CaseDetailsHeader from './caseDetails/CaseDetailsHeader';
@@ -50,7 +50,6 @@ type Props = {
   office: string | undefined;
   childIsAtRisk: boolean;
   isOrphanedCase: boolean | undefined;
-  isCreating?: boolean;
   editCaseSummary: () => void;
   handlePrintCase: () => void;
   availableStatusTransitions: StatusInfo[];

--- a/plugin-hrm-form/src/components/caseMergingBanners/CaseCreatedBanner.tsx
+++ b/plugin-hrm-form/src/components/caseMergingBanners/CaseCreatedBanner.tsx
@@ -28,6 +28,9 @@ import { selectCaseByCaseId } from '../../states/case/selectCaseStateByCaseId';
 import { showRemovedFromCaseBannerAction } from '../../states/case/caseBanners';
 import { CustomITask, StandaloneITask } from '../../types/types';
 import { BannerActionLink, BannerContainer, Text } from '../../styles/banners';
+import { getInitializedCan, PermissionActions } from '../../permissions';
+import { selectContactsByCaseIdInCreatedOrder } from '../../states/contacts/selectContactByCaseId';
+import selectContactByTaskSid from '../../states/contacts/selectContactByTaskSid';
 
 type OwnProps = {
   task?: CustomITask | StandaloneITask;
@@ -40,9 +43,13 @@ type Props = OwnProps & ConnectedProps<typeof connector>;
 const mapStateToProps = (state, { task, caseId }: OwnProps) => {
   const taskSid = task ? task.taskSid : getOfflineContactTaskSid();
   const cas = selectCaseByCaseId(state, caseId)?.connectedCase;
+  const caseContacts = selectContactsByCaseIdInCreatedOrder(state, caseId);
+  const taskContact = selectContactByTaskSid(state, taskSid)?.savedContact;
   return {
     cas,
     taskSid,
+    hasOtherContacts: Boolean(caseContacts.find(contact => contact.savedContact?.taskId !== taskSid)),
+    taskContact,
   };
 };
 
@@ -57,30 +64,45 @@ const CreatedCaseBanner: React.FC<Props> = ({
   taskSid,
   caseId,
   cas,
+  hasOtherContacts,
+  taskContact,
   removeContactFromCase,
   cancelCase,
   showRemovedFromCaseBanner,
   navigateBack,
 }) => {
+  const can = React.useMemo(() => {
+    return getInitializedCan();
+  }, []);
+
+  const canRemoveContactsFromCase =
+    can(PermissionActions.REMOVE_CONTACT_FROM_CASE, taskContact) && can(PermissionActions.UPDATE_CASE_CONTACTS, cas);
+
   const handleCancelCase = async () => {
-    const contactIds = cas.connectedContacts.map(c => c.id);
-    await Promise.all(contactIds.map(id => removeContactFromCase(id)));
+    await removeContactFromCase(taskContact?.id);
 
     // Navigating back before removing the case provides a better user experience.
     navigateBack(taskSid);
-    contactIds.forEach(id => showRemovedFromCaseBanner(id));
-    await cancelCase(caseId);
+    showRemovedFromCaseBanner(taskContact?.id);
+    if (!hasOtherContacts) {
+      await cancelCase(caseId);
+    }
   };
 
   return (
     <BannerContainer color="blue">
       <InfoIcon color="#001489" />
       <Text>
-        <Template code="CaseMerging-CaseCreatedAndContactAdded" caseId={caseId} />
+        <Template
+          code={hasOtherContacts ? 'CaseMerging-ContactAddedToExistingCase' : 'CaseMerging-CaseCreatedAndContactAdded'}
+          caseId={caseId}
+        />
       </Text>
-      <BannerActionLink type="button" onClick={handleCancelCase} data-fs-id="CancelNewCase-Button">
-        <Template code="CaseMerging-CancelCase" />
-      </BannerActionLink>
+      {canRemoveContactsFromCase && (
+        <BannerActionLink type="button" onClick={handleCancelCase} data-fs-id="CancelNewCase-Button">
+          <Template code={hasOtherContacts ? 'CaseMerging-RemoveFromCase' : 'CaseMerging-CancelCase'} />
+        </BannerActionLink>
+      )}
     </BannerContainer>
   );
 };

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedFormsTabs.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedFormsTabs.tsx
@@ -212,7 +212,11 @@ const TabbedFormsTabs: React.FC<Props> = ({
   } = updatedContact;
 
   const tabsToIndex = mapTabsToIndex(savedContact, updatedContact.rawJson);
-  const tabIndex = tabsToIndex.findIndex(t => t === subroute);
+  // tabIndex -1 doesn't cause user facing errors but it does generate lots of console log noise
+  const tabIndex = Math.max(
+    tabsToIndex.findIndex(t => t === subroute),
+    0,
+  );
   const tabs = tabsToIndex.map(mapTabsComponents(methods.errors));
 
   // TODO: abstract this to a separate file for shared use

--- a/plugin-hrm-form/src/states/contacts/selectContactByCaseId.ts
+++ b/plugin-hrm-form/src/states/contacts/selectContactByCaseId.ts
@@ -21,10 +21,9 @@ import { ContactState } from './existingContacts';
 import { namespace } from '../storeNamespaces';
 import { Case } from '../../types/types';
 
-const selectFirstContactByCaseId = (state: RootState, caseId: Case['id']): ContactState =>
+const selectContactsByCaseIdInCreatedOrder = (state: RootState, caseId: Case['id']): ContactState[] =>
   Object.values(state[namespace].activeContacts.existingContacts)
     .filter(cs => cs.savedContact?.caseId === caseId)
-    .sort((a, b) => parseISO(a.savedContact?.createdAt).valueOf() - parseISO(b.savedContact?.createdAt).valueOf())[0] ||
-  null;
+    .sort((a, b) => parseISO(a.savedContact?.createdAt).valueOf() - parseISO(b.savedContact?.createdAt).valueOf());
 
-export { selectFirstContactByCaseId };
+export { selectContactsByCaseIdInCreatedOrder };

--- a/plugin-hrm-form/src/translations/en-CA/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-CA/flexUI.json
@@ -476,6 +476,7 @@
   "CaseMerging-RemoveFromCase": "Remove from Emergency Referral",
   "CaseMerging-ContactRemovedFromCase": "Contact removed from Emergency Referral",
   "CaseMerging-CaseCreatedAndContactAdded": "Emergency Referral #{{caseId}} created and contact added",
+  "CaseMerging-ContactAddedToExistingCase": "Contact added to Emergency Referral #{{caseId}}",
   "CaseMerging-CancelCase": "Cancel Referral",
 
   "Profile-NoCasesFound": "No Referrals Found",

--- a/plugin-hrm-form/src/translations/en-GB/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-GB/flexUI.json
@@ -5,5 +5,6 @@
   "CaseMerging-RemoveFromCase": "Remove from Case",
   "CaseMerging-ContactRemovedFromCase": "Contact removed from case",
   "CaseMerging-CaseCreatedAndContactAdded": "Case #{{caseId}} created and contact added",
+  "CaseMerging-ContactAddedToExistingCase": "Contact added to Case #{{caseId}}",
   "CaseMerging-CancelCase": "Cancel Case"
 }

--- a/plugin-hrm-form/src/translations/en-IN/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-IN/flexUI.json
@@ -12,6 +12,7 @@
   "CaseMerging-RemoveFromCase": "Remove from Case",
   "CaseMerging-ContactRemovedFromCase": "Contact removed from case",
   "CaseMerging-CaseCreatedAndContactAdded": "Case #{{caseId}} created and contact added",
+  "CaseMerging-ContactAddedToExistingCase": "Contact added to Case #{{caseId}}",
   "CaseMerging-CancelCase": "Cancel Case",
   "TaskHeaderLineTwitter": "@{{task.attributes.twitterUserHandle}}",
   "ChatWelcomeText": "Conversation started",

--- a/plugin-hrm-form/src/translations/en-MT/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-MT/flexUI.json
@@ -566,5 +566,6 @@
   "CaseMerging-RemoveFromCase": "Remove from Case",
   "CaseMerging-ContactRemovedFromCase": "Contact removed from case",
   "CaseMerging-CaseCreatedAndContactAdded": "Case #{{caseId}} created and contact added",
+  "CaseMerging-ContactAddedToExistingCase": "Contact added to Case #{{caseId}}",
   "CaseMerging-CancelCase": "Cancel Case"
 }

--- a/plugin-hrm-form/src/translations/en-NZ/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-NZ/flexUI.json
@@ -176,6 +176,7 @@
   "CaseMerging-RemoveFromCase": "Remove from Incident",
   "CaseMerging-ContactRemovedFromCase": "Contact removed from incident",
   "CaseMerging-CaseCreatedAndContactAdded": "Incident #{{caseId}} created and contact added",
+  "CaseMerging-ContactAddedToExistingCase": "Contact added to Incident #{{caseId}}",
   "CaseMerging-CancelCase": "Cancel Incident",
   "AcceptTaskTooltip": "Accept",
   "AddButtons-Header": "Add",

--- a/plugin-hrm-form/src/translations/en-SG/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-SG/flexUI.json
@@ -507,6 +507,7 @@
   "CaseMerging-RemoveFromCase": "Remove from Case",
   "CaseMerging-ContactRemovedFromCase": "Interaction removed from case",
   "CaseMerging-CaseCreatedAndContactAdded": "Case #{{caseId}} created and interaction added",
+  "CaseMerging-ContactAddedToExistingCase": "Interaction added to Case #{{caseId}}",
   "CaseMerging-CancelCase": "Cancel Case",
   "CaseMerging-ContactUndoRemovedFromCase": "Undo"
 }

--- a/plugin-hrm-form/src/translations/en-UK/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-UK/flexUI.json
@@ -4,5 +4,6 @@
   "CaseMerging-RemoveFromCase": "Remove from Case",
   "CaseMerging-ContactRemovedFromCase": "Contact removed from case",
   "CaseMerging-CaseCreatedAndContactAdded": "Case #{{caseId}} created and contact added",
+  "CaseMerging-ContactAddedToExistingCase": "Contact added to Case #{{caseId}}",
   "CaseMerging-CancelCase": "Cancel Case"
 }

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -535,6 +535,7 @@
   "CaseMerging-RemoveFromCase": "Remove from Case",
   "CaseMerging-ContactRemovedFromCase": "Contact removed from case",
   "CaseMerging-CaseCreatedAndContactAdded": "Case #{{caseId}} created and contact added",
+  "CaseMerging-ContactAddedToExistingCase": "Contact added to Case #{{caseId}}",
   "CaseMerging-CancelCase": "Cancel Case",
   "CaseMerging-ContactUndoRemovedFromCase": "Undo"
 }

--- a/plugin-hrm-form/src/translations/es-CL/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-CL/flexUI.json
@@ -518,6 +518,7 @@
   "CaseMerging-RemoveFromCase": "Quitar del caso",
   "CaseMerging-ContactRemovedFromCase": "Contacto eliminado del caso",
   "CaseMerging-CaseCreatedAndContactAdded": "Caso #{{caseId}} creado y contacto agregado",
+  "CaseMerging-ContactAddedToExistingCase": "Contacto agregado al Caso #{{caseId}}",
   "CaseMerging-CancelCase": "Cancelar Caso",
   "Something Else": "Enfoque Recomendado",
   "Profile-NoIdentifiersFound": "No se encontraron identificadores",

--- a/plugin-hrm-form/src/translations/es-CO/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-CO/flexUI.json
@@ -516,6 +516,7 @@
   "CaseMerging-RemoveFromCase": "Quitar del caso",
   "CaseMerging-ContactRemovedFromCase": "Contacto eliminado del caso",
   "CaseMerging-CaseCreatedAndContactAdded": "Caso #{{caseId}} creado y contacto agregado",
+  "CaseMerging-ContactAddedToExistingCase": "Contacto agregado al Caso #{{caseId}}",
   "CaseMerging-CancelCase": "Cancelar Caso",
 
   "Profile-NoIdentifiersFound": "No se encontraron identificadores",

--- a/plugin-hrm-form/src/translations/es-ES/flexUI.json
+++ b/plugin-hrm-form/src/translations/es-ES/flexUI.json
@@ -570,8 +570,9 @@
   "CaseMerging-RemoveFromCase": "Quitar del caso",
   "CaseMerging-ContactRemovedFromCase": "Contacto eliminado del caso",
   "CaseMerging-CaseCreatedAndContactAdded": "Caso #{{caseId}} creado y contacto agregado",
-  "CaseMerging-CancelCase": "Cancelar Caso",
+  "CaseMerging-ContactAddedToExistingCase": "Contacto agregado al Caso #{{caseId}}",
 
+  "CaseMerging-CancelCase": "Cancelar Caso",
   "Profile-NoIdentifiersFound": "No se encontraron identificadores",
   "Profile-EditButton": "Editar",
   "Profile-DetailsHeader-Overview": "Descripción general",

--- a/plugin-hrm-form/src/translations/hu-HU/flexUI.json
+++ b/plugin-hrm-form/src/translations/hu-HU/flexUI.json
@@ -513,5 +513,6 @@
   "CaseMerging-RemoveFromCase": "Távolítsa el a tokból",
   "CaseMerging-ContactRemovedFromCase": "Az érintkező eltávolítva a tokból",
   "CaseMerging-CaseCreatedAndContactAdded": "A(z) {{caseId}} számú eset létrehozva, és a kapcsolattartó hozzáadva",
+  "CaseMerging-ContactAddedToExistingCase": "Kapcsolattartó hozzáadva a {{caseId}} számú ügyhöz",
   "CaseMerging-CancelCase": "Törölje az ügyet"
 }

--- a/plugin-hrm-form/src/translations/pl-PL/flexUI.json
+++ b/plugin-hrm-form/src/translations/pl-PL/flexUI.json
@@ -566,5 +566,6 @@
     "CaseMerging-RemoveFromCase": "Usuń ze skrzynki",
     "CaseMerging-ContactRemovedFromCase": "Kontakt usunięty ze sprawy",
     "CaseMerging-CaseCreatedAndContactAdded": "Utworzono sprawę nr {{caseId}} i dodano kontakt",
+    "CaseMerging-ContactAddedToExistingCase": "Kontakt dodany do sprawy nr{{caseId}}",
     "CaseMerging-CancelCase": "Anuluj Sprawę"
     }

--- a/plugin-hrm-form/src/translations/pt-BR/flexUI.json
+++ b/plugin-hrm-form/src/translations/pt-BR/flexUI.json
@@ -466,5 +466,6 @@
   "CaseMerging-RemoveFromCase": "Remover do Caso",
   "CaseMerging-ContactRemovedFromCase": "Contato removido do caso",
   "CaseMerging-CaseCreatedAndContactAdded": "Case #{{caseId}} criado e contato adicionado",
+  "CaseMerging-ContactAddedToExistingCase": "Contato adicionado ao caso nº{{caseId}}",
   "CaseMerging-CancelCase": "Cancelar Caso"
 }

--- a/plugin-hrm-form/src/translations/ro-RO/flexUI.json
+++ b/plugin-hrm-form/src/translations/ro-RO/flexUI.json
@@ -566,5 +566,6 @@
     "CaseMerging-RemoveFromCase": "Eliminați din carcasă",
     "CaseMerging-ContactRemovedFromCase": "Contact eliminat din carcasă",
     "CaseMerging-CaseCreatedAndContactAdded": "Cazul #{{caseId}} a fost creat și persoana de contact a fost adăugată",
+    "CaseMerging-ContactAddedToExistingCase": "Persoana de contact a fost adăugată în cazul #{{caseId}}",
     "CaseMerging-CancelCase": "Anulează Cazul"
 }

--- a/plugin-hrm-form/src/translations/th-TH/flexUI.json
+++ b/plugin-hrm-form/src/translations/th-TH/flexUI.json
@@ -593,9 +593,10 @@
   "Service Subcategories": "หมวดหมู่บริการย่อย",
   "Other Relationship to Child": "ความสัมพันธ์อื่นๆกับเด็ก",
   "CaseMerging-ContactAddedTo": "เพิ่มผู้ติดต่อไปที่",
-  "CaseMerging-RemoveFromCase": "Remove from Case",
-  "CaseMerging-ContactRemovedFromCase": "Contact removed from Case",
+  "CaseMerging-RemoveFromCase": "ถอดออกจากเคส",
+  "CaseMerging-ContactRemovedFromCase": "ผู้ติดต่อถูกลบออกจากเคส",
   "CaseMerging-CaseCreatedAndContactAdded": "สร้างเคส #{{caseId}} และเพิ่มผู้ติดต่อแล้ว",
+  "CaseMerging-ContactAddedToExistingCase": "เพิ่มผู้ติดต่อในกรณี #{{caseId}}",
   "CaseMerging-CancelCase": "ยกเลิกกรณี",
 
   "Profile-NoIdentifiersFound": "ไม่พบตัวระบุ",


### PR DESCRIPTION
## Description

* Fix logic to hide 'cancel banner' when a case is not created for this contact
* Silence console log error spam around tabbed forms

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- [X] Strings are localized
- [X] Tested for chat contacts
- [ X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket