### PR TITLE
fix(case): child at risk checkbox being set to array [CHI-3321]

### DIFF
--- a/plugin-hrm-form/src/components/case/caseOverview/EditCaseOverview.tsx
+++ b/plugin-hrm-form/src/components/case/caseOverview/EditCaseOverview.tsx
@@ -168,20 +168,24 @@ const EditCaseOverview: React.FC<Props> = ({
 
   const { getValues } = methods;
 
+  const initialValues = useMemo(() => {
+    const formValues = getValues() as CaseSummaryWorkingCopy;
+    return {
+      status: connectedCase.status,
+      ...connectedCase.info,
+      ...formValues,
+    };
+  }, [connectedCase.info, connectedCase.status, getValues]);
+
   useEffect(() => {
     if (!workingCopy) {
-      const formValues = getValues() as CaseSummaryWorkingCopy;
-      initialiseWorkingCopy(connectedCase.id, {
-        status: connectedCase.status,
-        ...connectedCase.info,
-        ...formValues,
-      });
+      initialiseWorkingCopy(connectedCase.id, initialValues);
     }
-  });
+  }, [connectedCase.id, initialValues, initialiseWorkingCopy, workingCopy]);
 
   const form = useCreateFormFromDefinition({
     definition: formDefinition,
-    initialValues: workingCopy,
+    initialValues,
     parentsPath: '',
     updateCallback: () => updateWorkingCopy(connectedCase.id, getValues() as CaseSummaryWorkingCopy),
     isItemEnabled: item => item.name === 'status' || can(PermissionActions.EDIT_CASE_OVERVIEW),


### PR DESCRIPTION
TODO:
- [x] On top of the fixes of this PR, we need to "patch" the existing broken cases. @stephenhand could you review this query and let me know if you think it's good to go?
    ```
    UPDATE public."Cases"
    SET "info" = jsonb_set("info", '{childIsAtRisk}', '"true"', false)
    WHERE"info"->>'childIsAtRisk' = '["on"]';

    UPDATE public."Cases"
    SET "info" = jsonb_set("info", '{childIsAtRisk}', '"false"', false)
    WHERE"info"->>'childIsAtRisk' = '[]';
    ```

## Description
This PR fixes the bug described in the ticket linked below, where checkin the "child at risk" checkbox might end setting it's value as `['on']` or `[ ]`, rather than the expected `true`/`fase` values.

The root cause seems to be how react hooks forms registers a component: if multiple checkbox components are registered under the same name, it's internal value will be set to an array. The exact cause of why this is being registered multiple times is not clear to me, but the changes I've made in this PR fix the issue since the initial values are set only once to the working copy, when the form component mounts. On top of this, I think the internal form using `workingCopy` as the initial value could cause some issues, as the first mount won't have a working copy at all.

To replicate the bug:
- Create a new case.
- Edit the overview, by setting "child at risk" to true. Save.
- Edit the overview, by setting "child at risk" to false. Save.
- If you open the edit overview page again, you'll notice that, even when the checkbox should be unchecked, it will be checked this time.
  - The internal rhf state will contain a broken array value when it should be `false`.
- Save without any further changes. Now your case will be in the broken `['on']` state.

You should be able to replicate this bug in `master` but not in this branch. 


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3321)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P