### PR TITLE
CHI-2660: Remove Datadog RUM monitoring

### DIFF
--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.3",
-    "@datadog/browser-rum": "^1.20.0",
     "@emoji-mart/react": "^1.1.1",
     "@emotion/css": "^11.9.3",
     "@emotion/react": "^11.9.3",

--- a/plugin-hrm-form/src/utils/setUpMonitoring.ts
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.ts
@@ -14,32 +14,11 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import * as Flex from '@twilio/flex-ui';
-import { datadogRum } from '@datadog/browser-rum';
 import * as FullStory from '@fullstory/browser';
 import { ServiceConfiguration } from '@twilio/flex-ui';
 import type { Worker } from 'twilio-taskrouter';
 
-import { datadogAccessToken, datadogApplicationID, fullStoryId } from '../private/secret';
-
-function setUpDatadogRum(workerClient: Worker, monitoringEnv: string) {
-  datadogRum.init({
-    applicationId: datadogApplicationID,
-    clientToken: datadogAccessToken,
-    site: 'datadoghq.com',
-    env: monitoringEnv,
-    sampleRate: 100,
-    trackInteractions: true,
-    // service: 'my-web-application',
-  });
-
-  datadogRum.addRumGlobalContext('person', {
-    id: workerClient.sid,
-    account: workerClient.accountSid,
-    workspace: workerClient.workspaceSid,
-    helpline: (workerClient.attributes as any).helpline,
-  });
-}
+import { fullStoryId } from '../private/secret';
 
 function setUpFullStory() {
   FullStory.init({
@@ -59,12 +38,6 @@ function helplineIdentifierFullStory(workerClient) {
 }
 
 export default function setUpMonitoring(workerClient: Worker, serviceConfiguration: ServiceConfiguration) {
-  const monitoringEnv = serviceConfiguration.attributes.monitoringEnv || 'staging';
-
-  if (process.env.ENABLE_MONITORING === 'true') {
-    setUpDatadogRum(workerClient, monitoringEnv);
-  }
-
   if (serviceConfiguration.attributes.feature_flags.enable_fullstory_monitoring) {
     setUpFullStory();
     helplineIdentifierFullStory(workerClient);


### PR DESCRIPTION
## Description
Removes Datadog's SDK from our frontend and stops sending real-user monitoring traffic to Datadog. We have not been using this since adding Full Story, and we are about to start getting charged for it. There is no reason to continue.

I **think** this should be a patch release next week. But there's a cost vs time tradeoff here and it's a valid question.

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- N/A Tested for chat contacts
- N/A Tested for call contacts

### Verification steps
- Find an account where datadog RUM monitoring is in use (should be all accounts). Double-check by running Flex and checking the network tab for calls to datadog
- Deploy this change
- Note that datadog calls are no longer being sent

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P