### PR TITLE
Revert "Adds debug logging to ZM staging - temporarily"

### DIFF
--- a/twilio-iac/helplines/zm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zm/configs/service-configuration/staging.json
@@ -11,8 +11,5 @@
             "semver": "~1.31.2",
             "version": "1.31.2"
         }
-    },
-    "ui_attributes": {
-      "logLevel": "debug"
-  }
+    }
 }


### PR DESCRIPTION
Reverts techmatters/flex-plugins#2270

Now that we've worked out the issue, we can remove this.