### PR TITLE
Pre-emptively check if token is valid before using it to make API calls

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -61,6 +61,10 @@ jest.mock('@twilio/flex-ui', () => ({
   },
 }));
 
+jest.mock('../../authentication', () => ({
+  getValidToken: () => 'valid token',
+}));
+
 const { mockFetchImplementation, mockReset, buildBaseURL } = mockLocalFetchDefinitions();
 
 /**

--- a/plugin-hrm-form/src/___tests__/services/fetchResourcesApi.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/fetchResourcesApi.test.ts
@@ -19,96 +19,114 @@ import each from 'jest-each';
 import { getReferrableResourceConfig } from '../../hrmConfig';
 import { ApiError } from '../../services/fetchApi';
 import fetchResourcesApi from '../../services/fetchResourcesApi';
+import { getValidToken } from '../../authentication';
 
 global.fetch = jest.fn();
 
 jest.mock('../../hrmConfig');
+jest.mock('../../authentication', () => ({
+  getValidToken: jest.fn(),
+}));
 
-describe('fetchHrmApi', () => {
-  const mockFetch = fetch as jest.Mock<Promise<Partial<Response>>>;
-  const mockGetReferrableResourceConfig = getReferrableResourceConfig as jest.Mock<
-    Partial<ReturnType<typeof getReferrableResourceConfig>>
-  >;
-  const requestBody = { an: 'input', another: '1' };
+const mockGetValidToken = getValidToken as jest.MockedFunction<typeof getValidToken>;
+
+const mockFetch = fetch as jest.Mock<Promise<Partial<Response>>>;
+const mockGetReferrableResourceConfig = getReferrableResourceConfig as jest.Mock<
+  Partial<ReturnType<typeof getReferrableResourceConfig>>
+>;
+const requestBody = { an: 'input', another: '1' };
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  mockGetReferrableResourceConfig.mockClear();
+  mockGetReferrableResourceConfig.mockReturnValue({
+    resourcesBaseUrl: 'https://all.your/base',
+  });
+  mockGetValidToken.mockClear();
+  mockGetValidToken.mockReturnValue('of my appreciation');
+});
+
+describe('OK response', () => {
+  const responseBody = { a: 'property' };
 
   beforeEach(() => {
-    mockFetch.mockClear();
-    mockGetReferrableResourceConfig.mockClear();
-    mockGetReferrableResourceConfig.mockReturnValue({
-      token: 'of my appreciation',
-      resourcesBaseUrl: 'https://all.your/base',
-    });
-  });
-
-  describe('OK response', () => {
-    const responseBody = { a: 'property' };
-
-    beforeEach(() => {
-      mockFetch.mockResolvedValue({
-        json(): Promise<any> {
-          return Promise.resolve(responseBody);
-        },
-        text(): Promise<any> {
-          return Promise.resolve(responseBody);
-        },
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-      });
-    });
-    test('Default request options - Makes a GET request to the provided endpoint with the token from configuration set as the Bearer token, returning the serialised body', async () => {
-      const response = await fetchResourcesApi('/areBelongToUs');
-      expect(response).toStrictEqual(responseBody);
-      expect(fetch).toHaveBeenCalledWith(
-        'https://all.your/base/resources/areBelongToUs',
-        expect.objectContaining({
-          method: 'GET',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer of my appreciation` },
-        }),
-      );
-    });
-    test('POST request with body - Makes a POST request to the provided endpoint, creates URL parameters out of body, appending the token', async () => {
-      const response = await fetchResourcesApi('/areBelongToUs', { method: 'POST', body: JSON.stringify(requestBody) });
-      expect(response).toStrictEqual(responseBody);
-      const { body, headers }: { body: URLSearchParams; headers: Record<string, string> } = mockFetch.mock.calls[0][1];
-      expect(body).toBe(JSON.stringify(requestBody));
-      expect(headers).toStrictEqual({ 'Content-Type': 'application/json', Authorization: `Bearer of my appreciation` });
-    });
-    test('Extra headers specified - retains default headers', async () => {
-      const response = await fetchResourcesApi('/areBelongToUs', { headers: { Accept: 'text/plain' } });
-      expect(response).toStrictEqual(responseBody);
-      const { headers }: { body: URLSearchParams; headers: Record<string, string> } = mockFetch.mock.calls[0][1];
-      expect(headers).toStrictEqual({
-        'Content-Type': 'application/json',
-        Authorization: `Bearer of my appreciation`,
-        Accept: 'text/plain',
-      });
-    });
-  });
-  each([
-    { status: 500, statusText: 'Internal Error' },
-    { status: 502, statusText: 'Bad Gateway' },
-    { status: 504, statusText: 'Gateway Timeout' },
-    { status: 400, statusText: 'Bad Request' },
-    { status: 401, statusText: 'Unauthorized' },
-    { status: 403, statusText: 'Forbidden' },
-    { status: 404, statusText: 'Not Found' },
-  ]).test('other error response - throws ApiError with generic message', async ({ status, statusText }) => {
-    const requestBody = { error: 'message' };
-    const mockResponse = {
+    mockFetch.mockResolvedValue({
       json(): Promise<any> {
-        return Promise.resolve(requestBody);
+        return Promise.resolve(responseBody);
       },
-      ok: false,
-      status,
-      statusText,
-    };
-    mockFetch.mockResolvedValue(mockResponse);
-    await expect(fetchResourcesApi('/areBelongToUs')).rejects.toThrow(
-      new ApiError(`Error response: ${status} (${statusText})`, {
-        body: { error: 'message' },
-        response: mockResponse as Response,
+      text(): Promise<any> {
+        return Promise.resolve(responseBody);
+      },
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+    });
+  });
+  test('Default request options - Makes a GET request to the provided endpoint with the token from configuration set as the Bearer token, returning the serialised body', async () => {
+    const response = await fetchResourcesApi('/areBelongToUs');
+    expect(response).toStrictEqual(responseBody);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://all.your/base/resources/areBelongToUs',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer of my appreciation` },
       }),
     );
   });
+  test('POST request with body - Makes a POST request to the provided endpoint, creates URL parameters out of body, appending the token', async () => {
+    const response = await fetchResourcesApi('/areBelongToUs', { method: 'POST', body: JSON.stringify(requestBody) });
+    expect(response).toStrictEqual(responseBody);
+    const { body, headers }: { body: URLSearchParams; headers: Record<string, string> } = mockFetch.mock.calls[0][1];
+    expect(body).toBe(JSON.stringify(requestBody));
+    expect(headers).toStrictEqual({ 'Content-Type': 'application/json', Authorization: `Bearer of my appreciation` });
+  });
+  test('Extra headers specified - retains default headers', async () => {
+    const response = await fetchResourcesApi('/areBelongToUs', { headers: { Accept: 'text/plain' } });
+    expect(response).toStrictEqual(responseBody);
+    const { headers }: { body: URLSearchParams; headers: Record<string, string> } = mockFetch.mock.calls[0][1];
+    expect(headers).toStrictEqual({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer of my appreciation`,
+      Accept: 'text/plain',
+    });
+  });
+});
+
+test('Invalid token - aborts request and throws ApiError', async () => {
+  const tokenError = new Error('not appreciated');
+  mockGetValidToken.mockReturnValue(tokenError);
+  try {
+    await fetchResourcesApi('/areBelongToUs');
+    expect(false).toBe(true); // should not reach this point
+  } catch (error) {
+    expect(error).toEqual(new ApiError('Aborting request due to token issue: not appreciated', {}, tokenError));
+  }
+  expect(mockFetch).not.toHaveBeenCalled();
+});
+
+each([
+  { status: 500, statusText: 'Internal Error' },
+  { status: 502, statusText: 'Bad Gateway' },
+  { status: 504, statusText: 'Gateway Timeout' },
+  { status: 400, statusText: 'Bad Request' },
+  { status: 401, statusText: 'Unauthorized' },
+  { status: 403, statusText: 'Forbidden' },
+  { status: 404, statusText: 'Not Found' },
+]).test('other error response - throws ApiError with generic message', async ({ status, statusText }) => {
+  const requestBody = { error: 'message' };
+  const mockResponse = {
+    json(): Promise<any> {
+      return Promise.resolve(requestBody);
+    },
+    ok: false,
+    status,
+    statusText,
+  };
+  mockFetch.mockResolvedValue(mockResponse);
+  await expect(fetchResourcesApi('/areBelongToUs')).rejects.toThrow(
+    new ApiError(`Error response: ${status} (${statusText})`, {
+      body: { error: 'message' },
+      response: mockResponse as Response,
+    }),
+  );
 });

--- a/plugin-hrm-form/src/authentication.ts
+++ b/plugin-hrm-form/src/authentication.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { Manager } from '@twilio/flex-ui';
+import { isAfter } from 'date-fns';
+
+/**
+ * Pulls info directly from manager to ensure it is up to date
+ */
+export const getValidToken = (): string | Error => {
+  const { token, tokenExpirationDate } = Manager.getInstance().user;
+  if (!tokenExpirationDate || isAfter(tokenExpirationDate, new Date())) {
+    return token || new Error('Token not found');
+  }
+  return new Error('Token expired');
+};

--- a/plugin-hrm-form/src/hrmConfig.ts
+++ b/plugin-hrm-form/src/hrmConfig.ts
@@ -27,7 +27,7 @@ type ContactSaveFrequency = 'onTabChange' | 'onFinalSaveAndTransfer';
 
 const readConfig = () => {
   const manager = Flex.Manager.getInstance();
-  const { identity, token } = manager.user;
+  const { identity } = manager.user;
 
   // This is a really hacky test, need a better way to determine if the user is one of our bots
   const userIsAseloBot = /aselo.+@techmatters\.org/.test(identity);
@@ -112,7 +112,6 @@ const readConfig = () => {
       counselorLanguage,
       helplineLanguage,
       identity,
-      token,
       counselorName,
       isSupervisor,
       definitionVersion,
@@ -128,7 +127,6 @@ const readConfig = () => {
     },
     referrableResources: {
       resourcesBaseUrl,
-      token,
     },
   };
 };

--- a/plugin-hrm-form/src/services/fetchHrmApi.ts
+++ b/plugin-hrm-form/src/services/fetchHrmApi.ts
@@ -14,9 +14,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { fetchApi, FetchOptions } from './fetchApi';
+import { ApiError, fetchApi, FetchOptions } from './fetchApi';
 import { getHrmConfig } from '../hrmConfig';
 import { GenerateSignedUrlPathParams } from '../types/types';
+import { getValidToken } from '../authentication';
 
 /**
  * Factored out function that handles api calls hosted in HRM backend.
@@ -26,7 +27,9 @@ import { GenerateSignedUrlPathParams } from '../types/types';
  * @returns {Promise<any>} the api response (if not error)
  */
 export const fetchHrmApi = (endPoint: string, options: Partial<FetchOptions> = {}): Promise<any> => {
-  const { hrmBaseUrl, token } = getHrmConfig();
+  const { hrmBaseUrl } = getHrmConfig();
+  const token = getValidToken();
+  if (token instanceof Error) throw new ApiError(`Aborting request due to token issue: ${token.message}`, {}, token);
 
   return fetchApi(new URL(hrmBaseUrl), endPoint, {
     ...options,

--- a/plugin-hrm-form/src/services/fetchProtectedApi.ts
+++ b/plugin-hrm-form/src/services/fetchProtectedApi.ts
@@ -16,6 +16,7 @@
 
 import { ApiError, fetchApi } from './fetchApi';
 import { getHrmConfig } from '../hrmConfig';
+import { getValidToken } from '../authentication';
 
 export class ProtectedApiError extends ApiError {
   constructor(message, options: Pick<ApiError, 'body' | 'response'>, cause?: Error) {
@@ -36,7 +37,9 @@ export class ProtectedApiError extends ApiError {
  * @returns {Promise<any>} the api response (if not error)
  */
 const fetchProtectedApi = async (endPoint, body: Record<string, string> = {}) => {
-  const { serverlessBaseUrl, token } = getHrmConfig();
+  const { serverlessBaseUrl } = getHrmConfig();
+  const token = getValidToken();
+  if (token instanceof Error) throw new ApiError(`Aborting request due to token issue: ${token.message}`, {}, token);
   const options: RequestInit = {
     method: 'POST',
     body: new URLSearchParams({ ...body, Token: token }),

--- a/plugin-hrm-form/src/services/fetchResourcesApi.ts
+++ b/plugin-hrm-form/src/services/fetchResourcesApi.ts
@@ -17,7 +17,8 @@
 import * as path from 'path';
 
 import { getReferrableResourceConfig } from '../hrmConfig';
-import { fetchApi } from './fetchApi';
+import { ApiError, fetchApi } from './fetchApi';
+import { getValidToken } from '../authentication';
 
 /**
  * Factored out function that handles api calls hosted in the resources service.
@@ -27,7 +28,9 @@ import { fetchApi } from './fetchApi';
  * @returns {Promise<any>} the api response (if not error)
  */
 const fetchResourcesApi = (endPoint: string, options: Partial<RequestInit> = {}): Promise<any> => {
-  const { resourcesBaseUrl, token } = getReferrableResourceConfig();
+  const { resourcesBaseUrl } = getReferrableResourceConfig();
+  const token = getValidToken();
+  if (token instanceof Error) throw new ApiError(`Aborting request due to token issue: ${token.message}`, {}, token);
 
   return fetchApi(new URL(resourcesBaseUrl), path.join('resources', endPoint), {
     ...options,


### PR DESCRIPTION
## Description

A minor update to pre-emptively check if a token is still valid before calling an API with it. Prevents the back end being spammed from expired flex sessions

### Verification steps

Monitor the '4xx from ELB target' alarm to see if it stops spiking

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P