### PR TITLE
Make contact identifier checkbox marked when there're previous contacts

### DIFF
--- a/plugin-hrm-form/src/components/profile/IdentifierBanner/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/IdentifierBanner/PreviousContactsBanner.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useEffect } from 'react';
+import { bindActionCreators } from 'redux';
 import { connect, ConnectedProps } from 'react-redux';
 import { Template } from '@twilio/flex-ui';
 
@@ -22,6 +23,7 @@ import {
   searchCases as searchCasesAction,
   searchContacts as searchContactsAction,
   viewPreviousContacts as viewPreviousContactsAction,
+  handleSearchFormChange as handleSearchFormChangeAction,
 } from '../../../states/search/actions';
 import { RootState } from '../../../states';
 import { CASES_PER_PAGE, CONTACTS_PER_PAGE } from '../../search/SearchResults';
@@ -48,6 +50,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
   task,
   searchContacts,
   searchCases,
+  handleSearchFormChange,
   openContactSearchResults,
   openCaseSearchResults,
   contact,
@@ -70,6 +73,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
       const searchParams = { contactNumber };
       searchContacts(searchParams, CONTACTS_PER_PAGE, 0, true);
       searchCases(searchParams, CASES_PER_PAGE, 0, true);
+      handleSearchFormChange('contactNumber', contactNumber);
     }
   };
 
@@ -146,6 +150,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     viewPreviousContacts: viewPreviousContactsAction(dispatch)(task),
     searchContacts: searchContactsAction(dispatch)(taskId),
     searchCases: searchCasesAction(dispatch)(taskId),
+    handleSearchFormChange: bindActionCreators(handleSearchFormChangeAction(taskId), dispatch),
     openContactSearchResults: (contextContactId: string) => {
       // We put the form 'under' the search results in the modal stack so the back button takes them to the form without needing custom handlers
       dispatch(newOpenModalAction({ contextContactId, route: 'search', subroute: 'form' }, taskId));


### PR DESCRIPTION
## Description
**Previous behavior:**
When the user clicked on the previous contacts banner and navigate to the search form, the checkbox "Only show records for <contact-identifier>" was not marked by default.

**Behaviour after fix:**
Now the checkbox "Only show records for <contact-identifier>" is marked by default on the search form when there are previous contacts.

### Other Related Issues
https://tech-matters.atlassian.net/browse/CHI-2669

### Verification steps
When `enable_client_profiles` is false, and there're previous contacts, the checkbox "Only show records for <contact-identifier>"should be marked by default.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P