### PR TITLE
CHI-2670: Read text for notes on CasePrintView correctly

### DIFF
--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintNotes.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintNotes.tsx
@@ -18,20 +18,23 @@
 /* eslint-disable dot-notation */
 import React from 'react';
 import { Text, View } from '@react-pdf/renderer';
+import { DefinitionVersion } from 'hrm-form-definitions';
 
 import { formatName, formatStringToDateAndTime } from '../../../utils';
 import styles from './styles';
 import { getTemplateStrings } from '../../../hrmConfig';
 import { ApiCaseSection } from '../../../services/caseSectionService';
+import { getNoteActivityText } from '../../../states/case/caseActivities';
 
 type OwnProps = {
   notes: ApiCaseSection[];
   counselorsHash: { [sid: string]: string };
+  formDefinition: DefinitionVersion;
 };
 
 type Props = OwnProps;
 
-const CasePrintNotes: React.FC<Props> = ({ notes, counselorsHash }) => {
+const CasePrintNotes: React.FC<Props> = ({ notes, counselorsHash, formDefinition }) => {
   const strings = getTemplateStrings();
 
   if (!notes || notes.length === 0) return null;
@@ -43,15 +46,15 @@ const CasePrintNotes: React.FC<Props> = ({ notes, counselorsHash }) => {
       </View>
       {notes &&
         notes.length > 0 &&
-        notes.map(({ createdBy, sectionTypeSpecificData: note, createdAt }, i) => {
+        notes.map((noteSection, i) => {
           return (
             <View key={i} style={{ ...styles['sectionBody'], ...styles['caseSummaryText'] }}>
               <View style={{ ...styles.flexRow, justifyContent: 'space-between' }}>
-                <Text style={{ fontWeight: 600 }}>{formatName(counselorsHash[createdBy])}</Text>
-                <Text style={{ fontStyle: 'italic' }}>{formatStringToDateAndTime(createdAt)}</Text>
+                <Text style={{ fontWeight: 600 }}>{formatName(counselorsHash[noteSection.createdBy])}</Text>
+                <Text style={{ fontStyle: 'italic' }}>{formatStringToDateAndTime(noteSection.createdAt)}</Text>
               </View>
               <View>
-                <Text style={styles['noteSummaryText']}>{note.text}</Text>
+                <Text style={styles['noteSummaryText']}>{getNoteActivityText(noteSection, formDefinition)}</Text>
               </View>
             </View>
           );

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
@@ -213,7 +213,7 @@ const CasePrintView: React.FC<Props> = ({
                   sectionKey="referral"
                   values={referral}
                 />
-                <CasePrintNotes notes={note} counselorsHash={counselorsHash} />
+                <CasePrintNotes notes={note} counselorsHash={counselorsHash} formDefinition={definitionVersion} />
                 <CasePrintSummary summary={connectedCase.info.summary} />
                 <CasePrintCSAMReports csamReports={contact?.csamReports} />
               </View>


### PR DESCRIPTION
## Description

Correct the CassePrintNotes.tsx component to infer the printed text from a case section using the same method that was previously used in the NoteActivity type

BUG CAUSE ANALYSIS:

As part of the rework to use case section specific endpoints (CHI-2422), there was an effort to standardise the types that components displaying case section data used as a data source, which included moving rendering case notes in a PDF away from using the NoteActivity type, a secondary type that was used in some parts of the UI but not in others to using the ApiCaseSection type, the standard type that is stored in Redux.

As part of this move, the part of the component rendering the text itself omitted some of the logic required to render the desired text. This logic was previously in the conversion to NoteActivity, but when the use of that type was removed, so was the mapping of the displayable note text, and it needed to be moved to the component. This was missed in the conversion

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P