### PR TITLE
CHI-2566 Filter Panel CSS overrides

### DIFF
--- a/plugin-hrm-form/src/components/teamsView/SkillsColumn.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SkillsColumn.tsx
@@ -80,6 +80,7 @@ const SkillsListCell = ({ availableSkills, disabledSkills, workerName }) => {
             setShowMore(!showMore);
           }}
           aria-label={showMore ? `See less skills for ${workerName}` : `See more skills for ${workerName}`}
+          data-fs-id="TeamsView-ToggleSkills"
         >
           <Template code={showMore ? 'ReadLess' : 'ReadMore'} />
         </StyledLink>

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -145,6 +145,10 @@ div.Twilio-Splitter div.Twilio-AgentDesktopView\.Panel2 {
  .Twilio-WorkersDataTable {
     min-width: 900px !important;
  }
+
+/**  
+ * Overrides to allow better UX for Reset and Apply (buttons) in the Filter Panel
+ */
  .Twilio-FilterListButtons-Container {
     min-width: 0px;
     width: -webkit-fill-available;
@@ -154,9 +158,9 @@ div.Twilio-Splitter div.Twilio-AgentDesktopView\.Panel2 {
     background-color: white;
     margin-left: -1px;
     border-left: 1px solid #cacdd8;
+    border-top: 1px solid #cacdd8;
  }
-
  .Twilio-TeamFiltersPanel {
-    height: calc(100% - 79px);
+    height: calc(100% - 79px); /* 79px is the height of the Filter Buttons Container */
     flex-grow: 0;
  }

--- a/plugin-hrm-form/src/styles/global-overrides.css
+++ b/plugin-hrm-form/src/styles/global-overrides.css
@@ -145,3 +145,18 @@ div.Twilio-Splitter div.Twilio-AgentDesktopView\.Panel2 {
  .Twilio-WorkersDataTable {
     min-width: 900px !important;
  }
+ .Twilio-FilterListButtons-Container {
+    min-width: 0px;
+    width: -webkit-fill-available;
+    overflow: visible;
+    position: fixed;
+    bottom: 0;
+    background-color: white;
+    margin-left: -1px;
+    border-left: 1px solid #cacdd8;
+ }
+
+ .Twilio-TeamFiltersPanel {
+    height: calc(100% - 79px);
+    flex-grow: 0;
+ }


### PR DESCRIPTION
## Description
- This PR introduces overrides to Filter Panel Container and Buttons to ensure the user can see the buttons to Reset and Apply. 
    - see https://tech-matters.atlassian.net/browse/CHI-2566?focusedCommentId=14322
    - This is a solution that accounts for a standard laptop or a desktop computer. There may be issues if the screen viewport is too big or too small.
- This PR also adds a full story ID to the 'see more/less' button in the Skills column 

### Checklist
- [ ] New tests added
- [ ] Corresponding issue has been opened
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
[screencast](https://github.com/techmatters/flex-plugins/assets/102122005/01978d27-6e4c-4361-b814-910d00ec0edc)

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P