### PR TITLE
CHI-2661: Extra recording check

### DIFF
--- a/plugin-hrm-form/src/services/getExternalRecordingInfo.ts
+++ b/plugin-hrm-form/src/services/getExternalRecordingInfo.ts
@@ -81,7 +81,19 @@ export const getExternalRecordingInfo = async (task: CustomITask): Promise<Exter
   recordDebugEvent(task, 'Starting');
 
   // The call id related to the worker is always the one with the recording, as far as I can tell (rbd)
-  const { conference } = isTwilioTask(task) && task.attributes;
+  const { conference, conversations } = isTwilioTask(task) && task.attributes;
+  if (conversations?.segment_link) {
+    // The recording location is already added to the task, lets just use that, no need to go to the API
+    const recordingUrl = new URL(conversations.segment_link);
+    const recordingSid = recordingUrl.pathname.split('/').pop();
+    const successResult: ExternalRecordingInfo = {
+      status: 'success',
+      recordingSid,
+      bucket: getHrmConfig().docsBucket,
+      key: recordingUrl.pathname,
+    };
+    recordDebugEvent(task, 'Success', successResult);
+  }
   if (!conference) {
     const result: ExternalRecordingInfo = {
       status: 'failure',

--- a/plugin-hrm-form/src/services/getExternalRecordingInfo.ts
+++ b/plugin-hrm-form/src/services/getExternalRecordingInfo.ts
@@ -90,9 +90,10 @@ export const getExternalRecordingInfo = async (task: CustomITask): Promise<Exter
       status: 'success',
       recordingSid,
       bucket: getHrmConfig().docsBucket,
-      key: recordingUrl.pathname,
+      key: recordingUrl.pathname.indexOf('/') === 0 ? recordingUrl.pathname.substring(1) : recordingUrl.pathname,
     };
-    recordDebugEvent(task, 'Success', successResult);
+    recordDebugEvent(task, 'Success', { ...successResult, lookupMethod: 'conversation.segment_link' });
+    return successResult;
   }
   if (!conference) {
     const result: ExternalRecordingInfo = {
@@ -134,6 +135,6 @@ export const getExternalRecordingInfo = async (task: CustomITask): Promise<Exter
     bucket,
     key,
   };
-  recordDebugEvent(task, 'Success', successResult);
+  recordDebugEvent(task, 'Success', { ...successResult, lookupMethod: 'conference worker callSid' });
   return successResult;
 };


### PR DESCRIPTION
## Description

Because FS data revealed that often, when the conference callSid is not available, the conversations.segment_link is, we check for this first and infer the recording location from there if it's available

Because the opposite situation is also true, the original check needs to remain in place

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

General regression. Check voice media is saving for voice calls consistently

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P