### PR TITLE
feat: add isPII flag to form definitions [CHI-3107]

### DIFF
--- a/hrm-form-definitions/form-definitions/as/v1/caseForms/CaseOverview.json
+++ b/hrm-form-definitions/form-definitions/as/v1/caseForms/CaseOverview.json
@@ -1,0 +1,3 @@
+{
+  "summary": { "isPII": true }
+}

--- a/hrm-form-definitions/form-definitions/as/v1/caseForms/HouseholdForm.json
+++ b/hrm-form-definitions/form-definitions/as/v1/caseForms/HouseholdForm.json
@@ -3,13 +3,15 @@
     "name": "firstName",
     "type": "input",
     "label": "First Name",
-    "required": { "value": true, "message": "RequiredFieldError" }
+    "required": { "value": true, "message": "RequiredFieldError" },
+    "isPII": true
   },
   {
     "name": "lastName",
     "type": "input",
     "label": "Last Name",
-    "required": { "value": true, "message": "RequiredFieldError" }
+    "required": { "value": true, "message": "RequiredFieldError" },
+    "isPII": true
   },
   {
     "name": "relationshipToChild",
@@ -32,7 +34,8 @@
   {
     "name": "streetAddress",
     "label": "Street Address",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "province",

--- a/hrm-form-definitions/form-definitions/as/v1/caseForms/PerpetratorForm.json
+++ b/hrm-form-definitions/form-definitions/as/v1/caseForms/PerpetratorForm.json
@@ -3,13 +3,15 @@
     "name": "firstName",
     "type": "input",
     "label": "First Name",
-    "required": { "value": true, "message": "RequiredFieldError" }
+    "required": { "value": true, "message": "RequiredFieldError" },
+    "isPII": true
   },
   {
     "name": "lastName",
     "type": "input",
     "label": "Last Name",
-    "required": { "value": true, "message": "RequiredFieldError" }
+    "required": { "value": true, "message": "RequiredFieldError" },
+    "isPII": true
   },
   {
     "name": "relationshipToChild",
@@ -32,7 +34,8 @@
   {
     "name": "streetAddress",
     "label": "Street Address",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "province",

--- a/hrm-form-definitions/form-definitions/as/v1/profileForms/ProfileOverview.json
+++ b/hrm-form-definitions/form-definitions/as/v1/profileForms/ProfileOverview.json
@@ -1,0 +1,4 @@
+{
+  "name": { "isPII": true }, 
+  "identifiers": { "isPII": true }
+}

--- a/hrm-form-definitions/form-definitions/as/v1/profileForms/Sections.json
+++ b/hrm-form-definitions/form-definitions/as/v1/profileForms/Sections.json
@@ -24,6 +24,7 @@
     "type": "textarea",
     "rows": 20,
     "width": 500,
-    "placeholder": "Enter Details"
+    "placeholder": "Enter Details",
+    "isPII": true
   }
 ]

--- a/hrm-form-definitions/form-definitions/as/v1/tabbedForms/CallerInformationTab.json
+++ b/hrm-form-definitions/form-definitions/as/v1/tabbedForms/CallerInformationTab.json
@@ -2,12 +2,14 @@
   {
     "name": "firstName",
     "label": "First Name",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "lastName",
     "label": "Last Name",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "relationshipToChild",
@@ -31,7 +33,8 @@
   {
     "name": "streetAddress",
     "label": "Street Address",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "province",

--- a/hrm-form-definitions/form-definitions/as/v1/tabbedForms/CaseInformationTab.json
+++ b/hrm-form-definitions/form-definitions/as/v1/tabbedForms/CaseInformationTab.json
@@ -3,7 +3,8 @@
     "name": "callSummary",
     "label": "Contact Summary",
     "type": "textarea",
-    "required": { "value": true, "message": "RequiredFieldError" }
+    "required": { "value": true, "message": "RequiredFieldError" },
+    "isPII": true
   },
   {
     "name": "repeatCaller",

--- a/hrm-form-definitions/form-definitions/as/v1/tabbedForms/ChildInformationTab.json
+++ b/hrm-form-definitions/form-definitions/as/v1/tabbedForms/ChildInformationTab.json
@@ -2,12 +2,14 @@
   {
     "name": "firstName",
     "label": "First Name",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "lastName",
     "label": "Last Name",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "gender",
@@ -63,7 +65,8 @@
   {
     "name": "streetAddress",
     "label": "Street Address",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "city",
@@ -126,12 +129,14 @@
   {
     "name": "phone1",
     "label": "Phone #1",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "phone2",
     "label": "Phone #2",
-    "type": "input"
+    "type": "input",
+    "isPII": true
   },
   {
     "name": "language",

--- a/hrm-form-definitions/src/__tests__/fetchDefinitionsMock.ts
+++ b/hrm-form-definitions/src/__tests__/fetchDefinitionsMock.ts
@@ -27,6 +27,7 @@ const BASE_URL_MOCK = 'http://base_url_mock';
 
 const files = [
   'LayoutDefinitions.json',
+  'caseForms/CaseOverview.json',
   'caseForms/HouseholdForm.json',
   'caseForms/IncidentForm.json',
   'caseForms/NoteForm.json',
@@ -47,6 +48,7 @@ const files = [
   'PrepopulateKeys.json',
   'ReferenceData.json',
   'BlockedEmojis.json',
+  'profileForms/ProfileOverview.json',
   'profileForms/Sections.json',
   'profileForms/FlagDurations.json',
 ];

--- a/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import {
   CallTypeButtonsDefinitions,
   CannedResponsesDefinitions,
+  CaseOverviewDefinition,
   CategoriesDefinition,
   DefinitionVersion,
   FormDefinition,
@@ -31,6 +32,7 @@ import {
   isSelectDefinitionWithReferenceOptions,
   LayoutVersion,
   ProfileFlagDurationDefinition,
+  ProfileOverviewDefinition,
   ProfileSectionDefinition,
 } from './types';
 import { OneToManyConfigSpecs, OneToOneConfigSpec } from './insightsConfig';
@@ -146,6 +148,7 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
    */
   const [
     layoutVersion,
+    caseOverview,
     householdForm,
     incidentForm,
     noteForm,
@@ -166,10 +169,12 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     prepopulateKeys,
     referenceData,
     blockedEmojis,
+    profileOverview,
     profileSections,
     profileFlagDurations,
   ] = await Promise.all([
     fetchDefinition<LayoutVersion>('LayoutDefinitions.json'),
+    fetchDefinition<CaseOverviewDefinition>('caseForms/CaseOverview.json', {}),
     fetchDefinition<FormItemJsonDefinition[]>('caseForms/HouseholdForm.json'),
     fetchDefinition<FormItemJsonDefinition[]>('caseForms/IncidentForm.json'),
     fetchDefinition<FormItemJsonDefinition[]>('caseForms/NoteForm.json'),
@@ -196,6 +201,7 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     ),
     fetchDefinition<Record<string, any>>('ReferenceData.json', {}),
     fetchDefinition<string[]>('BlockedEmojis.json', []),
+    fetchDefinition<ProfileOverviewDefinition>('profileForms/ProfileOverview.json', {}),
     fetchDefinition<ProfileSectionDefinition[]>('profileForms/Sections.json', []),
     fetchDefinition<ProfileFlagDurationDefinition[]>('profileForms/FlagDurations.json', []),
   ]);
@@ -206,6 +212,7 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     helplines[0].value;
   return {
     caseForms: {
+      CaseOverview: caseOverview,
       HouseholdForm: expandFormDefinition(householdForm, referenceData),
       IncidentForm: expandFormDefinition(incidentForm, referenceData),
       NoteForm: expandFormDefinition(noteForm, referenceData),
@@ -234,6 +241,7 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     referenceData,
     blockedEmojis,
     profileForms: {
+      ProfileOverview: profileOverview,
       Sections: profileSections,
       FlagDurations: profileFlagDurations,
     },

--- a/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -20,7 +20,6 @@ import path from 'path';
 import {
   CallTypeButtonsDefinitions,
   CannedResponsesDefinitions,
-  CaseOverviewDefinition,
   CategoriesDefinition,
   DefinitionVersion,
   FormDefinition,
@@ -32,7 +31,6 @@ import {
   isSelectDefinitionWithReferenceOptions,
   LayoutVersion,
   ProfileFlagDurationDefinition,
-  ProfileOverviewDefinition,
   ProfileSectionDefinition,
 } from './types';
 import { OneToManyConfigSpecs, OneToOneConfigSpec } from './insightsConfig';
@@ -148,7 +146,6 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
    */
   const [
     layoutVersion,
-    caseOverview,
     householdForm,
     incidentForm,
     noteForm,
@@ -169,12 +166,10 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     prepopulateKeys,
     referenceData,
     blockedEmojis,
-    profileOverview,
     profileSections,
     profileFlagDurations,
   ] = await Promise.all([
     fetchDefinition<LayoutVersion>('LayoutDefinitions.json'),
-    fetchDefinition<CaseOverviewDefinition>('caseForms/CaseOverview.json', {}),
     fetchDefinition<FormItemJsonDefinition[]>('caseForms/HouseholdForm.json'),
     fetchDefinition<FormItemJsonDefinition[]>('caseForms/IncidentForm.json'),
     fetchDefinition<FormItemJsonDefinition[]>('caseForms/NoteForm.json'),
@@ -201,7 +196,6 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     ),
     fetchDefinition<Record<string, any>>('ReferenceData.json', {}),
     fetchDefinition<string[]>('BlockedEmojis.json', []),
-    fetchDefinition<ProfileOverviewDefinition>('profileForms/ProfileOverview.json', {}),
     fetchDefinition<ProfileSectionDefinition[]>('profileForms/Sections.json', []),
     fetchDefinition<ProfileFlagDurationDefinition[]>('profileForms/FlagDurations.json', []),
   ]);
@@ -212,7 +206,6 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     helplines[0].value;
   return {
     caseForms: {
-      CaseOverview: caseOverview,
       HouseholdForm: expandFormDefinition(householdForm, referenceData),
       IncidentForm: expandFormDefinition(incidentForm, referenceData),
       NoteForm: expandFormDefinition(noteForm, referenceData),
@@ -241,7 +234,6 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     referenceData,
     blockedEmojis,
     profileForms: {
-      ProfileOverview: profileOverview,
       Sections: profileSections,
       FlagDurations: profileFlagDurations,
     },

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -328,7 +328,7 @@ export type ProfileOverviewDefinition = {
  */
 export type DefinitionVersion = {
   caseForms: {
-    CaseOverview: CaseOverviewDefinition;
+    // CaseOverview: CaseOverviewDefinition;
     HouseholdForm: FormDefinition;
     IncidentForm: FormDefinition;
     NoteForm: FormDefinition;
@@ -369,7 +369,7 @@ export type DefinitionVersion = {
   referenceData?: Record<string, any>;
   blockedEmojis: string[];
   profileForms?: {
-    ProfileOverview: ProfileOverviewDefinition;
+    // ProfileOverview: ProfileOverviewDefinition;
     Sections: ProfileSectionDefinition[];
     FlagDurations: ProfileFlagDurationDefinition[];
   };

--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -49,6 +49,10 @@ export enum FormInputType {
   CustomContactComponent = 'custom-contact-component',
 }
 
+type IsPIIFlag = {
+  isPII?: boolean;
+};
+
 /**
  * Types used for customizable forms
  */
@@ -57,7 +61,8 @@ type ItemBase = {
   label: string;
   type: FormInputType;
   metadata?: Record<string, any>;
-} & RegisterOptions;
+} & IsPIIFlag &
+  RegisterOptions;
 
 type NonSaveable = {
   saveable: false;
@@ -201,7 +206,7 @@ export declare type ProfileSectionDefinition = {
   rows: number;
   placeholder: string;
   width: number;
-};
+} & IsPIIFlag;
 
 export declare type ProfileFlagDurationDefinition = {
   flag: string;
@@ -307,11 +312,23 @@ export type StatusInfo = {
   transitions: string[]; // possible statuses this one can transition to (further update may be to include who can make such a transition for a more granular control)
 };
 
+export type CaseOverviewDefinition = {
+  followUpDate?: IsPIIFlag;
+  childIsAtRisk?: IsPIIFlag;
+  summary?: IsPIIFlag;
+};
+
+export type ProfileOverviewDefinition = {
+  name?: IsPIIFlag;
+  identifiers?: IsPIIFlag;
+};
+
 /**
  * Type that defines a complete version for all the customizable forms used across the app
  */
 export type DefinitionVersion = {
   caseForms: {
+    CaseOverview: CaseOverviewDefinition;
     HouseholdForm: FormDefinition;
     IncidentForm: FormDefinition;
     NoteForm: FormDefinition;
@@ -352,6 +369,7 @@ export type DefinitionVersion = {
   referenceData?: Record<string, any>;
   blockedEmojis: string[];
   profileForms?: {
+    ProfileOverview: ProfileOverviewDefinition;
     Sections: ProfileSectionDefinition[];
     FlagDurations: ProfileFlagDurationDefinition[];
   };

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -69,7 +69,6 @@ export type CSAMReportEntry = {
 } & Omit<EntryInfo, 'id'>;
 
 export type CaseOverview = {
-
   followUpDate?: string;
   childIsAtRisk?: boolean;
   summary?: string;
@@ -97,7 +96,6 @@ export type Case = {
   previousStatus?: string;
   categories: Record<string, string[]>;
   firstContact?: Contact;
-
 };
 
 export type TwilioStoredMedia = {


### PR DESCRIPTION
## Description
This PR
- Adds a new flag to form definitions, `isPII`, which can be used to flag the fields as PII. This flag can be added to
  - Any customizable form input (contact, case, case section, etc).
  - Case overview. For this a new file, `caseForms/CaseOverview.json`, needs to be added.
  - Profile root. For this a new file, `profileForms/ProfileOverview.json`, needs to be added.
  - Profile sections.
- Adds examples to `AS` form definitions.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3107)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- CI passes.
- `npm ci && npm run dev` to confirm local server compiles and runs correctly.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P