### PR TITLE
CHI-2632: Move contact finalization & conversation media saving to after task completed. Add debug FS custom events

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -24,6 +24,7 @@ import HrmTheme, { overrides } from './styles/HrmTheme';
 import { initLocalization } from './utils/pluginHelpers';
 import * as Providers from './utils/setUpProviders';
 import * as ActionFunctions from './utils/setUpActions';
+import { recordCallState } from './utils/setUpActions';
 import * as TaskRouterListeners from './utils/setUpTaskRouterListeners';
 import * as Components from './utils/setUpComponents';
 import * as Channels from './channels/setUpChannels';
@@ -161,6 +162,10 @@ const setUpActions = (
   setUpTransferActions(featureFlags.enable_transfers, setupObject);
 
   Flex.Actions.replaceAction('HangupCall', ActionFunctions.hangupCall);
+  Flex.Manager.getInstance().workerClient.addListener('reservationCreated', reservation => {
+    reservation.addListener('wrapup', recordCallState);
+    reservation.addListener('completed', recordCallState);
+  });
 
   Flex.Actions.replaceAction('WrapupTask', wrapupOverride);
 

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -119,6 +119,7 @@ export const handleTwilioTask = async (task): Promise<HandleTwilioTaskResponse> 
         recordingError: externalRecordingInfo.error,
         isCallTask: TaskHelper.isCallTask(task),
         isChatBasedTask: TaskHelper.isChatBasedTask(task),
+        attributes: JSON.stringify(task.attributes),
       });
       return returnData;
     }
@@ -146,11 +147,6 @@ export const handleTwilioTask = async (task): Promise<HandleTwilioTaskResponse> 
     );
   }
   return returnData;
-};
-
-type SaveContactToHrmResponse = {
-  response: Contact;
-  externalRecordingInfo?: ExternalRecordingInfoSuccess;
 };
 
 export const createContact = async (
@@ -206,7 +202,7 @@ const saveContactToHrm = async (
   workerSid: WorkerSID,
   uniqueIdentifier: TaskSID,
   shouldFillEndMillis = true,
-): Promise<SaveContactToHrmResponse> => {
+): Promise<Contact> => {
   // if we got this far, we assume the form is valid and ready to submit
   const metadataForDuration = shouldFillEndMillis ? fillEndMillis(metadata) : metadata;
   const conversationDuration = getConversationDuration(task, metadataForDuration);
@@ -236,9 +232,6 @@ const saveContactToHrm = async (
 
   // This might change if isNonDataCallType, that's why we use rawForm
   const timeOfContact = new Date(getDateTime(form.contactlessTask)).toISOString();
-  const twilioTaskResult = await handleTwilioTask(task);
-  const { channelSid, serviceSid, externalRecordingInfo } = twilioTaskResult;
-  await saveConversationMedia(contact.id, twilioTaskResult.conversationMedia);
 
   /*
    * We do a transform from the original and then add things.
@@ -255,16 +248,20 @@ const saveContactToHrm = async (
     conversationDuration,
     timeOfContact,
     taskId: uniqueIdentifier,
+  };
+
+  return updateContactInHrm(contact.id, contactToSave, false);
+};
+
+export const finalizeContact = async (task, contact: Contact): Promise<Contact> => {
+  const twilioTaskResult = await handleTwilioTask(task);
+  const { channelSid, serviceSid } = twilioTaskResult;
+  await saveConversationMedia(contact.id, twilioTaskResult.conversationMedia);
+  const contactUpdates: ContactDraftChanges = {
     channelSid,
     serviceSid,
   };
-
-  const response = await updateContactInHrm(contact.id, contactToSave, true);
-
-  return {
-    response,
-    externalRecordingInfo: externalRecordingInfo ?? null,
-  };
+  return updateContactInHrm(contact.id, contactUpdates, true);
 };
 
 export const saveContact = async (
@@ -275,21 +272,27 @@ export const saveContact = async (
   uniqueIdentifier: TaskSID,
   shouldFillEndMillis = true,
 ) => {
-  const payloads = await saveContactToHrm(task, contact, metadata, workerSid, uniqueIdentifier, shouldFillEndMillis);
-
+  const savedContact = await saveContactToHrm(
+    task,
+    contact,
+    metadata,
+    workerSid,
+    uniqueIdentifier,
+    shouldFillEndMillis,
+  );
   // TODO: add catch clause to handle saving to Sync Doc
   try {
     // Add the old category format back, but leave out all the explicit false values
     const legacyCategories = {};
-    Object.entries(payloads.response.rawJson.categories).forEach(([key, value]) => {
+    Object.entries(contact.rawJson.categories).forEach(([key, value]) => {
       legacyCategories[key] = Object.fromEntries(value.map(category => [category, true]));
     });
     await saveContactToExternalBackend(task, {
-      ...payloads.response,
+      ...savedContact,
       rawJson: {
-        ...payloads.response.rawJson,
+        ...savedContact.rawJson,
         caseInformation: {
-          ...payloads.response.rawJson.caseInformation,
+          ...savedContact.rawJson.caseInformation,
           categories: legacyCategories,
         },
       },
@@ -301,10 +304,7 @@ export const saveContact = async (
     );
   }
 
-  return {
-    contact: payloads.response,
-    externalRecordingInfo: payloads.externalRecordingInfo,
-  };
+  return savedContact;
 };
 
 export async function connectToCase(contactId: string, caseId: string) {

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -419,7 +419,7 @@ export const buildInsightsData = (
   contact: Contact,
   caseForm: Case,
   savedContact: Contact,
-  externalRecordingInfo: ExternalRecordingInfo | null = null,
+  externalRecordingInfo?: ExternalRecordingInfo,
 ) => {
   const logObject: any = {
     taskId: task.taskSid,
@@ -439,6 +439,7 @@ export const buildInsightsData = (
       .map(f => f(previousAttributes, contact, caseForm, savedContact))
       .reduce((acc: TaskAttributes, curr: InsightsAttributes) => mergeAttributes(acc, curr), previousAttributes);
 
+    // TODO: replace with a url provider that doesn't require the recording SID, but can use the task ID or contact ID to look it up at query time
     if (isSuccessfulExternalRecordingInfo(externalRecordingInfo)) {
       const urlProviderBlock = generateUrlProviderBlock(externalRecordingInfo, savedContact);
       finalAttributes.conversations = {

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -21,6 +21,7 @@ import { submitContactForm } from '../../services/formSubmissionHelpers';
 import {
   connectToCase,
   createContact,
+  finalizeContact,
   getContactById,
   getContactByTaskSid,
   removeFromCase,
@@ -32,6 +33,7 @@ import {
   ContactMetadata,
   ContactsState,
   CREATE_CONTACT_ACTION,
+  FINALIZE_CONTACT,
   LOAD_CONTACT_FROM_HRM_BY_ID_ACTION,
   LOAD_CONTACT_FROM_HRM_BY_TASK_ID_ACTION,
   LoadingStatus,
@@ -189,6 +191,13 @@ export const submitContactFormAsyncAction = createAsyncAction(
     metadata,
     caseForm,
   }),
+);
+
+export const finalizeContactAsyncAction = createAsyncAction(
+  FINALIZE_CONTACT,
+  async (task: CustomITask, contact: Contact) => {
+    return finalizeContact(task, contact);
+  },
 );
 
 export const loadContactFromHrmByTaskSidAsyncAction = createAsyncAction(
@@ -409,6 +418,13 @@ export const saveContactReducer = (initialState: ContactsState) =>
       removeFromCaseAsyncAction.fulfilled,
       (state, { payload: { contact } }): ContactsState => {
         if (!contact) return state;
+        return loadContactIntoRedux(state, contact);
+      },
+    ),
+
+    handleAction(
+      finalizeContactAsyncAction.fulfilled,
+      (state, { payload: contact }): ContactsState => {
         return loadContactIntoRedux(state, contact);
       },
     ),

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -193,7 +193,7 @@ export const submitContactFormAsyncAction = createAsyncAction(
   }),
 );
 
-export const finalizeContactAsyncAction = createAsyncAction(
+export const newFinalizeContactAsyncAction = createAsyncAction(
   FINALIZE_CONTACT,
   async (task: CustomITask, contact: Contact) => {
     return finalizeContact(task, contact);
@@ -423,7 +423,7 @@ export const saveContactReducer = (initialState: ContactsState) =>
     ),
 
     handleAction(
-      finalizeContactAsyncAction.fulfilled,
+      newFinalizeContactAsyncAction.fulfilled,
       (state, { payload: contact }): ContactsState => {
         return loadContactIntoRedux(state, contact);
       },

--- a/plugin-hrm-form/src/states/contacts/types.ts
+++ b/plugin-hrm-form/src/states/contacts/types.ts
@@ -44,8 +44,9 @@ export const CONNECT_TO_CASE = 'contact-action/connect-to-case';
 export const REMOVE_FROM_CASE = 'contact-action/remove-from-case';
 export const CONNECT_TO_CASE_ACTION_FULFILLED = `${CONNECT_TO_CASE}_FULFILLED` as const;
 export const REMOVE_FROM_CASE_ACTION_FULFILLED = `${REMOVE_FROM_CASE}_FULFILLED` as const;
-export const SET_SAVED_CONTACT = 'contact-action/set-saved-contact';
-export const CASE_CONNECTED_TO_CONTACT = 'CASE_CONNECTED_TO_CONTACT';
+export const SET_SAVED_CONTACT = 'contact-action/set-saved-contact' as const;
+export const FINALIZE_CONTACT = 'contact-action/finalize-contact' as const;
+export const CASE_CONNECTED_TO_CONTACT = 'CASE_CONNECTED_TO_CONTACT' as const;
 
 export const LoadingStatus = {
   LOADING: 'loading',

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -33,7 +33,7 @@ import { getNumberFromTask, getTaskLanguage } from './task';
 import selectContactByTaskSid from '../states/contacts/selectContactByTaskSid';
 import { newContact } from '../states/contacts/contactState';
 import asyncDispatch from '../states/asyncDispatch';
-import { createContactAsyncAction, finalizeContactAsyncAction } from '../states/contacts/saveContact';
+import { createContactAsyncAction, newFinalizeContactAsyncAction } from '../states/contacts/saveContact';
 import { handleTransferredTask } from '../transfer/setUpTransferActions';
 import { prepopulateForm } from './prepopulateForm';
 import { namespace } from '../states/storeNamespaces';
@@ -249,7 +249,7 @@ export const afterCompleteTask = async ({ task }: ActionPayload): Promise<void> 
   if (contactState) {
     const { savedContact } = contactState;
     if (savedContact) {
-      finalizeContactAsyncAction(task, savedContact);
+      manager.store.dispatch(newFinalizeContactAsyncAction(task, savedContact));
     }
     manager.store.dispatch(GeneralActions.removeContactState(task.taskSid, contactState.savedContact.id));
   }

--- a/plugin-hrm-form/src/utils/setUpMonitoring.ts
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.ts
@@ -14,10 +14,9 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import * as Flex from '@twilio/flex-ui';
+import { ServiceConfiguration } from '@twilio/flex-ui';
 import { datadogRum } from '@datadog/browser-rum';
 import * as FullStory from '@fullstory/browser';
-import { ServiceConfiguration } from '@twilio/flex-ui';
 import type { Worker } from 'twilio-taskrouter';
 
 import { datadogAccessToken, datadogApplicationID, fullStoryId } from '../private/secret';
@@ -65,7 +64,7 @@ export default function setUpMonitoring(workerClient: Worker, serviceConfigurati
     setUpDatadogRum(workerClient, monitoringEnv);
   }
 
-  if (serviceConfiguration.attributes.feature_flags.enable_fullstory_monitoring) {
+  if (process.env.ENABLE_MONITORING === 'true') {
     setUpFullStory();
     helplineIdentifierFullStory(workerClient);
   }

--- a/plugin-hrm-form/src/utils/setUpMonitoring.ts
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.ts
@@ -64,7 +64,7 @@ export default function setUpMonitoring(workerClient: Worker, serviceConfigurati
     setUpDatadogRum(workerClient, monitoringEnv);
   }
 
-  if (process.env.ENABLE_MONITORING === 'true') {
+  if (serviceConfiguration.attributes.feature_flags.enable_fullstory_monitoring) {
     setUpFullStory();
     helplineIdentifierFullStory(workerClient);
   }


### PR DESCRIPTION
## Description

* Move contact finalization & conversation media saving to after task completed. 
* Add debug FS custom events
* Fixed an issue where sending 'undefined' as a string for the conversation SID caused 500s 

This is a speculative fix with additional logging if the fix doesn't address the issue described in the ticket

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Monitor FS for the new telemetry events. If the fix is working, we should see errors where the task is in the 'wrapping' state followed by successes where the task is completed. If we see no failures at all, this inconclusive, whereas if it fails at both stages, we can conclusively say the fix is not working. 

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P