### PR TITLE
CHI-2823  Show all (missing) timeline activities

### DIFF
--- a/plugin-hrm-form/src/components/case/timeline/FullTimelineView.tsx
+++ b/plugin-hrm-form/src/components/case/timeline/FullTimelineView.tsx
@@ -26,7 +26,7 @@ import Timeline from './Timeline';
 import { RootState } from '../../../states';
 import { selectCurrentTopmostRouteForTask } from '../../../states/routing/getRoute';
 import { CaseTimelineRoute, ChangeRouteMode } from '../../../states/routing/types';
-import { selectTimelineCount } from '../../../states/case/timeline';
+import { newGetTimelineAsyncAction, selectTimelineCount } from '../../../states/case/timeline';
 import Pagination from '../../pagination';
 import { changeRoute } from '../../../states/routing/actions';
 
@@ -48,10 +48,17 @@ const mapStateToProps = (state: RootState, { task }: MyProps) => {
 
 const mapDispatchToProps = (dispatch: Dispatch<any>, { task }: MyProps) => {
   return {
-    changePage: (caseId: string) => (page: number) =>
+    changePage: (caseId: string) => (page: number) => {
       dispatch(
         changeRoute({ route: 'case', subroute: 'timeline', caseId, page }, task.taskSid, ChangeRouteMode.Replace),
-      ),
+      );
+      dispatch(
+        newGetTimelineAsyncAction(caseId, 'prime-timeline', ['note', 'referral'], true, {
+          offset: page * TIMELINE_PAGE_SIZE,
+          limit: TIMELINE_PAGE_SIZE,
+        }),
+      );
+    },
   };
 };
 


### PR DESCRIPTION
## Description
- This PR addresses a bug that was causing issues with more than 25 timeline items. The problem was due to a missing dispatch function for `newGetTimelineAsyncAction`. Users can now navigate through all timeline items beyond the initial 25

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2823)
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- Go to Case #6887 in Aselo Dev (page 6 with no filters applied)
- Open all activities. See that all activities can be viewed after 25. 
![Screenshot 2024-07-10 at 10 10 35 AM](https://github.com/techmatters/flex-plugins/assets/102122005/1c888bbe-bf42-44e0-8aee-ff9f6036d5d1)

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P