### PR TITLE
Group and Sort counselors based on activity

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -143,8 +143,8 @@ const setUpComponents = (
   }
 
   TeamsView.setUpSkillsColumn();
-  TeamsView.setUpSortingCallsAndChats();
-  TeamsView.setUpTeamViewFilters();
+  TeamsView.setUpTeamsViewSorting();
+  TeamsView.setUpTeamsViewFilters();
   TeamsView.setUpWorkerDirectoryFilters();
 
   if (featureFlags.enable_conferencing) setupConferenceComponents();

--- a/plugin-hrm-form/src/teamsView/SkillsColumn.tsx
+++ b/plugin-hrm-form/src/teamsView/SkillsColumn.tsx
@@ -22,7 +22,7 @@ import { StyledLink } from '../components/search/styles';
 import { OpaqueText } from '../styles';
 import { getAseloFeatureFlags } from '../hrmConfig';
 import { SkillsCell } from './styles';
-import { sortSkills } from './sortCallsAndChats';
+import { sortSkills } from './teamsViewSorting';
 
 export const setUpSkillsColumn = () => {
   if (!getAseloFeatureFlags().enable_teams_view_enhancements) return;

--- a/plugin-hrm-form/src/teamsView/index.ts
+++ b/plugin-hrm-form/src/teamsView/index.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { setUpSkillsColumn } from './SkillsColumn';
-import { setUpSortingCallsAndChats } from './sortCallsAndChats';
+import { setUpSortingCallsAndChats } from './teamsViewSorting';
 import { setUpTeamViewFilters, setUpWorkerDirectoryFilters } from './teamsViewFilters';
 
 const TeamsView = {

--- a/plugin-hrm-form/src/teamsView/index.ts
+++ b/plugin-hrm-form/src/teamsView/index.ts
@@ -15,12 +15,12 @@
  */
 import { setUpSkillsColumn } from './SkillsColumn';
 import { setUpTeamsViewSorting } from './teamsViewSorting';
-import { setUpTeamViewFilters, setUpWorkerDirectoryFilters } from './teamsViewFilters';
+import { setUpTeamsViewFilters, setUpWorkerDirectoryFilters } from './teamsViewFilters';
 
 const TeamsView = {
   setUpSkillsColumn,
-  setUpSortingCallsAndChats: setUpTeamsViewSorting,
-  setUpTeamViewFilters,
+  setUpTeamsViewSorting,
+  setUpTeamsViewFilters,
   setUpWorkerDirectoryFilters,
 };
 

--- a/plugin-hrm-form/src/teamsView/index.ts
+++ b/plugin-hrm-form/src/teamsView/index.ts
@@ -14,12 +14,12 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { setUpSkillsColumn } from './SkillsColumn';
-import { setUpSortingCallsAndChats } from './teamsViewSorting';
+import { setUpTeamsViewSorting } from './teamsViewSorting';
 import { setUpTeamViewFilters, setUpWorkerDirectoryFilters } from './teamsViewFilters';
 
 const TeamsView = {
   setUpSkillsColumn,
-  setUpSortingCallsAndChats,
+  setUpSortingCallsAndChats: setUpTeamsViewSorting,
   setUpTeamViewFilters,
   setUpWorkerDirectoryFilters,
 };

--- a/plugin-hrm-form/src/teamsView/teamsViewFilters.ts
+++ b/plugin-hrm-form/src/teamsView/teamsViewFilters.ts
@@ -73,7 +73,7 @@ const disabledSkillsFilterDefinition: FilterDefinitionFactory = () => {
  * The activity filter omits the default since we already include offline in the above, ie Flex.TeamsView.activitiesFilter
  * The skills filter is included if the feature flag is enabled.
  */
-export const setUpTeamViewFilters = () => {
+export const setUpTeamsViewFilters = () => {
   TeamsView.defaultProps.filters = [
     activityNoOfflineByDefault,
     ...(getAseloFeatureFlags().enable_teams_view_enhancements

--- a/plugin-hrm-form/src/teamsView/teamsViewSorting.ts
+++ b/plugin-hrm-form/src/teamsView/teamsViewSorting.ts
@@ -85,17 +85,27 @@ const sortWorkersByChatDuration = (a: SupervisorWorkerState, b: SupervisorWorker
   return 0;
 };
 
-const ACTIVITIES = Array.from(Manager.getInstance().store.getState().flex.worker.activities.values()).reduce(
-  (accum, activity, currIndex) => {
-    accum[activity.name] = currIndex;
-    return accum;
-  },
-  {},
-);
+
 
 const sortWorkersByActivity = (a: SupervisorWorkerState, b: SupervisorWorkerState) => {
+
+  const ACTIVITIES = Array.from(Manager.getInstance().store.getState().flex.worker.activities.values()).reduce(
+    (accum, activity, currIndex) => {
+      accum[activity.name] = currIndex;
+      return accum;
+    },
+    {},
+  );
+  
   const aActivityValue = ACTIVITIES[a?.worker.activityName];
   const bActivityValue = ACTIVITIES[b?.worker.activityName];
+
+    // Place available workers at the top
+    if (a.worker.isAvailable && !b.worker.isAvailable) {
+      return -1;
+    } else if (!a.worker.isAvailable && b.worker.isAvailable) {
+      return 1;
+    }
 
   // Place workers with "Offline" activity at the end
   if (aActivityValue === 0 && bActivityValue === 0) {
@@ -120,7 +130,7 @@ const sortWorkersByActivity = (a: SupervisorWorkerState, b: SupervisorWorkerStat
   return a.worker.name > b.worker.name ? 1 : -1;
 };
 
-export const setUpSortingCallsAndChats = () => {
+export const setUpTeamsViewSorting = () => {
   if (!getAseloFeatureFlags().enable_teams_view_enhancements) return;
   AgentsDataTable.defaultProps.sortCalls = sortWorkersByCallDuration;
   AgentsDataTable.defaultProps.sortTasks = sortWorkersByChatDuration;

--- a/plugin-hrm-form/src/teamsView/teamsViewSorting.ts
+++ b/plugin-hrm-form/src/teamsView/teamsViewSorting.ts
@@ -85,10 +85,7 @@ const sortWorkersByChatDuration = (a: SupervisorWorkerState, b: SupervisorWorker
   return 0;
 };
 
-
-
 const sortWorkersByActivity = (a: SupervisorWorkerState, b: SupervisorWorkerState) => {
-
   const ACTIVITIES = Array.from(Manager.getInstance().store.getState().flex.worker.activities.values()).reduce(
     (accum, activity, currIndex) => {
       accum[activity.name] = currIndex;
@@ -96,16 +93,16 @@ const sortWorkersByActivity = (a: SupervisorWorkerState, b: SupervisorWorkerStat
     },
     {},
   );
-  
+
   const aActivityValue = ACTIVITIES[a?.worker.activityName];
   const bActivityValue = ACTIVITIES[b?.worker.activityName];
 
-    // Place available workers at the top
-    if (a.worker.isAvailable && !b.worker.isAvailable) {
-      return -1;
-    } else if (!a.worker.isAvailable && b.worker.isAvailable) {
-      return 1;
-    }
+  // Place available workers at the top
+  const aAvailability = a.worker.isAvailable ? 1 : 0;
+  const bAvailability = b.worker.isAvailable ? 1 : 0;
+
+  const availability = bAvailability - aAvailability;
+  if (availability !== 0) return availability;
 
   // Place workers with "Offline" activity at the end
   if (aActivityValue === 0 && bActivityValue === 0) {
@@ -120,18 +117,17 @@ const sortWorkersByActivity = (a: SupervisorWorkerState, b: SupervisorWorkerStat
   }
 
   // Sort by activity value/index
-  if (aActivityValue > bActivityValue) {
-    return 1;
-  } else if (aActivityValue < bActivityValue) {
-    return -1;
+  if (aActivityValue !== bActivityValue) {
+    return aActivityValue > bActivityValue ? 1 : -1;
   }
 
   // If activities are the same, sort by worker name
-  return a.worker.name > b.worker.name ? 1 : -1;
+  return a.worker.name.localeCompare(b.worker.name);
 };
 
 export const setUpTeamsViewSorting = () => {
   if (!getAseloFeatureFlags().enable_teams_view_enhancements) return;
+
   AgentsDataTable.defaultProps.sortCalls = sortWorkersByCallDuration;
   AgentsDataTable.defaultProps.sortTasks = sortWorkersByChatDuration;
   AgentsDataTable.defaultProps.sortWorkers = sortWorkersByActivity;


### PR DESCRIPTION
## Description
- This PR alters the default order of the counsellors on the Teams View page which is an automatic grouping of agents based on their activity/status. For instance, agents with the status of "available" will be listed first, followed by those who are "unavailable" followed by "break" agents, and finally for "offline". Two way toggle is supported
- The activities / statuses and the order are helpline specific. 

### Checklist
- [x] Corresponding issue has been [opened](https://tech-matters.atlassian.net/browse/CHI-2570)
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- In Teams view, assign a few counsellors with different statuses.
- Check the order when you enter the page and also by sorting(click on the carat) on the Agent header
![Screenshot 2024-04-16 at 1 37 08 PM](https://github.com/techmatters/flex-plugins/assets/102122005/6bd9d9de-7b4c-450c-8dae-62bdf69cca0e)

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P