### PR TITLE
CHI-2726: Fix issue where identifier reducer was packing another copy of the profile state into its own data property

### DIFF
--- a/plugin-hrm-form/src/states/profile/profiles.ts
+++ b/plugin-hrm-form/src/states/profile/profiles.ts
@@ -161,11 +161,8 @@ const handleLoadIdentifierFulfilledAction = (state: t.ProfilesState, action: any
   let newState = { ...state };
   for (const profile of profiles) {
     const profileUpdate = {
-      data: {
-        ...t.newProfileEntry,
-        ...newState[profile.id]?.data,
-        ...profile,
-      },
+      ...t.newProfileEntry,
+      ...profile,
     };
 
     newState = loadProfileEntryIntoRedux(newState, profile.id, profileUpdate);


### PR DESCRIPTION
## Description

This was causing the profile not to load with a new contact being accepted, because the profile loader was detecting data on the data property, ebven though that data was BS

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P