### PR TITLE
CHI-2929: Move ALB responses into their own file. Ensure CORS headers are sent and OPTIONS preflights are handler correctly

### DIFF
--- a/lambdas/account-scoped/src/albResponses.ts
+++ b/lambdas/account-scoped/src/albResponses.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { ErrorResult } from './Result';
+import { HttpError } from './httpTypes';
+import { ALBEvent, ALBResult } from 'aws-lambda';
+
+export const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS,POST,GET,PUT,DELETE,PATCH,HEAD',
+  'Access-Control-Allow-Headers':
+    'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
+};
+
+export const okJsonResponse = (body: any = {}): ALBResult => ({
+  headers: {
+    ...CORS_HEADERS,
+    'Content-Type': 'application/json',
+  },
+  statusCode: 200,
+  body: JSON.stringify(body),
+});
+
+export const notFoundResponse = (event: ALBEvent): ALBResult => ({
+  statusCode: 404,
+  headers: {
+    ...CORS_HEADERS,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    message: `Route not found ${event.httpMethod} - ${event.path}`,
+  }),
+});
+
+export const convertHttpErrorResultToALBResult = (
+  result: ErrorResult<HttpError>,
+): ALBResult => ({
+  headers: {
+    ...CORS_HEADERS,
+    'Content-Type': 'application/json',
+  },
+  statusCode: result.error.statusCode,
+  body: JSON.stringify({
+    message: result.message,
+    cause: {
+      message: result.error.cause?.message,
+      stack: result.error.cause?.stack,
+    },
+  }),
+});


### PR DESCRIPTION
## Description

- Adds CORS headers to all responses
- Ensures OPTIONS preflight requests are handled correctly
- Create a module for generating ALB responses to keep entrypoint handler small & readable

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P