### PR TITLE
CHI-3260: Work around limitation introduced in Flex 2.11.0

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -60,7 +60,7 @@
         "@testing-library/user-event": "^14.1.1",
         "@twilio/flex-plugin": "^7.1.0",
         "@twilio/flex-plugin-scripts": "^7.1.0",
-        "@twilio/flex-ui": "^2.10.1",
+        "@twilio/flex-ui": "^2.11.0",
         "@twilio/flex-ui-dev-proxy": "^1.1.2",
         "@types/jest": "^27.5.2",
         "@types/react": "^17.0.47",
@@ -105,7 +105,7 @@
         "webpack-bundle-analyzer": "^4.10.2"
       },
       "engines": {
-        "node": "^18.20.0"
+        "node": "^20.18.0"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.3"
@@ -8211,6 +8211,8 @@
     },
     "node_modules/@apollo/client": {
       "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.11.tgz",
+      "integrity": "sha512-H7e9m7cRcFO93tokwzqrsbnfKorkpV24xU30hFH5u2g6B+c1DMo/ouyF/YrBPdrTzqxQCjTUmds/FLmJ7626GA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10115,9 +10117,11 @@
       }
     },
     "node_modules/@citrix/ucsdk": {
-      "version": "3.1.0",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@citrix/ucsdk/-/ucsdk-4.0.2.tgz",
+      "integrity": "sha512-FBMhkUPwtxQYgA8GkwxcJs/zjPPKWGC1DpX427SA9Enrl1MBES9uT8ma+kp793lxndAg1mTAIEptrhWruWuMUQ==",
       "dev": true,
-      "license": "CITRIX READY PARTNER DEVELOPER MATERIALS REDISTRIBUTION LICENSE AGREEMENT"
+      "license": "SEE LICENSE IN CITRIX_READY_PARTNER_DEVELOPER_MATERIALS_REDISTRIBUTION_LICENSE_AGREEMENT.txt"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -20872,7 +20876,9 @@
       "license": "MIT"
     },
     "node_modules/@twilio/flex-sdk": {
-      "version": "0.99.28-dev.1",
+      "version": "0.99.32-dev",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.99.32-dev.tgz",
+      "integrity": "sha512-TiAu5wuJgYijU24tSsN9IIeSLqGM67iJb7c017OsA6DGDZ2WXEcR+KfXoJwBRCcrOgn6HDmFNSkpTnUwUHbxAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -20880,7 +20886,9 @@
         "@segment/analytics-node": "1.3.0",
         "@twilio/voice-sdk": "^2.11.0",
         "buffer": "^6.0.3",
+        "core-js": "^3.19.3",
         "crypto-js": "^4.2.0",
+        "events": "^3.3.0",
         "graphql-tag": "^2.12.6",
         "graphql-ws": "5.15.0",
         "lodash": "^4.17.21",
@@ -20888,7 +20896,7 @@
         "query-string": "^6.2.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
-        "twilio-taskrouter": "^2.0.11",
+        "twilio-taskrouter": "^2.0.12",
         "twilsock": "^0.8.3",
         "ws": "^8.18.0"
       },
@@ -20915,6 +20923,8 @@
     },
     "node_modules/@twilio/flex-sdk/node_modules/loglevel": {
       "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20926,7 +20936,9 @@
       }
     },
     "node_modules/@twilio/flex-sdk/node_modules/rxjs": {
-      "version": "7.8.1",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -20935,6 +20947,8 @@
     },
     "node_modules/@twilio/flex-sdk/node_modules/twilsock": {
       "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/twilsock/-/twilsock-0.8.3.tgz",
+      "integrity": "sha512-jS7sFoecgofYiRAYvinL3cYlwqOXkgtdb81q24H8mD2DNbnTwNQ6GQNURJ5GxjTYo/iSsgQjYVUs9lJaXU1uaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20951,6 +20965,8 @@
     },
     "node_modules/@twilio/flex-sdk/node_modules/twilsock/node_modules/ws": {
       "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
+      "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20959,6 +20975,9 @@
     },
     "node_modules/@twilio/flex-sdk/node_modules/uuid": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -20966,7 +20985,9 @@
       }
     },
     "node_modules/@twilio/flex-sdk/node_modules/ws": {
-      "version": "8.18.0",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20986,12 +21007,14 @@
       }
     },
     "node_modules/@twilio/flex-ui": {
-      "version": "2.10.1",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-2.11.0.tgz",
+      "integrity": "sha512-OdgX5QZ8Gfg3LomwiVJhz8deXbx4rUozdTmBH4maXqK2lhI1Q/Btrt2RyI4yxPsnbmeJ1bniHkG/XM6tZ6MtHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "3.9.11",
-        "@citrix/ucsdk": "3.1.0",
+        "@citrix/ucsdk": "4.0.2",
         "@dnd-kit/core": "6.0.8",
         "@dnd-kit/modifiers": "6.0.1",
         "@dnd-kit/sortable": "7.0.2",
@@ -21013,7 +21036,7 @@
         "@twilio-paste/icons": "^9.2.0",
         "@twilio-paste/lexical-library": "^4.2.0",
         "@twilio/conversations": "2.5.0",
-        "@twilio/flex-sdk": "0.99.28-dev.1",
+        "@twilio/flex-sdk": "0.99.32-dev",
         "@twilio/flex-ui-telemetry": "1.3.2",
         "@twilio/player": "^1.1.1",
         "@twilio/voice-sdk": "2.11.1",
@@ -21404,11 +21427,15 @@
     },
     "node_modules/@twilio/voice-errors": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@twilio/voice-errors/-/voice-errors-1.4.0.tgz",
+      "integrity": "sha512-7BCg9MPz+KQ0JJ6Rl5W3Zw3E+i3Tt77VZw3/2i3Z+IPZITmCOQLu1nKx/0Nlj505Xtfr7eY9Mcern5PfIoBW0w==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@twilio/voice-sdk": {
       "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@twilio/voice-sdk/-/voice-sdk-2.11.1.tgz",
+      "integrity": "sha512-w/86SJ/kl8yJs4vj0sv4IUN9WT1djVzLcvSKmNblK4rnvPPKVxwjoxSFgyinAGGjrCTnfIb5lTGzrRKajS1jHw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -21701,6 +21728,8 @@
     },
     "node_modules/@types/md5": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.2.tgz",
+      "integrity": "sha512-v+JFDu96+UYJ3/UWzB0mEglIS//MZXgRaJ4ubUPwOM0gvLc/kcQ3TWNYwENEK7/EcXGQVrW8h/XqednSjBd/Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -22739,6 +22768,8 @@
     },
     "node_modules/@wry/caches": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22750,6 +22781,8 @@
     },
     "node_modules/@wry/context": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22761,6 +22794,8 @@
     },
     "node_modules/@wry/equality": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22772,6 +22807,8 @@
     },
     "node_modules/@wry/trie": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -29545,6 +29582,8 @@
     },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -29559,8 +29598,13 @@
     },
     "node_modules/graphql-ws": {
       "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.15.0.tgz",
+      "integrity": "sha512-xWGAtm3fig9TIhSaNsg0FaDZ8Pyn/3re3RFlP4rhQcmjRDIPpk1EhRuNB+YSJtLzttyuToaDiNhwT1OMoGnJnw==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "website"
+      ],
       "engines": {
         "node": ">=10"
       },
@@ -36760,6 +36804,8 @@
     },
     "node_modules/jwt-decode": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
       "dev": true,
       "license": "MIT"
     },
@@ -38682,6 +38728,8 @@
     },
     "node_modules/optimism": {
       "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -40524,6 +40572,8 @@
     },
     "node_modules/query-string": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
+      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -41597,6 +41647,8 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
+      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -41782,6 +41834,8 @@
     },
     "node_modules/rehackt": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.0.6.tgz",
+      "integrity": "sha512-l3WEzkt4ntlEc/IB3/mF6SRgNHA6zfQR7BlGOgBTOmx7IJJXojDASav+NsgXHFjHn+6RmwqsGPFgZpabWpeOdw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -42118,6 +42172,8 @@
     },
     "node_modules/response-iterator": {
       "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.20.tgz",
+      "integrity": "sha512-RfNi9saiJ9VKznrRZEGZtlfeiQI7NWMUlXvmkvO60xaHfW1y+36EOibZkV59LuKNak8VIqL6IyxYxhMOGTurIQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -42210,6 +42266,8 @@
     },
     "node_modules/rtcpeerconnection-shim": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.8.tgz",
+      "integrity": "sha512-5Sx90FGru1sQw9aGOM+kHU4i6mbP8eJPgxliu2X3Syhg8qgDybx8dpDTxUwfJvPnubXFnZeRNl59DWr4AttJKQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -42513,6 +42571,8 @@
     },
     "node_modules/sdp": {
       "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
+      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw==",
       "dev": true,
       "license": "MIT"
     },
@@ -43521,6 +43581,8 @@
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -43831,6 +43893,8 @@
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -44395,6 +44459,8 @@
     },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -46816,6 +46882,8 @@
     },
     "node_modules/twilio-taskrouter": {
       "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-2.0.12.tgz",
+      "integrity": "sha512-fH1lVarYy3ZUSFs4kWUwyJWleBA4zLxuTyop9nQz+X3jymyOEk2d5bEDLKrDFMLH20zYBk+VKB5esnPQmrDxfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -46835,7 +46903,9 @@
       }
     },
     "node_modules/twilio-taskrouter/node_modules/ws": {
-      "version": "8.18.0",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -47015,6 +47085,8 @@
     },
     "node_modules/typed-emitter": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
@@ -49265,11 +49337,15 @@
     },
     "node_modules/zen-observable": {
       "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -101,7 +101,7 @@
     "@testing-library/user-event": "^14.1.1",
     "@twilio/flex-plugin": "^7.1.0",
     "@twilio/flex-plugin-scripts": "^7.1.0",
-    "@twilio/flex-ui": "^2.10.1",
+    "@twilio/flex-ui": "^2.11.0",
     "@twilio/flex-ui-dev-proxy": "^1.1.2",
     "@types/jest": "^27.5.2",
     "@types/react": "^17.0.47",

--- a/plugin-hrm-form/src/channels/colors.ts
+++ b/plugin-hrm-form/src/channels/colors.ts
@@ -14,9 +14,8 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { ITask, ReservationStatuses, TaskChannelDefinition } from '@twilio/flex-ui';
+import { ITask, ReservationStatuses, TaskChannelDefinition, DefaultTaskChannels } from '@twilio/flex-ui';
 import React from 'react';
-import * as Flex from '@twilio/flex-ui';
 
 import { ChannelColors } from '../states/DomainConstants';
 
@@ -36,11 +35,11 @@ export const mainChannelColor = (
   }
 };
 
-const voiceColor = mainChannelColor(Flex.DefaultTaskChannels.Call);
-const webColor = mainChannelColor(Flex.DefaultTaskChannels.Chat);
-const facebookColor = mainChannelColor(Flex.DefaultTaskChannels.ChatMessenger);
-const smsColor = mainChannelColor(Flex.DefaultTaskChannels.ChatSms);
-const whatsappColor = mainChannelColor(Flex.DefaultTaskChannels.ChatWhatsApp);
+const voiceColor = '#a0a8bd'; // mainChannelColor(DefaultTaskChannels.Voice) errors without a valid task in Flex 2.11.0
+const webColor = mainChannelColor(DefaultTaskChannels.Chat);
+const facebookColor = mainChannelColor(DefaultTaskChannels.ChatMessenger);
+const smsColor = mainChannelColor(DefaultTaskChannels.ChatSms);
+const whatsappColor = mainChannelColor(DefaultTaskChannels.ChatWhatsApp);
 const telegramColor = '#1DA1F2';
 const instagramColor = '#833AB4';
 const lineColor = '#00C300';


### PR DESCRIPTION
## Description

- Replaced a call to `mainColor` is a hardcoded value taken from the code to determine the colour used for voice channels, because in Flex v2.11.0 that function started throwing errors if passed an undefined task

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P