### PR TITLE
CHI-3099: Create task for offline contact when saving offline contact from contact details

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.ts
@@ -33,7 +33,6 @@ import { ContactState } from '../../states/contacts/existingContacts';
 
 const helpline = 'ChildLine';
 const mockGetHrmConfig = getHrmConfig as jest.Mock;
-
 // eslint-disable-next-line no-empty-function
 global.fetch = global.fetch ? global.fetch : () => Promise.resolve(<any>{ ok: true });
 

--- a/plugin-hrm-form/src/___tests__/testContacts.ts
+++ b/plugin-hrm-form/src/___tests__/testContacts.ts
@@ -58,8 +58,8 @@ export const VALID_EMPTY_CONTACT: Contact = {
 };
 
 export const VALID_EMPTY_METADATA: ContactMetadata = {
-  startMillis: 0,
-  endMillis: 0,
+  startMillis: undefined,
+  endMillis: undefined,
   categories: { gridView: false, expanded: {} },
   recreated: false,
   draft: {

--- a/plugin-hrm-form/src/components/contact/ContactInProgressBanners.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactInProgressBanners.tsx
@@ -35,7 +35,7 @@ import { newSubmitAndFinalizeContactFromOutsideTaskContextAsyncAction } from '..
 import { getAseloFeatureFlags } from '../../hrmConfig';
 import { RootState } from '../../states';
 import selectContactStateByContactId from '../../states/contacts/selectContactStateByContactId';
-import { checkTaskAssignment, completeTaskAssignment } from '../../services/twilioTaskService';
+import { checkTaskAssignment } from '../../services/twilioTaskService';
 
 type ContactBannersProps = {
   contactId: string;
@@ -65,7 +65,6 @@ const ContactInProgressBanners: React.FC<ContactBannersProps> = ({ contactId }) 
         ...savedContact.rawJson,
       },
     };
-    await completeTaskAssignment(savedContact.taskId);
     dispatch(newSubmitAndFinalizeContactFromOutsideTaskContextAsyncAction(updatedContact));
     setShowResolvedBanner(true);
   };

--- a/plugin-hrm-form/src/components/contact/ContactInProgressBanners.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactInProgressBanners.tsx
@@ -17,7 +17,7 @@
 import React, { useMemo, useState } from 'react';
 import { Close } from '@material-ui/icons';
 import { Template, Manager } from '@twilio/flex-ui';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import InfoIcon from '../caseMergingBanners/InfoIcon';
 import SaveContactCallTypeDialog from '../callTypeButtons/SaveContactCallTypeDialog';
@@ -30,18 +30,19 @@ import {
   HiddenText,
   SaveAndEndButton,
 } from '../../styles';
-import { checkTaskAssignment, completeTaskAssignment } from '../../services/ServerlessService';
-import { Contact, RouterTask } from '../../types/types';
 import getCanEditInProgressContact from '../../permissions/canEditInProgressContact';
-import { newFinalizeContactAsyncAction } from '../../states/contacts/saveContact';
+import { newSubmitAndFinalizeContactFromOutsideTaskContextAsyncAction } from '../../states/contacts/saveContact';
 import { getAseloFeatureFlags } from '../../hrmConfig';
+import { RootState } from '../../states';
+import selectContactStateByContactId from '../../states/contacts/selectContactStateByContactId';
+import { checkTaskAssignment, completeTaskAssignment } from '../../services/twilioTaskService';
 
 type ContactBannersProps = {
-  savedContact: Contact;
-  task: RouterTask;
+  contactId: string;
 };
 
-const ContactInProgressBanners: React.FC<ContactBannersProps> = ({ savedContact, task }) => {
+const ContactInProgressBanners: React.FC<ContactBannersProps> = ({ contactId }) => {
+  const savedContact = useSelector((state: RootState) => selectContactStateByContactId(state, contactId)?.savedContact);
   const [showResolvedBanner, setShowResolvedBanner] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -50,10 +51,6 @@ const ContactInProgressBanners: React.FC<ContactBannersProps> = ({ savedContact,
   const isDraft = !savedContact.finalizedAt;
 
   const enableInProgressContacts = getAseloFeatureFlags().enable_save_in_progress_contacts;
-
-  const saveFinalizedContact = (task: RouterTask, contact: Contact) => {
-    dispatch(newFinalizeContactAsyncAction(task, contact));
-  };
 
   const canEditContact = useMemo(() => getCanEditInProgressContact(savedContact, workerRoles), [
     savedContact,
@@ -64,12 +61,12 @@ const ContactInProgressBanners: React.FC<ContactBannersProps> = ({ savedContact,
     const updatedContact = {
       ...savedContact,
       rawJson: {
-        ...savedContact.rawJson,
         callType: 'Uncategorized',
+        ...savedContact.rawJson,
       },
     };
     await completeTaskAssignment(savedContact.taskId);
-    saveFinalizedContact(task, updatedContact);
+    dispatch(newSubmitAndFinalizeContactFromOutsideTaskContextAsyncAction(updatedContact));
     setShowResolvedBanner(true);
   };
 

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -59,7 +59,7 @@ const delimiter = ';';
 type InsightsUpdateFunction = (
   attributes: TaskAttributes,
   contactForm: Contact,
-  caseForm: CaseStateEntry,
+  caseForm: Pick<CaseStateEntry, 'sections' | 'connectedCase'>,
   savedContact: Contact,
 ) => InsightsAttributes;
 
@@ -270,7 +270,7 @@ const convertCaseFormForInsights = (caseForm: Case, sections: CaseStateEntry['se
 
 const processHelplineConfig = (
   contact: Contact,
-  caseState: CaseStateEntry,
+  caseState: Pick<CaseStateEntry, 'sections' | 'connectedCase'>,
   oneToOneConfigSpec: OneToOneConfigSpec,
 ): InsightsAttributes => {
   const { connectedCase: caseForm, sections } = caseState ?? {};
@@ -427,7 +427,7 @@ const generateUrlProviderBlock = (externalRecordingInfo: ExternalRecordingInfoSu
 export const buildInsightsData = (
   task: CustomITask,
   contact: Contact,
-  caseState: CaseStateEntry,
+  caseState: Pick<CaseStateEntry, 'sections' | 'connectedCase'>,
   savedContact: Contact,
   externalRecordingInfo?: ExternalRecordingInfo,
 ) => {

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -14,6 +14,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+// WE ARE TRYING TO BREAK THIS FILE UP! NO NEW METHODS IN HERE PLEASE!
+// Add to one of the other function specific serverless service files that already exist like twilioTaskService.ts or twilioWorkerService.ts
+// If an appropriate file doesn't exist, start another one, and move any existing functions here that should also be in there into it
+
 /* eslint-disable sonarjs/prefer-immediate-return */
 /* eslint-disable camelcase */
 import { ITask, Notifications } from '@twilio/flex-ui';
@@ -134,19 +138,5 @@ export const getMediaUrl = async (serviceSid: string, mediaSid: string) => {
   const body = { serviceSid, mediaSid };
 
   const response = await fetchProtectedApi('/getMediaUrl', body);
-  return response;
-};
-
-export const checkTaskAssignment = async (taskSid: string) => {
-  const body = { taskSid };
-
-  const response = await fetchProtectedApi('/checkTaskAssignment', body);
-  return response;
-};
-
-export const completeTaskAssignment = async (taskSid: string) => {
-  const body = { taskSid };
-
-  const response = await fetchProtectedApi('/completeTaskAssignment', body);
   return response;
 };

--- a/plugin-hrm-form/src/services/fetchProtectedApi.ts
+++ b/plugin-hrm-form/src/services/fetchProtectedApi.ts
@@ -24,6 +24,8 @@ export class ProtectedApiError extends ApiError {
 
     this.name = 'ProtectedApiError';
     this.serverStack = this.body?.stack;
+
+    Object.setPrototypeOf(this, ProtectedApiError.prototype);
   }
 
   serverStack: any;

--- a/plugin-hrm-form/src/services/twilioTaskService.ts
+++ b/plugin-hrm-form/src/services/twilioTaskService.ts
@@ -16,6 +16,7 @@
 
 import fetchProtectedApi from './fetchProtectedApi';
 import { TaskSID } from '../types/twilio';
+import { ApiError } from './fetchApi';
 
 /**
  * Creates a new task (offline contact) in behalf of targetSid worker with attributes. Other attributes for routing are added to the task in the implementation of assignOfflineContact serverless function
@@ -76,10 +77,17 @@ export const checkTaskAssignment = async (taskSid: string) => {
 
 export const getTask = async (taskSid: string): Promise<ITask> => {
   const body = { taskSid };
-  return {
-    taskSid,
-    ...(await fetchProtectedApi('/getTask', body)),
-  };
+  try {
+    return {
+      taskSid,
+      ...(await fetchProtectedApi('/getTask', body)),
+    };
+  } catch (error) {
+    if (error instanceof ApiError && error.response.status === 404) {
+      return null;
+    }
+    throw error;
+  }
 };
 
 export const completeTaskAssignment = async (taskSid: string) => {

--- a/plugin-hrm-form/src/services/twilioTaskService.ts
+++ b/plugin-hrm-form/src/services/twilioTaskService.ts
@@ -14,8 +14,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { ITask } from '@twilio/flex-ui';
-
 import fetchProtectedApi from './fetchProtectedApi';
 import { TaskSID } from '../types/twilio';
 
@@ -69,3 +67,23 @@ export const wrapupConversationTask = async (taskSid: TaskSID) =>
  */
 export const completeConversationTask = async (taskSid: TaskSID) =>
   fetchProtectedApi('/interaction/transitionAgentParticipants', { taskSid, targetStatus: 'closed' });
+
+export const checkTaskAssignment = async (taskSid: string) => {
+  const body = { taskSid };
+
+  return fetchProtectedApi('/checkTaskAssignment', body);
+};
+
+export const getTask = async (taskSid: string): Promise<ITask> => {
+  const body = { taskSid };
+  return {
+    taskSid,
+    ...(await fetchProtectedApi('/getTask', body)),
+  };
+};
+
+export const completeTaskAssignment = async (taskSid: string) => {
+  const body = { taskSid };
+
+  return fetchProtectedApi('/completeTaskAssignment', body);
+};

--- a/plugin-hrm-form/src/states/configuration/selectDefinitions.ts
+++ b/plugin-hrm-form/src/states/configuration/selectDefinitions.ts
@@ -16,7 +16,7 @@
 
 import { RootState } from '..';
 import { namespace } from '../storeNamespaces';
-import { Case } from '../../types/types';
+import { Case, Contact } from '../../types/types';
 
 export const selectDefinitionVersions = (state: RootState) => state[namespace].configuration.definitionVersions;
 
@@ -26,3 +26,6 @@ export const selectCurrentDefinitionVersion = (state: RootState) =>
 export const selectDefinitionVersionForCase = ({ [namespace]: { configuration } }: RootState, connectedCase: Case) =>
   configuration.definitionVersions[connectedCase?.info?.definitionVersion ?? ''] ??
   configuration.currentDefinitionVersion;
+
+export const selectDefinitionVersionForContact = ({ [namespace]: { configuration } }: RootState, contact: Contact) =>
+  configuration.definitionVersions[contact?.rawJson?.definitionVersion ?? ''] ?? configuration.currentDefinitionVersion;

--- a/plugin-hrm-form/src/states/contacts/selectContactDetailsByContext.ts
+++ b/plugin-hrm-form/src/states/contacts/selectContactDetailsByContext.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { namespace } from '../storeNamespaces';
+import { RootState } from '..';
+import { DetailsContext } from './contactDetails';
+
+const selectContactDetailsByContext = (state: RootState, context: DetailsContext) =>
+  state[namespace].activeContacts.contactDetails[context];
+
+export default selectContactDetailsByContext;

--- a/plugin-hrm-form/src/states/contacts/types.ts
+++ b/plugin-hrm-form/src/states/contacts/types.ts
@@ -46,6 +46,7 @@ export const CONNECT_TO_CASE_ACTION_FULFILLED = `${CONNECT_TO_CASE}_FULFILLED` a
 export const REMOVE_FROM_CASE_ACTION_FULFILLED = `${REMOVE_FROM_CASE}_FULFILLED` as const;
 export const SET_SAVED_CONTACT = 'contact-action/set-saved-contact' as const;
 export const FINALIZE_CONTACT = 'contact-action/finalize-contact' as const;
+export const SUBMIT_AND_FINALIZE_CONTACT_FROM_OUTSIDE_TASK_CONTEXT = 'contact-action/submit-and-finalize-contact-from-outside-task-context' as const;
 export const CASE_CONNECTED_TO_CONTACT = 'CASE_CONNECTED_TO_CONTACT' as const;
 
 export const LoadingStatus = {

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -42,8 +42,6 @@ export type EntryInfo = {
 
 export type CaseItemFormValues = { [key: string]: string | boolean };
 
-export type CaseItemEntry = { form: CaseItemFormValues } & EntryInfo;
-
 export type Household = { [key: string]: string | boolean };
 
 export type Perpetrator = { [key: string]: string | boolean };

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -365,7 +365,7 @@ export function isOfflineContact(contact: Contact): boolean {
  * Checks if the task is issued by someone else to avoid showing certain things in the UI. This is done by checking isInMyBehalf task attribute (attached while creating offline contacts)
  */
 export function isInMyBehalfITask(task: RouterTask): task is InMyBehalfITask {
-  return task.attributes && task.attributes.isContactlessTask && (task.attributes as any).isInMyBehalf;
+  return task?.attributes && task.attributes.isContactlessTask && (task.attributes as any).isInMyBehalf;
 }
 
 export function isTwilioTask(task: RouterTask): task is ITask {


### PR DESCRIPTION
## Description

* Reworked 'Save and End' button to reuse the 'submit form' flow used in the tabbed forms. This will mean the following additional work is done: 
  - A job to retrieve the transcript is created. 
  - A task is created and assigned to an offline contact
  - The details are saved to insights (if the task still exists)
* The ContactDetailsHome.tsx component is refactored to use redux hooks
* The Banner component gets data from redux not prop drilling
* Setting the conversation duration is handled up in the redux layer rather than down in the service. This is a more appropriate place for such business logic and it simplifies the service layer call signatures
* Added fallback code that adds a unique placeholder task sid for offline contacts in the event we fail to create a task in Twilio. This means that the contact can be finalised without messing up the 'in progress' offline task

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- [ ] Feature flags added
- [N/A] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket
Also, general Save & End regression

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P