### PR TITLE
CHI-2568 Support sorting calls in Teams view by duration of calls / wrap up time

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -141,6 +141,7 @@ const setUpComponents = (
   }
 
   TeamsView.setUpSkillsColumn();
+  TeamsView.setUpSortingCalls();
   TeamsView.setUpTeamViewFilters();
   TeamsView.setUpWorkerDirectoryFilters();
 

--- a/plugin-hrm-form/src/components/teamsView/SortCalls.ts
+++ b/plugin-hrm-form/src/components/teamsView/SortCalls.ts
@@ -50,9 +50,9 @@ const sortWorkersByCallDuration = (a: SupervisorWorkerState, b: SupervisorWorker
   const aDuration = aCallTask ? convertDurationToSeconds(new TaskHelper(aCallTask).durationSinceUpdate) : 0;
   const bDuration = bCallTask ? convertDurationToSeconds(new TaskHelper(bCallTask).durationSinceUpdate) : 0;
 
-  if (!aIsLiveCallTask && !bIsLiveCallTask) {
+  if (aIsLiveCallTask && bIsLiveCallTask) {
     return aDuration - bDuration; // both are live calls, longest duration first
-  } else if (aIsLiveCallTask && bIsLiveCallTask) {
+  } else if (!aIsLiveCallTask && !bIsLiveCallTask) {
     return aDuration - bDuration; // both are not live calls, longest duration first
   } else if (aIsLiveCallTask && !bIsLiveCallTask) {
     return 1; // a is a live call and b is not, a comes first

--- a/plugin-hrm-form/src/components/teamsView/SortCalls.ts
+++ b/plugin-hrm-form/src/components/teamsView/SortCalls.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { AgentsDataTable, TaskHelper } from '@twilio/flex-ui';
+import { SupervisorWorkerState } from '@twilio/flex-ui/src/state/State.definition';
+
+/**
+ * Converts a duration string in the format "HH:MM:SS" or "MM:SS" to seconds.
+ */
+const convertDurationToSeconds = (duration: string): number => {
+  const timeParts = duration.split(':').map(Number);
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
+
+  if (timeParts.length === 3) {
+    [hours, minutes, seconds] = timeParts;
+  } else if (timeParts.length === 2) {
+    [minutes, seconds] = timeParts;
+  }
+  return hours * 60 * 60 + minutes * 60 + seconds;
+};
+
+/**
+ * Sorts agents by the duration of their calls.
+ * If a worker doesn't have a call, they will be sorted to the end.
+ */
+const sortWorkersByCallDuration = (a: SupervisorWorkerState, b: SupervisorWorkerState) => {
+  // find the call task for each worker if it exists
+  const aCallTask = a.tasks.find(task => TaskHelper.isCallTask(task));
+  const bCallTask = b.tasks.find(task => TaskHelper.isCallTask(task));
+
+  if (!aCallTask && !bCallTask) {
+    // if neither worker has a call task
+    return 0;
+  } else if (!aCallTask) {
+    // if worker a doesn't have a call task
+    return -1;
+  } else if (!bCallTask) {
+    // if worker b doesn't have a call task
+    return 1;
+  }
+  const aDuration = convertDurationToSeconds(new TaskHelper(aCallTask).durationSinceUpdate);
+  const bDuration = convertDurationToSeconds(new TaskHelper(bCallTask).durationSinceUpdate);
+
+  return aDuration - bDuration;
+};
+
+export const setUpSortingCalls = () => {
+  AgentsDataTable.defaultProps.sortCalls = sortWorkersByCallDuration;
+};

--- a/plugin-hrm-form/src/components/teamsView/SortCalls.ts
+++ b/plugin-hrm-form/src/components/teamsView/SortCalls.ts
@@ -17,6 +17,8 @@
 import { AgentsDataTable, TaskHelper } from '@twilio/flex-ui';
 import { SupervisorWorkerState } from '@twilio/flex-ui/src/state/State.definition';
 
+import { getAseloFeatureFlags } from '../../hrmConfig';
+
 /**
  * Converts a duration string in the format "HH:MM:SS" or "MM:SS" to seconds.
  */
@@ -39,18 +41,14 @@ const convertDurationToSeconds = (duration: string): number => {
  * If a worker doesn't have a call, they will be sorted to the end.
  */
 const sortWorkersByCallDuration = (a: SupervisorWorkerState, b: SupervisorWorkerState) => {
-  // find the call task for each worker if it exists
   const aCallTask = a.tasks.find(task => TaskHelper.isCallTask(task));
   const bCallTask = b.tasks.find(task => TaskHelper.isCallTask(task));
 
   if (!aCallTask && !bCallTask) {
-    // if neither worker has a call task
     return 0;
   } else if (!aCallTask) {
-    // if worker a doesn't have a call task
     return -1;
   } else if (!bCallTask) {
-    // if worker b doesn't have a call task
     return 1;
   }
   const aDuration = convertDurationToSeconds(new TaskHelper(aCallTask).durationSinceUpdate);
@@ -60,5 +58,6 @@ const sortWorkersByCallDuration = (a: SupervisorWorkerState, b: SupervisorWorker
 };
 
 export const setUpSortingCalls = () => {
+  if (!getAseloFeatureFlags().enable_teams_view_enhancements) return;
   AgentsDataTable.defaultProps.sortCalls = sortWorkersByCallDuration;
 };

--- a/plugin-hrm-form/src/components/teamsView/index.ts
+++ b/plugin-hrm-form/src/components/teamsView/index.ts
@@ -14,10 +14,12 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { setUpSkillsColumn } from './SkillsColumn';
+import { setUpSortingCalls } from './SortCalls';
 import { setUpTeamViewFilters, setUpWorkerDirectoryFilters } from './Filters';
 
 const TeamsView = {
   setUpSkillsColumn,
+  setUpSortingCalls,
   setUpTeamViewFilters,
   setUpWorkerDirectoryFilters,
 };


### PR DESCRIPTION
## Description

- This PR adds sorting functionality to Teams View Calls column by the duration of counselor calls, prioritizing live calls first and then wrap-up calls
- This work is behind the feature flag - `enable_teams_view_enhancements`


### Checklist
- [x] Corresponding issue has been [opened](https://tech-matters.atlassian.net/browse/CHI-2568)
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- Get some co-workers to initiate calls. At least two live and a couple in wrap up
- Check that the Acceptance criteria in the jira ticket are fulfilled. Note that header styling (nice to have) is skipped.
![Screenshot 2024-03-29 at 10 08 05 AM](https://github.com/techmatters/flex-plugins/assets/102122005/5292a24d-898f-4315-ba05-b4f05ff5b049)
![Screenshot 2024-03-28 at 1 58 34 PM](https://github.com/techmatters/flex-plugins/assets/102122005/43e7060e-c811-4de8-84c6-f2836688c148)


### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P