### PR TITLE
CHI-2685: Create an SSM parameter containing the studio flow SID for custom channels

### DIFF
--- a/twilio-iac/terraform-modules/channels/v1/main.tf
+++ b/twilio-iac/terraform-modules/channels/v1/main.tf
@@ -89,6 +89,7 @@ resource "twilio_flex_flex_flows_v1" "channel_flow" {
   enabled              = true
 }
 
+# Legacy format, remove once serverless & webchat are migrated to the new format below
 resource "aws_ssm_parameter" "channel_flex_flow_sid_parameter" {
   for_each = {
     for idx, channel in var.channels :
@@ -97,5 +98,28 @@ resource "aws_ssm_parameter" "channel_flex_flow_sid_parameter" {
   name        = "${var.short_environment}_TWILIO_${var.short_helpline}_${upper(each.key)}_FLEX_FLOW_SID"
   type        = "SecureString"
   value       = twilio_flex_flex_flows_v1.channel_flow[each.key].sid
+  description = "${title(replace(each.key, "_", " "))} Flex Flow SID (Legacy)"
+}
+
+
+resource "aws_ssm_parameter" "channel_flex_flow_sid" {
+  for_each = {
+  for idx, channel in var.channels :
+  idx => channel if(channel.channel_type == "custom")
+  }
+  name        = "/${lower(var.environment)}/twilio/${nonsensitive(var.twilio_account_sid)}/flex_flow_sid"
+  type        = "SecureString"
+  value       = twilio_flex_flex_flows_v1.channel_flow[each.key].sid
   description = "${title(replace(each.key, "_", " "))} Flex Flow SID"
+}
+
+resource "aws_ssm_parameter" "channel_studio_flow_sid" {
+  for_each = {
+  for idx, channel in var.channels :
+  idx => channel if(channel.channel_type == "custom")
+  }
+  name        = "/${lower(var.environment)}/twilio/${nonsensitive(var.twilio_account_sid)}/studio_flow_sid"
+  type        = "SecureString"
+  value       = twilio_studio_flows_v2.channel_studio_flow[each.key].sid
+  description = "${title(replace(each.key, "_", " "))} Studio Flow SID"
 }

--- a/twilio-iac/terraform-modules/channels/v1/variables.tf
+++ b/twilio-iac/terraform-modules/channels/v1/variables.tf
@@ -18,6 +18,11 @@ variable "short_helpline" {
   type        = string
 }
 
+variable "twilio_account_sid" {
+  description = "Twilio Account SID (ACxxxx)"
+  type        = string
+}
+
 variable "serverless_url" {
   description = "Serverless URL"
   type        = string

--- a/twilio-iac/terraform-modules/stages/configure/main.tf
+++ b/twilio-iac/terraform-modules/stages/configure/main.tf
@@ -53,6 +53,7 @@ module "channel" {
   task_language              = var.task_language
   helpline                   = var.helpline
   short_helpline             = upper(var.short_helpline)
+  twilio_account_sid         = local.secrets.twilio_account_sid
   serverless_url             = local.serverless_url
   serverless_service_sid     = local.serverless_service_sid
   serverless_environment_sid = local.serverless_environment_production_sid


### PR DESCRIPTION
## Description

For use by serverless deploys setting up the channel on conversations.

@janorivera - I don't know how you are thinking oof approaching the channel setup for conversations, whether you want to extend the existing channel module or adapt the conversation specific one? This PR should provide an example of what is needed however you plan to approach it.