### PR TITLE
Turn on language selector for CA

### DIFF
--- a/twilio-iac/helplines/ca/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/common.json
@@ -11,13 +11,14 @@
             "enableUnmaskingCalls": true
         },
         "feature_flags": {
+            "enable_client_profiles": false,
+            "enable_conferencing": true,
+            "enable_language_selector": true,
             "enable_manual_pulling": false,
             "enable_previous_contacts": false,
-            "enable_upload_documents": false,
-            "enable_voice_recordings": true,
-            "enable_conferencing": true,
             "enable_region_resource_search": true,
-            "enable_client_profiles": false
+            "enable_upload_documents": false,
+            "enable_voice_recordings": true
         },
         "helplineLanguage": "en-CA",
         "permissionConfig": "ca"

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -1,7 +1,6 @@
 {
   "attributes": {
     "feature_flags": {
-      "enable_language_selector": false
     },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",
     "resources_base_url": "https://hrm-staging.tl.techmatters.org",


### PR DESCRIPTION
Turning on the feature flag `enable_language_selector` for Canada Stg and Prod. 

We'll apply the change for staging now, and wait until later to apply for production.