### PR TITLE
Tag Twilio Lambda images with version on creating a QA version

### DIFF
--- a/.github/workflows/global-production-release-tag.yml
+++ b/.github/workflows/global-production-release-tag.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github/actions
 
       - name: Create production release
         uses: ./.github/actions/generate-production-release
@@ -53,6 +57,51 @@ jobs:
           source-git-reference: ${{ github.ref_name }}
           target-git-tag: ${{ inputs.tag-name }}
 
+  tag-images:
+    needs: generate-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lambda_path:
+          - account-scoped
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.PRIMARY_AWS_REGION }}
+          # this plugin sets the AWS account ID to a secret which is not allowed in outputs
+          # we have to disable that so repo output will work
+          mask-aws-account-id: 'no'
+        env:
+          # if anything is set as a secret, it can't be used in outputs. So we need to set it as an env var
+          PRIMARY_AWS_REGION: us-east-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Tag Image with version
+        run: |
+          REF_NAME="${{ github.ref_name }}"
+          REF_NAME_FOR_DOCKER_TAG="${REF_NAME//\//_-}"
+          REPOSITORY_NAME="twilio/lambda/${{matrix.lambda_path}}"
+          MANIFEST=$(aws ecr batch-get-image --repository-name $REPOSITORY_NAME --image-ids imageTag="${{ github.ref_type }}.$REF_NAME_FOR_DOCKER_TAG" --output text --query 'images[].imageManifest')
+          aws ecr put-image --repository-name $REPOSITORY_NAME --image-tag tag.${{ inputs.tag-name }} --image-manifest "$MANIFEST"
+
+  send-slack-message:
+    needs: tag-images
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github/actions
+
       # Send Slack notifying success
       - name: Slack aselo-deploys channel
         uses: ./.github/actions/notify-deploys
@@ -60,6 +109,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          slack-message: "`[Flex]` Production Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_prod_release.outputs.generated-release-tag }}` :rocket:."
+          slack-message: "`[Flex]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_pre_release.outputs.generated-pre-release-tag }}` :rocket:."
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/global-qa-release-tag.yml
+++ b/.github/workflows/global-qa-release-tag.yml
@@ -128,7 +128,9 @@ jobs:
           # this plugin sets the AWS account ID to a secret which is not allowed in outputs
           # we have to disable that so repo output will work
           mask-aws-account-id: 'no'
-
+        env:
+          # if anything is set as a secret, it can't be used in outputs. So we need to set it as an env var
+          PRIMARY_AWS_REGION: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/global-qa-release-tag.yml
+++ b/.github/workflows/global-qa-release-tag.yml
@@ -64,15 +64,20 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-
   generate-pre-release:
     needs: run-e2e-tests
 
     runs-on: ubuntu-latest
+    outputs:
+      qa-version: ${{ steps.create_pre_release.outputs.generated-pre-release-tag }}
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github/actions
 
       - name: Create pre release
         uses: ./.github/actions/generate-pre-release
@@ -93,6 +98,7 @@ jobs:
           source-git-reference-type: ${{ github.ref_type }}
           source-git-reference: ${{ github.ref_name }}
           target-git-tag: ${{ steps.create_pre_release.outputs.generated-pre-release-tag }}
+          
 
       # Send Slack notifying success
       - name: Slack aselo-deploys channel
@@ -104,3 +110,37 @@ jobs:
           slack-message: "`[Flex]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_pre_release.outputs.generated-pre-release-tag }}` :rocket:."
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}
+  tag-images:
+    needs: generate-pre-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lambda_path:
+          - account-scoped
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.PRIMARY_AWS_REGION }}
+          # this plugin sets the AWS account ID to a secret which is not allowed in outputs
+          # we have to disable that so repo output will work
+          mask-aws-account-id: 'no'
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Read ECR url from SSM
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: /twilio/lambda/${{ matrix.lambda_path }}/ecr-url
+          env_variable_name: ECR_URL
+
+      - name: Tag Image with version
+        run: |
+          REF_NAME="${{ github.ref_name }}"
+          REF_NAME_FOR_DOCKER_TAG="${REF_NAME//\//_-}"
+          MANIFEST=$(aws ecr batch-get-image --repository-name $ECR_URL --image-ids imageTag=$REF_NAME_FOR_DOCKER_TAG --output text --query 'images[].imageManifest')
+          aws ecr describe-images --repository-name ${{ needs.generate-pre-release.outputs.qa-version }}

--- a/.github/workflows/global-qa-release-tag.yml
+++ b/.github/workflows/global-qa-release-tag.yml
@@ -134,15 +134,10 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-      - name: Read ECR url from SSM
-        uses: "marvinpinto/action-inject-ssm-secrets@latest"
-        with:
-          ssm_parameter: /twilio/lambda/${{ matrix.lambda_path }}/ecr-url
-          env_variable_name: ECR_URL
 
       - name: Tag Image with version
         run: |
           REF_NAME="${{ github.ref_name }}"
           REF_NAME_FOR_DOCKER_TAG="${REF_NAME//\//_-}"
-          MANIFEST=$(aws ecr batch-get-image --repository-name $ECR_URL --image-ids imageTag=$REF_NAME_FOR_DOCKER_TAG --output text --query 'images[].imageManifest')
+          MANIFEST=$(aws ecr batch-get-image --repository-name twilio/lambda/${{matrix.lambda_path}} --image-ids imageTag=$REF_NAME_FOR_DOCKER_TAG --output text --query 'images[].imageManifest')
           aws ecr describe-images --repository-name ${{ needs.generate-pre-release.outputs.qa-version }}

--- a/.github/workflows/global-qa-release-tag.yml
+++ b/.github/workflows/global-qa-release-tag.yml
@@ -140,5 +140,5 @@ jobs:
           REF_NAME="${{ github.ref_name }}"
           REF_NAME_FOR_DOCKER_TAG="${REF_NAME//\//_-}"
           REPOSITORY_NAME="twilio/lambda/${{matrix.lambda_path}}"
-          MANIFEST=$(aws ecr batch-get-image --repository-name $REPOSITORY_NAME --image-ids imageTag="$REF_NAME_FOR_DOCKER_TAG" --output text --query 'images[].imageManifest')
-          aws ecr put-image --repository-name $REPOSITORY_NAME --image-tag ${{ needs.generate-pre-release.outputs.qa-version }} --image-manifest "$MANIFEST"
+          MANIFEST=$(aws ecr batch-get-image --repository-name $REPOSITORY_NAME --image-ids imageTag="${{ github.ref_type }}.$REF_NAME_FOR_DOCKER_TAG" --output text --query 'images[].imageManifest')
+          aws ecr put-image --repository-name $REPOSITORY_NAME --image-tag tag.${{ needs.generate-pre-release.outputs.qa-version }} --image-manifest "$MANIFEST"

--- a/.github/workflows/global-qa-release-tag.yml
+++ b/.github/workflows/global-qa-release-tag.yml
@@ -139,5 +139,6 @@ jobs:
         run: |
           REF_NAME="${{ github.ref_name }}"
           REF_NAME_FOR_DOCKER_TAG="${REF_NAME//\//_-}"
-          MANIFEST=$(aws ecr batch-get-image --repository-name twilio/lambda/${{matrix.lambda_path}} --image-ids imageTag=$REF_NAME_FOR_DOCKER_TAG --output text --query 'images[].imageManifest')
-          aws ecr describe-images --repository-name ${{ needs.generate-pre-release.outputs.qa-version }}
+          REPOSITORY_NAME="twilio/lambda/${{matrix.lambda_path}}"
+          MANIFEST=$(aws ecr batch-get-image --repository-name $REPOSITORY_NAME --image-ids imageTag="$REF_NAME_FOR_DOCKER_TAG" --output text --query 'images[].imageManifest')
+          aws ecr put-image --repository-name $REPOSITORY_NAME --image-tag ${{ needs.generate-pre-release.outputs.qa-version }} --image-manifest "$MANIFEST"

--- a/.github/workflows/global-qa-release-tag.yml
+++ b/.github/workflows/global-qa-release-tag.yml
@@ -98,18 +98,7 @@ jobs:
           source-git-reference-type: ${{ github.ref_type }}
           source-git-reference: ${{ github.ref_name }}
           target-git-tag: ${{ steps.create_pre_release.outputs.generated-pre-release-tag }}
-          
 
-      # Send Slack notifying success
-      - name: Slack aselo-deploys channel
-        uses: ./.github/actions/notify-deploys
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          slack-message: "`[Flex]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_pre_release.outputs.generated-pre-release-tag }}` :rocket:."
-        env:
-          SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}
   tag-images:
     needs: generate-pre-release
     runs-on: ubuntu-latest
@@ -142,3 +131,26 @@ jobs:
           REPOSITORY_NAME="twilio/lambda/${{matrix.lambda_path}}"
           MANIFEST=$(aws ecr batch-get-image --repository-name $REPOSITORY_NAME --image-ids imageTag="${{ github.ref_type }}.$REF_NAME_FOR_DOCKER_TAG" --output text --query 'images[].imageManifest')
           aws ecr put-image --repository-name $REPOSITORY_NAME --image-tag tag.${{ needs.generate-pre-release.outputs.qa-version }} --image-manifest "$MANIFEST"
+  send-slack-message:
+    needs: tag-images
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github/actions
+
+      # Send Slack notifying success
+      - name: Slack aselo-deploys channel
+        uses: ./.github/actions/notify-deploys
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          slack-message: "`[Flex]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_pre_release.outputs.generated-pre-release-tag }}` :rocket:."
+        env:
+          SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/twilio-lambda-ci.yml
+++ b/.github/workflows/twilio-lambda-ci.yml
@@ -111,9 +111,3 @@ jobs:
           push: true
           # 'latest' is never used, but it keeps terraform happy
           tags: ${{ env.ECR_URL }}:${{ github.ref_type }}.${{ env.ref_name_for_docker }},${{ env.ECR_URL }}:${{ github.sha }},${{ env.ECR_URL }}:latest
-
-      - name: Generate output
-        id: generate-output
-        run: |
-          # output to logs
-          echo "docker_image=${{ env.ECR_URL }}:${{ github.sha }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

- Adds step to the QA tagging workflow to tag the Twilio Lambda image already tagged with the workflow branch with the QA version
- Remove some redundant code from lambda CI job

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Feature flags added
- [N/A] Strings are localized
- [N/A] Tested for chat contacts
- [N/A] Tested for call contacts

Tested with tagging & deploying a QA release

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P