### PR TITLE
chore: added "Non Data Contact" toggle behavior to Generalized Search [CHI-2933]

### DIFF
--- a/plugin-hrm-form/src/components/search/GeneralizedSearchForm/index.tsx
+++ b/plugin-hrm-form/src/components/search/GeneralizedSearchForm/index.tsx
@@ -48,9 +48,15 @@ type OwnProps = {
   initialValues: SearchFormValues;
   handleSearchFormUpdate: (values: Partial<SearchFormValues>) => void;
   handleSearch: (searchParams: any) => void;
+  onlyDataContacts: boolean;
 };
 
-export const GeneralizedSearchForm: React.FC<OwnProps> = ({ initialValues, handleSearchFormUpdate, handleSearch }) => {
+export const GeneralizedSearchForm: React.FC<OwnProps> = ({
+  initialValues,
+  handleSearchFormUpdate,
+  handleSearch,
+  onlyDataContacts,
+}) => {
   const containerRef = useRef(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const updateWidth = () => {
@@ -68,7 +74,7 @@ export const GeneralizedSearchForm: React.FC<OwnProps> = ({ initialValues, handl
   const dispatch = useDispatch();
 
   const methods = useForm<Pick<SearchFormValues, 'searchTerm' | 'dateFrom' | 'dateTo' | 'counselor'>>();
-  const { getValues, watch, setError, clearErrors, reset, handleSubmit } = methods;
+  const { getValues, watch, setError, clearErrors, reset, handleSubmit, register, setValue } = methods;
 
   const validateEmptyForm =
     watch().searchTerm === '' && watch().counselor === '' && watch().dateFrom === '' && watch().dateTo === '';
@@ -84,6 +90,14 @@ export const GeneralizedSearchForm: React.FC<OwnProps> = ({ initialValues, handl
       handleSearch(values);
     }
   });
+
+  useEffect(() => {
+    register('onlyDataContacts');
+  }, [register]);
+
+  useEffect(() => {
+    setValue('onlyDataContacts', onlyDataContacts);
+  }, [onlyDataContacts, setValue]);
 
   const counselor =
     typeof initialValues.counselor === 'string' ? initialValues.counselor : initialValues.counselor.value;

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -272,6 +272,7 @@ const Search: React.FC<Props> = ({
             task={task}
             handleSearchFormUpdate={handleSearchFormUpdate(searchContext)}
             handleSearch={setSearchParamsAndHandleSearch}
+            onlyDataContacts={Boolean(searchParams?.onlyDataContacts)}
           />
         ) : (
           <SearchForm

--- a/plugin-hrm-form/src/states/search/actions.ts
+++ b/plugin-hrm-form/src/states/search/actions.ts
@@ -101,6 +101,7 @@ const pickGeneralizedSearchParams = (searchParams: SearchParams): GeneralizedSea
   helpline: typeof searchParams.helpline === 'string' ? searchParams.helpline : searchParams.helpline.value,
   dateFrom: searchParams.dateFrom ? formatISO(startOfDay(parseISO(searchParams.dateFrom))) : searchParams.dateFrom,
   dateTo: searchParams.dateTo ? formatISO(startOfDay(parseISO(searchParams.dateTo))) : searchParams.dateTo,
+  onlyDataContacts: searchParams.onlyDataContacts,
 });
 
 export const generalizedSearchContacts = (dispatch: Dispatch<any>) => (taskId: string, context: string) => async (

--- a/plugin-hrm-form/src/states/search/types.ts
+++ b/plugin-hrm-form/src/states/search/types.ts
@@ -43,6 +43,7 @@ export const newSearchFormEntry = {
   contactNumber: '',
   helpline: { label: '', value: '' },
   searchTerm: '',
+  onlyDataContacts: false,
 };
 
 export type SearchFormValues = {


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/hrm/pull/737

## Description
This PR adds support for to use "Non Data Contact" toggle. It does so by
- `onlyDataContacts` property is added to search forms (redux). This could be avoided but it adds consistency on how search action works.
- A "fake input" is registered in search form UI under the name of `onlyDataContacts`. This will be updated using the same value as the toggle, and will in turn update the redux forms. This is achieved using React effects.

### Checklist
- [ ] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2933)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
See linked PR

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P