### PR TITLE
Service configuration: Adding Force Keep fields and logic

### DIFF
--- a/twilio-iac/helplines/ca/configs/service-configuration/production.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/production.json
@@ -1,24 +1,24 @@
 {
-    "attributes": {
-        "feature_flags": {
-            "enable_aselo_messaging_ui": true
-        },
-        "form_definitions_base_url": "https://assets-production.tl.techmatters.org/form-definitions/",
-        "resources_base_url": "https://hrm-production-ca.tl.techmatters.org",
-        "previous_ui_version": {
-            "date": "2023-08-08T17:58:25.241Z",
-            "semver": "~2.0.0",
-            "version": "2.0.3"
-        }
+  "attributes": {
+    "feature_flags": {
+      "enable_aselo_messaging_ui": true
     },
-    "ui_attributes": {
-        "colorTheme": {
-            "light": null,
-            "baseName": null,
-            "preset": null,
-            "overrides": null
-        },
-        "internalChatServerlessUrl": "serverless-internal-chat-7504.twil.io",
-        "appianAddonUrl": "vps.appiancloud.com/suite/webapi"
+    "form_definitions_base_url": "https://assets-production.tl.techmatters.org/form-definitions/",
+    "resources_base_url": "https://hrm-production-ca.tl.techmatters.org",
+    "previous_ui_version": {
+      "date": "2023-08-08T17:58:25.241Z",
+      "semver": "~2.0.0",
+      "version": "2.0.3"
     }
+  },
+  "ui_attributes": {
+    "colorTheme": {
+      "light": null,
+      "baseName": null,
+      "preset": null,
+      "overrides": null
+    },
+    "internalChatServerlessUrl": "serverless-internal-chat-7504.twil.io",
+    "appianAddonUrl": "vps.appiancloud.com/suite/webapi"
+  }
 }

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "feature_flags": {
-      "enable_aselo_messaging_ui": true
+      "enable_aselo_messaging_ui": false
     },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,13 +1,15 @@
 {
   "attributes": {
-    "feature_flags": {
-    },
+    "feature_flags": {},
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",
     "logo_url": "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"
   },
   "ui_attributes": {
     "theme": null,
-    "internalChatServerlessUrl": "serverless-internal-chat-6272.twil.io"
+    "internalChatServerlessUrl": "serverless-internal-chat-6272.twil.io",
+    "appianAddonUrl": "vps.appiancloud.com/suite/webapi",
+    "flexAddonKey": "testing",
+    "appianApiKey": "testing"
   }
 }

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "feature_flags": {
-      "enable_aselo_messaging_ui": false
+      "enable_aselo_messaging_ui": true
     },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,6 +1,8 @@
 {
   "attributes": {
-    "feature_flags": {},
+    "feature_flags": {
+      "enable_aselo_messaging_ui": true
+    },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",
     "logo_url": "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -10,8 +10,7 @@
   "ui_attributes": {
     "theme": null,
     "internalChatServerlessUrl": "serverless-internal-chat-6272.twil.io",
-    "appianAddonUrl": "vps.appiancloud.com/suite/webapi",
-    "flexAddonKey": "testing",
-    "appianApiKey": "testing"
+    "appianAddonUrl": "vps.appiancloud.com/suite/webapi"
+
   }
 }

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -8,8 +8,6 @@
   "ui_attributes": {
     "theme": null,
     "internalChatServerlessUrl": "serverless-internal-chat-6272.twil.io",
-    "appianAddonUrl": "vps.appiancloud.com/suite/webapi",
-    "flexAddonKey": "testing",
-    "appianApiKey": "testing"
+    "appianAddonUrl": "vps.appiancloud.com/suite/webapi"
   }
 }

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,8 +1,6 @@
 {
   "attributes": {
-    "feature_flags": {
-      "enable_aselo_messaging_ui": true
-    },
+    "feature_flags": {},
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",
     "logo_url": "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"
@@ -10,6 +8,8 @@
   "ui_attributes": {
     "theme": null,
     "internalChatServerlessUrl": "serverless-internal-chat-6272.twil.io",
-    "appianAddonUrl": "vps.appiancloud.com/suite/webapi"
+    "appianAddonUrl": "vps.appiancloud.com/suite/webapi",
+    "flexAddonKey": "testing",
+    "appianApiKey": "testing"
   }
 }

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,8 +1,6 @@
 {
   "attributes": {
-    "feature_flags": {
-      "enable_aselo_messaging_ui": false
-    },
+    "feature_flags": {},
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",
     "logo_url": "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,6 +1,8 @@
 {
   "attributes": {
-    "feature_flags": {},
+    "feature_flags": {
+      "enable_aselo_messaging_ui": true
+    },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",
     "logo_url": "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"
@@ -8,8 +10,6 @@
   "ui_attributes": {
     "theme": null,
     "internalChatServerlessUrl": "serverless-internal-chat-6272.twil.io",
-    "appianAddonUrl": "vps.appiancloud.com/suite/webapi",
-    "flexAddonKey": "testing",
-    "appianApiKey": "testing"
+    "appianAddonUrl": "vps.appiancloud.com/suite/webapi"
   }
 }

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "feature_flags": {
-      "enable_aselo_messaging_ui": true
+      "enable_aselo_messaging_ui": false
     },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",
@@ -10,6 +10,8 @@
   "ui_attributes": {
     "theme": null,
     "internalChatServerlessUrl": "serverless-internal-chat-6272.twil.io",
-    "appianAddonUrl": "vps.appiancloud.com/suite/webapi"
+    "appianAddonUrl": "vps.appiancloud.com/suite/webapi",
+    "flexAddonKey": "testing",
+    "appianApiKey": "testing"
   }
 }

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "feature_flags": {
-      "enable_aselo_messaging_ui": false
+      "enable_aselo_messaging_ui": true
     },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",
@@ -10,8 +10,6 @@
   "ui_attributes": {
     "theme": null,
     "internalChatServerlessUrl": "serverless-internal-chat-6272.twil.io",
-    "appianAddonUrl": "vps.appiancloud.com/suite/webapi",
-    "flexAddonKey": "testing",
-    "appianApiKey": "testing"
+    "appianAddonUrl": "vps.appiancloud.com/suite/webapi"
   }
 }

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -231,12 +231,10 @@ class ServiceConfiguration():
 
         self.init_ssm_fields()
         self.init_template_fields()
-
+        # override fields in the new state with the remote state
         for field in FORCE_KEEP_FIELDS:
             remote_value = get_nested_key(self.remote_state, field)
             if remote_value:
-                print("Adding {} from remote state to new state".format(field))
-                print("Value: {}".format(remote_value))
                 set_nested_key(self.new_state, field, remote_value)
         
         for key, value in self.template_config.items():

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -48,6 +48,8 @@ EXCLUDED_FIELDS = [
     "service_version",
     "taskrouter_offline_activity_sid",
     "status",
+    'ui_attributes.appianApiKey',
+    'ui_attributes.flexAddonKey',
 ]
 
 OVERRIDE_FIELDS = [
@@ -290,7 +292,7 @@ class ServiceConfiguration():
         # self.new_state for the changelog
         for field in EXCLUDED_FIELDS:
             delete_nested_key(new_state, field)
-
+        print(new_state)
         self._twilio_client.update_flex_configuration(new_state)
 
         # add a new version for the new state

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -48,13 +48,19 @@ EXCLUDED_FIELDS = [
     "service_version",
     "taskrouter_offline_activity_sid",
     "status",
-    #'ui_attributes.appianApiKey',
-    #'ui_attributes.flexAddonKey',
+    'ui_attributes.appianApiKey',
+    'ui_attributes.flexAddonKey',
 ]
 
 OVERRIDE_FIELDS = [
     'attributes',
     'ui_attributes.colorTheme',
+]
+
+# These are fields that will be kept from the remote state and added to the new state 
+FORCE_KEEP_FIELDS = [
+    'ui_attributes.appianApiKey',
+    'ui_attributes.flexAddonKey',
 ]
 
 REGION_URL_POSTFIX_MAP = {
@@ -227,6 +233,11 @@ class ServiceConfiguration():
 
         self.init_ssm_fields()
         self.init_template_fields()
+
+        for field in FORCE_KEEP_FIELDS:
+            remote_value = get_nested_key(self.remote_state, field)
+            if remote_value:
+                set_nested_key(self.new_state, field, remote_value)
 
         for key, value in self.template_config.items():
             local_value = get_nested_key(self.local_state, key)

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -48,7 +48,6 @@ EXCLUDED_FIELDS = [
     "service_version",
     "taskrouter_offline_activity_sid",
     "status",
-
 ]
 
 OVERRIDE_FIELDS = [

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -80,7 +80,6 @@ def set_nested_key(data, key, value):
         current = current[path_key]
 
     current[path[-1]] = value
-    print(current)
 
 
 def get_nested_key(data, key):

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -48,8 +48,8 @@ EXCLUDED_FIELDS = [
     "service_version",
     "taskrouter_offline_activity_sid",
     "status",
-    'ui_attributes.appianApiKey',
-    'ui_attributes.flexAddonKey',
+    #'ui_attributes.appianApiKey',
+    #'ui_attributes.flexAddonKey',
 ]
 
 OVERRIDE_FIELDS = [
@@ -292,7 +292,11 @@ class ServiceConfiguration():
         # self.new_state for the changelog
         for field in EXCLUDED_FIELDS:
             delete_nested_key(new_state, field)
-        print(new_state)
+
+        print("new state")
+        print(json.dumps(new_state, indent=4))
+        print("remote state")
+        print(json.dumps(self.remote_state, indent=4))
         self._twilio_client.update_flex_configuration(new_state)
 
         # add a new version for the new state

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -302,10 +302,6 @@ class ServiceConfiguration():
         for field in EXCLUDED_FIELDS:
             delete_nested_key(new_state, field)
 
-        print("new state")
-        print(json.dumps(new_state, indent=4))
-        print("remote state")
-        print(json.dumps(self.remote_state, indent=4))
         self._twilio_client.update_flex_configuration(new_state)
 
         # add a new version for the new state

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -48,8 +48,7 @@ EXCLUDED_FIELDS = [
     "service_version",
     "taskrouter_offline_activity_sid",
     "status",
-    'ui_attributes.appianApiKey',
-    'ui_attributes.flexAddonKey',
+
 ]
 
 OVERRIDE_FIELDS = [
@@ -82,6 +81,7 @@ def set_nested_key(data, key, value):
         current = current[path_key]
 
     current[path[-1]] = value
+    print(current)
 
 
 def get_nested_key(data, key):
@@ -237,8 +237,10 @@ class ServiceConfiguration():
         for field in FORCE_KEEP_FIELDS:
             remote_value = get_nested_key(self.remote_state, field)
             if remote_value:
+                print("Adding {} from remote state to new state".format(field))
+                print("Value: {}".format(remote_value))
                 set_nested_key(self.new_state, field, remote_value)
-
+        
         for key, value in self.template_config.items():
             local_value = get_nested_key(self.local_state, key)
             # We want to allow the user to override the template value with a

--- a/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
+++ b/twilio-iac/scripts/python_tools/src/service_configuration/service_configuration.py
@@ -48,8 +48,6 @@ EXCLUDED_FIELDS = [
     "service_version",
     "taskrouter_offline_activity_sid",
     "status",
-    'ui_attributes.appianApiKey',
-    'ui_attributes.flexAddonKey',
 ]
 
 OVERRIDE_FIELDS = [
@@ -108,7 +106,6 @@ def delete_nested_key(data, key):
                 # if the sub-dictionary is empty after the deletion, remove it
                 del data[path[0]]
         return not bool(data)
-
 
 
 def get_dot_notation_path(change) -> str:


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
There was an issue with CA in which even that the keys for quick chat were being excluded, just because we were not sending those values when doing the service configuration update, the keys got deleted. 
I think this is due these attributes are not "Twilio" attributes so they are not expected, and if they are not set explicitly and update will just delete them (which what happened).

I've added the new list FORCE_KEEP_FIELDS, the idea is simple, we will get these attributes from the remote state and then insert them in the new state to be able to retain them.


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P