### PR TITLE
CHI-2685: Use customChannelType in preference to channelType if it is set on the task attributes

### DIFF
--- a/plugin-hrm-form/src/channels/setUpChannels.tsx
+++ b/plugin-hrm-form/src/channels/setUpChannels.tsx
@@ -178,7 +178,10 @@ export const setupInstagramChatChannel = () => {
 };
 
 export const setupLineChatChannel = () => {
-  const LineChatChannel = DefaultTaskChannels.createChatTaskChannel('line', task => task.channelType === 'line');
+  const LineChatChannel = DefaultTaskChannels.createChatTaskChannel(
+    'line',
+    task => task.channelType === 'line' || task.attributes.customChannelType === 'line',
+  );
 
   const icon = <LineIcon width="24px" height="24px" color={colors.line} />;
   LineChatChannel.icons = generateIcons(icon);

--- a/plugin-hrm-form/src/components/queuesStatus/helpers.ts
+++ b/plugin-hrm-form/src/components/queuesStatus/helpers.ts
@@ -49,10 +49,15 @@ const subscribedToQueue = (queue: string, queues: QueuesStatus) => Boolean(queue
  * This function is used to determine the channel of a task.
  * It handles additional SMS channels, such as Modica.
  */
-const getChannel = (task: any): CoreChannelTypes => {
-  if (task.channel_type === 'voice') return 'voice';
+const getChannel = ({
+  channel_type: taskChannelType,
+  attributes: { channelType, customChannelType },
+}: any): CoreChannelTypes => {
+  if (taskChannelType === 'voice') return 'voice';
 
-  return isSmsChannelType(task.attributes.channelType) ? 'sms' : task.attributes.channelType;
+  if (isSmsChannelType(customChannelType || channelType)) return 'sms';
+
+  return customChannelType || channelType;
 };
 
 /**

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -173,7 +173,7 @@ export const createContact = async (
   const { definitionVersion } = getHrmConfig();
   const contactForApi: Contact = {
     ...contact,
-    channel: task.channelType as Contact['channel'],
+    channel: (task.attributes?.channelType || task.channelType) as Contact['channel'],
     rawJson: {
       definitionVersion,
       ...contact.rawJson,

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -173,7 +173,7 @@ export const createContact = async (
   const { definitionVersion } = getHrmConfig();
   const contactForApi: Contact = {
     ...contact,
-    channel: (task.attributes?.channelType || task.channelType) as Contact['channel'],
+    channel: ((task.attributes as any)?.customChannelType || task.channelType) as Contact['channel'],
     rawJson: {
       definitionVersion,
       ...contact.rawJson,

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -126,7 +126,7 @@ const baseUpdates: InsightsUpdateFunction = (
 ): CoreAttributes => {
   const communication_channel = taskAttributes.isContactlessTask
     ? mapChannelForInsights(contactlessTask.channel)
-    : mapChannelForInsights(taskAttributes.channelType);
+    : mapChannelForInsights(taskAttributes.customChannelType || taskAttributes.channelType);
 
   // First add the data we add whether or not there's contact form data
   const coreAttributes: CoreAttributes = {


### PR DESCRIPTION

## Description
Required for custom channels on conversations, complements https://github.com/techmatters/serverless/pull/618

Updates Flex to check for `customChannelType` and use it in preference to `channelType` in task attributes and use it in preference where available. This is to work around an issue we are seeing where our attempt to set the channelType in our studio flow is being ignored for conversations.

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Ensure Line contacts are correctly identified as Line Contacts everywhere in the UI, HRM and Insights when using 'Line on Conversations'

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P