### PR TITLE
Turn on General Search for all helplines

### DIFF
--- a/twilio-iac/helplines/as/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/common.json
@@ -6,7 +6,6 @@
             "enable_client_profiles": true,
             "enable_conferencing": true,
             "enable_fullstory_monitoring": true,
-            "enable_generalized_search": true,
             "enable_hierarchical_translations": true,
             "enable_permissions_from_backend": true,
             "enable_region_resource_search": true,

--- a/twilio-iac/helplines/as/configs/service-configuration/development.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/development.json
@@ -16,7 +16,6 @@
             "enable_client_profiles": true,
             "enable_lex": true,
             "enable_llm_summary": true,
-            "enable_generalized_search": true,
             "enable_post_survey": true,
             "enable_save_in_progress_contacts": true,
             "enable_save_insights": true,

--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -14,7 +14,6 @@
             "enable_active_contact_header": true,
             "enable_csam_report": true,
             "enable_lex": true,
-            "enable_generalized_search": true,
             "enable_post_survey": true,
             "enable_voice_recordings": true,
             "enable_backend_hrm_contact_creation": true

--- a/twilio-iac/helplines/ca/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/common.json
@@ -17,8 +17,7 @@
             "enable_voice_recordings": true,
             "enable_conferencing": true,
             "enable_region_resource_search": true,
-            "enable_client_profiles": false,
-            "enable_generalized_search": true
+            "enable_client_profiles": false
         },
         "helplineLanguage": "en-CA",
         "permissionConfig": "ca"

--- a/twilio-iac/helplines/configs/service-configuration/defaults.json
+++ b/twilio-iac/helplines/configs/service-configuration/defaults.json
@@ -65,7 +65,7 @@
             "enable_external_transcripts": true,
             "enable_filter_cases": true,
             "enable_fullstory_monitoring": true,
-            "enable_generalized_search": false,
+            "enable_generalized_search": true,
             "enable_last_case_status_update_info": true,
             "enable_lex": false,
             "enable_hierarchical_translations": false,

--- a/twilio-iac/helplines/in/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/in/configs/service-configuration/common.json
@@ -3,8 +3,7 @@
         "definitionVersion": "in-v1",
         "feature_flags": {
             "enable_csam_clc_report": true,
-            "enable_csam_report": true,
-            "enable_generalized_search": true
+            "enable_csam_report": true
         },
         "helplineLanguage": "en-IN",
         "permissionConfig": "in"

--- a/twilio-iac/helplines/jm/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/jm/configs/service-configuration/common.json
@@ -9,8 +9,7 @@
         ],
         "definitionVersion": "jm-v1",
         "feature_flags": {
-            "enable_lex": true,
-            "enable_generalized_search": true       
+            "enable_lex": true
         },
         "helplineLanguage": "en-JM",
         "permissionConfig": "jm"

--- a/twilio-iac/helplines/nz/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/nz/configs/service-configuration/common.json
@@ -16,7 +16,6 @@
         "feature_flags": {
             "enable_client_profiles": true,
             "enable_conferencing": true,
-            "enable_generalized_search": true,
             "enable_last_case_status_update_info": false,
             "enable_lex": true,
             "enable_separate_timeline_view": false,

--- a/twilio-iac/helplines/sg/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/sg/configs/service-configuration/common.json
@@ -11,8 +11,7 @@
         },
         "feature_flags": {
             "enable_voice_recordings": true,
-            "enable_post_survey": false,
-            "enable_generalized_search": true
+            "enable_post_survey": false
         },
         "helplineLanguage": "en-SG",
         "permissionConfig": "sg"

--- a/twilio-iac/helplines/th/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/th/configs/service-configuration/common.json
@@ -3,7 +3,6 @@
         "definitionVersion": "th-v1",
         "feature_flags": {
             "enable_manual_pulling": false,
-            "enable_generalized_search": true,
             "enable_backend_hrm_contact_creation": false
         },
         "helplineLanguage": "th-TH",

--- a/twilio-iac/helplines/tz/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/tz/configs/service-configuration/common.json
@@ -9,8 +9,7 @@
         "definitionVersion": "tz-v1",
         "feature_flags": {
             "enable_lex": true,
-            "enable_permissions_from_backend": true,
-            "enable_generalized_search": true
+            "enable_permissions_from_backend": true
         },
         "helplineLanguage": "en-US",
         "permissionConfig": "tz"

--- a/twilio-iac/helplines/ukmh/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/ukmh/configs/service-configuration/common.json
@@ -5,7 +5,6 @@
         ],
         "definitionVersion": "ukmh-v1",
         "feature_flags": {
-            "enable_generalized_search": true
         },
         "helplineLanguage": "en-GB",
         "permissionConfig": "ukmh"

--- a/twilio-iac/helplines/usch/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/usch/configs/service-configuration/common.json
@@ -10,8 +10,7 @@
         "feature_flags": {
             "enable_voice_recordings": true,
             "enable_client_profiles":true,
-            "enable_conferencing": true,
-            "enable_generalized_search": true
+            "enable_conferencing": true
         },
         "definitionVersion": "usch-v1",
         "external_recordings_enabled": false,

--- a/twilio-iac/helplines/uscr/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/uscr/configs/service-configuration/common.json
@@ -11,8 +11,7 @@
         "feature_flags": {
             "enable_voice_recordings": true,
             "enable_client_profiles":true,
-            "enable_conferencing": true,
-            "enable_generalized_search": true
+            "enable_conferencing": true
         },
         "definitionVersion": "uscr-v1",
         "external_recordings_enabled": false,

--- a/twilio-iac/helplines/zw/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/zw/configs/service-configuration/common.json
@@ -2,7 +2,6 @@
     "attributes": {
         "definitionVersion": "zw-v1",
         "feature_flags": {
-            "enable_generalized_search": true
         },
         "helplineLanguage": "en-US",
         "permissionConfig": "zw"


### PR DESCRIPTION
I added `"enable_generalized_search": true` to the default config file. Then I removed any lines with "enable_generalized_search" from the other config files. My goal is to turn General Search on by default for all helplines. Please let me know if this looks right to you!

I plan to terraform apply these changes to staging today (running `HL_ENV=staging make service-config-apply` in the terminal). Then I'll terraform apply these changes to production on Wednesday during our upcoming release.

Question: I plan to merge these changes into master. Is that right, or should I merge them into `v2.29-rc` instead? 

------

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P