### PR TITLE
CHI-2567 Add reveal phone number in the supervisor task canvas

### DIFF
--- a/plugin-hrm-form/src/maskIdentifiers/unmaskPhoneNumber/ViewTaskNumber.tsx
+++ b/plugin-hrm-form/src/maskIdentifiers/unmaskPhoneNumber/ViewTaskNumber.tsx
@@ -24,9 +24,9 @@ import { PhoneNumberPopperText, UnmaskStyledButton } from './styles';
 import { Box, HiddenText } from '../../styles';
 import { CloseButton } from '../../components/callTypeButtons/styles';
 
-type Props = ThemeProps & { task?: ITask };
+type Props = ThemeProps & { task?: ITask; isSupervisor?: boolean };
 
-const ViewTaskNumber = ({ task }: Props) => {
+const ViewTaskNumber = ({ task, isSupervisor }: Props) => {
   const [viewNumber, setViewNumber] = useState(false);
   const viewNumberRef = useRef(null);
 
@@ -35,26 +35,32 @@ const ViewTaskNumber = ({ task }: Props) => {
   };
 
   return (
-    <span>
-      <UnmaskStyledButton onClick={toggleViewNumber} ref={viewNumberRef}>
+    <>
+      <UnmaskStyledButton
+        onClick={toggleViewNumber}
+        ref={viewNumberRef}
+        style={isSupervisor ? { position: 'fixed', alignSelf: 'center', marginRight:'5rem'} : {}}
+      >
         {viewNumber ? <EyeOpenIcon /> : <EyeCloseIcon />}
       </UnmaskStyledButton>
       {viewNumber ? (
-        <Popper open={viewNumber} anchorEl={viewNumberRef.current} placement="bottom-start">
-          <Paper style={{ width: '300px', padding: '20px' }}>
+        <Popper open={viewNumber} anchorEl={viewNumberRef.current} placement="bottom">
+          <Paper style={{ width: '250px', padding: '15px' }}>
             <Box style={{ float: 'right' }}>
               <HiddenText id="CloseButton">
                 <Template code="CloseButton" />
               </HiddenText>
-              <CloseButton aria-label="CloseButton" onClick={toggleViewNumber} />
+              <CloseButton aria-label="CloseButton" fontSizeSmall onClick={toggleViewNumber} />
             </Box>
-            <PhoneNumberPopperText>Phone Number Revealed</PhoneNumberPopperText>
+            <PhoneNumberPopperText>
+              <Template code="UnmaskPhoneNumber" />
+            </PhoneNumberPopperText>
             <br />
             {getFormattedNumberFromTask(task)}
           </Paper>
         </Popper>
       ) : null}
-    </span>
+    </>
   );
 };
 

--- a/plugin-hrm-form/src/maskIdentifiers/unmaskPhoneNumber/ViewTaskNumber.tsx
+++ b/plugin-hrm-form/src/maskIdentifiers/unmaskPhoneNumber/ViewTaskNumber.tsx
@@ -39,7 +39,7 @@ const ViewTaskNumber = ({ task, isSupervisor }: Props) => {
       <UnmaskStyledButton
         onClick={toggleViewNumber}
         ref={viewNumberRef}
-        style={isSupervisor ? { position: 'fixed', alignSelf: 'center', marginRight:'5rem'} : {}}
+        style={isSupervisor ? { position: 'fixed', alignSelf: 'center', marginRight: '5rem' } : {}}
       >
         {viewNumber ? <EyeOpenIcon /> : <EyeCloseIcon />}
       </UnmaskStyledButton>

--- a/plugin-hrm-form/src/maskIdentifiers/unmaskPhoneNumber/index.tsx
+++ b/plugin-hrm-form/src/maskIdentifiers/unmaskPhoneNumber/index.tsx
@@ -30,13 +30,13 @@ export const setUpViewMaskedVoiceNumber = () => {
   if (!maskIdentifiers) return;
   if (!getAseloConfigFlags().enableUnmaskingCalls) return;
 
-  TaskCanvasHeader.Content.add(<ViewTaskNumber key="view-task-number" />, {
+  TaskCanvasHeader.Content.add(<ViewTaskNumber key="view-task-number" isSupervisor={false} />, {
     sortOrder: 1,
     if: props => props.task.channelType === 'voice',
   });
 
-  // Supervisor.TaskCanvasHeader.Content.add(<ViewTaskNumber key="view-supervisor-task-number" />, {
-  //   sortOrder: 0,
-  //   if: props => props.task.channelType === 'voice',
-  // });
+  Supervisor.TaskCanvasHeader.Content.add(<ViewTaskNumber key="view-supervisor-task-number" isSupervisor={true} />, {
+    sortOrder: 0,
+    if: props => props.task.channelType === 'voice',
+  });
 };

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -84,6 +84,7 @@
   "ReadMore": "see more",
   "ReadLess": "see less",
   "CaseSummary-NoSummaryProvided": "No Summary provided",
+  "CaseSummary-None": "- No case summary -",
   "SectionEntry-Yes": "Yes",
   "SectionEntry-No": "No",
   "SharedStateSaveFormError": "The information stored in the form couldn't be saved. Task will be transferred anyway.",
@@ -459,10 +460,10 @@
   "BottomBar-Save": "Yes, Save",
   "Toolkit-ConfirmTextOne": "You will be redirected to {{helpline}}'s knowledge management system.",
   "Toolkit-ConfirmTextTwo": "Are you sure you want to continue?",
-
-  "CaseSummary-None": "- No case summary -",
-  "MaskIdentifiers": "XXXXXX",
   
+  "MaskIdentifiers": "XXXXXX",
+  "UnmaskPhoneNumber": "Phone Number Revealed",
+
   "RecordingSection-Error": "Something went wrong on our end. Please contact your support team or supervisor.",
 
   "Resources-LoadResourceError": "Something went wrong trying to load this resource.",


### PR DESCRIPTION
## Description
- This PR adds the reveal phone number icon to the Supervisor task canvas seen in the teams view
[screencast-localhost_3000-2024.04.19-10_51_13.webm](https://github.com/techmatters/flex-plugins/assets/102122005/1f0c6abb-1411-4ca6-b8d2-2478eedffdf3)
- It is not possible to add the button beside the canvas container like in the other one, so I implemented a hacky version with position of fixed.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P