### PR TITLE
Adds debug logging to ZM staging - temporarily

### DIFF
--- a/twilio-iac/helplines/zm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zm/configs/service-configuration/staging.json
@@ -10,5 +10,8 @@
             "semver": "~1.31.2",
             "version": "1.31.2"
         }
-    }
+    },
+    "ui_attributes": {
+      "logLevel": "debug"
+  }
 }


### PR DESCRIPTION
Adds debug logging, like we have on Aselo Development, to ZM staging. The intention is for this to be temporary during the Aselo Connector launch phase.

This has already been deployed.

FYI @sinehome 