### PR TITLE
CHI-2799: Fix saving the number to the contact for custom channels on conversations

### DIFF
--- a/plugin-hrm-form/src/utils/task.ts
+++ b/plugin-hrm-form/src/utils/task.ts
@@ -43,15 +43,17 @@ const channelTransformations: { [k in ChannelTypes]: TransformIdentifierFunction
 export const getNumberFromTask = (task: CustomITask) => {
   if (!isTwilioTask(task)) return null;
 
+  const channelType: ChannelTypes = task.attributes.customChannelType || task.channelType;
+
   // webchat is a special case since it does not only depends on channel but in the task attributes too
-  if (task.channelType === channelTypes.web) {
+  if (channelType === channelTypes.web) {
     return getContactValueFromWebchat(task);
   }
 
-  if (!channelTransformations[task.channelType]) return null;
+  if (!channelTransformations[channelType]) return null;
 
   // otherwise, return the "defaultFrom" with the transformations on the identifier corresponding to each channel
-  return channelTransformations[task.channelType as ChannelTypes].reduce((accum, f) => f(accum), task.defaultFrom);
+  return channelTransformations[channelType].reduce((accum, f) => f(accum), task.defaultFrom);
 };
 
 /**


### PR DESCRIPTION
## Description

The logic for checking a number wasn't taking into account the new customChannelType attribute. Now it is the behaviour is fixed

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- N/A Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P