### PR TITLE
Update CallTypeButtons.json

### DIFF
--- a/lambdas/packages/hrm-form-definitions/form-definitions/ca/v1/CallTypeButtons.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/ca/v1/CallTypeButtons.json
@@ -19,31 +19,31 @@
   },
   {
     "name": "hangup",
-    "label": "HangUp",
+    "label": "Hang Up",
     "type": "button",
     "category": "non-data"
   },    
   {
     "name": "abuse",
-    "label": "DirectAbusetoCounsellor",
+    "label": "Direct Abuse to Counsellor",
     "type": "button",
     "category": "non-data"
   },  
   {
     "name": "arousal",
-    "label": "ArousalCaller",
+    "label": "Arousal Caller",
     "type": "button",
     "category": "non-data"
   },  
   {
     "name": "training",
-    "label": "Training/TechTesting",
+    "label": "Training/Tech Testing",
     "type": "button",
     "category": "non-data"
   }, 
   {
     "name": "emergency",
-    "label": "CMOnlyEmergency",
+    "label": "CM Only - Emergency",
     "type": "button",
     "category": "non-data"
   }


### PR DESCRIPTION
Revert non-data call type button labels, not able to be translated