### PR TITLE
CHI-2726: Support the hasContacts hack for driving the display of the previous …

### DIFF
--- a/plugin-hrm-form/src/components/profile/IdentifierBanner/ProfileIdentifierBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/IdentifierBanner/ProfileIdentifierBanner.tsx
@@ -67,7 +67,8 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal, open
    */
   const profileId = identifier?.profiles?.[0]?.id;
 
-  const { canView } = useProfile({ profileId });
+  const { canView, profile } = useProfile({ profileId });
+  const showProfile = canView && profile?.hasContacts !== false; // If the flag is null or undefined, we assume the backend doesn't support it and show the profile to be on the safe side
 
   const { total: contactsCount, loading: contactsLoading } = useProfileRelationshipsByType({
     profileId,
@@ -83,7 +84,7 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal, open
   const maskIdentifiers = !can(PermissionActions.VIEW_IDENTIFIERS);
 
   // We immediately create a contact when a task is created, so we don't want to show the banner
-  const shouldDisplayBanner = canView || contactsCount > 0 || casesCount > 0;
+  const shouldDisplayBanner = showProfile || contactsCount > 0 || casesCount > 0;
   if (!shouldDisplayBanner || contactsLoading || casesLoading) return null;
 
   const handleViewClients = () => {
@@ -115,7 +116,7 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal, open
       </BannerLink>
       {casesCount > 0 && (
         <>
-          {canView ? (
+          {showProfile ? (
             contactsCount > 0 && <>, </>
           ) : (
             <div style={{ margin: '1px 0 0 0', alignSelf: 'end' }}>
@@ -130,7 +131,7 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal, open
           </BannerLink>
         </>
       )}
-      {canView && (
+      {showProfile && (
         <>
           {(contactsCount > 0 || casesCount > 0) && (
             <div>

--- a/plugin-hrm-form/src/components/profile/IdentifierBanner/ProfileIdentifierBanner.tsx
+++ b/plugin-hrm-form/src/components/profile/IdentifierBanner/ProfileIdentifierBanner.tsx
@@ -68,7 +68,7 @@ const ProfileIdentifierBanner: React.FC<Props> = ({ task, openProfileModal, open
   const profileId = identifier?.profiles?.[0]?.id;
 
   const { canView, profile } = useProfile({ profileId });
-  const showProfile = canView && profile?.hasContacts !== false; // If the flag is null or undefined, we assume the backend doesn't support it and show the profile to be on the safe side
+  const showProfile = canView && profile && profile.hasContacts !== false; // If the flag is null or undefined, we assume the backend doesn't support it and show the profile to be on the safe side
 
   const { total: contactsCount, loading: contactsLoading } = useProfileRelationshipsByType({
     profileId,

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -397,6 +397,9 @@ export type Profile = {
   identifiers?: Identifier[];
   profileFlags?: {id: ProfileFlag['id'], name: ProfileFlag['name'], validUntil: ProfileFlag['validUntil']}[];
   profileSections?: ProfileSection[];
+  // This is a flag to indicate if the profile has contacts or not. It will be set to 'true' even if the user as no permission to view any of the contacts.
+  // It is a hack to work around the fact we don't support limited contact view permission. Once we do, this property along with its backend logic should be removed.
+  hasContacts?: boolean;
 };
 
 


### PR DESCRIPTION

…contacts banner

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Requires a HRM build with https://github.com/techmatters/hrm/pull/632

Shows profile when contacts you have no permission to view are attached:

1. Create a contact request from a new IP or new client profile.
2. Take the contact with a supervisor account and save it.
3. Create a new contact request from the same IP.
4. Take the contact with a supervisor account, you should see the yellow banner appear and saying that there is 1 client and 1 previous contact. Save the contact.
5. Create a new contact request from the same IP.
6. Take the contact with an agent account. No yellow banner appears. There should be a yellow banner saying that there is 1 client.

Does not show profile when no contacts at all are attached:

1. Log in with a user with 'view profile' permissions
2. Start creating a new chat contact from a 'clean' IP with no existing contacts
3. Verify that the banner is NOT present

Also regression test other banner functionality like when viewable contacts and cases are present

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
5. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
6. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P