### PR TITLE
CHI-3318: Align isContactOwner Check with updated contactObj Structure

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -184,6 +184,11 @@ export default class HrmFormPlugin extends FlexPlugin {
 
     const config = getHrmConfig();
     const featureFlags = getAseloFeatureFlags();
+<<<<<<< Updated upstream
+=======
+    // eslint-disable-next-line camelcase
+    // featureFlags.enable_permissions_from_backend = true;
+>>>>>>> Stashed changes
 
     await validateAndSetPermissionRules();
     await ActionFunctions.loadCurrentDefinitionVersion();

--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -184,8 +184,6 @@ export default class HrmFormPlugin extends FlexPlugin {
 
     const config = getHrmConfig();
     const featureFlags = getAseloFeatureFlags();
-    // eslint-disable-next-line camelcase
-    featureFlags.enable_permissions_from_backend = true;
 
     await validateAndSetPermissionRules();
     await ActionFunctions.loadCurrentDefinitionVersion();

--- a/plugin-hrm-form/src/___tests__/permissions/index.test.ts
+++ b/plugin-hrm-form/src/___tests__/permissions/index.test.ts
@@ -356,7 +356,7 @@ describe('ContactActions', () => {
 
       const can = getInitializedCan();
 
-      expect(can(action, { twilioWorkerId: 'owner', createdAt })).toBe(expectedResult);
+      expect(can(action, { activity: { twilioWorkerId: 'owner' }, createdAt })).toBe(expectedResult);
     },
   );
 });

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -212,6 +212,7 @@ const Case: React.FC<Props> = ({
   }
 
   if (routing.subroute === 'timeline') {
+    console.log('>>> timeline routing',{ routing, task});
     return <FullTimelineView task={task} />;
   }
 

--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -72,6 +72,7 @@ const CaseHome: React.FC<CaseHomeProps> = ({ task, handlePrintCase, handleClose,
   const firstConnectedContact = useSelector(
     (state: RootState) => selectFirstContactByCaseId(state, routing.caseId)?.savedContact,
   );
+  console.log('>>> firstConnectedContact', firstConnectedContact);
   const activityCount = useSelector((state: RootState) =>
     routing.route === 'case' ? selectTimelineCount(state, routing.caseId, MAIN_TIMELINE_ID) : 0,
   );
@@ -114,6 +115,7 @@ const CaseHome: React.FC<CaseHomeProps> = ({ task, handlePrintCase, handleClose,
   const onEditCaseOverviewClick = () => {
     openModal({ route: 'case', subroute: 'caseOverview', action: CaseItemAction.Edit, id: '', caseId });
   };
+
 
   return (
     <NavigableContainer

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedFormsTabs.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedFormsTabs.tsx
@@ -245,6 +245,7 @@ const TabbedFormsTabs: React.FC<Props> = ({
       navigateToTab(tab);
     }
   };
+  console.log('>>> savedContact', savedContact);
 
   const HeaderControlButtons = () => (
     <Box marginTop="10px" marginBottom="5px" paddingLeft="20px">

--- a/plugin-hrm-form/src/hrmConfig.ts
+++ b/plugin-hrm-form/src/hrmConfig.ts
@@ -93,6 +93,7 @@ const readConfig = () => {
     ...featureFlagsFromServiceConfig,
     ...featureFlagsFromEnv,
   };
+  featureFlags.enable_permissions_from_backend = false;
   const { strings } = (manager as unknown) as {
     strings: { [key: string]: string };
   };

--- a/plugin-hrm-form/src/permissions/dev.json
+++ b/plugin-hrm-form/src/permissions/dev.json
@@ -8,7 +8,7 @@
   "editCaseOverview": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "updateCaseContacts": [["isSupervisor"], ["isCaseOpen"]],
 
-  "viewContact": [["everyone"]],
+  "viewContact": [["isOwner"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
   "editInProgressContact": [["isSupervisor"], ["isOwner"]],
  "viewExternalTranscript": [["everyone"]],

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -18,8 +18,8 @@ import parseISO from 'date-fns/parseISO';
 import { differenceInDays, differenceInHours } from 'date-fns';
 
 import { fetchRules } from './fetchRules';
-import { getHrmConfig, getAseloFeatureFlags } from '../hrmConfig';
-import { ProfileSection } from '../types/types';
+import { getHrmConfig } from '../hrmConfig';
+import { ProfileSection, Contact } from '../types/types';
 
 export { canOnlyViewOwnCases, canOnlyViewOwnContacts } from './search-permissions';
 
@@ -288,7 +288,14 @@ const isCounselorWhoCreated = (user: TwilioUser, caseObj: any) => user.workerSid
 
 const isCaseOpen = (caseObj: any) => caseObj?.status !== 'closed';
 
+<<<<<<< Updated upstream
 const isContactOwner = (user: TwilioUser, contactObj: any) => user.workerSid === contactObj?.activity?.twilioWorkerId;
+=======
+const isContactOwner = (user: TwilioUser, contactObj: Contact) => {
+  console.log(`>>> isContactOwner check: user.workerSid=${user.workerSid}, contactObj.twilioWorkerId=${contactObj.twilioWorkerId}`,{contactObj});
+  return user.workerSid === contactObj.twilioWorkerId;
+};
+>>>>>>> Stashed changes
 
 const isCaseContactOwner = (caseObj: any) => caseObj?.precalculatedPermissions?.userOwnsContact;
 

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -288,7 +288,7 @@ const isCounselorWhoCreated = (user: TwilioUser, caseObj: any) => user.workerSid
 
 const isCaseOpen = (caseObj: any) => caseObj?.status !== 'closed';
 
-const isContactOwner = (user: TwilioUser, contactObj: any) => user.workerSid === contactObj?.twilioWorkerId || user.workerSid === contactObj?.activity?.twilioWorkerId;
+const isContactOwner = (user: TwilioUser, contactObj: any) => user.workerSid === contactObj?.activity?.twilioWorkerId;
 
 const isCaseContactOwner = (caseObj: any) => caseObj?.precalculatedPermissions?.userOwnsContact;
 

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -288,7 +288,7 @@ const isCounselorWhoCreated = (user: TwilioUser, caseObj: any) => user.workerSid
 
 const isCaseOpen = (caseObj: any) => caseObj?.status !== 'closed';
 
-const isContactOwner = (user: TwilioUser, contactObj: any) => user.workerSid === contactObj?.twilioWorkerId;
+const isContactOwner = (user: TwilioUser, contactObj: any) => user.workerSid === contactObj?.activty?.twilioWorkerId;
 
 const isCaseContactOwner = (caseObj: any) => caseObj?.precalculatedPermissions?.userOwnsContact;
 

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -288,7 +288,7 @@ const isCounselorWhoCreated = (user: TwilioUser, caseObj: any) => user.workerSid
 
 const isCaseOpen = (caseObj: any) => caseObj?.status !== 'closed';
 
-const isContactOwner = (user: TwilioUser, contactObj: any) => user.workerSid === contactObj?.activty?.twilioWorkerId;
+const isContactOwner = (user: TwilioUser, contactObj: any) => user.workerSid === contactObj?.twilioWorkerId || user.workerSid === contactObj?.activity?.twilioWorkerId;
 
 const isCaseContactOwner = (caseObj: any) => caseObj?.precalculatedPermissions?.userOwnsContact;
 


### PR DESCRIPTION
## Description
This PR updates the `isContactOwner` check to ensure that contact owners("isOwner", without "isSupervisor") can view their own contacts. This modification aligns with how the twilioWorkerId is now structured within the contact object.

### Checklist
- [ ] Corresponding issue has been[ opened](https://tech-matters.atlassian.net/browse/CHI-3318)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- From an account with no supervisor attribute, check for your own cases, check the Case home to view your contact
[
![Screenshot 2025-04-23 at 11 32 54 AM](https://github.com/user-attachments/assets/681d9948-c4ae-4fa0-8af5-4dd18257af3e)
](url)
### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P