### PR TITLE
CHI-2910: Fix mapping of site phone numbers to reflect source data changes

### DIFF
--- a/plugin-hrm-form/src/components/resources/convertKHPResourceAttributes.ts
+++ b/plugin-hrm-form/src/components/resources/convertKHPResourceAttributes.ts
@@ -192,10 +192,11 @@ const extractSiteLocation = (site: Attributes) => {
   };
 };
 
-const extractPhoneNumbers = (phoneObj: Attributes) => {
+const extractPhoneNumbers = (phoneObj: Attributes): Record<string, string> => {
   const phoneNumbers = {};
   Object.keys(phoneObj ?? {}).forEach(key => {
-    phoneNumbers[key] = getAttributeValue(phoneObj, '', key);
+    const { info } = getAttributeData(phoneObj, '', key);
+    phoneNumbers[(info.type ?? key).toLowerCase()] = `${info.number}${info.name ? ` (${info.name})` : ''}`;
   });
   return phoneNumbers;
 };
@@ -256,7 +257,7 @@ const extractSiteDetails = (resource: Attributes, sites: Attributes, language: L
       operations: extractSiteOperatingHours(siteId, operationsAttributes, siteOperations, language),
       isActive: getBooleanAttributeValue(site, 'isActive'),
       details: getAttributeData(site, language, 'details')?.info?.details ?? '',
-      phoneNumbers: extractPhoneNumbers(getAttributeNode(site, 'phoneNumbers')),
+      phoneNumbers: extractPhoneNumbers(getAttributeNode(site, 'phone')),
       coverage: extractCoverage(coverageAttributes, siteId),
     });
   }

--- a/plugin-hrm-form/src/components/resources/resourceView/SiteDetails.tsx
+++ b/plugin-hrm-form/src/components/resources/resourceView/SiteDetails.tsx
@@ -75,26 +75,26 @@ const SiteDetails: React.FC<Props> = ({ sites }) => {
 };
 
 const PhoneNumbersDisplay = ({ phoneNumbers }) => {
-  const { businessLine, afterHoursLine, tty } = phoneNumbers;
+  const { business, 'after hours': afterHours, tty } = phoneNumbers;
   return (
     <ResourceAttributeContent>
-      {businessLine && (
+      {business && (
         <tr>
           <td style={{ padding: '0 4px', width: '0', lineBreak: 'anywhere' }}>
             <ResourceSubtitle>Business</ResourceSubtitle>
           </td>
           <td style={{ padding: '0 4px', fontSize: '12px' }}>
-            <FontOpenSans>{businessLine}</FontOpenSans>
+            <FontOpenSans>{business}</FontOpenSans>
           </td>
         </tr>
       )}
-      {afterHoursLine && (
+      {afterHours && (
         <tr>
           <td style={{ padding: '0 4px', width: '0' }}>
             <ResourceSubtitle>After Hours</ResourceSubtitle>
           </td>
           <td style={{ padding: '0 4px', fontSize: '12px' }}>
-            <FontOpenSans>{afterHoursLine}</FontOpenSans>
+            <FontOpenSans>{afterHours}</FontOpenSans>
           </td>
         </tr>
       )}


### PR DESCRIPTION
## Description

* The Flex side mapping code for site phone numbers has been fixed to reflect the changed shape of the data

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- N/A Feature flags added
- N/A Strings are localized
- N/A Tested for chat contacts
- N/A Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Idendtify a resource that has sites with populated phone numbers
Find the resource in Aselo (searching by resource ID or site ID will do the trick)
Open the site(s) with phone number information (TTY, Business or Out of Hours)
Verify it displays the phone number under the correct category

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P