### PR TITLE
CHI-3286-record_taskSids_on_convos_all_channels

### DIFF
--- a/lambdas/account-scoped/tests/testTwilioValues.ts
+++ b/lambdas/account-scoped/tests/testTwilioValues.ts
@@ -23,6 +23,9 @@ export const TEST_TASK_SID: TaskSID = 'WTut';
 export const TEST_WORKER_SID: WorkerSID = 'WKut';
 export const TEST_CONTACT_ID = '1337';
 export const TEST_WORKSPACE_SID = 'WSut';
+export const TEST_CONVERSATION_SID = 'CHut';
+export const TEST_CHAT_SERVICE_SID = 'ISut';
+export const TEST_CHANNEL_SID = 'CHut';
 export const DEFAULT_CONFIGURATION_ATTRIBUTES: AseloServiceConfigurationAttributes = {
   definitionVersion: 'ut-v1',
   hrm_api_version: 'v1',

--- a/lambdas/account-scoped/tests/unit/conversation/addTaskSidToChannelAttributesTaskRouterListener.test.ts
+++ b/lambdas/account-scoped/tests/unit/conversation/addTaskSidToChannelAttributesTaskRouterListener.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import twilio from 'twilio';
+import { RecursivePartial } from '../RecursivePartial';
+import {
+  TEST_ACCOUNT_SID,
+  TEST_CHANNEL_SID,
+  TEST_CHAT_SERVICE_SID,
+  TEST_CONVERSATION_SID,
+  TEST_TASK_SID,
+  TEST_WORKSPACE_SID,
+} from '../../testTwilioValues';
+import { TaskContext, TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
+import { WorkspaceContext } from 'twilio/lib/rest/taskrouter/v1/workspace';
+import { TaskSID } from '../../../src/twilioTypes';
+import { addTaskSidToChannelAttributes } from '../../../src/conversation/addTaskSidToChannelAttributesTaskRouterListener';
+import {
+  ConversationContext,
+  ConversationInstance,
+} from 'twilio/lib/rest/conversations/v1/conversation';
+import { setConfigurationAttributes } from '../mockServiceConfiguration';
+import { EventFields } from '../../../src/taskrouter';
+import each from 'jest-each';
+import { ChannelContext, ChannelInstance } from 'twilio/lib/rest/chat/v2/service/channel';
+
+jest.mock('../../../src/configuration/twilioConfiguration', () => ({
+  getWorkspaceSid: jest.fn().mockResolvedValue(TEST_WORKSPACE_SID),
+  getChatServiceSid: jest.fn().mockResolvedValue(TEST_CHAT_SERVICE_SID),
+}));
+
+let twilioClient: twilio.Twilio;
+
+const mockFetchTask: jest.MockedFunction<TaskContext['fetch']> = jest.fn();
+
+const setTaskReturnedByFetch = (
+  taskSid: TaskSID,
+  isContactlessTask: boolean,
+  isConversation: boolean,
+) => {
+  mockFetchTask.mockClear();
+  mockFetchTask.mockResolvedValue({
+    attributes: JSON.stringify({
+      isContactlessTask,
+      [isConversation ? 'conversationSid' : 'channelSid']: isConversation
+        ? TEST_CONVERSATION_SID
+        : TEST_CHANNEL_SID,
+    }),
+    sid: taskSid,
+    update: jest.fn() as TaskInstance['update'],
+  } as TaskInstance);
+};
+
+const mockFetchConversation: jest.MockedFunction<ConversationContext['fetch']> =
+  jest.fn();
+
+const mockUpdateConversation: jest.MockedFunction<ConversationInstance['update']> =
+  jest.fn();
+
+const setConversationReturnedByFetch = (
+  conversationSid: string,
+  tasksSids?: string[],
+) => {
+  mockFetchConversation.mockClear();
+  mockFetchConversation.mockResolvedValue({
+    attributes: JSON.stringify({ ...(tasksSids ? { tasksSids } : {}) }),
+    sid: conversationSid,
+    update: mockUpdateConversation as ConversationInstance['update'],
+  } as ConversationInstance);
+};
+
+const mockFetchChannel: jest.MockedFunction<ChannelContext['fetch']> = jest.fn();
+
+const mockUpdateChannel: jest.MockedFunction<ChannelInstance['update']> = jest.fn();
+
+const setChannelReturnedByFetch = (channelSid: string, tasksSids?: string[]) => {
+  mockFetchChannel.mockClear();
+  mockFetchChannel.mockResolvedValue({
+    attributes: JSON.stringify({ ...(tasksSids ? { tasksSids } : {}) }),
+    sid: channelSid,
+    update: mockUpdateChannel as ChannelInstance['update'],
+  } as ChannelInstance);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  const mockTwilioClient: RecursivePartial<twilio.Twilio> = {
+    taskrouter: {
+      v1: {
+        workspaces: {
+          get: (workspaceSid: string) => {
+            if (workspaceSid === TEST_WORKSPACE_SID) {
+              return {
+                tasks: {
+                  get: (taskSid: string) => {
+                    if (taskSid === TEST_TASK_SID) {
+                      return {
+                        fetch: mockFetchTask as TaskContext['fetch'],
+                      } as TaskContext;
+                    } else throw new Error(`Unexpected task SID: ${taskSid}`);
+                  },
+                },
+              } as WorkspaceContext;
+            } else throw new Error(`Unexpected workspace SID: ${workspaceSid}`);
+          },
+        },
+      },
+    },
+    conversations: {
+      v1: {
+        conversations: {
+          get: (conversationSid: string) => {
+            if (conversationSid === TEST_CONVERSATION_SID) {
+              return {
+                fetch: mockFetchConversation as ConversationContext['fetch'],
+                update: mockUpdateConversation as ConversationContext['update'],
+              } as ConversationInstance;
+            } else throw new Error(`Unexpected conversation SID: ${conversationSid}`);
+          },
+        },
+      },
+    },
+    chat: {
+      v2: {
+        services: {
+          get: (serviceSid: string) => {
+            if (serviceSid === TEST_CHAT_SERVICE_SID) {
+              return {
+                channels: {
+                  get: (channelSid: string) => {
+                    if (channelSid === TEST_CHANNEL_SID) {
+                      return {
+                        fetch: mockFetchChannel as ChannelContext['fetch'],
+                      } as ChannelContext;
+                    } else throw new Error(`Unexpected channel SID: ${channelSid}`);
+                  },
+                },
+              };
+            } else throw new Error(`Unexpected service SID: ${serviceSid}`);
+          },
+        },
+      },
+    },
+  };
+
+  twilioClient = mockTwilioClient as twilio.Twilio;
+
+  mockUpdateConversation.mockImplementation(
+    async update =>
+      ({
+        ...(await mockFetchConversation()),
+        ...update,
+      }) as ConversationInstance,
+  );
+
+  mockUpdateChannel.mockImplementation(
+    async update =>
+      ({
+        ...(await mockFetchChannel()),
+        ...update,
+      }) as ChannelInstance,
+  );
+});
+
+const newEventFields = (
+  taskChannelUniqueName: string,
+  isContactlessTask: boolean,
+  isConversation: boolean,
+) =>
+  ({
+    TaskChannelUniqueName: taskChannelUniqueName,
+    TaskAttributes: JSON.stringify({
+      isContactlessTask,
+      [isConversation ? 'conversationSid' : 'channelSid']: isConversation
+        ? TEST_CONVERSATION_SID
+        : TEST_CHANNEL_SID,
+    }),
+    TaskSid: TEST_TASK_SID,
+  }) as EventFields;
+
+describe('addTaskSidToChannelAttributes', () => {
+  each([{ taskType: 'Conversation' }, { taskType: 'Programmable Chat' }]).describe(
+    '$taskType task',
+    ({ taskType }) => {
+      const isConversation = taskType === 'Conversation';
+      const mockUpdate = isConversation ? mockUpdateConversation : mockUpdateChannel;
+      beforeEach(() => {
+        setTaskReturnedByFetch(TEST_TASK_SID, false, isConversation);
+        setConversationReturnedByFetch(TEST_CONVERSATION_SID);
+        setChannelReturnedByFetch(TEST_CHANNEL_SID);
+        twilioClient = setConfigurationAttributes(twilioClient, {
+          feature_flags: { lambda_task_created_handler: true },
+        });
+      });
+      test('Twilio task, no taskSids already set, chat task channel - adds taskSid to attributes', async () => {
+        // Act
+        await addTaskSidToChannelAttributes(
+          newEventFields('chat', false, isConversation),
+          TEST_ACCOUNT_SID,
+          twilioClient,
+        );
+
+        // Assert
+        expect(mockUpdate).toHaveBeenCalledWith({
+          attributes: JSON.stringify({ tasksSids: [TEST_TASK_SID] }),
+        });
+      });
+      test('Flag not set - noop', async () => {
+        //Arrange
+        twilioClient = setConfigurationAttributes(twilioClient, {
+          feature_flags: { lambda_task_created_handler: false },
+        });
+        // Act
+        await addTaskSidToChannelAttributes(
+          newEventFields('chat', false, isConversation),
+          TEST_ACCOUNT_SID,
+          twilioClient,
+        );
+
+        // Assert
+        expect(mockUpdate).not.toHaveBeenCalled();
+      });
+      test('survey task - noop', async () => {
+        // Act
+        await addTaskSidToChannelAttributes(
+          newEventFields('survey', false, isConversation),
+          TEST_ACCOUNT_SID,
+          twilioClient,
+        );
+
+        // Assert
+        expect(mockUpdate).not.toHaveBeenCalled();
+      });
+      test('Twilio task, taskSids already set, chat task channel - adds taskSid to existing array', async () => {
+        // Arrange
+        if (isConversation) {
+          setConversationReturnedByFetch(TEST_CONVERSATION_SID, ['WTexisting']);
+        } else {
+          setChannelReturnedByFetch(TEST_CHANNEL_SID, ['WTexisting']);
+        }
+
+        // Act
+        await addTaskSidToChannelAttributes(
+          newEventFields('chat', false, isConversation),
+          TEST_ACCOUNT_SID,
+          twilioClient,
+        );
+
+        // Assert
+        expect(mockUpdate).toHaveBeenCalledWith({
+          attributes: JSON.stringify({ tasksSids: ['WTexisting', TEST_TASK_SID] }),
+        });
+      });
+    },
+  );
+});

--- a/twilio-iac/helplines/templates/studio-flows/messaging-custom-channel-lex-v3-blocking.tftpl
+++ b/twilio-iac/helplines/templates/studio-flows/messaging-custom-channel-lex-v3-blocking.tftpl
@@ -14,7 +14,7 @@ ${
           "event": "incomingCall"
         },
         {
-          "next": "getProfileFlagsForIdentifier",
+          "next": "set_hasNonSurveyTasks",
           "event": "incomingConversationMessage"
         },
         {
@@ -30,7 +30,55 @@ ${
           "y": -460
         }
       }
-    },
+    },{
+              "name": "set_hasNonSurveyTasks",
+              "type": "set-variables",
+              "transitions": [
+                {
+                  "next": "block_if_non_survey_task_associated",
+                  "event": "next"
+                }
+              ],
+              "properties": {
+                "variables": [
+                  {
+                    "value": "{% if trigger.conversation.ChannelAttributes.tasksSids %}true{% elif trigger.message.ChannelAttributes.tasksSids %}true{% else %}false{% endif %}",
+                    "key": "hasNonSurveyTasks"
+                  }
+                ],
+                "offset": {
+                  "x": 520,
+                  "y": 1760
+                }
+              }
+          },
+          {
+            "name": "block_if_non_survey_task_associated",
+            "type": "split-based-on",
+            "transitions": [
+              {
+                "next": "getProfileFlagsForIdentifier",
+                "event": "match",
+                "conditions": [
+                  {
+                    "friendly_name": "Has no non-survey tasks",
+                    "arguments": [
+                      "{{widgets.set_hasNonSurveyTasks.hasNonSurveyTasks}}"
+                    ],
+                    "type": "equal_to",
+                    "value": "false"
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "input": "{{widgets.getProfileFlagsForIdentifier.parsed.flags}}",
+              "offset": {
+                "x": -690,
+                "y": -60
+              }
+            }
+          },
     {
       "name": "getProfileFlagsForIdentifier",
       "type": "make-http-request",

--- a/twilio-iac/helplines/templates/studio-flows/messaging-custom-channel-lex-v3-blocking.tftpl
+++ b/twilio-iac/helplines/templates/studio-flows/messaging-custom-channel-lex-v3-blocking.tftpl
@@ -42,7 +42,7 @@ ${
               "properties": {
                 "variables": [
                   {
-                    "value": "{% if trigger.conversation.ChannelAttributes.tasksSids %}true{% elif trigger.message.ChannelAttributes.tasksSids %}true{% else %}false{% endif %}",
+                    "value": "{% if trigger.conversation.ChannelAttributes.tasksSids %}{{true}}{% elsif trigger.message.ChannelAttributes.tasksSids %}{{true}}{% else %}{{false}}{% endif %}",
                     "key": "hasNonSurveyTasks"
                   }
                 ],


### PR DESCRIPTION
## Description

- Change the logic for putting task sids in the channel attributes to apply to all tasks EXCEPT 'survey' tasks (i.e. chatbot control tasks)
- Add an example of how a studio flow would be updated to use the task sids in the channel attributes to prevent the initial studio flow being rerun when the conversation is already ongoing
- Unit tests for the listener to add the task sids to the channel attributes on task creation

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P