### PR TITLE
CHI-2566 Filtering Counselor skills in Teams view

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -140,7 +140,7 @@ const setUpComponents = (
     if (featureFlags.enable_canned_responses) Components.setupCannedResponses();
   }
 
-  if (featureFlags.enable_teams_view) TeamsView.setUpSkillsColumn();
+  TeamsView.setUpSkillsColumn();
   TeamsView.setUpTeamViewFilters();
   TeamsView.setUpWorkerDirectoryFilters();
 

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -48,7 +48,7 @@ import { setUpTransferActions } from './transfer/setUpTransferActions';
 import { playNotification } from './notifications/playNotification';
 import { namespace } from './states/storeNamespaces';
 import { setUpTransferComponents } from './components/transfer/setUpTransferComponents';
-import { setUpSkillsColumn } from './components/teamsView';
+import TeamsView from './components/teamsView';
 
 const PLUGIN_NAME = 'HrmFormPlugin';
 
@@ -140,9 +140,9 @@ const setUpComponents = (
     if (featureFlags.enable_canned_responses) Components.setupCannedResponses();
   }
 
-  Components.setupTeamViewFilters();
-  setUpSkillsColumn();
-  Components.setupWorkerDirectoryFilters();
+  TeamsView.setUpSkillsColumn();
+  TeamsView.setUpTeamViewFilters();
+  TeamsView.setUpWorkerDirectoryFilters();
 
   if (featureFlags.enable_conferencing) setupConferenceComponents();
 };

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -140,7 +140,7 @@ const setUpComponents = (
     if (featureFlags.enable_canned_responses) Components.setupCannedResponses();
   }
 
-  TeamsView.setUpSkillsColumn();
+  if (featureFlags.enable_teams_view) TeamsView.setUpSkillsColumn();
   TeamsView.setUpTeamViewFilters();
   TeamsView.setUpWorkerDirectoryFilters();
 

--- a/plugin-hrm-form/src/components/teamsView/Filters.ts
+++ b/plugin-hrm-form/src/components/teamsView/Filters.ts
@@ -58,33 +58,24 @@ const skillsFilterDefinition: FilterDefinitionFactory = (_appState, _teamFilters
   };
 };
 
+/**
+ * This function sets up filters for the TeamsView component
+ * The activity filter omits the default since we already include offline in the above, ie Flex.TeamsView.activitiesFilter
+ * The skills filter is included if the feature flag is enabled.
+ */
 export const setUpTeamViewFilters = () => {
-  // eslint-disable-next-line camelcase
-  const { enable_teams_view } = getAseloFeatureFlags();
-
-  // eslint-disable-next-line camelcase
-  if (enable_teams_view) {
-    TeamsView.defaultProps.filters = [
-      activityNoOfflineByDefault,
-      /*
-       * Omit the default since we already include offline in the above
-       * Flex.TeamsView.activitiesFilter
-       */
-      skillsFilterDefinition,
-    ];
-  } else {
-    TeamsView.defaultProps.filters = [activityNoOfflineByDefault];
-  }
+  TeamsView.defaultProps.filters = [
+    activityNoOfflineByDefault,
+    ...(getAseloFeatureFlags().enable_teams_view_enhancements ? [skillsFilterDefinition] : []),
+  ];
 };
 
 export const setUpWorkerDirectoryFilters = () => {
   const managerInstance = Manager.getInstance();
 
   const activitiesArray = Array.from(managerInstance.store.getState().flex.worker.activities.values());
-
   const availableActivities = activitiesArray.filter(a => a.available).map(a => a.name);
 
   const activitiesFilter = `data.activity_name IN ${JSON.stringify(availableActivities)}`;
-
   WorkerDirectoryTabs.defaultProps.hiddenWorkerFilter = `(${activitiesFilter})`;
 };

--- a/plugin-hrm-form/src/components/teamsView/SkillsColumn.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SkillsColumn.tsx
@@ -20,12 +20,15 @@ import { WorkersDataTable, ColumnDefinition, Template } from '@twilio/flex-ui';
 import SkillChip from './SkillChip';
 import { StyledLink } from '../search/styles';
 import { OpaqueText } from '../../styles';
+import { getAseloFeatureFlags } from '../../hrmConfig';
 
 const sortFn = (first, second) => {
   return 0;
 };
 
 export const setUpSkillsColumn = () => {
+  if (!getAseloFeatureFlags().enable_teams_view_enhancements) return;
+
   WorkersDataTable.Content.add(
     <ColumnDefinition
       key="skills"

--- a/plugin-hrm-form/src/components/teamsView/index.ts
+++ b/plugin-hrm-form/src/components/teamsView/index.ts
@@ -13,4 +13,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-export { setUpSkillsColumn } from './SkillsColumn';
+import { setUpSkillsColumn } from './SkillsColumn';
+import { setUpTeamViewFilters, setUpWorkerDirectoryFilters } from './Filters';
+
+const TeamsView = {
+  setUpSkillsColumn,
+  setUpTeamViewFilters,
+  setUpWorkerDirectoryFilters,
+};
+
+// eslint-disable-next-line import/no-unused-modules
+export default TeamsView;

--- a/plugin-hrm-form/src/components/teamsView/index.ts
+++ b/plugin-hrm-form/src/components/teamsView/index.ts
@@ -22,5 +22,4 @@ const TeamsView = {
   setUpWorkerDirectoryFilters,
 };
 
-// eslint-disable-next-line import/no-unused-modules
 export default TeamsView;

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -289,7 +289,7 @@ export type FeatureFlags = {
   enable_save_insights: boolean; // Enables Saving Aditional Data on Insights
   enable_separate_timeline_view: boolean; // Enables a limited inline case timelinbe with a link to the full timeline
   enable_sort_cases: boolean; // Enables Sorting at Case List
-  enable_teams_view: boolean; // Enables custom Teams View UI
+  enable_teams_view_enhancements: boolean; // Enables custom Teams View UI
   enable_transfers: boolean; // Enables Transfering Contacts
   enable_twilio_transcripts: boolean; // Enables Viewing Transcripts Stored at Twilio
   enable_upload_documents: boolean; // Enables Case Documents

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -289,11 +289,11 @@ export type FeatureFlags = {
   enable_save_insights: boolean; // Enables Saving Aditional Data on Insights
   enable_separate_timeline_view: boolean; // Enables a limited inline case timelinbe with a link to the full timeline
   enable_sort_cases: boolean; // Enables Sorting at Case List
+  enable_teams_view: boolean; // Enables custom Teams View UI
   enable_transfers: boolean; // Enables Transfering Contacts
   enable_twilio_transcripts: boolean; // Enables Viewing Transcripts Stored at Twilio
   enable_upload_documents: boolean; // Enables Case Documents
   enable_voice_recordings: boolean; // Enables Loading Voice Recordings
-  enable_teams_view: boolean; // Enables custom Teams View UI
 };
 /* eslint-enable camelcase */
 

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -293,6 +293,7 @@ export type FeatureFlags = {
   enable_twilio_transcripts: boolean; // Enables Viewing Transcripts Stored at Twilio
   enable_upload_documents: boolean; // Enables Case Documents
   enable_voice_recordings: boolean; // Enables Loading Voice Recordings
+  enable_teams_view: boolean; // Enables custom Teams View UI
 };
 /* eslint-enable camelcase */
 

--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -18,7 +18,6 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
 import * as Flex from '@twilio/flex-ui';
-import type { FilterDefinitionFactory } from '@twilio/flex-ui/src/components/view/TeamsView';
 
 import * as TransferHelpers from '../transfer/transferTaskState';
 import EmojiPicker from '../components/emojiPicker';
@@ -422,42 +421,4 @@ export const setupCannedResponses = () => {
  */
 export const setupEmojiPicker = () => {
   Flex.MessageInputActions.Content.add(<EmojiPicker key="emoji-picker" />);
-};
-
-const activityNoOfflineByDefault: FilterDefinitionFactory = (appState, _teamFiltersPanelProps) => {
-  const activitiesArray = Array.from(appState.flex.worker.activities.values());
-
-  const options = activitiesArray.map(activity => ({
-    value: activity.name,
-    label: activity.name,
-    default: activity.name !== 'Offline',
-  }));
-
-  return {
-    id: 'data.activity_name',
-    fieldName: 'activity',
-    type: Flex.FiltersListItemType.multiValue,
-    title: 'Activities',
-    options,
-  };
-};
-
-export const setupTeamViewFilters = () => {
-  Flex.TeamsView.defaultProps.filters = [
-    activityNoOfflineByDefault,
-    /*
-     * Omit the default since we already include offline in the above
-     * Flex.TeamsView.activitiesFilter
-     */
-  ];
-};
-
-export const setupWorkerDirectoryFilters = () => {
-  const activitiesArray = Array.from(Flex.Manager.getInstance().store.getState().flex.worker.activities.values());
-
-  const availableActivities = activitiesArray.filter(a => a.available).map(a => a.name);
-
-  Flex.WorkerDirectoryTabs.defaultProps.hiddenWorkerFilter = `data.activity_name IN ${JSON.stringify(
-    availableActivities,
-  )}`;
 };

--- a/twilio-iac/helplines/as/configs/service-configuration/development.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/development.json
@@ -9,6 +9,7 @@
             "enableUnmaskingCalls": true
         },
         "feature_flags": {
+            "backend_handled_chat_janitor": false,
             "enable_aselo_messaging_ui": true,
             "enable_counselor_toolkits": true,
             "enable_csam_clc_report": true,
@@ -16,14 +17,13 @@
             "enable_client_profiles": true,
             "enable_fullstory_monitoring": true,
             "enable_lex": true,
+            "enable_post_survey": false,
             "enable_resources": true,
             "enable_resources_elastic_search": true,
             "enable_save_insights": true,
+            "enable_teams_view": true,
             "enable_transcripts": true,
-            "backend_handled_chat_janitor": false,
-            "enable_voice_recordings": false,
-            "enable_post_survey": false,
-            "enable_teams_view": true
+            "enable_voice_recordings": false
         },
         "contact_save_frequency": "onTabChange",
         "multipleOfficeSupport": true,

--- a/twilio-iac/helplines/as/configs/service-configuration/development.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/development.json
@@ -22,7 +22,8 @@
             "enable_transcripts": true,
             "backend_handled_chat_janitor": false,
             "enable_voice_recordings": false,
-            "enable_post_survey": false
+            "enable_post_survey": false,
+            "enable_teams_view": true
         },
         "contact_save_frequency": "onTabChange",
         "multipleOfficeSupport": true,

--- a/twilio-iac/helplines/as/configs/service-configuration/development.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/development.json
@@ -21,7 +21,7 @@
             "enable_resources": true,
             "enable_resources_elastic_search": true,
             "enable_save_insights": true,
-            "enable_teams_view": true,
+            "enable_teams_view_enhancements": true,
             "enable_transcripts": true,
             "enable_voice_recordings": false
         },

--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -17,8 +17,8 @@
             "enable_csam_report": true,
             "enable_lex": true,
             "enable_save_insights": true,
-            "enable_voice_recordings": true,
-            "enable_teams_view": true
+            "enable_teams_view": true,
+            "enable_voice_recordings": true
         },
         "hrm_base_url": "https://hrm-test.tl.techmatters.org",
         "multipleOfficeSupport": true,

--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -17,7 +17,8 @@
             "enable_csam_report": true,
             "enable_lex": true,
             "enable_save_insights": true,
-            "enable_voice_recordings": true
+            "enable_voice_recordings": true,
+            "enable_teams_view": true
         },
         "hrm_base_url": "https://hrm-test.tl.techmatters.org",
         "multipleOfficeSupport": true,

--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -17,7 +17,7 @@
             "enable_csam_report": true,
             "enable_lex": true,
             "enable_save_insights": true,
-            "enable_teams_view": true,
+            "enable_teams_view_enhancements": true,
             "enable_voice_recordings": true
         },
         "hrm_base_url": "https://hrm-test.tl.techmatters.org",

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,7 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
-            "enable_teams_view": true
+            "enable_teams_view_enhancements": true
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
         "resources_base_url": "https://hrm-staging.tl.techmatters.org"

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "enable_teams_view": true
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
         "resources_base_url": "https://hrm-staging.tl.techmatters.org"


### PR DESCRIPTION
## Description
- This PR adds the feature to filter through counsellor skills in the Teams view.
- Adds a new feature flag: `enable_teams_view`

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [x] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- Hardcode `enable_teams_view` to true in two places where it is used
- Filter through the Skills in the Filter side panel