### PR TITLE
fix: flush generalized search form values before triggering search

### DIFF
--- a/plugin-hrm-form/src/components/search/GeneralizedSearchForm/index.tsx
+++ b/plugin-hrm-form/src/components/search/GeneralizedSearchForm/index.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 import type { FormDefinition } from 'hrm-form-definitions';
@@ -73,7 +73,13 @@ export const GeneralizedSearchForm: React.FC<OwnProps> = ({ initialValues, handl
   const validateEmptyForm =
     watch().searchTerm === '' && watch().counselor === '' && watch().dateFrom === '' && watch().dateTo === '';
 
+  const updateCallback = useCallback(() => {
+    const values = getValues();
+    dispatch(handleSearchFormUpdate(values));
+  }, [dispatch, getValues, handleSearchFormUpdate]);
+
   const onSubmit = handleSubmit(values => {
+    updateCallback(); // make sure all changes has been flushed before submitting
     if (!validateEmptyForm) {
       handleSearch(values);
     }
@@ -93,10 +99,7 @@ export const GeneralizedSearchForm: React.FC<OwnProps> = ({ initialValues, handl
     definition: formDefinition,
     initialValues: sanitizedInitialValues,
     parentsPath: '',
-    updateCallback: () => {
-      const values = getValues();
-      dispatch(handleSearchFormUpdate(values));
-    },
+    updateCallback,
   });
 
   const arrangeSearchFormItems = (margin: number) => (formItems: JSX.Element[]) => {

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -137,7 +137,7 @@ const Search: React.FC<Props> = ({
 
   const handleSearchContacts = (newSearchParams: SearchParams, newOffset) => {
     if (enableGeneralizedSearch) {
-      return generalizedSearchContacts(searchContext)(form, CONTACTS_PER_PAGE, newOffset);
+      return generalizedSearchContacts(searchContext)({ ...form, ...newSearchParams }, CONTACTS_PER_PAGE, newOffset);
     }
 
     return searchContacts(searchContext)({ ...form, ...newSearchParams }, CONTACTS_PER_PAGE, newOffset);
@@ -145,7 +145,7 @@ const Search: React.FC<Props> = ({
 
   const handleSearchCases = (newSearchParams, newOffset) => {
     if (enableGeneralizedSearch) {
-      return generalizedSearchCases(searchContext)(form, CONTACTS_PER_PAGE, newOffset);
+      return generalizedSearchCases(searchContext)({ ...form, ...newSearchParams }, CONTACTS_PER_PAGE, newOffset);
     }
 
     return searchCases(searchContext)({ ...form, ...newSearchParams }, CASES_PER_PAGE, newOffset);


### PR DESCRIPTION
## Description
This PR fixes the bug [General Search: redux form not updated](https://tech-matters.atlassian.net/browse/CHI-2924).
The bug is caused because our form generators are designed to reduce the amount of updates it sends to redux, hence only calling the `updateCallback` when the input is "un-focused" (`onBlur` event) (this is not true for all inputs, but it is for free text ones). The way the generalized search form is implemented supports submitting the search when pressing enter. While this is a better UX, it does not triggers the `updateCallback` if the usear does not "un-focus" the input first.

The fix involves two parts
- Make sure that `updateCallback` function is called before calling `onSubmit` handler, so the values are flushed before performing the search and make they way into redux.
- The call to `generalizedSearchCases` is the merge between whatever the redux state is plus the "new values", which are the latest values that the form hold (even if they are not in redux yet). This is because we don't have access to the redux values in the action itself, so we pass them from the component.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2924)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
See the Slack thread in the linked Jira ticket and confirm that you can't replicate the bug, or what is the same
- Start development server (`npm run dev`).
- Perform a search (using generalized search) by typing something in the "search input" and immediately pressing enter without changing the input focus.
- Confirm that the values are correctly picked by the search and they show up in the "search terms bar" as in the image.
  ![image](https://github.com/user-attachments/assets/fcca365b-5d7e-4c76-88d1-7f8822e93164)


### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P