### PR TITLE
CHI-2573 Truncate skill name with long length

### DIFF
--- a/plugin-hrm-form/src/components/teamsView/SkillChip.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SkillChip.tsx
@@ -26,6 +26,8 @@ type Props = {
 };
 
 const SkillChip: React.FC<Props> = ({ skill, skillType }) => {
+  const SKILL_LENGTH = 30;
+
   let bgColor;
   let fontColor;
   if (skillType === 'active') {
@@ -41,9 +43,9 @@ const SkillChip: React.FC<Props> = ({ skill, skillType }) => {
       {skillType === 'active' && <SmallCheckIcon htmlColor={fontColor} />}
       {skillType === 'disabled' && <SmallDisabledIcon htmlColor={fontColor} />}
       <ChipText bold color={fontColor}>
-        {skill.length > 30 ? (
+        {skill.length > SKILL_LENGTH ? (
           <Tooltip title={skill}>
-            <span>{`${skill.substring(0, 30)}...`}</span>
+            <span>{`${skill.substring(0, SKILL_LENGTH)}…`}</span>
           </Tooltip>
         ) : (
           skill

--- a/plugin-hrm-form/src/components/teamsView/SkillChip.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SkillChip.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { Tooltip } from '@material-ui/core';
 
 import { SkillChipStyled, SmallCheckIcon, SmallDisabledIcon } from './styles';
 import { ChipText } from '../../styles';
@@ -40,7 +41,13 @@ const SkillChip: React.FC<Props> = ({ skill, skillType }) => {
       {skillType === 'active' && <SmallCheckIcon htmlColor={fontColor} />}
       {skillType === 'disabled' && <SmallDisabledIcon htmlColor={fontColor} />}
       <ChipText bold color={fontColor}>
-        {skill}
+        {skill.length > 30 ? (
+          <Tooltip title={skill}>
+            <span>{`${skill.substring(0, 30)}...`}</span>
+          </Tooltip>
+        ) : (
+          skill
+        )}
       </ChipText>
     </SkillChipStyled>
   );

--- a/plugin-hrm-form/src/components/teamsView/SkillsColumn.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SkillsColumn.tsx
@@ -68,7 +68,7 @@ const SkillsListCell = ({ availableSkills, disabledSkills, workerName }) => {
   }
 
   return (
-    <SkillsCell>
+    <SkillsCell style={{ marginBottom: combinedSkills.length <= 3 ? '8px' : '0px' }}>
       {displayedSkills.map(({ skill, type }) => (
         <SkillChip key={skill} skill={skill} skillType={type} />
       ))}

--- a/plugin-hrm-form/src/components/teamsView/styles.tsx
+++ b/plugin-hrm-form/src/components/teamsView/styles.tsx
@@ -20,7 +20,6 @@ import CheckIcon from '@material-ui/icons/Check';
 import DisabledIcon from '@material-ui/icons/Block';
 
 import { ChipBase } from '../../styles';
-import { StyledLink } from '../search/styles';
 
 type SkillChipProps = {
   color: string;
@@ -50,6 +49,6 @@ export const SmallCheckIcon = withSmallIcon(CheckIcon);
 export const SmallDisabledIcon = withSmallIcon(DisabledIcon);
 
 export const SkillsCell = styled('div')`
-  padding: 8px 0;
+  padding: 8px 8px 0px 0;
 `;
 SkillsCell.displayName = 'SkillsCell';


### PR DESCRIPTION
## Description
- Addressed this 'bug' - https://tech-matters.slack.com/archives/C035K8919U7/p1711059364850309
- The skill name gets truncated if longer than 30 characters along with a tooltip

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P