### PR TITLE
webchat contact identifiers always returns a non-empty string

### DIFF
--- a/plugin-hrm-form/src/utils/task.ts
+++ b/plugin-hrm-form/src/utils/task.ts
@@ -23,7 +23,7 @@ import selectChannelType from './selectChannelType';
 const getContactValueFromWebchat = task => {
   const { preEngagementData } = task.attributes;
   if (!preEngagementData) return '';
-  return preEngagementData.contactIdentifier;
+  return preEngagementData.contactIdentifier || task.defaultFrom || '';
 };
 
 /**


### PR DESCRIPTION
## Description
- CA webchat's contacts "Save and End" button does not appear during active contact. This is due to the contact identifiers missing in KHP web chat
- Ensure getContactValueFromWebchat always returns a non-empty string 
- Modified getContactValueFromWebchat function to return a default value if preEngagementData, contactIdentifier, or defaultFrom are absent. 

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
1. Start a webchat task with CA staging configuration - https://tl-public-chat-ca-stg.s3.amazonaws.com/ca-chat-staging.html
2. In Flex, Find the contact and in contact details, try to 'Save and End' that contact from `/search` form. You should be able to now see the 'Save and End' button and complete this action. This was not working before

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
3. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
4. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P