### PR TITLE
Bump axios in /e2e-tests in the npm_and_yarn group across 1 directory

### DIFF
--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -70,6 +70,7 @@
         "eslint-plugin-prettier": "^3.1.4",
         "jest": "^27.4.5",
         "jest-each": "^28.1.1",
+        "jest-junit": "^16.0.0",
         "prettier": "^2.3.2",
         "react-hook-form": "^6.11.0",
         "ts-jest": "^27.1.2",
@@ -2850,10 +2851,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -9874,9 +9876,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.6",
@@ -11512,6 +11514,7 @@
         "eslint-plugin-prettier": "^3.1.4",
         "jest": "^27.4.5",
         "jest-each": "^28.1.1",
+        "jest-junit": "^16.0.0",
         "lodash": "^4.17.21",
         "prettier": "^2.3.2",
         "react-hook-form": "^6.11.0",


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /e2e-tests directory: [axios](https://github.com/axios/axios).


Updates `axios` from 1.7.9 to 1.8.2
- [Release notes](https://github.com/axios/axios/releases)
- [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
- [Commits](https://github.com/axios/axios/compare/v1.7.9...v1.8.2)

---
updated-dependencies:
- dependency-name: axios dependency-type: indirect dependency-group: npm_and_yarn ...

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P