### PR TITLE
Upgrade flex-ui to 2.11.1

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -60,7 +60,7 @@
         "@testing-library/user-event": "^14.1.1",
         "@twilio/flex-plugin": "^7.1.0",
         "@twilio/flex-plugin-scripts": "^7.1.0",
-        "@twilio/flex-ui": "2.9.1",
+        "@twilio/flex-ui": "2.11.1",
         "@twilio/flex-ui-dev-proxy": "^1.1.2",
         "@types/jest": "^27.5.2",
         "@types/react": "^17.0.47",
@@ -8198,9 +8198,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.4.tgz",
-      "integrity": "sha512-Ot3RaN2M/rhIKDqXBdOVlN0dQbHydUrYJ9lTxkvd6x7W1pAjwduUccfoz2gsO4U9by7oWtRj/ySF0MFNUp+9Aw==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.11.tgz",
+      "integrity": "sha512-H7e9m7cRcFO93tokwzqrsbnfKorkpV24xU30hFH5u2g6B+c1DMo/ouyF/YrBPdrTzqxQCjTUmds/FLmJ7626GA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8212,7 +8212,8 @@
         "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.18.0",
         "prop-types": "^15.7.2",
-        "rehackt": "^0.1.0",
+        "rehackt": "0.0.6",
+        "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
@@ -8220,9 +8221,9 @@
       },
       "peerDependencies": {
         "graphql": "^15.0.0 || ^16.0.0",
-        "graphql-ws": "^5.5.5 || ^6.0.3",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
@@ -10104,11 +10105,11 @@
       }
     },
     "node_modules/@citrix/ucsdk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@citrix/ucsdk/-/ucsdk-3.1.0.tgz",
-      "integrity": "sha512-C4KhrsSZdBlevWGF263xSmykbFl6JDCiHpLHJDVEAsCHbt3wtIo1qx1E3HO8e43BSR2OBFkUNMiUBS4REC3efA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@citrix/ucsdk/-/ucsdk-4.0.2.tgz",
+      "integrity": "sha512-FBMhkUPwtxQYgA8GkwxcJs/zjPPKWGC1DpX427SA9Enrl1MBES9uT8ma+kp793lxndAg1mTAIEptrhWruWuMUQ==",
       "dev": true,
-      "license": "CITRIX READY PARTNER DEVELOPER MATERIALS REDISTRIBUTION LICENSE AGREEMENT"
+      "license": "SEE LICENSE IN CITRIX_READY_PARTNER_DEVELOPER_MATERIALS_REDISTRIBUTION_LICENSE_AGREEMENT.txt"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -11431,95 +11432,6 @@
         "lodash": "^4.17.11"
       }
     },
-    "node_modules/@graphql-tools/batch-delegate": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-delegate/-/batch-delegate-8.4.27.tgz",
-      "integrity": "sha512-efgDDJhljma9d3Ky/LswIu1xm/if2oS27XA1sOcxcShW+Ze+Qxi0hZZ6iyI4eQxVDX5Lyy/n+NvQEZAK1riqnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/delegate": "^9.0.35",
-        "@graphql-tools/utils": "^9.2.1",
-        "dataloader": "2.2.2",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/batch-execute": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.22.tgz",
-      "integrity": "sha512-hcV1JaY6NJQFQEwCKrYhpfLK8frSXDbtNMoTur98u10Cmecy1zrqNKSqhEyGetpgHxaJRqszGzKeI3RuroDN6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
-        "dataloader": "^2.2.2",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/delegate": {
-      "version": "9.0.35",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.35.tgz",
-      "integrity": "sha512-jwPu8NJbzRRMqi4Vp/5QX1vIUeUPpWmlQpOkXQD2r1X45YsVceyUUBnktCrlJlDB4jPRVy7JQGwmYo3KFiOBMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/batch-execute": "^8.5.22",
-        "@graphql-tools/executor": "^0.0.20",
-        "@graphql-tools/schema": "^9.0.19",
-        "@graphql-tools/utils": "^9.2.1",
-        "dataloader": "^2.2.2",
-        "tslib": "^2.5.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/executor": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-0.0.20.tgz",
-      "integrity": "sha512-GdvNc4vszmfeGvUqlcaH1FjBoguvMYzxAfT6tDd4/LgwymepHhinqLNA5otqwVLW+JETcDaK7xGENzFomuE6TA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
-        "@graphql-typed-document-node/core": "3.2.0",
-        "@repeaterjs/repeater": "^3.0.4",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/executor-http": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.10.tgz",
-      "integrity": "sha512-hnAfbKv0/lb9s31LhWzawQ5hghBfHS+gYWtqxME6Rl0Aufq9GltiiLBcl7OVVOnkLF0KhwgbYP1mB5VKmgTGpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
-        "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/fetch": "^0.8.1",
-        "dset": "^3.1.2",
-        "extract-files": "^11.0.0",
-        "meros": "^1.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/merge": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
@@ -11534,43 +11446,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/schema": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
-      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/merge": "^8.4.1",
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/stitch": {
-      "version": "8.7.50",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-8.7.50.tgz",
-      "integrity": "sha512-VB1/uZyXjj1P5Wj0c4EKX3q8Q1Maj4dy6uNwodEPaO3EHMpaJU/DqyN0Bvnhxu0ol7RzdY3kgsvsdUjU2QMImw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/batch-delegate": "^8.4.27",
-        "@graphql-tools/delegate": "^9.0.35",
-        "@graphql-tools/executor": "^0.0.20",
-        "@graphql-tools/merge": "^8.4.2",
-        "@graphql-tools/schema": "^9.0.18",
-        "@graphql-tools/utils": "^9.2.1",
-        "@graphql-tools/wrap": "^9.4.2",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.11"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/utils": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
@@ -11580,23 +11455,6 @@
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/wrap": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-9.4.2.tgz",
-      "integrity": "sha512-DFcd9r51lmcEKn0JW43CWkkI2D6T9XI1juW/Yo86i04v43O9w2/k4/nx2XTJv4Yv+iXwUw7Ok81PGltwGJSDSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/delegate": "^9.0.31",
-        "@graphql-tools/schema": "^9.0.18",
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -14253,48 +14111,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz",
-      "integrity": "sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.6",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.25",
       "dev": true,
@@ -14632,13 +14448,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@repeaterjs/repeater": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
-      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@segment/analytics-core": {
       "version": "1.4.1",
@@ -21012,20 +20821,19 @@
       "license": "MIT"
     },
     "node_modules/@twilio/flex-sdk": {
-      "version": "0.99.26-dev",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.99.26-dev.tgz",
-      "integrity": "sha512-Y5UskDTS0WVBzkZ/WTA0wI+W06kh/x++IKxbX6wYyh8t5QejjbGzhGONVy9usCLRtpBP7VEad9cKTq/ZVdRiyQ==",
+      "version": "0.99.32-dev",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.99.32-dev.tgz",
+      "integrity": "sha512-TiAu5wuJgYijU24tSsN9IIeSLqGM67iJb7c017OsA6DGDZ2WXEcR+KfXoJwBRCcrOgn6HDmFNSkpTnUwUHbxAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.9.6",
-        "@graphql-tools/executor-http": "^0.1.10",
-        "@graphql-tools/schema": "^9.0.19",
-        "@graphql-tools/stitch": "^8.7.50",
         "@segment/analytics-node": "1.3.0",
         "@twilio/voice-sdk": "^2.11.0",
         "buffer": "^6.0.3",
+        "core-js": "^3.19.3",
         "crypto-js": "^4.2.0",
+        "events": "^3.3.0",
         "graphql-tag": "^2.12.6",
         "graphql-ws": "5.15.0",
         "lodash": "^4.17.21",
@@ -21033,8 +20841,9 @@
         "query-string": "^6.2.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
-        "twilio-taskrouter": "^2.0.11",
-        "twilsock": "^0.8.3"
+        "twilio-taskrouter": "^2.0.12",
+        "twilsock": "^0.8.3",
+        "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=14",
@@ -21099,6 +20908,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@twilio/flex-sdk/node_modules/twilsock/node_modules/ws": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
+      "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/@twilio/flex-sdk/node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -21111,24 +20930,36 @@
       }
     },
     "node_modules/@twilio/flex-sdk/node_modules/ws": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
-      "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@twilio/flex-ui": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-2.9.1.tgz",
-      "integrity": "sha512-rOdeGxPIVpm2Gcs4HOT75laNeWyMFyt31tICmEedzcVckakXwizSozGmbO46RAWIYpmNEztmTewsg/ycBRZZJQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-2.11.1.tgz",
+      "integrity": "sha512-chS4guZjb2YD37NSdaca5nDW0rx5ziWZEMXYABefhoRhPWGDR0QFvKZ69Bw4C79nLUqjY6LwTU8oWh/V3eag2g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/client": "^3.9.6",
-        "@citrix/ucsdk": "3.1.0",
+        "@apollo/client": "3.9.11",
+        "@citrix/ucsdk": "4.0.2",
         "@dnd-kit/core": "6.0.8",
         "@dnd-kit/modifiers": "6.0.1",
         "@dnd-kit/sortable": "7.0.2",
@@ -21137,11 +20968,8 @@
         "@emotion/react": "^11.1.5",
         "@emotion/styled": "^11.1.5",
         "@gooddata/gooddata-js": "13.2.0",
-        "@graphql-tools/executor-http": "^0.1.10",
-        "@graphql-tools/schema": "^9.0.19",
-        "@graphql-tools/stitch": "^8.7.50",
+        "@graphql-tools/merge": "^8.4.2",
         "@graphql-tools/utils": "^9.2.1",
-        "@graphql-tools/wrap": "^9.4.2",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@opentelemetry/api": "1.4.1",
@@ -21149,10 +20977,11 @@
         "@reduxjs/toolkit": "^1.6.0",
         "@twilio-paste/core": "^15.3.1",
         "@twilio-paste/customization": "^5.0.0",
+        "@twilio-paste/design-tokens": "^8.1.0",
         "@twilio-paste/icons": "^9.2.0",
         "@twilio-paste/lexical-library": "^4.2.0",
         "@twilio/conversations": "2.5.0",
-        "@twilio/flex-sdk": "0.99.26-dev",
+        "@twilio/flex-sdk": "0.99.32-dev",
         "@twilio/flex-ui-telemetry": "1.3.2",
         "@twilio/player": "^1.1.1",
         "@twilio/voice-sdk": "2.11.1",
@@ -21174,7 +21003,6 @@
         "core-js": "^3.32.1",
         "date-fns": "^2.17.0",
         "date-fns-tz": "^3.1.3",
-        "deep-diff": "^1.0.2",
         "dompurify": "^2.2.9",
         "eventemitter3": "4.0.0",
         "fuse.js": "^6.4.6",
@@ -21203,7 +21031,6 @@
         "query-string": "6.2.0",
         "queue": "6.0.1",
         "react-cool-dimensions": "^2.0.7",
-        "react-hotkeys": "2.0.0",
         "react-jss": "^10.6.0",
         "react-redux": "^7.2.2",
         "react-router-dom": "^5.2.0",
@@ -21212,7 +21039,6 @@
         "redux-logger": "3.0.6",
         "redux-promise-middleware": "4.2.1",
         "reselect": "4.0.0",
-        "semver": "~5.7.0",
         "slate": "^0.66.1",
         "slate-history": "^0.66.0",
         "slate-hyperscript": "^0.66.0",
@@ -21353,13 +21179,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@twilio/flex-ui/node_modules/deep-diff": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
-      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@twilio/flex-ui/node_modules/queue": {
       "version": "6.0.1",
       "dev": true,
@@ -21372,16 +21191,6 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@twilio/flex-ui/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/@twilio/flex-ui/node_modules/slate": {
       "version": "0.66.5",
@@ -22847,41 +22656,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@whatwg-node/events": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
-      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@whatwg-node/fetch": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
-      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/webcrypto": "^1.4.0",
-        "@whatwg-node/node-fetch": "^0.3.6",
-        "busboy": "^1.6.0",
-        "urlpattern-polyfill": "^8.0.0",
-        "web-streams-polyfill": "^3.2.1"
-      }
-    },
-    "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
-      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@whatwg-node/events": "^0.0.3",
-        "busboy": "^1.6.0",
-        "fast-querystring": "^1.1.1",
-        "fast-url-parser": "^1.1.3",
-        "tslib": "^2.3.1"
-      }
-    },
     "node_modules/@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.7",
       "dev": true,
@@ -23597,21 +23371,6 @@
       "version": "4.12.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/assert": {
       "version": "1.5.1",
@@ -24727,18 +24486,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -26282,13 +26029,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/dataloader": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
-      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -28706,26 +28446,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extract-files": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
-      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jaydenseric"
-      }
-    },
-    "node_modules/fast-decode-uri-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -28770,30 +28490,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-querystring": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
-      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-decode-uri-component": "^1.0.1"
-      }
-    },
     "node_modules/fast-uri": {
       "version": "3.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -37874,24 +37574,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/meros": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
-      "integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=13"
-      },
-      "peerDependencies": {
-        "@types/node": ">=13"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "dev": true,
@@ -40819,26 +40501,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pvtsutils": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/q": {
       "version": "1.5.1",
       "dev": true,
@@ -41226,19 +40888,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17"
-      }
-    },
-    "node_modules/react-hotkeys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
-      "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "prop-types": "^15.6.1"
-      },
-      "peerDependencies": {
-        "react": ">= 0.14.0"
       }
     },
     "node_modules/react-input-autosize": {
@@ -42138,9 +41787,9 @@
       }
     },
     "node_modules/rehackt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
-      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.0.6.tgz",
+      "integrity": "sha512-l3WEzkt4ntlEc/IB3/mF6SRgNHA6zfQR7BlGOgBTOmx7IJJXojDASav+NsgXHFjHn+6RmwqsGPFgZpabWpeOdw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -42473,6 +42122,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/response-iterator": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.20.tgz",
+      "integrity": "sha512-RfNi9saiJ9VKznrRZEGZtlfeiQI7NWMUlXvmkvO60xaHfW1y+36EOibZkV59LuKNak8VIqL6IyxYxhMOGTurIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/responselike": {
@@ -43873,15 +43532,6 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
@@ -47967,13 +47617,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/urlpattern-polyfill": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
-      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/use": {
       "version": "3.1.1",
       "dev": true,
@@ -48157,16 +47800,6 @@
       "version": "0.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/value-or-promise": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
-      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -48512,30 +48145,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -101,7 +101,7 @@
     "@testing-library/user-event": "^14.1.1",
     "@twilio/flex-plugin": "^7.1.0",
     "@twilio/flex-plugin-scripts": "^7.1.0",
-    "@twilio/flex-ui": "2.9.1",
+    "@twilio/flex-ui": "2.11.1",
     "@twilio/flex-ui-dev-proxy": "^1.1.2",
     "@types/jest": "^27.5.2",
     "@types/react": "^17.0.47",


### PR DESCRIPTION
## Description
- Upgrade to 2.11.1 and tested to check that chat based tasks will wrap-up and complete when closed (this was the the previous bug in 2.11.0), thus letting the user complete saving the contact

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P