### PR TITLE
CHI-3271: Fix inconsistencies with defaultOption where some parts of the code expect an object and others a string

### DIFF
--- a/hrm-form-definitions/src/formDefinition/types.ts
+++ b/hrm-form-definitions/src/formDefinition/types.ts
@@ -113,7 +113,7 @@ export type InputOption = { value: any; label: string };
 type RadioInputDefinition = {
   type: FormInputType.RadioInput;
   options: InputOption[];
-  defaultOption?: InputOption['value'];
+  defaultOption?: InputOption;
 } & ItemBase;
 
 /**
@@ -133,7 +133,7 @@ export type SelectOption = { value: any; label: string };
 
 type BaseSelectDefinition = {
   type: FormInputType.Select;
-  defaultOption?: SelectOption['value'];
+  defaultOption?: SelectOption;
   unknownOption?: SelectOption['value'];
 } & ItemBase;
 

--- a/lambdas/account-scoped/src/hrm/populateHrmContactFormFromTask.ts
+++ b/lambdas/account-scoped/src/hrm/populateHrmContactFormFromTask.ts
@@ -42,6 +42,7 @@ export enum FormInputType {
 }
 
 export type FormItemDefinition = {
+  type: FormInputType;
   name: string;
   unknownOption?: string;
   options?: { value: string }[];
@@ -50,7 +51,9 @@ export type FormItemDefinition = {
 } & (
   | {
       type: Exclude<FormInputType, FormInputType.DependentSelect>;
-      defaultOption?: string;
+      defaultOption?: {
+        value: string;
+      };
     }
   | {
       type: FormInputType.DependentSelect;
@@ -184,14 +187,14 @@ const getInitialValue = (def: FormItemDefinition): FormValue => {
       return '';
     }
     case FormInputType.RadioInput:
-      return def.defaultOption ?? '';
+      return def.defaultOption?.value ?? '';
     case FormInputType.ListboxMultiselect:
       return [];
     case FormInputType.Select:
-      if (def.defaultOption) return def.defaultOption;
+      if (def.defaultOption) return def.defaultOption.value;
       return def.options && def.options[0] ? def.options[0].value : null;
     case FormInputType.DependentSelect:
-      return def.defaultOption?.value;
+      return def.defaultOption?.value ?? '';
     case FormInputType.CopyTo:
     case FormInputType.Checkbox:
       return Boolean(def.initialChecked);

--- a/lambdas/account-scoped/tests/testHrmValues.ts
+++ b/lambdas/account-scoped/tests/testHrmValues.ts
@@ -45,7 +45,9 @@ const BASE_PERSON_FORM_DEFINITION: FormItemDefinition[] = [
   },
   {
     name: 'gender',
-    defaultOption: 'Unknown',
+    defaultOption: {
+      value: 'Unknown',
+    },
     type: FormInputType.Select,
     options: [
       {

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -83,7 +83,7 @@ export const getInitialValue = (def: FormItemDefinition) => {
     case FormInputType.ListboxMultiselect:
       return [];
     case FormInputType.Select:
-      return def.defaultOption ? def.defaultOption : def.options[0].value;
+      return def.defaultOption?.value || def.options[0].value;
     case FormInputType.DependentSelect:
       return def.defaultOption.value;
     case FormInputType.CopyTo:
@@ -337,7 +337,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
             const [isMounted, setIsMounted] = React.useState(false); // value to avoid setting the default in the first render.
 
             React.useEffect(() => {
-              if (isMounted && def.defaultOption) setValue(path, def.defaultOption);
+              if (isMounted && def.defaultOption) setValue(path, def.defaultOption.value);
               else setIsMounted(true);
             }, [isMounted, setValue]);
 
@@ -570,7 +570,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
 
             React.useEffect(() => {
               if (isMounted.current && prevDependeeValue.current && dependeeValue !== prevDependeeValue.current) {
-                setValue(path, def.defaultOption.value, { shouldValidate: true });
+                setValue(path, def.defaultOption, { shouldValidate: true });
               } else isMounted.current = true;
 
               prevDependeeValue.current = dependeeValue;

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -45,9 +45,8 @@ export const createContactlessTaskTabDefinition = ({
   const helplineLabel = helplineInformation.label;
   const mapHelplineEntriesToOptions = ({ value, label }) => ({ value, label });
   const helplineOptions = helplineInformation.helplines.map(mapHelplineEntriesToOptions);
-  const defaultHelplineOption = (
-    helplineInformation.helplines.find(helpline => helpline.default) || helplineInformation.helplines[0]
-  ).value;
+  const defaultHelplineOption =
+    helplineInformation.helplines.find(helpline => helpline.default) || helplineInformation.helplines[0];
 
   const channelOptions = definition.offlineChannels
     ? defaultChannelOptions.concat(definition.offlineChannels.map(c => ({ value: c, label: c })))


### PR DESCRIPTION
## Description

Some parts of the code expect form definitions 'select' item's `defaultOption` attribute to be a simple string, whereas others expect the SelectOption object (with a label and a value property). This inconsistency is causing bad data to get saved to case sections in rare circumstances

This PR standardises the code to expect the object form, as this is how the definitions are already configured

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P