### PR TITLE
CHI-2994: Add deployment matrix update to self hosted deploy

### DIFF
--- a/.github/workflows/flex-deploy-all-production-helplines.yml
+++ b/.github/workflows/flex-deploy-all-production-helplines.yml
@@ -36,7 +36,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - id: determine-target-helplines
-        name: Executing main-action
+        name: Determining helplines to deploy to
         uses: ./.github/actions/determine-target-helplines-action
         with:
           environment: production

--- a/.github/workflows/flex-deploy-all-staging-helplines.yml
+++ b/.github/workflows/flex-deploy-all-staging-helplines.yml
@@ -36,7 +36,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - id: determine-target-helplines
-        name: Executing main-action
+        name: Determining helplines to deploy to
         uses: ./.github/actions/determine-target-helplines-action
         with:
           environment: staging

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -138,7 +138,7 @@ jobs:
         shell: bash
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         name: Disable the Aselo plugin deployed to Twilio, if there is one.
-        run: twilio flex:plugins:release --disable-plugin=plugin-hrm-form || true
+        run: twilio flex:plugins:release --disable-plugin=plugin-hrm-form -l debug || true
         shell: bash
       # Point the account at the s3 hosted plugin
       - if: env.SELF_HOSTED_DEPLOY == 'true'

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -65,8 +65,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Only need the source for twilio deploys
-      - if: env.SELF_HOSTED_DEPLOY != 'true'
+      # Can be removed once we drop support for Twilio hosted plugins
+      #- if: env.SELF_HOSTED_DEPLOY != 'true'
         uses: actions/checkout@v4
 
       - if: env.SELF_HOSTED_DEPLOY != 'true'

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -65,9 +65,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Can be removed once we drop support for Twilio hosted plugins
       - if: env.SELF_HOSTED_DEPLOY != 'true'
         uses: actions/checkout@v4
+      - if: env.SELF_HOSTED_DEPLOY == 'true'
+        uses: actions/checkout@v4
+        with:
+          - filter: '.github/actions/**'
 
       # Can be removed once we drop support for Twilio hosted plugins
       - name: Use Node.js

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -137,7 +137,7 @@ jobs:
         shell: bash
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         name: Disable the Aselo plugin deployed to Twilio, if there is one.
-        run: twilio flex:plugins:release --disable-plugin plugin-hrm-form || true
+        run: twilio flex:plugins:release --disable-plugin=plugin-hrm-form || true
         shell: bash
       # Point the account at the s3 hosted plugin
       - if: env.SELF_HOSTED_DEPLOY == 'true'

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         uses: actions/checkout@v4
         with:
-          - filter: '.github/actions/**'
+          filter: '.github/actions/**'
 
       # Can be removed once we drop support for Twilio hosted plugins
       - name: Use Node.js

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -126,11 +126,9 @@ jobs:
 
       # Install the Twilio CLI and the flex plugin, then disable the twilio hosted plugin
       # These steps can be removed once Twilio hosted flex plugins are fully retired
-      - if: env.SELF_HOSTED_DEPLOY == 'true'
-        name: Install Twilio CLI
-        run: npm install twilio-cli@5.20.1 -g && twilio plugins:install @twilio-labs/plugin-flex@7.0.0
-        shell: bash
-        working-directory: ./plugin-hrm-form
+      # Ridiculous that we need top run from the plugin source with dependencies installed just to disable it on Twilio, but that seems to be the situation
+      - name: Install Flex Plugin
+        uses: ./.github/actions/install-flex-plugin
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         name: Disable the Aselo plugin deployed to Twilio, if there is one.
         run: twilio flex:plugins:release --disable-plugin=plugin-hrm-form -l debug || true

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -66,11 +66,12 @@ jobs:
 
     steps:
       # Can be removed once we drop support for Twilio hosted plugins
-      #- if: env.SELF_HOSTED_DEPLOY != 'true'
+      - if: env.SELF_HOSTED_DEPLOY != 'true'
         uses: actions/checkout@v4
 
-      - if: env.SELF_HOSTED_DEPLOY != 'true'
-        name: Use Node.js
+      # Can be removed once we drop support for Twilio hosted plugins
+      - name: Use Node.js
+      # if: env.SELF_HOSTED_DEPLOY != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '18.x'
@@ -130,12 +131,10 @@ jobs:
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         name: Install Twilio CLI
         run: npm install twilio-cli@5.20.1 -g && twilio plugins:install @twilio-labs/plugin-flex@7.0.0
-        working-directory: ./plugin-hrm-form
         shell: bash
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         name: Disable the Aselo plugin deployed to Twilio, if there is one.
         run: twilio flex:plugins:release --disable-plugin plugin-hrm-form || true
-        working-directory: ./plugin-hrm-form
         shell: bash
       # Point the account at the s3 hosted plugin
       - if: env.SELF_HOSTED_DEPLOY == 'true'

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -125,6 +125,19 @@ jobs:
               "plugin_service_attributes":null
           }'
 
+      # Install the Twilio CLI and the flex plugin, then disable the twilio hosted plugin
+      # These steps can be removed once Twilio hosted flex plugins are fully retired
+      - if: env.SELF_HOSTED_DEPLOY == 'true'
+        name: Install Twilio CLI
+        run: npm install twilio-cli@5.20.1 -g && twilio plugins:install @twilio-labs/plugin-flex@7.0.0
+        working-directory: ./plugin-hrm-form
+        shell: bash
+      - if: env.SELF_HOSTED_DEPLOY == 'true'
+        name: Disable the Aselo plugin deployed to Twilio, if there is one.
+        run: twilio flex:plugins:release --disable-plugin plugin-hrm-form || true
+        working-directory: ./plugin-hrm-form
+        shell: bash
+      # Point the account at the s3 hosted plugin
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         name: Configure Account to point to S3 Hosted Plugin
         shell: bash
@@ -138,6 +151,18 @@ jobs:
                   "custom_plugins": [{"name": "HRM Forms", "version": "0.0.1", "src": "https://assets-${{ inputs.environment_code }}.tl.techmatters.org/plugins/hrm-form/${{ github.ref_type }}/${{ github.ref_name }}/plugin-hrm-form.js"}]
               }
           }'
+
+      # Update deployment matrix with script and ssm parameters
+      - name: Update deployment matrix
+        uses: ./.github/actions/deployment-matrix
+        with:
+          account-sid: ${{env.TWILIO_ACCOUNT_SID}}
+          auth-token: ${{env.TWILIO_AUTH_TOKEN}}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          identifier: ${{ inputs.helpline_code }}
+          environment: ${{ inputs.environment}}
+          service_repo: 'flex-plugins'
+          version_tag: ${{ github.ref_name }}
 
   deploy_form_definitions:
     uses: ./.github/workflows/deploy-form-definitions.yml

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -157,13 +157,14 @@ jobs:
 
       # Update deployment matrix with script and ssm parameters
       - name: Update deployment matrix
+        if: env.SELF_HOSTED_DEPLOY == 'true'
         uses: ./.github/actions/deployment-matrix
         with:
           account-sid: ${{env.TWILIO_ACCOUNT_SID}}
           auth-token: ${{env.TWILIO_AUTH_TOKEN}}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           identifier: ${{ inputs.helpline_code }}
-          environment: ${{ inputs.environment}}
+          environment: ${{ inputs.environment_code}}
           service_repo: 'flex-plugins'
           version_tag: ${{ github.ref_name }}
 

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -70,7 +70,8 @@ jobs:
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         uses: actions/checkout@v4
         with:
-          filter: '.github/actions/**'
+          sparse-checkout: |
+            .github/actions
 
       # Can be removed once we drop support for Twilio hosted plugins
       - name: Use Node.js

--- a/.github/workflows/flex-deploy.yml
+++ b/.github/workflows/flex-deploy.yml
@@ -65,13 +65,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - if: env.SELF_HOSTED_DEPLOY != 'true'
-        uses: actions/checkout@v4
-      - if: env.SELF_HOSTED_DEPLOY == 'true'
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github/actions
+      - uses: actions/checkout@v4
 
       # Can be removed once we drop support for Twilio hosted plugins
       - name: Use Node.js
@@ -136,10 +130,12 @@ jobs:
         name: Install Twilio CLI
         run: npm install twilio-cli@5.20.1 -g && twilio plugins:install @twilio-labs/plugin-flex@7.0.0
         shell: bash
+        working-directory: ./plugin-hrm-form
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         name: Disable the Aselo plugin deployed to Twilio, if there is one.
         run: twilio flex:plugins:release --disable-plugin=plugin-hrm-form -l debug || true
         shell: bash
+        working-directory: ./plugin-hrm-form
       # Point the account at the s3 hosted plugin
       - if: env.SELF_HOSTED_DEPLOY == 'true'
         name: Configure Account to point to S3 Hosted Plugin


### PR DESCRIPTION
## Description

Also add steps to automatically disable Twilio hosted plugins for self hosted deploys

Most of the deploy speed benefit has been lost because the flex plugins CLI doesn't seem to be able to disable a plugin without running from the plugins source directory with all the dependencies installed, for some reason - I opened a ticket with Twilio about this because it seems like a but

But we will regain most of that when the support for Twilio hosted plugins is dropped

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- [X] Feature flags added
- N/A Strings are localized
- N/A Tested for chat contacts
- N/A Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Tested workflows

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P