### PR TITLE
fix: General Search Date Filters behavior [CHI-2978]

### DIFF
--- a/plugin-hrm-form/src/states/search/actions.ts
+++ b/plugin-hrm-form/src/states/search/actions.ts
@@ -100,7 +100,7 @@ const pickGeneralizedSearchParams = (searchParams: SearchParams): GeneralizedSea
   counselor: typeof searchParams.counselor === 'string' ? searchParams.counselor : searchParams.counselor.value,
   helpline: typeof searchParams.helpline === 'string' ? searchParams.helpline : searchParams.helpline.value,
   dateFrom: searchParams.dateFrom ? formatISO(startOfDay(parseISO(searchParams.dateFrom))) : searchParams.dateFrom,
-  dateTo: searchParams.dateTo ? formatISO(startOfDay(parseISO(searchParams.dateTo))) : searchParams.dateTo,
+  dateTo: searchParams.dateTo ? formatISO(endOfDay(parseISO(searchParams.dateTo))) : searchParams.dateTo,
   onlyDataContacts: searchParams.onlyDataContacts,
 });
 

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -377,7 +377,7 @@
   "NotURLFieldError": "This field only accepts URLs.",
   "DateCantBeGreaterThanToday": "Date can't be greater than today.",
   "DateCantBeLesserThanEpoch": "Date can't be lesser than 00:00:00 UTC on 1 January 1970.",
-  "DateToCantBeGreaterThanFrom": "End date can't be greater than start date.",
+  "DateToCantBeGreaterThanFrom": "End date can't be lesser than start date.",
   "TimeCantBeGreaterThanNow": "Time can't be greater than now.",
   "NoCaseSummary": "No case summary",
   "CannedResponses": "Canned Responses",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -377,7 +377,7 @@
   "NotURLFieldError": "This field only accepts URLs.",
   "DateCantBeGreaterThanToday": "Date can't be greater than today.",
   "DateCantBeLesserThanEpoch": "Date can't be lesser than 00:00:00 UTC on 1 January 1970.",
-  "DateToCantBeGreaterThanFrom": "End date can't be lesser than start date.",
+  "DateToCantBeGreaterThanFrom": "End date can't be before start date.",
   "TimeCantBeGreaterThanNow": "Time can't be greater than now.",
   "NoCaseSummary": "No case summary",
   "CannedResponses": "Canned Responses",


### PR DESCRIPTION
## Description
This PR
- Uses `endOfDay` helper before sending `dateTo` filter to the service. This changes the behavior to be an "inclusive" filter.
- Changes UI validation, to prevent invalid dates to allow submission.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2978)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
Bugs described in the Jira ticket are not replicable.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P