### PR TITLE
CA: Adding support for configurable S3 lifecycle rules

### DIFF
--- a/twilio-iac/helplines/ca/common.hcl
+++ b/twilio-iac/helplines/ca/common.hcl
@@ -111,5 +111,22 @@ locals {
         "friendly_name"  = "E2E Test Queue"
       }
     }
+    s3_lifecycle_rules = {
+      hrm_export_expiry : {
+        id                 = "HRM Exported Data Expiration Policy"
+        expiration_in_days = 30
+        prefix             = "hrm-data/"
+      },
+      transcripts_expiry : {
+        id                 = "Transcripts Data Expiration Policy"
+        expiration_in_days = 90
+        prefix             = "transcripts/"
+      },
+      voice_recordings_expiry : {
+        id                 = "Voice Recordings Data Expiration Policy"
+        expiration_in_days = 90
+        prefix             = "voice-recordings/"
+      }
+    }
   }
 }

--- a/twilio-iac/helplines/ca/common.hcl
+++ b/twilio-iac/helplines/ca/common.hcl
@@ -113,17 +113,17 @@ locals {
     }
     s3_lifecycle_rules = {
       hrm_export_expiry : {
-        id                 = "HRM Exported Data Expiration Policy"
+        id                 = "HRM Exported Data Expiration Rule"
         expiration_in_days = 30
         prefix             = "hrm-data/"
       },
       transcripts_expiry : {
-        id                 = "Transcripts Data Expiration Policy"
+        id                 = "Transcripts Data Expiration Rule"
         expiration_in_days = 90
         prefix             = "transcripts/"
       },
       voice_recordings_expiry : {
-        id                 = "Voice Recordings Data Expiration Policy"
+        id                 = "Voice Recordings Data Expiration Rule"
         expiration_in_days = 90
         prefix             = "voice-recordings/"
       }

--- a/twilio-iac/helplines/ca/templates/workflows/master.tftpl
+++ b/twilio-iac/helplines/ca/templates/workflows/master.tftpl
@@ -66,7 +66,7 @@
         },
         {
           "filter_friendly_name": "French Interpreter",
-          "expression": "((to IN [${join(", ", formatlist("'%s'", phone_numbers.khp))}] OR to IN [${join(", ", formatlist("'%s'", phone_numbers.ab211))}] OR to IN [${join(", ", formatlist("'%s'", phone_numbers.g2tns))}] OR to IN [${join(", ", formatlist("'%s'", phone_numbers.hc))}]) AND interpreter CONTAINS \"fr\")",
+          "expression": "((to IN [${join(", ", formatlist("'%s'", phone_numbers.khp))}] OR to IN [${join(", ", formatlist("'%s'", phone_numbers.ab211))}] OR to IN [${join(", ", formatlist("'%s'", phone_numbers.g2tns))}] ) AND interpreter CONTAINS \"fr\")",
           "targets": [
             {
               "expression": "(worker.waitingOfflineContact != true AND ((task.channelType == 'voice' AND worker.channel.chat.assigned_tasks == 0) OR (task.channelType != 'voice' AND worker.channel.voice.assigned_tasks == 0)) AND ((task.transferTargetType == 'worker' AND task.targetSid == worker.sid) OR (task.transferTargetType != 'worker' AND worker.sid != task.ignoreAgent))) OR (worker.waitingOfflineContact == true AND task.targetSid == worker.sid AND task.isContactlessTask == true)",
@@ -88,7 +88,7 @@
         },
         {
           "filter_friendly_name": "KHP English",
-          "expression": "((to IN [${join(", ", formatlist("'%s'", phone_numbers.khp))}] OR to IN [${join(", ", formatlist("'%s'", phone_numbers.hc))}]) AND language CONTAINS \"en-CA\")",
+          "expression": "((to IN [${join(", ", formatlist("'%s'", phone_numbers.khp))}]) AND language CONTAINS \"en-CA\")",
             "targets": [
               {
                 "queue": "${task_queues.khp_en}",
@@ -123,7 +123,7 @@
         },
         {
           "filter_friendly_name": "KHP French",
-          "expression": "((to IN [${join(", ", formatlist("'%s'", phone_numbers.khp))}] OR to IN [${join(", ", formatlist("'%s'", phone_numbers.hc))}]) AND language CONTAINS \"fr-CA\")",
+          "expression": "((to IN [${join(", ", formatlist("'%s'", phone_numbers.khp))}]) AND language CONTAINS \"fr-CA\")",
           "targets": [
             {
               "expression": "(worker.waitingOfflineContact != true AND ((task.channelType == 'voice' AND worker.channel.chat.assigned_tasks == 0) OR (task.channelType != 'voice' AND worker.channel.voice.assigned_tasks == 0)) AND ((task.transferTargetType == 'worker' AND task.targetSid == worker.sid) OR (task.transferTargetType != 'worker' AND worker.sid != task.ignoreAgent))) OR (worker.waitingOfflineContact == true AND task.targetSid == worker.sid AND task.isContactlessTask == true)",

--- a/twilio-iac/helplines/defaults.hcl
+++ b/twilio-iac/helplines/defaults.hcl
@@ -85,6 +85,16 @@ locals {
     survey : "Survey"
   }
 
+  s3_lifecycle_rules = {
+    hrm_export_expiry : {
+      id                 = "HRM Exported Data Expiration Policy"
+      expiration_in_days = 30
+      prefix             = "hrm-data/"
+      status             = "Enabled"
+    }
+  }
+
+
   mock_outputs = {
     chatbot = {
       chatbot_languages_selector_sid = "chatbot_languages_selector_sid"

--- a/twilio-iac/helplines/defaults.hcl
+++ b/twilio-iac/helplines/defaults.hcl
@@ -87,7 +87,7 @@ locals {
 
   s3_lifecycle_rules = {
     hrm_export_expiry : {
-      id                 = "HRM Exported Data Expiration Policy"
+      id                 = "HRM Exported Data Expiration Rule"
       expiration_in_days = 30
       prefix             = "hrm-data/"
     }

--- a/twilio-iac/helplines/defaults.hcl
+++ b/twilio-iac/helplines/defaults.hcl
@@ -90,7 +90,6 @@ locals {
       id                 = "HRM Exported Data Expiration Policy"
       expiration_in_days = 30
       prefix             = "hrm-data/"
-      status             = "Enabled"
     }
   }
 

--- a/twilio-iac/terraform-modules/aws/default/main.tf
+++ b/twilio-iac/terraform-modules/aws/default/main.tf
@@ -80,7 +80,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_lifecycle_rules" {
       prefix = each.value.prefix
     }
     id     = each.value.id
-    status = try(each.value.status, "Enabled") 
+    status = "Enabled"
   }
 
 }

--- a/twilio-iac/terraform-modules/aws/default/main.tf
+++ b/twilio-iac/terraform-modules/aws/default/main.tf
@@ -68,21 +68,23 @@ resource "aws_s3_bucket_ownership_controls" "docs" {
   }
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "hrm_export_expiry" {
-  bucket = aws_s3_bucket.docs.bucket
+resource "aws_s3_bucket_lifecycle_configuration" "s3_lifecycle_rules" {
+  for_each = var.s3_lifecycle_rules
+  bucket   = aws_s3_bucket.docs.bucket
   provider = aws.bucket
   rule {
     expiration {
-      days = 30
+      days = each.value.expiration_in_days
     }
     filter {
-      prefix = "hrm-data/"
+      prefix = each.value.prefix
     }
-    id = "HRM Exported Data Expiration Policy"
-    status = "Enabled"
+    id     = each.value.id
+    status = try(each.value.status, "Enabled") 
   }
 
 }
+
 
 resource "aws_s3_bucket" "chat" {
   bucket   = local.chat_s3_location
@@ -143,7 +145,7 @@ locals {
     OPERATING_INFO_KEY = jsonencode(["TWILIO", var.operating_info_key, "Twilio account - Operating Key info"])
     APP_ID             = jsonencode(["DATADOG", var.datadog_app_id, "Datadog - Application ID"])
     ACCESS_TOKEN       = jsonencode(["DATADOG", var.datadog_access_token, "Datadog - Access Token"])
-    }
+  }
 }
 
 /****************************************************************

--- a/twilio-iac/terraform-modules/aws/default/variables.tf
+++ b/twilio-iac/terraform-modules/aws/default/variables.tf
@@ -89,3 +89,13 @@ variable "serverless_url" {
   description = "URL used to access Aselo Twilio serverless functions"
   type        = string
 }
+
+variable "s3_lifecycle_rules" {
+  description = "S3 Bucket Lifecycle Rules"
+  type = map(object({
+    id                 = string
+    expiration_in_days = number
+    prefix             = string
+    status             = optional(string)
+  }))
+}

--- a/twilio-iac/terraform-modules/stages/provision/main.tf
+++ b/twilio-iac/terraform-modules/stages/provision/main.tf
@@ -78,8 +78,9 @@ module "aws" {
   # we need to add a non-valid workflow sid.
   survey_workflow_sid = try(module.taskRouter.workflow_sids.survey, "NOTVALIDWORKFLOWSID")
   #TODO: convert bucket_region to helpline_region (or, better yet,  pass in the correct provider)
-  bucket_region   = var.helpline_region
-  helpline_region = var.helpline_region
+  bucket_region      = var.helpline_region
+  helpline_region    = var.helpline_region
+  s3_lifecycle_rules = var.s3_lifecycle_rules
 }
 
 #TODO: Remove the provider and moved once this has been applied everywhere

--- a/twilio-iac/terraform-modules/stages/provision/variables.tf
+++ b/twilio-iac/terraform-modules/stages/provision/variables.tf
@@ -33,6 +33,16 @@ variable "aws_monitoring_region" {
   description = "The region for the AWS monitoring."
 }
 
+variable "s3_lifecycle_rules" {
+  description = "S3 Bucket Lifecycle Rules"
+  type = map(object({
+    id                 = string
+    expiration_in_days = number
+    prefix             = string
+    status             = optional(string)
+  }))
+}
+
 variable "manage_github_secrets" {
   type        = bool
   description = "Whether to manage the github secrets for the helpline."


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
These changes make lifecycle policies configurable now.
A lifecycle rule can be defined like:
s3_lifecycle_rules = {
    hrm_export_expiry : {
      id                 = "HRM Exported Data Expiration Policy"
      expiration_in_days = 30
      prefix             = "hrm-data/"
    }
  }


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P