### PR TITLE
Display search query when there are zero results in Search

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -79,7 +79,7 @@ runs:
       working-directory: ${{ inputs.path }}/e2e-tests
       shell: bash
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: test-artifacts

--- a/plugin-hrm-form/src/components/search/SearchResults/SearchResultsQueryTemplate.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/SearchResultsQueryTemplate.tsx
@@ -51,8 +51,6 @@ export const SearchResultsQueryTemplate: React.FC<SearchResultsQueryTemplateProp
     };
   });
 
-  const transformDate = date => new Date(date).toLocaleDateString();
-
   const countString = (subroute, casesCount: number, contactsCount: number) => {
     if (subroute === 'case-results') {
       return casesCount === 1 ? (
@@ -100,10 +98,12 @@ export const SearchResultsQueryTemplate: React.FC<SearchResultsQueryTemplateProp
     currentContext = agentFormQuery;
   }
 
+  const transformDate = date => new Date(date).toLocaleDateString();
+
   const ContextItem = ({ label, value }) => {
     if (!value) return null;
-
-    const formattedValue = enableGeneralizedSearch || !transformDate ? value : transformDate(value);
+    const formattedValue =
+      !enableGeneralizedSearch && (label === 'DateFrom' || label === 'DateTo') ? transformDate(value) : value;
     return (
       <>
         <Template code={`SearchResults-${label}`} /> <Bold>{formattedValue}.&nbsp;</Bold>
@@ -114,17 +114,20 @@ export const SearchResultsQueryTemplate: React.FC<SearchResultsQueryTemplateProp
   return (
     <FontOpenSans>
       <span data-testid="SearchResultsCount">{countString(subroute, casesCount, contactsCount)}</span>
+
+      {/* The following are for legacy search fields */}
+      {!enableGeneralizedSearch && <>.&nbsp;</>}
       <ContextItem label="FirstName" value={currentContext?.firstName} />
       <ContextItem label="LastName" value={currentContext?.lastName} />
       <ContextItem label="PhoneNumber" value={currentContext?.phoneNumber} />
       <ContextItem label="Email" value={currentContext?.email} />
-      {enableGeneralizedSearch ? (
+
+      {/* The following are for generalized search fields */}
+      {enableGeneralizedSearch && (
         <>
           <Template code="SearchResults-For" />
           &nbsp;
         </>
-      ) : (
-        <>.&nbsp;</>
       )}
       {currentContext?.searchTerm && <Bold>&quot;{currentContext?.searchTerm}&quot;.&nbsp;</Bold>}
       {counselorNameString(currentContext?.counselor, counselorsHash)}

--- a/plugin-hrm-form/src/components/search/SearchResults/SearchResultsQueryTemplate.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/SearchResultsQueryTemplate.tsx
@@ -131,6 +131,8 @@ export const SearchResultsQueryTemplate: React.FC<SearchResultsQueryTemplateProp
       )}
       {currentContext?.searchTerm && <Bold>&quot;{currentContext?.searchTerm}&quot;.&nbsp;</Bold>}
       {counselorNameString(currentContext?.counselor, counselorsHash)}
+
+      {/* The following are for both types of search fields */}
       <ContextItem label="DateFrom" value={currentContext?.dateFrom} />
       <ContextItem label="DateTo" value={currentContext?.dateTo} />
     </FontOpenSans>

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -305,38 +305,50 @@ const SearchResults: React.FC<Props> = ({
       : 'SearchResultsIndex-SearchAgainForCase';
 
   const handleNoSearchResult = () => (
-    <SearchResultWarningContainer
-      data-testid={currentResultPage === 'contact-results' ? 'ContactsCount' : 'CasesCount'}
-    >
-      <Row style={{ paddingTop: '20px' }}>
-        <InfoIcon style={{ color: '#ffc811' }} />
-        <Text padding="0" fontWeight="700" margin="20px" color="#282a2b">
-          <Template code={noResultsTemplateCode} />
-        </Text>
-      </Row>
+    <>
+      <div style={{ padding: '0 20px' }}>
+        <SearchResultsQueryTemplate
+          task={task}
+          searchContext={searchContext}
+          subroute={routing.subroute}
+          casesCount={casesCount}
+          contactsCount={contactsCount}
+          counselorsHash={counselorsHash}
+        />
+      </div>
+      <SearchResultWarningContainer
+        data-testid={currentResultPage === 'contact-results' ? 'ContactsCount' : 'CasesCount'}
+      >
+        <Row style={{ paddingTop: '20px' }}>
+          <InfoIcon style={{ color: '#ffc811' }} />
+          <Text padding="0" fontWeight="700" margin="20px" color="#282a2b">
+            <Template code={noResultsTemplateCode} />
+          </Text>
+        </Row>
 
-      <Row>
-        <NoResultTextLink
-          margin="44px"
-          decoration="underline"
-          color="#1976D2"
-          cursor="pointer"
-          onClick={openSearchModal}
-        >
-          <Template code={searchAgainTemplateCode} />
-        </NoResultTextLink>
-        {routing.action && (
-          <>
-            <Text>
-              <Template code="SearchResultsIndex-Or" />
-            </Text>
-            <NoResultTextLink decoration="underline" color="#1976D2" cursor="pointer" onClick={handleOpenNewCase}>
-              <Template code="SearchResultsIndex-SaveToNewCase" />
-            </NoResultTextLink>
-          </>
-        )}
-      </Row>
-    </SearchResultWarningContainer>
+        <Row>
+          <NoResultTextLink
+            margin="44px"
+            decoration="underline"
+            color="#1976D2"
+            cursor="pointer"
+            onClick={openSearchModal}
+          >
+            <Template code={searchAgainTemplateCode} />
+          </NoResultTextLink>
+          {routing.action && (
+            <>
+              <Text>
+                <Template code="SearchResultsIndex-Or" />
+              </Text>
+              <NoResultTextLink decoration="underline" color="#1976D2" cursor="pointer" onClick={handleOpenNewCase}>
+                <Template code="SearchResultsIndex-SaveToNewCase" />
+              </NoResultTextLink>
+            </>
+          )}
+        </Row>
+      </SearchResultWarningContainer>
+    </>
   );
 
   const handleCaseResultsSearch = () => (cases.length === 0 ? handleNoSearchResult() : caseResults());


### PR DESCRIPTION
## Description
- This PR displays the search query when there are zero results on the Search Results page (for both legacy and Generalized Search).

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- Use a search query that will return zero results. The Search query should be displayed
![Screenshot 2024-09-10 at 10 37 42 AM](https://github.com/user-attachments/assets/5dec8b03-de24-49a2-8828-c5b06f3a503d)

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P