### PR TITLE
CHI-2770: Post Survey support for conversations

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -93,6 +93,9 @@
       },
       "engines": {
         "node": "^18.20.3"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
       }
     },
     "../hrm-form-definitions": {
@@ -27922,7 +27925,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -79131,7 +79133,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -93,9 +93,6 @@
       },
       "engines": {
         "node": "^18.20.3"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
       }
     },
     "../hrm-form-definitions": {
@@ -27925,6 +27922,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -79133,6 +79131,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -155,6 +155,8 @@ const setUpActions = (
 
   Flex.Actions.replaceAction('WrapupTask', wrapupOverride);
 
+  Flex.Actions.replaceAction('CompleteTask', ActionFunctions.completeTaskOverride);
+
   Flex.Actions.addListener('beforeCompleteTask', beforeCompleteAction);
 
   Flex.Actions.addListener('afterCompleteTask', ActionFunctions.afterCompleteTask);

--- a/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
+++ b/plugin-hrm-form/src/___tests__/utils/setUpActions.test.ts
@@ -92,33 +92,12 @@ describe('afterCompleteTask', () => {
   });
 });
 
-describe('excludeDeactivateConversationOrchestration', () => {
-  test('backend_handled_chat_janitor === false and enable_post_survey === false should not change ChatOrchestrator', async () => {
-    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations');
-    excludeDeactivateConversationOrchestration(<FeatureFlags>{
-      enable_post_survey: false,
-      backend_handled_chat_janitor: false,
-    });
+test('excludeDeactivateConversationOrchestration - should remove DeactivateConversation orchestration from task complete and wrapup transitions via ChatOrchestrator', () => {
+  const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
 
-    expect(setOrchestrationsSpy).not.toHaveBeenCalled();
-  });
+  excludeDeactivateConversationOrchestration(<FeatureFlags>{ enable_post_survey: true });
 
-  test('featureFlags.enable_post_survey === true should change ChatOrchestrator', async () => {
-    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
-
-    excludeDeactivateConversationOrchestration(<FeatureFlags>{ enable_post_survey: true });
-
-    expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
-    expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));
-    expect(setOrchestrationsSpy).toHaveBeenCalledWith('completed', expect.any(Function));
-  });
-  test('backend_handled_chat_janitor === true should change ChatOrchestrator', async () => {
-    const setOrchestrationsSpy = jest.spyOn(ChatOrchestrator, 'setOrchestrations').mockImplementation();
-
-    excludeDeactivateConversationOrchestration(<FeatureFlags>{ backend_handled_chat_janitor: true });
-
-    expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
-    expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));
-    expect(setOrchestrationsSpy).toHaveBeenCalledWith('completed', expect.any(Function));
-  });
+  expect(setOrchestrationsSpy).toHaveBeenCalledTimes(2);
+  expect(setOrchestrationsSpy).toHaveBeenCalledWith('wrapup', expect.any(Function));
+  expect(setOrchestrationsSpy).toHaveBeenCalledWith('completed', expect.any(Function));
 });

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/ConferencePanel.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/ConferencePanel.tsx
@@ -21,13 +21,13 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { createCallStatusSyncDocument } from '../../../utils/sharedState';
 import { ConferenceNotifications } from '../../../conference/setUpConferenceActions';
-import { conferenceApi } from '../../../services/ServerlessService';
 import PhoneInputDialog from './PhoneInputDialog';
 import { ConferenceButtonWrapper, ConferenceButton } from './styles';
 import { RootState } from '../../../states';
 import { setCallStatusAction, setIsDialogOpenAction, setPhoneNumberAction } from '../../../states/conferencing';
 import { CallStatus, isCallStatusLoading } from '../../../states/conferencing/callStatus';
 import { conferencingBase, namespace } from '../../../states/storeNamespaces';
+import * as conferenceApi from '../../../services/conferenceService';
 
 type Props = TaskContextProps;
 

--- a/plugin-hrm-form/src/components/Conference/ConferenceActions/ToggleMute.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceActions/ToggleMute.tsx
@@ -16,11 +16,11 @@
 
 import React from 'react';
 import { TaskContextProps, TaskHelper, Template, withTaskContext } from '@twilio/flex-ui';
-import MicNoneOutlined from '@material-ui/icons/MicNoneOutlined';
 import MicOffOutlined from '@material-ui/icons/MicOffOutlined';
+import MicNoneOutlined from '@material-ui/icons/MicNoneOutlined';
 
-import { conferenceApi } from '../../../services/ServerlessService';
 import { ConferenceButtonWrapper, ConferenceButton } from './styles';
+import * as conferenceApi from '../../../services/conferenceService';
 
 type Props = TaskContextProps;
 

--- a/plugin-hrm-form/src/components/Conference/ConferenceMonitor/index.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceMonitor/index.tsx
@@ -18,8 +18,8 @@ import { ConferenceParticipant } from '@twilio/flex-ui';
 import '../../../types';
 import { Conference } from '@twilio/flex-ui/src/state/Conferences';
 
-import { conferenceApi } from '../../../services/ServerlessService';
 import { hasTaskControl, isOriginalReservation, isTransferring } from '../../../transfer/transferTaskState';
+import * as conferenceApi from '../../../services/conferenceService';
 
 const isJoinedWithEnd = (p: ConferenceParticipant) => p.status === 'joined' && p.mediaProperties.endConferenceOnExit;
 const isJoinedWithoutEnd = (p: ConferenceParticipant) =>

--- a/plugin-hrm-form/src/components/Conference/HoldParticipantButton/index.tsx
+++ b/plugin-hrm-form/src/components/Conference/HoldParticipantButton/index.tsx
@@ -18,8 +18,8 @@ import React from 'react';
 import { IconButton, Notifications, TaskHelper } from '@twilio/flex-ui';
 import type { ParticipantCanvasChildrenProps } from '@twilio/flex-ui/src/components/canvas/ParticipantCanvas/ParticipantCanvas.definitions';
 
-import { conferenceApi } from '../../../services/ServerlessService';
 import { ConferenceNotifications } from '../../../conference/setUpConferenceActions';
+import * as conferenceApi from '../../../services/conferenceService';
 
 type Props = Partial<ParticipantCanvasChildrenProps>;
 

--- a/plugin-hrm-form/src/components/Conference/ParticipantLabel/index.tsx
+++ b/plugin-hrm-form/src/components/Conference/ParticipantLabel/index.tsx
@@ -18,11 +18,11 @@ import React from 'react';
 import type { ParticipantCanvasChildrenProps } from '@twilio/flex-ui/src/components/canvas/ParticipantCanvas/ParticipantCanvas.definitions';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { conferenceApi } from '../../../services/ServerlessService';
 import { RootState } from '../../../states';
 import { addParticipantLabelAction } from '../../../states/conferencing';
 import { ParticipantLabelContainer, ParticipantLabelText } from './styles';
 import { conferencingBase, namespace } from '../../../states/storeNamespaces';
+import * as conferenceApi from '../../../services/conferenceService';
 
 type Props = ParticipantCanvasChildrenProps;
 

--- a/plugin-hrm-form/src/components/Conference/RemoveParticipantButton/index.tsx
+++ b/plugin-hrm-form/src/components/Conference/RemoveParticipantButton/index.tsx
@@ -18,8 +18,8 @@ import React from 'react';
 import { IconButton, Notifications, TaskHelper } from '@twilio/flex-ui';
 import type { ParticipantCanvasChildrenProps } from '@twilio/flex-ui/src/components/canvas/ParticipantCanvas/ParticipantCanvas.definitions';
 
-import { conferenceApi } from '../../../services/ServerlessService';
 import { ConferenceNotifications } from '../../../conference/setUpConferenceActions';
+import * as conferenceApi from '../../../services/conferenceService';
 
 type Props = Partial<ParticipantCanvasChildrenProps>;
 

--- a/plugin-hrm-form/src/services/conferenceService.ts
+++ b/plugin-hrm-form/src/services/conferenceService.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import fetchProtectedApi from './fetchProtectedApi';
+
+const validUpdates = ['endConferenceOnExit', 'hold', 'muted'] as const;
+type ConferenceAddParticipantParams = {
+  conferenceSid: string;
+  to: string;
+  from: string;
+  callStatusSyncDocumentSid: string;
+  label: string;
+};
+type ConferenceGetParticipantParams = { conferenceSid: string; callSid: string };
+type ConferenceRemoveParticipantParams = { conferenceSid: string; callSid: string };
+type ConferenceUpdateParticipantParams = {
+  conferenceSid: string;
+  callSid: string;
+  updates: { [K in typeof validUpdates[number]]?: boolean };
+};
+export const addParticipant = async ({
+  conferenceSid,
+  to,
+  from,
+  callStatusSyncDocumentSid,
+  label,
+}: ConferenceAddParticipantParams) => {
+  const body = {
+    conferenceSid,
+    to,
+    from,
+    callStatusSyncDocumentSid,
+    label,
+  };
+
+  return fetchProtectedApi('/conference/addParticipant', body);
+};
+
+export const getParticipant = async ({
+  callSid,
+  conferenceSid,
+}: ConferenceGetParticipantParams): Promise<{ participant: any }> => {
+  const body = {
+    conferenceSid,
+    callSid,
+  };
+
+  return fetchProtectedApi('/conference/getParticipant', body);
+};
+
+export const removeParticipant = async ({ conferenceSid, callSid }: ConferenceRemoveParticipantParams) => {
+  const body = {
+    conferenceSid,
+    callSid,
+  };
+
+  return fetchProtectedApi('/conference/removeParticipant', body);
+};
+
+export const updateParticipant = async ({ callSid, conferenceSid, updates }: ConferenceUpdateParticipantParams) => {
+  const body = {
+    conferenceSid,
+    callSid,
+    updates: JSON.stringify(updates),
+  };
+
+  return fetchProtectedApi('/conference/updateParticipant', body);
+};

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -22,7 +22,6 @@ import { Contact, CustomITask, isOfflineContact, isOfflineContactTask, isTwilioT
 import { channelTypes } from '../states/DomainConstants';
 import { buildInsightsData } from './InsightsService';
 import { finalizeContact, saveContact } from './ContactService';
-import { assignOfflineContactInit, assignOfflineContactResolve } from './ServerlessService';
 import { getHrmConfig } from '../hrmConfig';
 import { ContactMetadata } from '../states/contacts/types';
 import * as GeneralActions from '../states/actions';
@@ -32,6 +31,7 @@ import { getOfflineContactTaskSid } from '../states/contacts/offlineContactTask'
 import '../types';
 import { CaseStateEntry } from '../states/case/types';
 import { getExternalRecordingInfo } from './getExternalRecordingInfo';
+import { assignOfflineContactInit, assignOfflineContactResolve } from './twilioTaskService';
 
 /**
  * Function used to manually complete a task (making sure it transitions to wrapping state first).

--- a/plugin-hrm-form/src/services/twilioTaskService.ts
+++ b/plugin-hrm-form/src/services/twilioTaskService.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 import { ITask } from '@twilio/flex-ui';
 
 import fetchProtectedApi from './fetchProtectedApi';

--- a/plugin-hrm-form/src/services/twilioTaskService.ts
+++ b/plugin-hrm-form/src/services/twilioTaskService.ts
@@ -1,0 +1,55 @@
+import { ITask } from '@twilio/flex-ui';
+
+import fetchProtectedApi from './fetchProtectedApi';
+import { TaskSID } from '../types/twilio';
+
+/**
+ * Creates a new task (offline contact) in behalf of targetSid worker with attributes. Other attributes for routing are added to the task in the implementation of assignOfflineContact serverless function
+ */
+export const assignOfflineContactInit = async (targetSid: string, taskAttributes: ITask['attributes']) => {
+  const body = {
+    targetSid,
+    taskAttributes: JSON.stringify(taskAttributes),
+  };
+
+  return fetchProtectedApi('/assignOfflineContactInit', body);
+};
+
+type OfflineContactComplete = {
+  action: 'complete';
+  taskSid: string;
+  finalTaskAttributes: ITask['attributes'];
+};
+type OfflineContactRemove = {
+  action: 'remove';
+  taskSid: string;
+};
+
+/**
+ * Completes or removes the task (offline contact) in behalf of targetSid worker updating with finalTaskAttributes.
+ */
+export const assignOfflineContactResolve = async (payload: OfflineContactComplete | OfflineContactRemove) => {
+  const body =
+    payload.action === 'complete'
+      ? {
+          ...payload,
+          finalTaskAttributes: JSON.stringify(payload.finalTaskAttributes),
+        }
+      : payload;
+
+  return fetchProtectedApi('/assignOfflineContactResolve', body);
+};
+
+/**
+ * Wraps up a conversations task using the interactions API rather than the default actions API.
+ * This prevents the underlying conversation being closed so a post survey can vbe performed.
+ */
+export const wrapupConversationTask = async (taskSid: TaskSID) =>
+  fetchProtectedApi('/interaction/transitionAgentParticipants', { taskSid, targetStatus: 'wrapup' });
+
+/**
+ * Completes a conversations task using the interactions API rather than the default actions API.
+ * This prevents the underlying conversation being closed so a post survey can vbe performed.
+ */
+export const completeConversationTask = async (taskSid: TaskSID) =>
+  fetchProtectedApi('/interaction/transitionAgentParticipants', { taskSid, targetStatus: 'closed' });

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { ActionFunction, ChatOrchestrator, ChatOrchestratorEvent, Manager, TaskHelper } from '@twilio/flex-ui';
+import {
+  ActionFunction,
+  ChatOrchestrator,
+  ChatOrchestratorEvent,
+  ConversationHelper,
+  Manager,
+  TaskHelper,
+} from '@twilio/flex-ui';
 import { Conversation } from '@twilio/conversations';
 import type { ChatOrchestrationsEvents } from '@twilio/flex-ui/src/ChatOrchestrator';
 
@@ -38,6 +45,7 @@ import { handleTransferredTask } from '../transfer/setUpTransferActions';
 import { prepopulateForm } from './prepopulateForm';
 import { namespace } from '../states/storeNamespaces';
 import { recordEvent } from '../fullStory';
+import { completeConversationTask, wrapupConversationTask } from '../services/twilioTaskService';
 
 type SetupObject = ReturnType<typeof getHrmConfig>;
 type GetMessage = (key: string) => (key: string) => Promise<string>;
@@ -182,13 +190,29 @@ export const hangupCall = fromActionFunction(saveEndMillis);
 /**
  * Override for WrapupTask action. Sends a message before leaving (if it should) and saves the end time of the conversation
  */
-export const wrapupTask = (setupObject: SetupObject, getMessage: GetMessage) =>
-  fromActionFunction(async payload => {
-    if (TaskHelper.isChatBasedTask(payload.task)) {
-      await sendGoodbyeMessage(payload.task.taskSid)(setupObject, getMessage)(payload);
-    }
-    await saveEndMillis(payload);
-  });
+export const wrapupTask = (setupObject: SetupObject, getMessage: GetMessage) => async (
+  payload,
+  original: ActionFunction,
+): Promise<any> => {
+  if (TaskHelper.isChatBasedTask(payload.task)) {
+    await sendGoodbyeMessage(payload.task.taskSid)(setupObject, getMessage)(payload);
+  }
+  await saveEndMillis(payload);
+  if (payload.task.attributes.conversationSid) {
+    return wrapupConversationTask(payload.task.taskSid);
+  }
+  return original(payload);
+};
+
+/**
+ * Override for WrapupTask action. Sends a message before leaving (if it should) and saves the end time of the conversation
+ */
+export const completeTaskOverride = async (payload: ActionPayload, original: ActionFunction): Promise<any> => {
+  if (payload.task.attributes.conversationSid) {
+    return completeConversationTask(payload.task.taskSid);
+  }
+  return original(payload);
+};
 
 export const recordCallState = ({ task }) => {
   if (isTwilioTask(task) && TaskHelper.isCallTask(task)) {
@@ -223,33 +247,28 @@ const isAseloCustomChannelTask = (task: CustomITask) =>
   (<string[]>Object.values(customChannelTypes)).includes(task.channelType);
 
 /**
- * This function manipulates the default chat orchetrations to allow our implementation of post surveys.
+ * This function manipulates the default chat orchestrations to allow our implementation of post surveys.
  * Since we rely on the same chat channel as the original contact for it, we don't want it to be "deactivated" by Flex.
  * Hence this function modifies the following orchestration events:
  * - task wrapup: removes DeactivateConversation
  * - task completed: removes DeactivateConversation
  */
 export const excludeDeactivateConversationOrchestration = (featureFlags: FeatureFlags) => {
-  // TODO: remove conditions once all accounts are updated, since we want this code to be executed in all Flex instances once CHI-2202 is implemented and in place
-  if (featureFlags.backend_handled_chat_janitor || featureFlags.enable_post_survey) {
-    const setExcludedDeactivateConversation = (event: keyof ChatOrchestrationsEvents) => {
-      const excludeDeactivateConversation = (orchestrations: ChatOrchestratorEvent[]) =>
-        orchestrations.filter(e => e !== ChatOrchestratorEvent.DeactivateConversation);
+  const setExcludedDeactivateConversation = (event: keyof ChatOrchestrationsEvents) => {
+    const excludeDeactivateConversation = (orchestrations: ChatOrchestratorEvent[]) =>
+      orchestrations.filter(e => e !== ChatOrchestratorEvent.DeactivateConversation);
 
-      const defaultOrchestrations = ChatOrchestrator.getOrchestrations(event);
+    const defaultOrchestrations = ChatOrchestrator.getOrchestrations(event);
 
-      if (Array.isArray(defaultOrchestrations)) {
-        ChatOrchestrator.setOrchestrations(event, task => {
-          return isAseloCustomChannelTask(task as ITask)
-            ? defaultOrchestrations
-            : excludeDeactivateConversation(defaultOrchestrations);
-        });
-      }
-    };
+    if (Array.isArray(defaultOrchestrations)) {
+      ChatOrchestrator.setOrchestrations(event, task => {
+        return excludeDeactivateConversation(defaultOrchestrations);
+      });
+    }
+  };
 
-    setExcludedDeactivateConversation('wrapup');
-    setExcludedDeactivateConversation('completed');
-  }
+  setExcludedDeactivateConversation('wrapup');
+  setExcludedDeactivateConversation('completed');
 };
 
 export const afterCompleteTask = async ({ task }: { task: CustomITask }): Promise<void> => {

--- a/twilio-iac/helplines/as/configs/service-configuration/development.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/development.json
@@ -16,7 +16,7 @@
             "enable_csam_report": true,
             "enable_client_profiles": true,
             "enable_lex": true,
-            "enable_post_survey": false,
+            "enable_post_survey": true,
             "enable_resources": true,
             "enable_resources_elastic_search": true,
             "enable_save_insights": true,

--- a/webchat/tsconfig.json
+++ b/webchat/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "commonjs",
     "strict": true,
     "allowJs": true,


### PR DESCRIPTION
Requires a serverless build with https://github.com/techmatters/serverless/pull/621 merged to be deployed to work

## Description

* Adds a client for a new serverless endpoint that wraps up and completes tasks without deactivating a conversation
* Replaces the current flex actions for completing and wrapping up tasks with ones that call this endpoint for conversations tasks
* Breaks up ServerlessService a little

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

* Test post surveys on conversations
* Test post surveys on programmable chat
* Test conversations without a post survey
* Test programmable chat without a post survey

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P