### PR TITLE
CHI-2620: HRM URL includes a '-aselo_test'  context for E2E tests

### DIFF
--- a/e2e-tests/tests/offlineContact.spec.ts
+++ b/e2e-tests/tests/offlineContact.spec.ts
@@ -18,9 +18,9 @@ import { expect, Page, request, test } from '@playwright/test';
 import { Categories, contactForm, ContactFormTab } from '../contactForm';
 import { caseHome } from '../case';
 import { agentDesktop, navigateToAgentDesktop } from '../agent-desktop';
-import { skipTestIfNotTargeted, skipTestIfDataUpdateDisabled } from '../skipTest';
+import { skipTestIfDataUpdateDisabled, skipTestIfNotTargeted } from '../skipTest';
 import { notificationBar } from '../notificationBar';
-import { setupContextAndPage, closePage } from '../browser';
+import { closePage, setupContextAndPage } from '../browser';
 import { apiHrmRequest } from '../hrm/hrmRequest';
 import { clearOfflineTask } from '../hrm/clearOfflineTask';
 
@@ -145,7 +145,7 @@ test.describe.serial('Offline Contact (with Case)', () => {
       async ([caseIdArg]) => {
         const manager = (window as any).Twilio.Flex.Manager.getInstance();
         const token = manager.user.token;
-        const hrmBaseUrl = `${manager.serviceConfiguration.attributes.hrm_base_url}/${manager.serviceConfiguration.attributes.hrm_api_version}/accounts/${manager.workerClient.accountSid}`;
+        const hrmBaseUrl = `${manager.serviceConfiguration.attributes.hrm_base_url}/${manager.serviceConfiguration.attributes.hrm_api_version}/accounts/${manager.workerClient.accountSid}-aselo_test`;
 
         const url = `${hrmBaseUrl}/cases/${caseIdArg}`;
         const options = {

--- a/plugin-hrm-form/src/hrmConfig.ts
+++ b/plugin-hrm-form/src/hrmConfig.ts
@@ -27,11 +27,15 @@ type ContactSaveFrequency = 'onTabChange' | 'onFinalSaveAndTransfer';
 
 const readConfig = () => {
   const manager = Flex.Manager.getInstance();
+  const { identity, token } = manager.user;
+
+  // This is a really hacky test, need a better way to determine if the user is one of our bots
+  const userIsAseloBot = /aselo.+@techmatters\.org/.test(identity);
 
   const accountSid = manager.serviceConfiguration.account_sid;
   const hrmBaseUrl = `${process.env.REACT_APP_HRM_BASE_URL || manager.serviceConfiguration.attributes.hrm_base_url}/${
     manager.serviceConfiguration.attributes.hrm_api_version
-  }/accounts/${accountSid}`;
+  }/accounts/${accountSid}${userIsAseloBot ? '-aselo_test' : ''}`;
   const hrmMicroserviceBaseUrl = process.env.REACT_APP_HRM_MICROSERVICE_BASE_URL
     ? `${process.env.REACT_APP_HRM_MICROSERVICE_BASE_URL}${manager.serviceConfiguration.attributes.hrm_api_version}/accounts/${accountSid}`
     : hrmBaseUrl;
@@ -61,7 +65,6 @@ const readConfig = () => {
   const workerSid = manager.workerClient.sid as WorkerSID;
   const { helpline, counselorLanguage, full_name: counselorName, roles } = manager.workerClient.attributes as any;
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
-  const { identity, token } = manager.user;
   const isSupervisor = roles.includes('supervisor');
   const {
     helplineLanguage,


### PR DESCRIPTION
## Description

Depends on a version HRM with changes in https://github.com/techmatters/hrm/pull/623

If the logged in user has an identity that is a tech matters email that starts with 'aselo' (which covers both our e2e test accounts), they will use a '-aselo_test' sub account specifier for all their HRM interactions. This should separate all the HRM data created by these accounts from other real data

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

E2E tests, regression test that HRM interactions for regular users are unaffected

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P