### PR TITLE
CHI-3283 Fix to load the channel type voice and recording for outbound calls

### DIFF
--- a/lambdas/account-scoped/src/hrm/createHrmContactTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/hrm/createHrmContactTaskRouterListener.ts
@@ -44,7 +44,7 @@ const BLANK_CONTACT: HrmContact = {
     caseInformation: {},
     callType: '',
     contactlessTask: {
-      channel: 'web',
+      channel: '' as any,
       date: '',
       time: '',
       createdOnBehalfOf: '',
@@ -87,6 +87,8 @@ export const handleEvent = async (
     transferTargetType,
     channelType,
     customChannelType,
+    conference,
+    direction,
   } = taskAttributes;
 
   if (isContactlessTask) {
@@ -155,10 +157,15 @@ export const handleEvent = async (
 
   console.debug('Creating HRM contact for task', taskSid, 'Hrm Account:', hrmAccountId);
 
+  const isOutboundVoiceTask = direction === 'outbound' && Boolean(conference);
+
   const newContact: HrmContact = {
     ...BLANK_CONTACT,
     definitionVersion,
-    channel: (customChannelType || channelType || 'default') as HrmContact['channel'],
+    channel: (customChannelType ||
+      (isOutboundVoiceTask && 'voice') ||
+      channelType ||
+      'default') as HrmContact['channel'],
     rawJson: {
       definitionVersion,
       ...BLANK_CONTACT.rawJson,

--- a/lambdas/account-scoped/src/hrm/createHrmContactTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/hrm/createHrmContactTaskRouterListener.ts
@@ -201,6 +201,7 @@ export const handleEvent = async (
   const updatedAttributes = {
     ...JSON.parse(currentTaskAttributes),
     contactId: id.toString(),
+    outboundVoiceTaskStartMillis: isOutboundVoiceTask ? new Date().getTime() : null,
   };
   await taskContext.update({ attributes: JSON.stringify(updatedAttributes) });
 };

--- a/lambdas/account-scoped/tests/unit/hrm/testContacts.ts
+++ b/lambdas/account-scoped/tests/unit/hrm/testContacts.ts
@@ -28,7 +28,7 @@ export const BLANK_CONTACT: HrmContact = {
     caseInformation: {},
     callType: '',
     contactlessTask: {
-      channel: 'web',
+      channel: '' as any,
       date: '',
       time: '',
       createdOnBehalfOf: '',


### PR DESCRIPTION
## Description
- Outbound voice calls were getting created but were not getting some essential fields updated because they were not labeled 'voice' calls with enable_backend_hrm_contact_creation flag on. There is now an explicit check for outbound voice calls.

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P