### PR TITLE
CHI-3291: Ensure the sidWithTaskControl transferMeta attribute is set when accepting a transfer reservation.

### DIFF
--- a/lambdas/account-scoped/tests/testTwilioValues.ts
+++ b/lambdas/account-scoped/tests/testTwilioValues.ts
@@ -23,6 +23,7 @@ export const TEST_TASK_SID: TaskSID = 'WTut';
 export const TEST_WORKER_SID: WorkerSID = 'WKut';
 export const TEST_CONTACT_ID = '1337';
 export const TEST_WORKSPACE_SID = 'WSut';
+export const TEST_RESERVATION_FOR_TEST_WORKER_ON_TEST_TASK_SID = 'WKut reservation for WTut'
 export const DEFAULT_CONFIGURATION_ATTRIBUTES: AseloServiceConfigurationAttributes = {
   definitionVersion: 'ut-v1',
   hrm_api_version: 'v1',

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -69,7 +69,8 @@ const TaskView: React.FC<Props> = ({ task }) => {
   const contactIsLoading = useSelector((state: RootState) => selectIsContactCreating(state, task?.taskSid));
   const shouldRecreateState =
     currentDefinitionVersion &&
-    !savedContact &&
+    // Needs reloading if taskSid on contact doesn't match the taskSid of the task
+    (!savedContact || savedContact.taskId !== task.taskSid) &&
     !(metadata?.loadingStatus === LoadingStatus.LOADING) &&
     !contactIsLoading;
 

--- a/plugin-hrm-form/src/states/contacts/saveContact.ts
+++ b/plugin-hrm-form/src/states/contacts/saveContact.ts
@@ -67,6 +67,7 @@ import {
   rollbackSavingStateInRedux,
   contactReduxUpdates,
 } from './contactReduxUpdates';
+import { getAseloFeatureFlags } from '../../hrmConfig';
 
 export const createContactAsyncAction = createAsyncAction(
   CREATE_CONTACT_ACTION,
@@ -104,7 +105,11 @@ export const createContactAsyncAction = createAsyncAction(
         contact = await createContact(contactToCreate, workerSid, task);
         await task.setAttributes({ ...attributes, contactId: contact.id });
       }
-      if (TransferHelpers.isColdTransfer(task) && !TransferHelpers.hasTaskControl(task))
+      if (
+        !getAseloFeatureFlags().enable_backend_hrm_contact_creation &&
+        TransferHelpers.isColdTransfer(task) &&
+        !TransferHelpers.hasTaskControl(task)
+      )
         await TransferHelpers.takeTaskControl(task);
     }
     let contactCase: Case | undefined;


### PR DESCRIPTION
## Description

- ensure that we set the sidWithTaskControl when accepting a reservation for a transfer if we are handling contact creation in task router
- do not set sidWithTaskControl in Flex if we are handling task creation on the backend. This is not strictly necessary but it makes redundant code easier to remove later and saves a call to Twilio
- Ensure we reload a contact if it's task ID doesn't match the task sid with it#'s contact ID, it means it's stale in redux following a transfer

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [x] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P