### PR TITLE
CHI-3181 - Fix Unrequested Offline Contact creation issues

### DIFF
--- a/plugin-hrm-form/src/components/OfflineContact/OfflineContactTask.tsx
+++ b/plugin-hrm-form/src/components/OfflineContact/OfflineContactTask.tsx
@@ -33,7 +33,7 @@ import {
 import selectContactByTaskSid from '../../states/contacts/selectContactByTaskSid';
 import { getOfflineContactTaskSid } from '../../states/contacts/offlineContactTask';
 import { getUnsavedContact } from '../../states/contacts/getUnsavedContact';
-import { namespace, routingBase } from '../../states/storeNamespaces';
+import selectCurrentOfflineContact from '../../states/contacts/selectCurrentOfflineContact';
 
 type OwnProps = { selectedTaskSid?: string };
 
@@ -48,7 +48,7 @@ const OfflineContactTask: React.FC<Props> = ({ isAddingOfflineContact, selectedT
     await Actions.invokeAction('SelectTask', { task: undefined });
   };
 
-  const selected = !selectedTaskSid && isAddingOfflineContact;
+  const selected = !selectedTaskSid;
   const name =
     offlineContactForms &&
     (offlineContactForms.childInformation.firstName || offlineContactForms.childInformation.lastName) &&
@@ -82,7 +82,7 @@ OfflineContactTask.displayName = 'OfflineContactTask';
 const mapStateToProps = (state: RootState) => {
   const { savedContact, draftContact } = selectContactByTaskSid(state, getOfflineContactTaskSid()) || {};
   return {
-    isAddingOfflineContact: state[namespace][routingBase].isAddingOfflineContact,
+    isAddingOfflineContact: selectCurrentOfflineContact(state),
     offlineContact: savedContact ? getUnsavedContact(savedContact, draftContact) : undefined,
   };
 };

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -82,8 +82,8 @@ const TaskView: React.FC<Props> = ({ task }) => {
   );
   const updateHelpline = (contactId: string, helpline: string) => dispatch(updateDraft(contactId, { helpline }));
   React.useEffect(() => {
-    if (shouldRecreateState) {
-      if (isOfflineContactTask(task) || (enableBackendHrmContactCreation && taskContactId)) {
+    if (shouldRecreateState && !isOfflineContactTask(task)) {
+      if (enableBackendHrmContactCreation && taskContactId) {
         asyncDispatcher(newLoadContactFromHrmForTaskAsyncAction(task, workerSid, `${task.taskSid}-active`));
       } else if (
         !enableBackendHrmContactCreation &&
@@ -161,8 +161,9 @@ const TaskView: React.FC<Props> = ({ task }) => {
         }}
       />
     );
-  // If state is partially loaded, don't render until everything settles
-  if (shouldRecreateState || contactIsLoading) {
+  // If state is partially loaded, don't render until everything settles.
+  // Also don't show the form if the contact is finalized
+  if (shouldRecreateState || contactIsLoading || unsavedContact.finalizedAt) {
     return null;
   }
 

--- a/plugin-hrm-form/src/services/formSubmissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSubmissionHelpers.ts
@@ -82,15 +82,14 @@ export const submitContactForm = async (
         taskSid: inBehalfTask.sid,
         finalTaskAttributes: finalAttributes,
       });
-      await finalizeContact(task, savedContact);
-      return savedContact;
+      return finalizeContact(task, savedContact);
     } catch (err) {
       // If something went wrong remove the task for this offline contact
       assignOfflineContactResolve({
         action: 'remove',
         taskSid: inBehalfTask.sid,
       });
-      // TODO: should we do this? Should we care about removing the savedContact if it succeded? This step could break our "idempotence on contacts"
+      // TODO: should we do this? Should we care about removing the savedContact if it succeeded? This step could break our "idempotence on contacts"
 
       // Raise error to caller
       throw err;

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -70,6 +70,25 @@ export const createContactAsyncAction = createAsyncAction(
     const { taskSid } = task;
     if (isOfflineContactTask(task)) {
       contact = await createContact(contactToCreate, workerSid, task);
+      if (!contact.rawJson.contactlessTask.createdOnBehalfOf) {
+        const now = new Date();
+        const time = format(now, 'HH:mm');
+        const date = format(now, 'yyyy-MM-dd');
+        contact = await updateContactInHrm(contact.id, {
+          ...BLANK_CONTACT_CHANGES,
+          timeOfContact: now.toISOString(),
+          rawJson: {
+            ...BLANK_CONTACT_CHANGES.rawJson,
+            contactlessTask: {
+              channel: null,
+              createdOnBehalfOf: workerSid,
+              date,
+              time,
+            },
+          },
+          channel: 'default',
+        });
+      }
     } else {
       const attributes = task.attributes ?? {};
       const { contactId } = attributes;
@@ -78,16 +97,11 @@ export const createContactAsyncAction = createAsyncAction(
         contact = await updateContactInHrm(contactId, { taskId: taskSid, twilioWorkerId: workerSid }, false);
       } else {
         contact = await createContact(contactToCreate, workerSid, task);
-        if (contact.taskId! !== taskSid || contact.twilioWorkerId !== workerSid) {
-          // If the contact is being transferred from a client that doesn't set the contactId on the task, we need to update the contact with the task id and worker id
-          contact = await updateContactInHrm(contact.id, { taskId: taskSid, twilioWorkerId: workerSid }, false);
-        }
         await task.setAttributes({ ...attributes, contactId: contact.id });
       }
       if (TransferHelpers.isColdTransfer(task) && !TransferHelpers.hasTaskControl(task))
         await TransferHelpers.takeTaskControl(task);
     }
-
     let contactCase: Case | undefined;
     if (contact.caseId) {
       contactCase = await getCase(contact.caseId);
@@ -153,26 +167,6 @@ export const newClearContactAsyncAction = (contact: Contact) =>
     ...BLANK_CONTACT_CHANGES,
     timeOfContact: new Date().toISOString(),
   });
-
-export const newRestartOfflineContactAsyncAction = (contact: Contact, createdOnBehalfOf: WorkerSID) => {
-  const now = new Date();
-  const time = format(now, 'HH:mm');
-  const date = format(now, 'yyyy-MM-dd');
-  return updateContactInHrmAsyncAction(contact, {
-    ...BLANK_CONTACT_CHANGES,
-    timeOfContact: now.toISOString(),
-    rawJson: {
-      ...BLANK_CONTACT_CHANGES.rawJson,
-      contactlessTask: {
-        channel: null,
-        createdOnBehalfOf,
-        date,
-        time,
-      },
-    },
-    channel: 'default',
-  });
-};
 
 type ConnectToCaseActionPayload = { contactId: string; caseId: string; contact: Contact; contactCase: Case };
 type RemoveFromCaseActionPayload = { contactId: string; contact: Contact };
@@ -454,7 +448,8 @@ export const saveContactReducer = (initialState: ContactsState) =>
     handleAction(
       submitContactFormAsyncAction.pending as typeof submitContactFormAsyncAction,
       (state, { meta: { contact } }): ContactsState => {
-        return setContactLoadingStateInRedux(state, contact, contact);
+        // Add a temporary finalizedAt to the contact to ensure the UI updates promptly
+        return setContactLoadingStateInRedux(state, contact, { ...contact, finalizedAt: new Date().toISOString() });
       },
     ),
     handleAction(

--- a/plugin-hrm-form/src/states/contacts/selectCurrentOfflineContact.ts
+++ b/plugin-hrm-form/src/states/contacts/selectCurrentOfflineContact.ts
@@ -21,7 +21,8 @@ import { ContactState } from './existingContacts';
 
 const selectCurrentOfflineContact = ({ [namespace]: { activeContacts } }: RootState): ContactState | undefined =>
   Object.values(activeContacts.existingContacts).find(
-    contact => contact.savedContact?.taskId === getOfflineContactTaskSid(),
+    ({ savedContact }) =>
+      savedContact?.taskId === getOfflineContactTaskSid() && savedContact.rawJson.contactlessTask.createdOnBehalfOf,
   );
 
 export default selectCurrentOfflineContact;

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -274,10 +274,10 @@ export const afterCompleteTask = async ({ task }: { task: CustomITask }): Promis
   const manager = Manager.getInstance();
   const contactState = selectContactByTaskSid(manager.store.getState() as RootState, task.taskSid);
   if (contactState) {
+    manager.store.dispatch(GeneralActions.removeContactState(task.taskSid, contactState.savedContact.id));
     const { savedContact } = contactState;
     if (savedContact) {
-      manager.store.dispatch(newFinalizeContactAsyncAction(task, savedContact));
+      await asyncDispatch(manager.store.dispatch)(newFinalizeContactAsyncAction(task, savedContact));
     }
-    manager.store.dispatch(GeneralActions.removeContactState(task.taskSid, contactState.savedContact.id));
   }
 };

--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -45,11 +45,11 @@ import { FeatureFlags, standaloneTaskSid } from '../types/types';
 import { colors } from '../channels/colors';
 import { getHrmConfig } from '../hrmConfig';
 import { AseloMessageInput, AseloMessageList } from '../components/AseloMessaging';
-import { namespace, routingBase } from '../states/storeNamespaces';
 import { changeRoute } from '../states/routing/actions';
 import { AppRoutes, ChangeRouteMode } from '../states/routing/types';
 import { selectCurrentBaseRoute } from '../states/routing/getRoute';
 import { RootState } from '../states';
+import selectCurrentOfflineContact from '../states/contacts/selectCurrentOfflineContact';
 
 type SetupObject = ReturnType<typeof getHrmConfig>;
 /**
@@ -168,7 +168,7 @@ const setUpOfflineContact = () => {
     if: props =>
       props.route.location.pathname === '/agent-desktop/' &&
       !props.selectedTaskSid &&
-      manager.store.getState()[namespace][routingBase].isAddingOfflineContact, // while this is inefficient because of calling getState several times in a short period of time (re-renders), the impact is minimized by the short-circuit evaluation of the AND operator
+      Boolean(selectCurrentOfflineContact(manager.store.getState() as RootState)), // while this is inefficient because of calling getState several times in a short period of time (re-renders), the impact is minimized by the short-circuit evaluation of the AND operator
   });
 };
 


### PR DESCRIPTION
## Description

- Replace addingOfflineContact maintained flag with select based on current state.
- Tighten up UI state around finalized contacts by marking local version as finalized whilst submitting for finalization and not displaying tabbed forms for finalized contacts
- Simplify logic for creating a new offline contact, now clicking the button always does a 'create or load', then if the returned offline contact is in a 'cleared' state (i.e. blanked after being cancelled, because we never delete contact records), update it to an active state
- CustomCRMContainer only ever loads contacts, doesn't try to create them

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [N/A] Feature flags added
- [N/A] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P