### PR TITLE
CHI-2749: Fix request spam

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/case/saveCase.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/saveCase.test.ts
@@ -24,7 +24,7 @@ import { reduce } from '../../../states/case/reducer';
 import { createCase, getCase, updateCaseOverview, updateCaseStatus } from '../../../services/CaseService';
 import { connectToCase } from '../../../services/ContactService';
 import { ReferralLookupStatus } from '../../../states/contacts/resourceReferral';
-import { Case } from '../../../types/types';
+import { Case, Contact } from '../../../types/types';
 import { RecursivePartial } from '../../RecursivePartial';
 import { VALID_EMPTY_CASE } from '../../testCases';
 
@@ -75,9 +75,9 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockCreateCase.mockReset();
-  mockCreateCase.mockResolvedValue({ id: '234' });
+  mockCreateCase.mockResolvedValue({ id: '234' } as Case);
   mockConnectedCase.mockReset();
-  mockConnectedCase.mockResolvedValue({ id: 'contact-1' });
+  mockConnectedCase.mockResolvedValue({ id: 'contact-1' } as Contact);
 });
 
 const boundSaveCaseReducer = saveCaseReducer(saveCaseState);
@@ -233,6 +233,7 @@ describe('createCaseAsyncAction', () => {
             references: new Set(),
             sections: {},
             timelines: {},
+            outstandingUpdateCount: 0,
           },
         },
       },
@@ -272,7 +273,7 @@ describe('updateCaseOverviewAsyncAction', () => {
   });
 
   test('overview populated in action but status omitted - just calls updateCaseOverview with case ID and overview object', async () => {
-    const action = updateCaseOverviewAsyncAction(mockPayload.id, overview);
+    const action = updateCaseOverviewAsyncAction(mockPayload.id, overview, undefined);
     expect(updateCaseOverview).toHaveBeenCalledWith(mockPayload.id, overview);
     expect(updateCaseStatus).not.toHaveBeenCalled();
 
@@ -307,7 +308,7 @@ describe('updateCaseOverviewAsyncAction', () => {
   });
 
   test('neither overview and status populated in action - just calls get to refresh case', async () => {
-    const action = updateCaseOverviewAsyncAction(mockPayload.id, {});
+    updateCaseOverviewAsyncAction(mockPayload.id, {}, undefined);
     expect(updateCaseStatus).not.toHaveBeenCalled();
     expect(updateCaseOverview).not.toHaveBeenCalled();
   });
@@ -315,7 +316,9 @@ describe('updateCaseOverviewAsyncAction', () => {
   describe('fulfilled', () => {
     test('case exists in redux store - updates case overview ', async () => {
       const { getState, dispatch } = testStore(nonInitialState);
-      await ((dispatch(updateCaseOverviewAsyncAction(mockPayload.id, overview)) as unknown) as PromiseLike<void>);
+      await ((dispatch(updateCaseOverviewAsyncAction(mockPayload.id, overview, undefined)) as unknown) as PromiseLike<
+        void
+      >);
       const {
         connectedCase: {
           cases: {
@@ -337,7 +340,9 @@ describe('updateCaseOverviewAsyncAction', () => {
       const {
         connectedCase: { cases: originalCases },
       } = getState() as HrmState;
-      await ((dispatch(updateCaseOverviewAsyncAction('ANOTHER_CASE', overview)) as unknown) as PromiseLike<void>);
+      await ((dispatch(updateCaseOverviewAsyncAction('ANOTHER_CASE', overview, undefined)) as unknown) as PromiseLike<
+        void
+      >);
       const {
         connectedCase: { cases: updatedCases },
       } = getState() as HrmState;
@@ -354,6 +359,7 @@ describe('updateCaseOverviewAsyncAction', () => {
           caseWorkingCopy: { sections: {} },
           sections: {},
           timelines: {},
+          outstandingUpdateCount: 0,
         },
       });
     });

--- a/plugin-hrm-form/src/___tests__/states/case/sections/caseSectionUpdates.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/sections/caseSectionUpdates.test.ts
@@ -149,22 +149,27 @@ describe('createCaseSectionAsyncAction', () => {
 
     test(`case already has sections of the same type - appends section to the appropriate section type list`, async () => {
       const { dispatch, getState } = testStore({});
-
-      await ((dispatch(
+      const actionResultPromise = (dispatch(
         createCaseSectionAsyncAction(CASE_ID, noteApi, payload, definitionVersion),
-      ) as unknown) as PromiseLike<unknown>);
+      ) as unknown) as PromiseLike<unknown>;
+      const pendingState = getState();
+      expect(pendingState.connectedCase.cases[CASE_ID].outstandingUpdateCount).toBe(1);
+      await actionResultPromise;
       const state = getState();
       expect(Object.keys(state.connectedCase.cases[CASE_ID].sections.note)).toHaveLength(2);
       expect(state.connectedCase.cases[CASE_ID].sections.note[EXPECTED_CASE_SECTION.sectionId]).toEqual(
         EXPECTED_CASE_SECTION,
       );
+      expect(state.connectedCase.cases[CASE_ID].outstandingUpdateCount).toBe(0);
     });
     test(`case has no existing sections of the same type - adds an appropriate section type list with the new item as its element`, async () => {
       const { dispatch, getState } = testStore({});
-
-      await ((dispatch(
+      const actionResultPromise = (dispatch(
         createCaseSectionAsyncAction(CASE_ID, referralApi, payload, definitionVersion),
-      ) as unknown) as PromiseLike<unknown>);
+      ) as unknown) as PromiseLike<unknown>;
+      const pendingState = getState();
+      expect(pendingState.connectedCase.cases[CASE_ID].outstandingUpdateCount).toBe(1);
+      await actionResultPromise;
       const state = getState();
       expect(Object.keys(state.connectedCase.cases[CASE_ID].sections.note)).toHaveLength(1);
       expect(Object.keys(state.connectedCase.cases[CASE_ID].sections.referral)).toHaveLength(1);
@@ -172,6 +177,7 @@ describe('createCaseSectionAsyncAction', () => {
         ...EXPECTED_CASE_SECTION,
         sectionType: 'referral',
       });
+      expect(state.connectedCase.cases[CASE_ID].outstandingUpdateCount).toBe(0);
     });
     test(`case has no existing sections object - adds a sections object with an appropriate section type list with the new item as its element`, async () => {
       const { dispatch, getState } = testStore({
@@ -276,28 +282,36 @@ describe('updateCaseSectionAsyncAction', () => {
 
     test(`case with caseId exists & section with sectionId exists - updates the section in the appropriate type list`, async () => {
       const { dispatch, getState } = testStore({});
-      await ((dispatch(
+      const actionResultPromise = (dispatch(
         updateCaseSectionAsyncAction(CASE_ID, noteApi, 'EXISTING_NOTE_ID', payload, definitionVersion),
-      ) as unknown) as PromiseLike<unknown>);
+      ) as unknown) as PromiseLike<unknown>;
+      const pendingState = getState();
+      expect(pendingState.connectedCase.cases[CASE_ID].outstandingUpdateCount).toBe(1);
+      await actionResultPromise;
       const state = getState();
       expect(Object.keys(state.connectedCase.cases[CASE_ID].sections.note)).toHaveLength(1);
       expect(state.connectedCase.cases[CASE_ID].sections.note[EXPECTED_CASE_SECTION.sectionId]).toEqual(
         EXPECTED_CASE_SECTION,
       );
+      expect(state.connectedCase.cases[CASE_ID].outstandingUpdateCount).toBe(0);
     });
 
     test(`case with caseId exists but section with sectionId does not exist - appends section to the appropriate section type list`, async () => {
       const { dispatch, getState } = testStore({});
 
-      await ((dispatch(
+      const actionResultPromise = (dispatch(
         updateCaseSectionAsyncAction(CASE_ID, noteApi, 'NEW_NOTE_ID', payload, definitionVersion),
-      ) as unknown) as PromiseLike<unknown>);
+      ) as unknown) as PromiseLike<unknown>;
+      const pendingState = getState();
+      expect(pendingState.connectedCase.cases[CASE_ID].outstandingUpdateCount).toBe(1);
+      await actionResultPromise;
       const state = getState();
       expect(Object.keys(state.connectedCase.cases[CASE_ID].sections.note)).toHaveLength(2);
       expect(state.connectedCase.cases[CASE_ID].sections.note.NEW_NOTE_ID).toEqual({
         ...EXPECTED_CASE_SECTION,
         sectionId: 'NEW_NOTE_ID',
       });
+      expect(state.connectedCase.cases[CASE_ID].outstandingUpdateCount).toBe(0);
     });
     test(`case has no existing sections of the same type - adds an appropriate section type list with the new item as its element`, async () => {
       const { dispatch, getState } = testStore({});

--- a/plugin-hrm-form/src/___tests__/states/case/sections/caseSectionUpdates.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/sections/caseSectionUpdates.test.ts
@@ -90,6 +90,7 @@ beforeEach(() => {
               },
             },
           },
+          outstandingUpdateCount: 0,
           connectedCase: {
             ...VALID_EMPTY_CASE,
           },
@@ -183,6 +184,7 @@ describe('createCaseSectionAsyncAction', () => {
               connectedCase: { ...VALID_EMPTY_CASE },
               timelines: {},
               sections: {},
+              outstandingUpdateCount: 0,
             },
           },
         },
@@ -323,6 +325,7 @@ describe('updateCaseSectionAsyncAction', () => {
               connectedCase: { ...VALID_EMPTY_CASE },
               timelines: {},
               sections: {},
+              outstandingUpdateCount: 0,
             },
           },
         },

--- a/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/contacts/saveContact.test.ts
@@ -16,12 +16,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import promiseMiddleware from 'redux-promise-middleware';
 
-import { connectToCase, updateContactInHrm } from '../../../services/ContactService';
+import { connectToCase, getContactByTaskSid, updateContactInHrm } from '../../../services/ContactService';
 import { completeTask, submitContactForm } from '../../../services/formSubmissionHelpers';
 import { Case, Contact, CustomITask } from '../../../types/types';
 import { ContactMetadata, ContactsState, LoadingStatus } from '../../../states/contacts/types';
 import {
   connectToCaseAsyncAction,
+  loadContactFromHrmByTaskSidAsyncAction,
   saveContactReducer,
   submitContactFormAsyncAction,
   updateContactInHrmAsyncAction,
@@ -37,6 +38,7 @@ jest.mock('../../../services/CaseService');
 jest.mock('../../../services/formSubmissionHelpers');
 jest.mock('../../../components/case/Case');
 
+const mockGetContactByTaskSid = getContactByTaskSid as jest.MockedFunction<typeof getContactByTaskSid>;
 const mockUpdateContactInHrm = updateContactInHrm as jest.Mock<ReturnType<typeof updateContactInHrm>>;
 const mockSubmitContactForm = submitContactForm as jest.Mock<ReturnType<typeof submitContactForm>>;
 const mockConnectToCase = connectToCase as jest.Mock<ReturnType<typeof connectToCase>>;
@@ -123,6 +125,29 @@ const baseState: ContactsState = {
 // const dispatch = jest.fn();
 
 describe('actions', () => {
+  describe('loadContactFromHrmByTaskSidAsyncAction', () => {
+    test('Finds a contact with no attached case - loads ', async () => {
+      const { dispatch, getState } = testStore(baseState);
+      const taskContact: Contact = {
+        ...VALID_EMPTY_CONTACT,
+        id: '666',
+        taskId: 'WT-load-me',
+      };
+      mockGetContactByTaskSid.mockResolvedValue(taskContact);
+      const actionPromiseResult = (dispatch(
+        loadContactFromHrmByTaskSidAsyncAction('WT-load-me', 'mock-ref'),
+      ) as unknown) as Promise<void>;
+      const pendingState = getState();
+      expect(pendingState.contactsBeingCreated.has('WT-load-me')).toBe(true);
+      await actionPromiseResult;
+      const state = getState();
+      expect(state.contactsBeingCreated.has('WT-load-me')).toBe(false);
+      expect(state.existingContacts['666'].savedContact).toEqual(taskContact);
+      expect(state.existingContacts['666'].references.has('mock-ref')).toBe(true);
+      expect(mockGetCase).not.toHaveBeenCalled();
+      expect(mockGetContactByTaskSid).toHaveBeenCalledWith('WT-load-me');
+    });
+  });
   test('Calls the updateContactsFormInHrmAsyncAction action, and update a contact', async () => {
     const { dispatch, getState } = testStore(baseState);
     const startingState = getState();
@@ -178,9 +203,10 @@ describe('actions', () => {
         connectedCase: baseCase,
         sections: {},
         timelines: {},
-        references: new Set(),
+        references: new Set<string>(),
         availableStatusTransitions: [],
         caseWorkingCopy: undefined,
+        outstandingUpdateCount: 0,
       };
       submitContactFormAsyncAction(task, baseContact, baseMetadata, caseState);
       expect(submitContactForm).toHaveBeenCalledWith(task, baseContact, baseMetadata, caseState);

--- a/plugin-hrm-form/src/___tests__/states/routing/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/routing/reducer.test.ts
@@ -39,7 +39,7 @@ import {
 // eslint-disable-next-line react-hooks/rules-of-hooks
 const { mockFetchImplementation, mockReset, buildBaseURL } = useFetchDefinitions();
 
-const task = { taskSid: 'task1' };
+const task = { taskSid: 'WT-task1' };
 
 const offlineContactTaskSid = 'offline-contact-task-workerSid';
 mockPartialConfiguration({ workerSid: 'workerSid' });
@@ -61,7 +61,7 @@ beforeEach(() => {
 describe('test reducer (specific actions)', () => {
   const stateWithTask: RoutingState = {
     tasks: {
-      task1: [{ route: 'tabbed-forms', subroute: 'childInformation' }],
+      'WT-task1': [{ route: 'tabbed-forms', subroute: 'childInformation' }],
       [standaloneTaskSid]: initialState.tasks[standaloneTaskSid],
     },
     isAddingOfflineContact: false,
@@ -77,7 +77,7 @@ describe('test reducer (specific actions)', () => {
   test('should handle CREATE_CONTACT_ACTION_FULFILLED', async () => {
     const expected = {
       tasks: {
-        task1: [{ route: 'tabbed-forms', subroute: 'childInformation' }],
+        'WT-task1': [{ route: 'tabbed-forms', subroute: 'childInformation' }],
         [standaloneTaskSid]: initialState.tasks[standaloneTaskSid],
       },
       isAddingOfflineContact: false,
@@ -110,7 +110,7 @@ describe('test reducer (specific actions)', () => {
 
   const stateWithRouteStack = (baseRoutes: AppRoutes[]): RoutingState => ({
     tasks: {
-      task1: baseRoutes,
+      'WT-task1': baseRoutes,
       [standaloneTaskSid]: initialState.tasks[standaloneTaskSid],
     },
     isAddingOfflineContact: false,
@@ -121,11 +121,11 @@ describe('test reducer (specific actions)', () => {
       {
         startingState: stateGenerator([
           { route: 'tabbed-forms', subroute: 'childInformation' },
-          { route: 'case', subroute: 'home' },
+          { route: 'case', subroute: 'home', caseId: '' },
         ]),
         expected: stateGenerator([
           { route: 'tabbed-forms', subroute: 'childInformation' },
-          { route: 'case', subroute: 'home' },
+          { route: 'case', subroute: 'home', caseId: '' },
           { route: 'tabbed-forms' },
         ]),
         action: actions.changeRoute({ route: 'tabbed-forms' }, task.taskSid),
@@ -134,7 +134,7 @@ describe('test reducer (specific actions)', () => {
       {
         startingState: stateGenerator([
           { route: 'tabbed-forms', subroute: 'childInformation' },
-          { route: 'case', subroute: 'home' },
+          { route: 'case', subroute: 'home', caseId: '' },
         ]),
         expected: stateGenerator([{ route: 'tabbed-forms', subroute: 'childInformation' }, { route: 'tabbed-forms' }]),
         action: actions.changeRoute({ route: 'tabbed-forms' }, task.taskSid, ChangeRouteMode.Replace),
@@ -143,7 +143,7 @@ describe('test reducer (specific actions)', () => {
       {
         startingState: stateGenerator([
           { route: 'tabbed-forms', subroute: 'childInformation' },
-          { route: 'case', subroute: 'home' },
+          { route: 'case', subroute: 'home', caseId: '' },
         ]),
         expected: stateGenerator([{ route: 'tabbed-forms' }]),
         action: actions.changeRoute({ route: 'tabbed-forms' }, task.taskSid, ChangeRouteMode.ResetModal),
@@ -157,12 +157,11 @@ describe('test reducer (specific actions)', () => {
     describe('When modal is open', () => {
       const stateWithModal = (modalRoutes: AppRoutes[]): RoutingState => ({
         tasks: {
-          task1: [
+          'WT-task1': [
             {
               route: 'tabbed-forms',
               subroute: 'childInformation',
               activeModal: modalRoutes,
-              contextContactId: undefined,
             },
           ],
           [standaloneTaskSid]: initialState.tasks[standaloneTaskSid],
@@ -185,9 +184,13 @@ describe('test reducer (specific actions)', () => {
         ]),
         expected: stateWithRouteStack([
           { route: 'select-call-type' },
-          { route: 'tabbed-forms', subroute: 'childInformation', activeModal: [{ route: 'case', subroute: 'home' }] },
+          {
+            route: 'tabbed-forms',
+            subroute: 'childInformation',
+            activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
+          },
         ]),
-        action: actions.newOpenModalAction({ route: 'case', subroute: 'home' }, task.taskSid),
+        action: actions.newOpenModalAction({ route: 'case', subroute: 'home', caseId: '' }, task.taskSid),
       },
       {
         description:
@@ -199,7 +202,7 @@ describe('test reducer (specific actions)', () => {
             subroute: 'childInformation',
             activeModal: [
               { route: 'search', subroute: 'form' },
-              { route: 'search', subroute: 'case-results' },
+              { route: 'search', subroute: 'case-results', contactsPage: 0, casesPage: 0 },
             ],
           },
         ]),
@@ -210,24 +213,42 @@ describe('test reducer (specific actions)', () => {
             subroute: 'childInformation',
             activeModal: [
               { route: 'search', subroute: 'form' },
-              { route: 'search', subroute: 'case-results', activeModal: [{ route: 'case', subroute: 'home' }] },
+              {
+                route: 'search',
+                subroute: 'case-results',
+                contactsPage: 0,
+                casesPage: 0,
+                activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
+              },
             ],
           },
         ]),
-        action: actions.newOpenModalAction({ route: 'case', subroute: 'home' }, task.taskSid),
+        action: actions.newOpenModalAction({ route: 'case', subroute: 'home', caseId: '' }, task.taskSid),
       },
       {
         description:
           "Current route has active modal on a previous route (shouldn't happen) - should still create activeModal on latest route in base stack",
         startingState: stateWithRouteStack([
-          { route: 'tabbed-forms', subroute: 'childInformation', activeModal: [{ route: 'case', subroute: 'home' }] },
+          {
+            route: 'tabbed-forms',
+            subroute: 'childInformation',
+            activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
+          },
           { route: 'tabbed-forms', subroute: 'childInformation' },
         ]),
         expected: stateWithRouteStack([
-          { route: 'tabbed-forms', subroute: 'childInformation', activeModal: [{ route: 'case', subroute: 'home' }] },
-          { route: 'tabbed-forms', subroute: 'childInformation', activeModal: [{ route: 'case', subroute: 'home' }] },
+          {
+            route: 'tabbed-forms',
+            subroute: 'childInformation',
+            activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
+          },
+          {
+            route: 'tabbed-forms',
+            subroute: 'childInformation',
+            activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
+          },
         ]),
-        action: actions.newOpenModalAction({ route: 'case', subroute: 'home' }, task.taskSid),
+        action: actions.newOpenModalAction({ route: 'case', subroute: 'home', caseId: '' }, task.taskSid),
       },
     ];
 
@@ -254,7 +275,7 @@ describe('test reducer (specific actions)', () => {
             subroute: 'childInformation',
             activeModal: [
               { route: 'search', subroute: 'form' },
-              { route: 'search', subroute: 'case-results' },
+              { route: 'search', subroute: 'case-results', contactsPage: 0, casesPage: 0 },
             ],
           },
         ]),
@@ -280,9 +301,11 @@ describe('test reducer (specific actions)', () => {
               {
                 route: 'search',
                 subroute: 'case-results',
+                contactsPage: 0,
+                casesPage: 0,
                 activeModal: [
-                  { route: 'case', subroute: 'home' },
-                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, id: '' },
+                  { route: 'case', subroute: 'home', caseId: '' },
+                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, caseId: '', id: '' },
                 ],
               },
             ],
@@ -298,7 +321,9 @@ describe('test reducer (specific actions)', () => {
               {
                 route: 'search',
                 subroute: 'case-results',
-                activeModal: [{ route: 'case', subroute: 'home' }],
+                contactsPage: 0,
+                casesPage: 0,
+                activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
               },
             ],
           },
@@ -309,11 +334,19 @@ describe('test reducer (specific actions)', () => {
         description:
           "Current route has active modal on a previous route (shouldn't happen) - should still pop the latest route from the base stack",
         startingState: stateWithRouteStack([
-          { route: 'tabbed-forms', subroute: 'childInformation', activeModal: [{ route: 'case', subroute: 'home' }] },
+          {
+            route: 'tabbed-forms',
+            subroute: 'childInformation',
+            activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
+          },
           { route: 'tabbed-forms', subroute: 'childInformation' },
         ]),
         expected: stateWithRouteStack([
-          { route: 'tabbed-forms', subroute: 'childInformation', activeModal: [{ route: 'case', subroute: 'home' }] },
+          {
+            route: 'tabbed-forms',
+            subroute: 'childInformation',
+            activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
+          },
         ]),
         action: actions.newGoBackAction(task.taskSid),
       },
@@ -328,10 +361,20 @@ describe('test reducer (specific actions)', () => {
         action: actions.newGoBackAction(task.taskSid),
       },
       {
+        description: 'Current route is the only route in the base stack and supports modals - should do nothing',
+        startingState: stateWithRouteStack([{ route: 'tabbed-forms', subroute: 'childInformation' }]),
+        expected: stateWithRouteStack([{ route: 'tabbed-forms', subroute: 'childInformation' }]),
+        action: actions.newGoBackAction(task.taskSid),
+      },
+      {
         description: 'Current route is the only route in the modal stack - should close modal',
         startingState: stateWithRouteStack([
           { route: 'select-call-type' },
-          { route: 'tabbed-forms', subroute: 'childInformation', activeModal: [{ route: 'case', subroute: 'home' }] },
+          {
+            route: 'tabbed-forms',
+            subroute: 'childInformation',
+            activeModal: [{ route: 'case', subroute: 'home', caseId: '' }],
+          },
         ]),
         expected: stateWithRouteStack([
           { route: 'select-call-type' },
@@ -366,7 +409,7 @@ describe('test reducer (specific actions)', () => {
             subroute: 'childInformation',
             activeModal: [
               { route: 'search', subroute: 'form' },
-              { route: 'search', subroute: 'case-results' },
+              { route: 'search', subroute: 'case-results', contactsPage: 0, casesPage: 0 },
             ],
           },
         ]),
@@ -388,9 +431,11 @@ describe('test reducer (specific actions)', () => {
               {
                 route: 'search',
                 subroute: 'case-results',
+                contactsPage: 0,
+                casesPage: 0,
                 activeModal: [
-                  { route: 'case', subroute: 'home' },
-                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, id: '' },
+                  { route: 'case', subroute: 'home', caseId: '' },
+                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, id: '', caseId: '' },
                 ],
               },
             ],
@@ -403,7 +448,7 @@ describe('test reducer (specific actions)', () => {
             subroute: 'childInformation',
             activeModal: [
               { route: 'search', subroute: 'form' },
-              { route: 'search', subroute: 'case-results' },
+              { route: 'search', subroute: 'case-results', contactsPage: 0, casesPage: 0 },
             ],
           },
         ]),
@@ -422,9 +467,11 @@ describe('test reducer (specific actions)', () => {
               {
                 route: 'search',
                 subroute: 'case-results',
+                contactsPage: 0,
+                casesPage: 0,
                 activeModal: [
-                  { route: 'case', subroute: 'home' },
-                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, id: '' },
+                  { route: 'case', subroute: 'home', caseId: '' },
+                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, caseId: '', id: '' },
                 ],
               },
             ],
@@ -451,9 +498,11 @@ describe('test reducer (specific actions)', () => {
               {
                 route: 'search',
                 subroute: 'case-results',
+                contactsPage: 0,
+                casesPage: 0,
                 activeModal: [
-                  { route: 'case', subroute: 'home' },
-                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, id: '' },
+                  { route: 'case', subroute: 'home', caseId: '' },
+                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, caseId: '', id: '' },
                 ],
               },
             ],
@@ -469,9 +518,11 @@ describe('test reducer (specific actions)', () => {
               {
                 route: 'search',
                 subroute: 'case-results',
+                contactsPage: 0,
+                casesPage: 0,
                 activeModal: [
-                  { route: 'case', subroute: 'home' },
-                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, id: '' },
+                  { route: 'case', subroute: 'home', caseId: '' },
+                  { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, caseId: '', id: '' },
                 ],
               },
             ],
@@ -498,9 +549,11 @@ describe('test reducer (specific actions)', () => {
                   {
                     route: 'search',
                     subroute: 'case-results',
+                    contactsPage: 0,
+                    casesPage: 0,
                     activeModal: [
-                      { route: 'case', subroute: 'home' },
-                      { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, id: '' },
+                      { route: 'case', subroute: 'home', caseId: '' },
+                      { route: 'case', subroute: 'caseSummary', action: CaseItemAction.View, caseId: '', id: '' },
                     ],
                   },
                 ],
@@ -530,7 +583,7 @@ describe('test reducer (specific actions)', () => {
   test('should handle LOAD_CONTACT_FROM_HRM_BY_TASK_ID_ACTION_FULFILLED and recreate the state as loaded', async () => {
     const expected = {
       tasks: {
-        task1: [{ route: 'tabbed-forms', subroute: 'childInformation' }],
+        'WT-task1': [{ route: 'tabbed-forms', subroute: 'childInformation' }],
         [standaloneTaskSid]: initialState.tasks[standaloneTaskSid],
       },
       isAddingOfflineContact: false,
@@ -549,7 +602,7 @@ describe('test reducer (specific actions)', () => {
   test('should handle LOAD_CONTACT_FROM_HRM_BY_TASK_ID_ACTION_FULFILLED and do nothing', async () => {
     const expected = {
       tasks: {
-        task1: [{ route: 'case', subroute: 'home' }],
+        'WT-task1': [{ route: 'case', subroute: 'home', caseId: '' }],
         [standaloneTaskSid]: initialState.tasks[standaloneTaskSid],
       },
       isAddingOfflineContact: false,
@@ -557,7 +610,7 @@ describe('test reducer (specific actions)', () => {
 
     const result1 = reduce(
       stateWithTask,
-      actions.changeRoute({ route: 'case', subroute: 'home' }, task.taskSid, ChangeRouteMode.Replace),
+      actions.changeRoute({ route: 'case', subroute: 'home', caseId: '' }, task.taskSid, ChangeRouteMode.Replace),
     );
 
     const result2 = reduce(result1, {
@@ -573,7 +626,7 @@ describe('test reducer (specific actions)', () => {
   test('should handle LOAD_CONTACT_FROM_HRM_BY_TASK_ID_ACTION_FULFILLED and change isAddingOfflineContact to true', async () => {
     const expected = {
       tasks: {
-        task1: [{ route: 'tabbed-forms', subroute: 'childInformation' }],
+        'WT-task1': [{ route: 'tabbed-forms', subroute: 'childInformation' }],
         [standaloneTaskSid]: initialState.tasks[standaloneTaskSid],
         [offlineContactTaskSid]: [{ ...newTaskEntry, route: 'tabbed-forms', subroute: 'childInformation' }],
       },
@@ -603,7 +656,7 @@ describe('test reducer (specific actions)', () => {
   test('should handle REMOVE_CONTACT_STATE', async () => {
     const expected = {
       tasks: {
-        task1: [{ route: 'tabbed-forms', subroute: 'childInformation' }],
+        'WT-task1': [{ route: 'tabbed-forms', subroute: 'childInformation' }],
         [standaloneTaskSid]: initialState.tasks[standaloneTaskSid],
       },
       isAddingOfflineContact: false,

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -164,12 +164,10 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   // Check if the entry for this task exists in each reducer
   const { savedContact, draftContact } = selectContactByTaskSid(state, task?.taskSid) ?? {};
   const unsavedContact = getUnsavedContact(savedContact, draftContact);
-  const contactFormStateExists = Boolean(savedContact);
   const currentRoute = selectCurrentBaseRoute(state, task?.taskSid);
   const contactIsCreating = selectIsContactCreating(state, task?.taskSid);
 
-  const shouldRecreateState =
-    currentDefinitionVersion && (!contactFormStateExists || !currentRoute) && !contactIsCreating;
+  const shouldRecreateState = currentDefinitionVersion && !savedContact && !contactIsCreating;
 
   return {
     unsavedContact,

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -43,7 +43,6 @@ import asyncDispatch from '../states/asyncDispatch';
 import { selectIsContactCreating } from '../states/contacts/selectContactSaveStatus';
 import selectContactByTaskSid from '../states/contacts/selectContactByTaskSid';
 import { selectCurrentDefinitionVersion } from '../states/configuration/selectDefinitions';
-import selectSearchStateForTask from '../states/search/selectSearchStateForTask';
 
 type OwnProps = {
   task: CustomITask;
@@ -169,7 +168,8 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
   const currentRoute = selectCurrentBaseRoute(state, task?.taskSid);
   const contactIsCreating = selectIsContactCreating(state, task?.taskSid);
 
-  const shouldRecreateState = currentDefinitionVersion && (!contactFormStateExists || !currentRoute);
+  const shouldRecreateState =
+    currentDefinitionVersion && (!contactFormStateExists || !currentRoute) && !contactIsCreating;
 
   return {
     unsavedContact,

--- a/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
+++ b/plugin-hrm-form/src/components/case/AddEditCaseItem.tsx
@@ -78,7 +78,7 @@ const mapStateToProps = (state: RootState, { task, sectionApi }: AddEditCaseItem
 
   if (isCaseRoute(currentRoute)) {
     const sectionId = isEditCaseSectionRoute(currentRoute) ? currentRoute.id : undefined;
-    const { caseWorkingCopy, sections } = selectCaseByCaseId(state, currentRoute.caseId);
+    const { caseWorkingCopy, sections, outstandingUpdateCount } = selectCaseByCaseId(state, currentRoute.caseId);
     const caseItemHistory = sectionId
       ? selectCaseItemHistory(state, currentRoute.caseId, sectionApi, sectionId)
       : {
@@ -90,7 +90,7 @@ const mapStateToProps = (state: RootState, { task, sectionApi }: AddEditCaseItem
 
     const workingCopy = sectionApi.getWorkingCopy(caseWorkingCopy, sectionId);
 
-    return { caseItemHistory, workingCopy, currentRoute, sections, sectionId };
+    return { caseItemHistory, workingCopy, currentRoute, sections, sectionId, isUpdating: outstandingUpdateCount > 0 };
   }
   return {
     connectedCase: undefined,
@@ -98,6 +98,7 @@ const mapStateToProps = (state: RootState, { task, sectionApi }: AddEditCaseItem
     caseItemHistory: undefined,
     workingCopy: undefined,
     sectionId: undefined,
+    isUpdating: false,
   };
 };
 
@@ -152,6 +153,7 @@ const AddEditCaseItem: React.FC<Props> = ({
   updateCaseSection,
   createCaseSection,
   sections,
+  isUpdating,
 }) => {
   const formDefinition = React.useMemo(() => sectionApi.getSectionFormDefinition(definitionVersion), [
     definitionVersion,
@@ -310,6 +312,7 @@ const AddEditCaseItem: React.FC<Props> = ({
                 secondary="true"
                 roundCorners
                 onClick={methods.handleSubmit(saveAndStay, onError)}
+                disabled={isUpdating}
               >
                 <Template code={`BottomBar-SaveAndAddAnother${sectionApi.label}`} />
               </StyledNextStepButton>
@@ -319,6 +322,7 @@ const AddEditCaseItem: React.FC<Props> = ({
             data-testid="Case-AddEditItemScreen-SaveItem"
             roundCorners
             onClick={methods.handleSubmit(() => saveAndLeave(DismissAction.BACK), onError)}
+            disabled={isUpdating}
           >
             <Template code={`BottomBar-Save${sectionApi.label}`} />
           </StyledNextStepButton>

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -82,7 +82,6 @@ const Case: React.FC<Props> = ({
   removeConnectedCase,
   redirectToNewCase,
   closeModal,
-  goBack,
   handleClose = closeModal,
   routing,
   // loadCase,
@@ -290,12 +289,10 @@ const mapDispatchToProps = (dispatch, { task }: OwnProps) => {
     openPrintModal: (caseId: CaseType['id']) => {
       dispatch(RoutingActions.newOpenModalAction({ route: 'case', subroute: 'case-print-view', caseId }, task.taskSid));
     },
-    goBack: () => dispatch(RoutingActions.newGoBackAction(task.taskSid)),
     removeConnectedCase: (contactId: string) => caseAsyncDispatch(removeFromCaseAsyncAction(contactId)),
     updateDefinitionVersion: updateCaseDefinition,
     releaseAllContacts: bindActionCreators(ContactActions.releaseAllContacts, dispatch),
     loadContacts: bindActionCreators(ContactActions.loadContacts, dispatch),
-    // loadCase: (caseId: CaseType['id']) => dispatch(updateCaseOverviewAsyncAction(caseId)), // Empty update loads case into state
   };
 };
 

--- a/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
+++ b/plugin-hrm-form/src/components/case/EditCaseSummary.tsx
@@ -66,8 +66,9 @@ const mapStateToProps = (state: RootState, { task }: EditCaseSummaryProps) => {
   const connectedCaseState = selectCurrentRouteCaseState(state, task.taskSid);
   const historyDetails = selectCaseHistoryDetails(state, connectedCaseState?.connectedCase);
   const workingCopy = connectedCaseState?.caseWorkingCopy.caseSummary;
+  const isUpdating = (connectedCaseState?.outstandingUpdateCount ?? 0) > 0;
   const definitionVersion = selectDefinitionVersionForCase(state, connectedCaseState?.connectedCase);
-  return { connectedCaseState, workingCopy, definitionVersion, historyDetails };
+  return { connectedCaseState, workingCopy, definitionVersion, historyDetails, isUpdating };
 };
 
 const mapDispatchToProps = (dispatch, { task }: EditCaseSummaryProps) => {
@@ -103,6 +104,7 @@ const EditCaseSummary: React.FC<Props> = ({
   closeActions,
   can,
   updateCaseAsyncAction,
+  isUpdating,
 }) => {
   const { connectedCase, availableStatusTransitions } = connectedCaseState ?? {};
 
@@ -221,6 +223,7 @@ const EditCaseSummary: React.FC<Props> = ({
         <div style={{ width: '100%', height: 5, backgroundColor: '#ffffff' }} />
         <BottomButtonBar>
           <StyledNextStepButton
+            disabled={isUpdating}
             data-testid="Case-EditCaseScreen-SaveItem"
             roundCorners
             onClick={methods.handleSubmit(saveAndLeave, onError)}

--- a/plugin-hrm-form/src/states/case/loadCaseIntoState.ts
+++ b/plugin-hrm-form/src/states/case/loadCaseIntoState.ts
@@ -61,6 +61,7 @@ export const loadCaseIntoState = ({
             : new Set<string>(),
           sections: {},
           timelines: {},
+          outstandingUpdateCount: 0,
           ...statusUpdates,
         },
       },

--- a/plugin-hrm-form/src/states/case/markCaseAsUpdating.ts
+++ b/plugin-hrm-form/src/states/case/markCaseAsUpdating.ts
@@ -23,10 +23,15 @@ export const markCaseAsUpdating = (state: HrmState, caseId: Case['id'], updating
     ...state.connectedCase,
     cases: {
       ...state.connectedCase.cases,
-      [caseId]: {
-        ...state.connectedCase.cases[caseId],
-        outstandingUpdateCount: (state.connectedCase.cases[caseId].outstandingUpdateCount || 0) + (updating ? 1 : -1),
-      },
+      ...(state.connectedCase.cases[caseId]
+        ? {
+            [caseId]: {
+              ...state.connectedCase.cases[caseId],
+              outstandingUpdateCount:
+                (state.connectedCase.cases[caseId]?.outstandingUpdateCount || 0) + (updating ? 1 : -1),
+            },
+          }
+        : {}),
     },
   },
 });

--- a/plugin-hrm-form/src/states/case/markCaseAsUpdating.ts
+++ b/plugin-hrm-form/src/states/case/markCaseAsUpdating.ts
@@ -13,31 +13,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { DefinitionVersionId } from 'hrm-form-definitions';
 
-import { Case } from '../types/types';
-import { CaseStateEntry } from '../states/case/types';
+import { HrmState } from '..';
+import { Case } from '../../types/types';
 
-export const VALID_EMPTY_CASE: Case = {
-  id: '1',
-  accountSid: 'AC',
-  info: {
-    definitionVersion: DefinitionVersionId.v1,
+export const markCaseAsUpdating = (state: HrmState, caseId: Case['id'], updating: boolean): HrmState => ({
+  ...state,
+  connectedCase: {
+    ...state.connectedCase,
+    cases: {
+      ...state.connectedCase.cases,
+      [caseId]: {
+        ...state.connectedCase.cases[caseId],
+        outstandingUpdateCount: (state.connectedCase.cases[caseId].outstandingUpdateCount || 0) + (updating ? 1 : -1),
+      },
+    },
   },
-  updatedAt: new Date(2000, 0, 1).toISOString(),
-  createdAt: new Date(2000, 0, 1).toISOString(),
-  helpline: '',
-  twilioWorkerId: 'WK',
-  status: '',
-  categories: {},
-};
-
-export const VALID_EMPTY_CASE_STATE_ENTRY: CaseStateEntry = {
-  connectedCase: VALID_EMPTY_CASE,
-  sections: {},
-  timelines: {},
-  availableStatusTransitions: [],
-  caseWorkingCopy: undefined,
-  references: new Set<string>(),
-  outstandingUpdateCount: 0,
-};
+});

--- a/plugin-hrm-form/src/states/case/reducer.ts
+++ b/plugin-hrm-form/src/states/case/reducer.ts
@@ -14,8 +14,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { omit } from 'lodash';
-
 import {
   CaseActionType,
   CaseState,
@@ -25,7 +23,7 @@ import {
   LOAD_CASE_ACTION_REJECTED,
   REFERENCE_CASE_ACTION,
 } from './types';
-import { DefinitionVersion, REMOVE_CONTACT_STATE, RemoveContactStateAction } from '../types';
+import { REMOVE_CONTACT_STATE, RemoveContactStateAction } from '../types';
 import { CaseWorkingCopyActionType, caseWorkingCopyReducer } from './caseWorkingCopy';
 import { HrmState } from '..';
 import { getAvailableCaseStatusTransitions } from './caseStatus';
@@ -104,6 +102,7 @@ const contactUpdatingReducer = (hrmState: HrmState, action: ContactUpdatingActio
               references,
               sections: {},
               timelines: {},
+              outstandingUpdateCount: 0,
             },
           },
         },

--- a/plugin-hrm-form/src/states/case/saveCase.ts
+++ b/plugin-hrm-form/src/states/case/saveCase.ts
@@ -84,6 +84,7 @@ const updateConnectedCase = (state: HrmState, connectedCase: Case): HrmState => 
   const caseDefinitionVersion = state.configuration.definitionVersions[connectedCase?.info?.definitionVersion];
   const stateCase = state.connectedCase.cases[connectedCase?.id]?.connectedCase;
   const stateInfo = stateCase?.info;
+  const outstandingUpdateCount = (state.connectedCase.cases[connectedCase.id]?.outstandingUpdateCount ?? 1) - 1;
 
   return {
     ...state,
@@ -105,7 +106,7 @@ const updateConnectedCase = (state: HrmState, connectedCase: Case): HrmState => 
           references: state.connectedCase.cases[connectedCase.id]?.references ?? new Set(),
           sections: state.connectedCase.cases[connectedCase.id]?.sections ?? {},
           timelines: state.connectedCase.cases[connectedCase.id]?.timelines ?? {},
-          outstandingUpdateCount: state.connectedCase.cases[connectedCase.id]?.outstandingUpdateCount ?? 0,
+          outstandingUpdateCount,
         },
       },
     },
@@ -115,11 +116,7 @@ const updateConnectedCase = (state: HrmState, connectedCase: Case): HrmState => 
 const handleUpdateCaseOverviewFulfilledAction = (
   handleAction: CreateHandlerMap<HrmState>,
   asyncAction: typeof updateCaseOverviewAsyncAction.fulfilled,
-) =>
-  handleAction(
-    asyncAction,
-    (state, { payload }): HrmState => markCaseAsUpdating(updateConnectedCase(state, payload), payload.id, false),
-  );
+) => handleAction(asyncAction, (state, { payload }): HrmState => updateConnectedCase(state, payload));
 
 const handleCreateCaseFulfilledAction = (
   handleAction: CreateHandlerMap<HrmState>,

--- a/plugin-hrm-form/src/states/case/sections/caseSectionUpdates.ts
+++ b/plugin-hrm-form/src/states/case/sections/caseSectionUpdates.ts
@@ -164,6 +164,10 @@ export const caseSectionUpdateReducer = (initialState: HrmState): ((state: HrmSt
       const { caseId, sections } = action.payload;
       return markCaseAsUpdating(updateCaseSections(state, caseId, sections), caseId, false);
     }),
+    handleAction(createCaseSectionAsyncAction.rejected, (state: HrmState, action: any) => {
+      const { caseId } = action.meta;
+      return markCaseAsUpdating(state, caseId, false);
+    }),
     handleAction(updateCaseSectionAsyncAction.pending, (state: HrmState, action: any) => {
       const { caseId } = action.meta;
       return markCaseAsUpdating(state, caseId, true);
@@ -171,5 +175,9 @@ export const caseSectionUpdateReducer = (initialState: HrmState): ((state: HrmSt
     handleAction(updateCaseSectionAsyncAction.fulfilled, (state: HrmState, action) => {
       const { caseId, sections } = action.payload;
       return markCaseAsUpdating(updateCaseSections(state, caseId, sections), caseId, false);
+    }),
+    handleAction(updateCaseSectionAsyncAction.rejected, (state: HrmState, action: any) => {
+      const { caseId } = action.meta;
+      return markCaseAsUpdating(state, caseId, false);
     }),
   ]);

--- a/plugin-hrm-form/src/states/case/sections/caseSectionUpdates.ts
+++ b/plugin-hrm-form/src/states/case/sections/caseSectionUpdates.ts
@@ -29,6 +29,7 @@ import { HrmState } from '../..';
 import { CaseSectionApi } from './api';
 import { lookupApi } from './lookupApi';
 import { copyCaseSectionItem } from './copySection';
+import { markCaseAsUpdating } from '../markCaseAsUpdating';
 
 type CaseSectionUpdatePayload = {
   caseId: Case['id'];
@@ -155,12 +156,20 @@ const updateCaseSections = (
 
 export const caseSectionUpdateReducer = (initialState: HrmState): ((state: HrmState, action) => HrmState) =>
   createReducer(initialState, handleAction => [
+    handleAction(createCaseSectionAsyncAction.pending, (state: HrmState, action: any) => {
+      const { caseId } = action.meta;
+      return markCaseAsUpdating(state, caseId, true);
+    }),
     handleAction(createCaseSectionAsyncAction.fulfilled, (state: HrmState, action) => {
       const { caseId, sections } = action.payload;
-      return updateCaseSections(state, caseId, sections);
+      return markCaseAsUpdating(updateCaseSections(state, caseId, sections), caseId, false);
+    }),
+    handleAction(updateCaseSectionAsyncAction.pending, (state: HrmState, action: any) => {
+      const { caseId } = action.meta;
+      return markCaseAsUpdating(state, caseId, true);
     }),
     handleAction(updateCaseSectionAsyncAction.fulfilled, (state: HrmState, action) => {
       const { caseId, sections } = action.payload;
-      return updateCaseSections(state, caseId, sections);
+      return markCaseAsUpdating(updateCaseSections(state, caseId, sections), caseId, false);
     }),
   ]);

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -125,6 +125,7 @@ export type CaseStateEntry = {
   timelines: Record<string, (ContactIdentifierTimelineActivity | CaseSectionIdentifierTimelineActivity)[]>;
   sections: { [sectionType in WellKnownCaseSection]?: { [sectionId: string]: FullCaseSection } };
   loading?: boolean;
+  outstandingUpdateCount: number;
   error?: ParseFetchErrorResult;
 };
 

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -46,7 +46,7 @@ import { newContactMetaData } from './contactState';
 import { getCase } from '../../services/CaseService';
 import { getUnsavedContact } from './getUnsavedContact';
 import * as TransferHelpers from '../../transfer/transferTaskState';
-import { WorkerSID } from '../../types/twilio';
+import { TaskSID, WorkerSID } from '../../types/twilio';
 import { CaseStateEntry } from '../case/types';
 
 export const createContactAsyncAction = createAsyncAction(
@@ -202,7 +202,7 @@ export const newFinalizeContactAsyncAction = createAsyncAction(
 
 export const loadContactFromHrmByTaskSidAsyncAction = createAsyncAction(
   LOAD_CONTACT_FROM_HRM_BY_TASK_ID_ACTION,
-  async (taskSid: string, reference: string = taskSid) => {
+  async (taskSid: TaskSID, reference: string = taskSid) => {
     const contact = await getContactByTaskSid(taskSid);
     let contactCase: Case | undefined;
     if (contact?.caseId) {
@@ -214,6 +214,9 @@ export const loadContactFromHrmByTaskSidAsyncAction = createAsyncAction(
       reference,
     };
   },
+  (taskSid: TaskSID) => ({
+    taskSid,
+  }),
 );
 
 export const loadContactFromHrmByIdAsyncAction = createAsyncAction(
@@ -230,6 +233,24 @@ export const loadContactFromHrmByIdAsyncAction = createAsyncAction(
   }),
 );
 
+const markContactAsCreatingInRedux = (state: ContactsState, taskSid: string): ContactsState => {
+  const contactsBeingCreated = new Set(state.contactsBeingCreated);
+  contactsBeingCreated.add(taskSid);
+  return {
+    ...state,
+    contactsBeingCreated,
+  };
+};
+
+const markContactAsNotCreatingInRedux = (state: ContactsState, taskSid: string): ContactsState => {
+  const contactsBeingCreated = new Set(state.contactsBeingCreated);
+  contactsBeingCreated.delete(taskSid);
+  return {
+    ...state,
+    contactsBeingCreated,
+  };
+};
+
 // TODO: Consolidate this logic with the loadContactReducer implementation?
 export const loadContactIntoRedux = (
   state: ContactsState,
@@ -243,8 +264,6 @@ export const loadContactIntoRedux = (
     references.add(reference);
   }
   const metadata = { ...newContactMetaData(false), ...(newMetadata ?? existingContacts[contact.id]?.metadata) };
-  const contactsBeingCreated = new Set(state.contactsBeingCreated);
-  contactsBeingCreated.delete(contact.taskId);
   const existingContact = existingContacts[contact.id]?.savedContact;
   const existingAssociations = {
     ...(existingContact?.csamReports ? { csamReports: existingContact.csamReports } : {}),
@@ -252,8 +271,7 @@ export const loadContactIntoRedux = (
     ...(existingContact?.referrals ? { referrals: existingContact.referrals } : {}),
   };
   return {
-    ...state,
-    contactsBeingCreated,
+    ...markContactAsNotCreatingInRedux(state, contact.taskId),
     existingContacts: {
       ...existingContacts,
       [contact.id]: {
@@ -342,20 +360,7 @@ export const saveContactReducer = (initialState: ContactsState) =>
     ),
     handleAction(
       createContactAsyncAction.pending as typeof createContactAsyncAction,
-      (state, { meta: { taskSid } }): ContactsState => {
-        const contactsBeingCreated = new Set(state.contactsBeingCreated);
-        contactsBeingCreated.add(taskSid);
-        return {
-          ...state,
-          contactsBeingCreated,
-        };
-      },
-    ),
-    handleAction(
-      loadContactFromHrmByIdAsyncAction.pending as typeof loadContactFromHrmByIdAsyncAction,
-      (state, { meta: { contactId } }): ContactsState => {
-        return setContactLoadingStateInRedux(state, contactId);
-      },
+      (state, { meta: { taskSid } }): ContactsState => markContactAsCreatingInRedux(state, taskSid),
     ),
     handleAction(
       createContactAsyncAction.fulfilled,
@@ -365,19 +370,22 @@ export const saveContactReducer = (initialState: ContactsState) =>
     ),
     handleAction(
       createContactAsyncAction.rejected,
-      (state, action): ContactsState => {
-        const {
-          meta: { taskSid },
-        } = action as typeof action & {
-          meta: { taskSid: string };
-        };
-        const contactsBeingCreated = new Set(state.contactsBeingCreated);
-        contactsBeingCreated.delete(taskSid);
-        return {
-          ...state,
-          contactsBeingCreated,
-        };
+      (state, { meta: { taskSid } }: any): ContactsState => markContactAsNotCreatingInRedux(state, taskSid),
+    ),
+    handleAction(
+      loadContactFromHrmByTaskSidAsyncAction.pending as typeof loadContactFromHrmByTaskSidAsyncAction,
+      (state, { meta: { taskSid } }): ContactsState => markContactAsCreatingInRedux(state, taskSid),
+    ),
+    handleAction(
+      loadContactFromHrmByTaskSidAsyncAction.fulfilled,
+      (state, { payload: { contact, reference } }): ContactsState => {
+        if (!contact) return state;
+        return loadContactIntoRedux(state, contact, reference, newContactMetaData(true));
       },
+    ),
+    handleAction(
+      loadContactFromHrmByTaskSidAsyncAction.rejected,
+      (state, { meta: { taskSid } }: any): ContactsState => markContactAsNotCreatingInRedux(state, taskSid),
     ),
     handleAction(
       submitContactFormAsyncAction.pending as typeof submitContactFormAsyncAction,
@@ -403,10 +411,9 @@ export const saveContactReducer = (initialState: ContactsState) =>
       },
     ),
     handleAction(
-      loadContactFromHrmByTaskSidAsyncAction.fulfilled,
-      (state, { payload: { contact, reference } }): ContactsState => {
-        if (!contact) return state;
-        return loadContactIntoRedux(state, contact, reference, newContactMetaData(true));
+      loadContactFromHrmByIdAsyncAction.pending as typeof loadContactFromHrmByIdAsyncAction,
+      (state, { meta: { contactId } }): ContactsState => {
+        return setContactLoadingStateInRedux(state, contactId);
       },
     ),
     handleAction(

--- a/plugin-hrm-form/src/states/profile/hooks/useProfileRelationshipsBytype.ts
+++ b/plugin-hrm-form/src/states/profile/hooks/useProfileRelationshipsBytype.ts
@@ -61,7 +61,7 @@ export const useProfileRelationshipsLoaderByType = ({ profileId, type, page }: U
 };
 
 export const useProfileRelationshipsByType = ({ profileId, type, page }: UseProfileRelationsByType) => {
-  // Triggerr a load on the profile relationships
+  // Trigger a load on the profile relationships
   useProfileRelationshipsLoaderByType({ profileId, type, page });
 
   const data = useSelector((state: RootState) => selectProfileRelationshipsByType(state, profileId, type))?.data;

--- a/plugin-hrm-form/src/states/routing/actions.ts
+++ b/plugin-hrm-form/src/states/routing/actions.ts
@@ -45,7 +45,9 @@ export const newCloseModalAction = (taskId: string, topRoute?: AppRoutes['route'
   topRoute,
 });
 
-export const newGoBackAction = (taskId: string): RoutingActionType => ({
-  type: GO_BACK,
-  taskId,
-});
+export const newGoBackAction = (taskId: string): RoutingActionType => {
+  return {
+    type: GO_BACK,
+    taskId,
+  };
+};

--- a/plugin-hrm-form/src/states/routing/reducer.ts
+++ b/plugin-hrm-form/src/states/routing/reducer.ts
@@ -142,17 +142,17 @@ const updateTopmostRoute = (baseRouteStack: AppRoutes[], newRoute, mode: ChangeR
   return [...(baseRouteStack ?? []), newRoute];
 };
 
-const popTopmostRoute = (baseRouteStack: AppRoutes[]): AppRoutes[] => {
+const popTopmostRoute = (baseRouteStack: AppRoutes[], bottomRouteStack = baseRouteStack): AppRoutes[] => {
   if (baseRouteStack?.length) {
     const currentRoute = baseRouteStack[baseRouteStack.length - 1];
     if (isRouteWithModalSupport(currentRoute) && currentRoute.activeModal) {
       return [
         ...baseRouteStack.slice(0, -1),
-        { ...currentRoute, activeModal: popTopmostRoute(currentRoute.activeModal) },
+        { ...currentRoute, activeModal: popTopmostRoute(currentRoute.activeModal, bottomRouteStack) },
       ];
     }
     // Don't empty the base route stack, this will result in Bad Things (TM)
-    if (baseRouteStack.length <= 1 && !isRouteWithModalSupport(currentRoute)) {
+    if (baseRouteStack.length <= 1 && baseRouteStack === bottomRouteStack) {
       console.warn(
         `Tried to go back in the base route stack but there was ${baseRouteStack.length} routes in the stack so doing nothing. This could indicate a routing logic issue in the components.`,
       );


### PR DESCRIPTION
## Description

Fix a number of small issues that contribute to getting the Flex plugin into a request loop

* Disable case summary and case save buttons when a request is in flight
* Fix the routing redux logic so routes cannot be completely emptied
* Fix logic issue in TaskView.tsx where it always tries to retrieve a contact if there is no route - this makes no sense because retrieving a contact won't create a route

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [X] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

1. Log into Aselo
2. Start creating an offline contact
3. Add a new case to the offline contact
4. Open Developer Tools and go to the 'Network' tab
5. Set Network Throttling to 'Slow 3G'
6. Click 'Edit on the Case Summary and make a change to the case summary text
7. Click 'Save' as many times as you can before the button disappears

Expected Behaviour:

The button should disable after the initial click, and only 1 PUT request to ../case/###/overview should be logged on the nework tab
Repeated requests to the GET 'byTaskSid/offline-task-WK-###' and GET cases/### should NOT be being loggged in the network tab

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P