### PR TITLE
fix: remove all spaces from identifier [CHI-2750]

### DIFF
--- a/plugin-hrm-form/src/utils/task.ts
+++ b/plugin-hrm-form/src/utils/task.ts
@@ -25,7 +25,7 @@ const getContactValueFromWebchat = task => {
   return preEngagementData.contactIdentifier;
 };
 
-const trimSpaces = (s: string) => s.replace(' ', '');
+const trimSpaces = (s: string) => s.replaceAll(' ', '');
 
 type TransformIdentifierFunction = (c: string) => string;
 const channelTransformations: { [k in ChannelTypes]: TransformIdentifierFunction[] } = {
@@ -40,6 +40,9 @@ const channelTransformations: { [k in ChannelTypes]: TransformIdentifierFunction
   web: [],
 };
 
+/**
+ * IMPORTANT: if any logic is changed here, replicate it in serverless/functions/getProfileFlagsForIdentifier.protected.ts
+ */
 export const getNumberFromTask = (task: CustomITask) => {
   if (!isTwilioTask(task)) return null;
 


### PR DESCRIPTION
## Description
This PR fixes the bug linked below, occurring due to Flex still sending blank spaces in identifiers.

### Checklist
- [x] [Corresponding issue has been opened
](https://tech-matters.atlassian.net/browse/CHI-2750)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P