### PR TITLE
CHI-2818: Added 'pull task' to serverless service. 

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -137,7 +137,7 @@ const setUpActions = (
   setupObject: ReturnType<typeof getHrmConfig>,
   getMessage: (key: string) => (language: string) => Promise<string>,
 ) => {
-  ActionFunctions.excludeDeactivateConversationOrchestration(featureFlags);
+  ActionFunctions.excludeDeactivateConversationOrchestration();
 
   // bind setupObject to the functions that requires some initialization
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject, getMessage);

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
@@ -24,7 +24,7 @@ import { newQueueEntry, initializeQueuesStatus, getNewQueuesStatus } from '../..
 
 jest.mock('../../../components/CSAMReport/CSAMReportFormDefinition');
 
-jest.mock('../../../services/ServerlessService', () => ({
+jest.mock('../../../services/twilioWorkerService', () => ({
   listWorkerQueues: async ({ workerSid }) => {
     if (workerSid === 'worker-admin')
       return { workerQueues: [{ friendlyName: 'Admin' }, { friendlyName: 'Everyone' }] };
@@ -84,7 +84,7 @@ const newTasks = {
     queue_name: 'Admin',
     attributes: { channelType: channelTypes.sms },
   },
-  T5: {
+  T6: {
     status: 'pending',
     date_created: secondsAgo,
     channel_type: 'default',

--- a/plugin-hrm-form/src/components/CustomCRMContainer.tsx
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.tsx
@@ -23,7 +23,6 @@ import { DefinitionVersion } from 'hrm-form-definitions';
 
 import TaskView from './TaskView';
 import { Absolute } from '../styles';
-import { populateCounselors } from '../services/ServerlessService';
 import { populateCounselorsState } from '../states/configuration/actions';
 import { RootState } from '../states';
 import { getOfflineContactTask, getOfflineContactTaskSid } from '../states/contacts/offlineContactTask';
@@ -35,6 +34,7 @@ import { getAseloFeatureFlags, getHrmConfig } from '../hrmConfig';
 import { newContact } from '../states/contacts/contactState';
 import { selectAnyContactIsSaving } from '../states/contacts/selectContactSaveStatus';
 import selectCurrentOfflineContact from '../states/contacts/selectCurrentOfflineContact';
+import { populateCounselors } from '../services/twilioWorkerService';
 
 type OwnProps = {
   task?: ITask;

--- a/plugin-hrm-form/src/components/queuesStatus/QueuesStatusWriter.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/QueuesStatusWriter.jsx
@@ -22,8 +22,8 @@ import { omit } from 'lodash';
 
 import { queuesStatusUpdate, queuesStatusFailure } from '../../states/queuesStatus/actions';
 import * as h from './helpers';
-import { listWorkerQueues } from '../../services/ServerlessService';
 import { namespace, queuesStatusBase } from '../../states/storeNamespaces';
+import { listWorkerQueues } from '../../services/twilioWorkerService';
 
 export class InnerQueuesStatusWriter extends React.Component {
   static displayName = 'QueuesStatusWriter';
@@ -143,13 +143,13 @@ export class InnerQueuesStatusWriter extends React.Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = state => {
   const queuesStatusState = state[namespace][queuesStatusBase];
 
   return { queuesStatusState };
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = dispatch => {
   return {
     queuesStatusUpdate: bindActionCreators(queuesStatusUpdate, dispatch),
     queuesStatusFailure: bindActionCreators(queuesStatusFailure, dispatch),

--- a/plugin-hrm-form/src/services/HelplineService.ts
+++ b/plugin-hrm-form/src/services/HelplineService.ts
@@ -15,8 +15,8 @@
  */
 
 import { CustomITask, isOfflineContactTask, ContactRawJson } from '../types/types';
-import { getWorkerAttributes } from './ServerlessService';
 import { getHrmConfig } from '../hrmConfig';
+import { getWorkerAttributes } from './twilioWorkerService';
 
 /**
  * Helper used to be the source of truth for the helpline value being passed to HRM and Insights

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -23,23 +23,6 @@ import fetchProtectedApi from './fetchProtectedApi';
 import type { ChildCSAMReportForm, CounselorCSAMReportForm } from '../states/csam-report/types';
 import { getHrmConfig } from '../hrmConfig';
 
-type PopulateCounselorsReturn = { sid: string; fullName: string }[];
-
-/**
- * [Protected] Fetches the workers within a workspace and helpline.
- */
-export const populateCounselors = async (): Promise<PopulateCounselorsReturn> => {
-  const { helpline, currentWorkspace } = getHrmConfig();
-  const body = {
-    workspaceSID: currentWorkspace,
-    helpline: helpline || '',
-  };
-
-  const { workerSummaries } = await fetchProtectedApi('/populateCounselors', body);
-
-  return workerSummaries;
-};
-
 type GetTranslationBody = { language: string };
 
 // Returns translations json for Flex in string format
@@ -83,35 +66,11 @@ export const issueSyncToken = async (): Promise<string> => {
   return syncToken;
 };
 
-export const adjustChatCapacity = async (adjustment: 'increase' | 'decrease'): Promise<void> => {
-  const { workerSid } = getHrmConfig();
-
-  const body = {
-    workerSid,
-    adjustment,
-  };
-
-  const response = await fetchProtectedApi('/adjustChatCapacity', body);
-
-  return response;
-};
-
 /**
  * Sends a new message to the channel bounded to the provided taskSid. Optionally you can change the "from" value (defaul is "system").
  */
 export const sendSystemMessage = async (body: { taskSid: ITask['taskSid']; message: string; from?: string }) => {
   const response = await fetchProtectedApi('/sendSystemMessage', body);
-
-  return response;
-};
-
-/**
- * Returns the task queues list for a given worker.
- */
-export const listWorkerQueues = async (body: {
-  workerSid: string;
-}): Promise<{ workerQueues: { friendlyName: string }[] }> => {
-  const response = await fetchProtectedApi('/listWorkerQueues', body);
 
   return response;
 };
@@ -128,16 +87,6 @@ export const getDefinitionVersionsList = async (missingDefinitionVersions: Defin
       return { version, definition };
     }),
   );
-
-/**
- * Gets the attributes of the target worker
- */
-export const getWorkerAttributes = async (workerSid: string) => {
-  const body = { workerSid };
-
-  const response = await fetchProtectedApi('/getWorkerAttributes', body);
-  return response;
-};
 
 /**
  * Gets a recording s3 information from the corresponding call sid

--- a/plugin-hrm-form/src/services/twilioWorkerService.ts
+++ b/plugin-hrm-form/src/services/twilioWorkerService.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { getHrmConfig } from '../hrmConfig';
+import fetchProtectedApi from './fetchProtectedApi';
+import { TaskSID } from '../types/twilio';
+import { ApiError } from './fetchApi';
+
+type PopulateCounselorsReturn = { sid: string; fullName: string }[];
+
+/**
+ * [Protected] Fetches the workers within a workspace and helpline.
+ */
+export const populateCounselors = async (): Promise<PopulateCounselorsReturn> => {
+  const { helpline, currentWorkspace } = getHrmConfig();
+  const body = {
+    workspaceSID: currentWorkspace,
+    helpline: helpline || '',
+  };
+
+  const { workerSummaries } = await fetchProtectedApi('/populateCounselors', body);
+
+  return workerSummaries;
+};
+
+/**
+ * Change the capacity for simultaneous chat sessions for a worker.
+ * @deprecated This should no longer be called from flex once backend manual pulling is activated for all helplines
+ * @param adjustment
+ */
+export const adjustChatCapacity = async (adjustment: 'increase' | 'decrease'): Promise<void> => {
+  const { workerSid } = getHrmConfig();
+
+  const body = {
+    workerSid,
+    adjustment,
+  };
+
+  return fetchProtectedApi('/adjustChatCapacity', body);
+};
+
+export const pullNextTask = async (): Promise<TaskSID | undefined> => {
+  const { workerSid } = getHrmConfig();
+
+  const body = {
+    workerSid,
+  };
+  try {
+    return (await fetchProtectedApi('/pullTask', body)).taskPulled;
+  } catch (e) {
+    if (e instanceof ApiError && e.response.status === 404) {
+      console.warn('No eligible queued task found to pull');
+      return undefined;
+    }
+    throw e;
+  }
+};
+
+/**
+ * Returns the task queues list for a given worker.
+ */
+export const listWorkerQueues = async (body: {
+  workerSid: string;
+}): Promise<{ workerQueues: { friendlyName: string }[] }> => {
+  return fetchProtectedApi('/listWorkerQueues', body);
+};
+
+/**
+ * Gets the attributes of the target worker
+ */
+export const getWorkerAttributes = async (workerSid: string) => {
+  const body = { workerSid };
+
+  return fetchProtectedApi('/getWorkerAttributes', body);
+};

--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -24,7 +24,7 @@ const defaultChannelTypes = {
   web: 'web',
 } as const;
 
-export const customChannelTypes = {
+const customChannelTypes = {
   telegram: 'telegram',
   instagram: 'instagram',
   line: 'line',

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -292,6 +292,7 @@ export type FeatureFlags = {
   enable_twilio_transcripts: boolean; // Enables Viewing Transcripts Stored at Twilio
   enable_upload_documents: boolean; // Enables Case Documents
   enable_voice_recordings: boolean; // Enables Loading Voice Recordings
+  enable_backend_manual_pulling: boolean; // Enables Backend Manual Pulling
 };
 /* eslint-enable camelcase */
 


### PR DESCRIPTION
## Description

* Moved worker related serverless functions to separate client. 
* Added support for a feature flag to switch between backend and frontend orchestrated manual pulling

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- [X] Feature flags added
- N/A Strings are localized
- [X] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

enable_backend_manual_pulling flag needs to be set.
https://github.com/techmatters/serverless/pull/635 needs to be deployed to serverless
Ensure issue is fixed
Regression test manual pulling
Regression test manual pulling with enable_backend_manual_pulling swwitched OFF (CHI-2818 will resurface)

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P