### PR TITLE
CHI-2672: Ensure case sections are correctly sorted for display

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -58,6 +58,7 @@ import selectCaseHelplineData from '../../states/case/selectCaseHelplineData';
 import { selectCounselorName } from '../../states/configuration/selectCounselorsHash';
 import { contactLabelFromHrmContact } from '../../states/contacts/contactIdentifier';
 import { selectContactsByCaseIdInCreatedOrder } from '../../states/contacts/selectContactByCaseId';
+import { getSectionItemsSortedByCreatedAt, getSectionItemsSortedByFormDate } from '../../states/case/sections/get';
 
 export type CaseHomeProps = {
   task: CustomITask | StandaloneITask;
@@ -156,7 +157,6 @@ const CaseHome: React.FC<Props> = ({
   const caseLayouts = definitionVersion.layoutVersion.case;
 
   const {
-    sections,
     info: { followUpDate, childIsAtRisk },
     status,
     id,
@@ -195,13 +195,6 @@ const CaseHome: React.FC<Props> = ({
       </CaseSection>
     </Box>
   );
-
-  const {
-    incident: incidentSections,
-    perpetrator: perpetratorSections,
-    household: householdSections,
-    document: documentSections,
-  } = sections ?? {};
 
   const onEditCaseSummaryClick = () => {
     openModal({ route: 'case', subroute: 'caseSummary', action: CaseItemAction.Edit, id: '', caseId });
@@ -262,12 +255,20 @@ const CaseHome: React.FC<Props> = ({
             )}
           </CaseDetailsBorder>
         </Box>
-        {genericSectionRenderer(NewCaseSubroutes.Household, PermissionActions.ADD_HOUSEHOLD, householdSections)}
-        {genericSectionRenderer(NewCaseSubroutes.Perpetrator, PermissionActions.ADD_PERPETRATOR, perpetratorSections)}
+        {genericSectionRenderer(
+          NewCaseSubroutes.Household,
+          PermissionActions.ADD_HOUSEHOLD,
+          getSectionItemsSortedByCreatedAt(connectedCase, NewCaseSubroutes.Household),
+        )}
+        {genericSectionRenderer(
+          NewCaseSubroutes.Perpetrator,
+          PermissionActions.ADD_PERPETRATOR,
+          getSectionItemsSortedByCreatedAt(connectedCase, NewCaseSubroutes.Perpetrator),
+        )}
         {genericSectionRenderer(
           NewCaseSubroutes.Incident,
           PermissionActions.ADD_INCIDENT,
-          incidentSections,
+          getSectionItemsSortedByFormDate(connectedCase, NewCaseSubroutes.Incident),
           (subroute, { sectionTypeSpecificData, sectionId }, index) => (
             <IncidentInformationRow
               key={`incident-${index}`}
@@ -282,7 +283,7 @@ const CaseHome: React.FC<Props> = ({
           genericSectionRenderer(
             NewCaseSubroutes.Document,
             PermissionActions.ADD_DOCUMENT,
-            documentSections,
+            getSectionItemsSortedByCreatedAt(connectedCase, NewCaseSubroutes.Document),
             (subroute, item, index) => (
               <DocumentInformationRow
                 key={`document-${index}`}

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
@@ -37,6 +37,7 @@ import { getImageAsString, ImageSource } from './images';
 import { getHrmConfig, getTemplateStrings } from '../../../hrmConfig';
 import NavigableContainer from '../../NavigableContainer';
 import { Case, CustomITask, StandaloneITask } from '../../../types/types';
+import { getSectionItemsSortedByCreatedAt, getSectionItemsSortedByFormDate } from '../../../states/case/sections/get';
 
 type OwnProps = {
   onClickClose: () => void;
@@ -68,8 +69,11 @@ const CasePrintView: React.FC<Props> = ({
   const [chkOnBlob, setChkOnBlob] = useState<string>(null);
   const [chkOffBlob, setChkOffBlob] = useState<string>(null);
 
-  const { incident, referral, household, perpetrator, note } = connectedCase?.sections ?? {};
-
+  const sortedIncidents = getSectionItemsSortedByFormDate(connectedCase, 'incident');
+  const sortedHouseholds = getSectionItemsSortedByCreatedAt(connectedCase, 'household');
+  const sortedPerpetrators = getSectionItemsSortedByCreatedAt(connectedCase, 'perpetrator');
+  const sortedNotes = getSectionItemsSortedByCreatedAt(connectedCase, 'note');
+  const sortedReferrals = getSectionItemsSortedByFormDate(connectedCase, 'referral');
   /*
    * The purpose of this effect is to load all the images at once, to avoid re-renders in PDFViewer that leads to issues
    * https://stackoverflow.com/questions/60614940/unhandled-rejection-typeerror-nbind-externallistnum-dereference-is-not-a-f
@@ -193,27 +197,31 @@ const CasePrintView: React.FC<Props> = ({
                   sectionName={strings['SectionName-HouseholdMember']}
                   sectionKey="household"
                   definitions={definitionVersion.caseForms.HouseholdForm}
-                  values={household}
+                  values={sortedHouseholds}
                 />
                 <CasePrintMultiSection
                   sectionName={strings['SectionName-Perpetrator']}
                   sectionKey="perpetrator"
                   definitions={definitionVersion.caseForms.PerpetratorForm}
-                  values={perpetrator}
+                  values={sortedPerpetrators}
                 />
                 <CasePrintMultiSection
                   sectionName={strings['SectionName-Incident']}
                   definitions={definitionVersion.caseForms.IncidentForm}
                   sectionKey="incident"
-                  values={incident}
+                  values={sortedIncidents}
                 />
                 <CasePrintMultiSection
                   sectionName={strings['SectionName-Referral']}
                   definitions={definitionVersion.caseForms.ReferralForm}
                   sectionKey="referral"
-                  values={referral}
+                  values={sortedReferrals}
                 />
-                <CasePrintNotes notes={note} counselorsHash={counselorsHash} formDefinition={definitionVersion} />
+                <CasePrintNotes
+                  notes={sortedNotes}
+                  counselorsHash={counselorsHash}
+                  formDefinition={definitionVersion}
+                />
                 <CasePrintSummary summary={connectedCase.info.summary} />
                 <CasePrintCSAMReports csamReports={contact?.csamReports} />
               </View>

--- a/plugin-hrm-form/src/states/case/sections/get.ts
+++ b/plugin-hrm-form/src/states/case/sections/get.ts
@@ -40,3 +40,35 @@ export const getMostRecentSectionItem = (propertyName: WellKnownCaseSection) => 
   }
   return undefined;
 };
+
+export const getSectionItemsSortedByCreatedAt = (
+  caseObj: Case,
+  propertyName: WellKnownCaseSection,
+): ApiCaseSection[] => {
+  const sectionList = caseObj?.sections[propertyName];
+  if (!sectionList) return sectionList;
+  if (Array.isArray(sectionList)) {
+    return [...sectionList].sort((a, b) => parseISO(b.createdAt).getTime() - parseISO(a.createdAt).getTime());
+  }
+  return [];
+};
+
+export const getSectionItemsSortedByFormDate = (
+  caseObj: Case,
+  propertyName: WellKnownCaseSection,
+): ApiCaseSection[] => {
+  const sectionList = caseObj?.sections[propertyName];
+  if (!sectionList) return sectionList;
+  if (Array.isArray(sectionList)) {
+    return [...sectionList].sort((a, b) => {
+      const timeA = a.sectionTypeSpecificData?.date
+        ? parseISO(a.sectionTypeSpecificData?.date.toString()).getTime()
+        : 0;
+      const timeB = b.sectionTypeSpecificData?.date
+        ? parseISO(b.sectionTypeSpecificData?.date.toString()).getTime()
+        : 0;
+      return timeB - timeA;
+    });
+  }
+  return [];
+};

--- a/plugin-hrm-form/src/states/case/sections/get.ts
+++ b/plugin-hrm-form/src/states/case/sections/get.ts
@@ -45,7 +45,7 @@ export const getSectionItemsSortedByCreatedAt = (
   caseObj: Case,
   propertyName: WellKnownCaseSection,
 ): ApiCaseSection[] => {
-  const sectionList = caseObj?.sections[propertyName];
+  const sectionList = caseObj?.sections?.[propertyName];
   if (!sectionList) return sectionList;
   if (Array.isArray(sectionList)) {
     return [...sectionList].sort((a, b) => parseISO(b.createdAt).getTime() - parseISO(a.createdAt).getTime());
@@ -57,7 +57,7 @@ export const getSectionItemsSortedByFormDate = (
   caseObj: Case,
   propertyName: WellKnownCaseSection,
 ): ApiCaseSection[] => {
-  const sectionList = caseObj?.sections[propertyName];
+  const sectionList = caseObj?.sections?.[propertyName];
   if (!sectionList) return sectionList;
   if (Array.isArray(sectionList)) {
     return [...sectionList].sort((a, b) => {


### PR DESCRIPTION
## Description

* Contrary to prior assumptions, the case sections were coming from the API unsorted. This is fixed with the move to timelines, but needs a temporary client side fix here

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P