### PR TITLE
CHI 3374 Add missing translations for Switchboarding and update tooltip link

### DIFF
--- a/lambdas/packages/hrm-form-definitions/form-definitions/ca/v1/customStrings/Substitutions.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/ca/v1/customStrings/Substitutions.json
@@ -163,10 +163,13 @@
   "CMOnlyEmergency": "CM Only - Emergency",
 
   "Switchboard-NoQueuesSwitchboarded": "No queues are currently being switchboarded",
-  "Switchboard-QueueSwitchboardedStatus": "{{queueName}} queue is currently being switchboarded by {{supervisorName}} since {{startTime}}",
+  "Switchboard-QueueSwitchboardedStatus": "{{queueName}} queue is currently being switchboarded by {{supervisorName}} since {{startDate}} at {{startTime}}",
   "Switchboard-SelectQueueModalTitle": "Select queue to switchboard",
   "Switchboard-StatusActive": "Switchboarding: In Progress",
-  "Switchboard-StatusInactive": "Switchboarding: Off"
+  "Switchboard-StatusInactive": "Switchboarding: Off",
+  "Switchboard-ModalTitleTurnOffSwitchboard": "Are you sure you want to turn off switchboarding?",
+  "Switchboard-ButtonTurnOffSwitchboard": "Turn off switchboard"
+  
   
   },
   "fr": {
@@ -382,7 +385,7 @@
   "incidentType": "Type d'incident ?",
 
   "Switchboard-NoQueuesSwitchboarded": "aucune file d'attente n'est commutée",
-  "Switchboard-QueueSwitchboardedStatus": "{{queueName}} est en cours de changement par {{supervisorName}} depuis {{startTime}}",
+  "Switchboard-QueueSwitchboardedStatus": "{{queueName}} est en cours de changement par {{supervisorName}} depuis {{startDate}} à {{startTime}}",
   "Switchboard-SelectQueueModalTitle": "Sélectionner la file d'attente pour changer",
   "Switchboard-StatusActive": "Commutation : en cours",
   "Switchboard-StatusInactive": "Commutation : désactivé"

--- a/lambdas/packages/hrm-form-definitions/form-definitions/ca/v1/customStrings/Substitutions.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/ca/v1/customStrings/Substitutions.json
@@ -168,8 +168,9 @@
   "Switchboard-StatusActive": "Switchboarding: In Progress",
   "Switchboard-StatusInactive": "Switchboarding: Off",
   "Switchboard-ModalTitleTurnOffSwitchboard": "Are you sure you want to turn off switchboarding?",
-  "Switchboard-ButtonTurnOffSwitchboard": "Turn off switchboard"
-  
+  "Switchboard-ButtonTurnOffSwitchboard": "Turn off switchboard",
+  "Switchboard-ActivateSwitchboarding": "Activate switchboarding",
+  "Switchboard-PleaseSelectQueue": "Please select a queue"
   
   },
   "fr": {
@@ -388,6 +389,9 @@
   "Switchboard-QueueSwitchboardedStatus": "{{queueName}} est en cours de changement par {{supervisorName}} depuis {{startDate}} à {{startTime}}",
   "Switchboard-SelectQueueModalTitle": "Sélectionner la file d'attente pour changer",
   "Switchboard-StatusActive": "Commutation : en cours",
-  "Switchboard-StatusInactive": "Commutation : désactivé"
+  "Switchboard-StatusInactive": "Commutation : désactivé",
+  "Switchboard-ModalTitleTurnOffSwitchboard": "Êtes-vous sûr de vouloir désactiver la commutation?",
+  "Switchboard-ButtonTurnOffSwitchboard": "Désactiver",
+  "Switchboard-ActivateSwitchboarding": "Activer la commutation"
   }
 }

--- a/plugin-hrm-form/src/components/queuesView/QueueSelectionModals.tsx
+++ b/plugin-hrm-form/src/components/queuesView/QueueSelectionModals.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { Modal } from '@material-ui/core';
 import { SwitchboardSyncState } from 'hrm-types';
-import { Template } from '@twilio/flex-ui';
+import { Template, Manager } from '@twilio/flex-ui';
 
 import { Box, SaveAndEndButton, StyledNextStepButton, TertiaryButton } from '../../styles';
 import { CloseButton, NonDataCallTypeDialogContainer, CloseTaskDialog } from '../callTypeButtons/styles';
@@ -120,11 +120,12 @@ export const SelectQueueModal: React.FC<SelectQueueModalProps> = ({ isOpen, onCl
               if (currentQueue) {
                 onSelect(currentQueue);
               } else {
-                alert('Please select a queue first');
+                const message = Manager.getInstance().strings['Switchboard-PleaseSelectQueue'];
+                alert(message);
               }
             }}
           >
-            Activate Switchboarding
+            <Template code="Switchboard-ActivateSwitchboarding" />
           </StyledNextStepButton>
         </ButtonGroup>
       </ModalPaper>
@@ -164,7 +165,7 @@ export const TurnOffSwitchboardDialog: React.FC<TurnOffSwitchboardDialogProps> =
           </StatusTextContainer>
           <ButtonGroup>
             <TertiaryButton type="button" onClick={onClose}>
-              Cancel
+              <Template code="BottomBar-Cancel" />
             </TertiaryButton>
             <SaveAndEndButton onClick={onConfirm}>
               <Template code="Switchboard-ButtonTurnOffSwitchboard" />

--- a/plugin-hrm-form/src/components/queuesView/QueueSelectionModals.tsx
+++ b/plugin-hrm-form/src/components/queuesView/QueueSelectionModals.tsx
@@ -155,7 +155,9 @@ export const TurnOffSwitchboardDialog: React.FC<TurnOffSwitchboardDialogProps> =
             <CloseButton tabIndex={3} aria-label="CloseButton" onClick={onClose} />
           </CloseButtonWrapper>
           <HeaderBox>
-            <DialogTitle id="turn-off-switchboard-title">Are you sure you want to turn off switchboarding?</DialogTitle>
+            <DialogTitle id="turn-off-switchboard-title">
+              <Template code="Switchboard-ModalTitleTurnOffSwitchboard" />
+            </DialogTitle>
           </HeaderBox>
           <StatusTextContainer>
             {renderStatusText(switchboardSyncState?.queueSid || '', switchboardSyncState?.startTime || null)}
@@ -164,7 +166,9 @@ export const TurnOffSwitchboardDialog: React.FC<TurnOffSwitchboardDialogProps> =
             <TertiaryButton type="button" onClick={onClose}>
               Cancel
             </TertiaryButton>
-            <SaveAndEndButton onClick={onConfirm}>Turn Off Switchboarding</SaveAndEndButton>
+            <SaveAndEndButton onClick={onConfirm}>
+              <Template code="Switchboard-ButtonTurnOffSwitchboard" />
+            </SaveAndEndButton>
           </ButtonGroup>
         </NonDataCallTypeDialogContainer>
       </TabPressWrapper>

--- a/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
+++ b/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
@@ -175,7 +175,7 @@ const SwitchboardTile = () => {
           <Switch checked={isSwitchboardingActive} onChange={handleSwitchToggle} color="primary" disabled={isLoading} />
         </Box>
 
-        <Box style={{ marginTop: '15px', display: 'flex', alignItems: 'center' }}>
+        <Box>
           {isSwitchboardingActive && queueSid ? (
             <div>{renderSwitchboardStatusText(queueName, startTime, getSupervisorName(supervisorWorkerSid))}</div>
           ) : (
@@ -188,14 +188,12 @@ const SwitchboardTile = () => {
                   rel="noopener noreferrer"
                   style={{
                     display: 'flex',
-                    marginLeft: '8px',
                     cursor: 'pointer',
-                    color: 'inherit',
                     textDecoration: 'none',
                   }}
                 >
-                  <InfoIcon style={{ fontSize: '18px', marginRight: '2px' }} />
-                  <OpenInNewIcon style={{ fontSize: '14px' }} />
+                  <InfoIcon style={{ fontSize: '20px' }} />
+                  <OpenInNewIcon style={{ fontSize: '12px' }} />
                 </a>
               </Tooltip>
             </div>

--- a/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
+++ b/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
@@ -27,6 +27,7 @@ import { Box } from '../../styles';
 import SwitchboardIcon from '../common/icons/SwitchboardIcon';
 import { RootState } from '../../states';
 import { namespace, configurationBase } from '../../states/storeNamespaces';
+import { selectLocaleState } from '../../states/configuration/selectLocaleState';
 import { SelectQueueModal, TurnOffSwitchboardDialog } from './QueueSelectionModals';
 import { SwitchboardTileBox, LoadingContainer } from './styles';
 import { useSwitchboard } from '../../states/switchboard/useSwitchboard';
@@ -109,21 +110,30 @@ const SwitchboardTile = () => {
       ? counselorsHash[supervisorWorkerSid]
       : 'Unknown supervisor';
   };
+  const { selected: currentlocale } = useSelector(selectLocaleState);
 
   const renderSwitchboardStatusText = (
     queueName: string | null,
     startTime: string | null,
     supervisorName: string | null,
   ) => {
-    const formattedTime = startTime
-      ? new Date(startTime).toLocaleString('en-US', {
-          month: 'long',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
-          hour12: true,
-        })
-      : '';
+    
+    const userLocale = (currentlocale==='fr')?'fr-FR':'en-US';
+    
+    let formattedDate = '';
+    let formattedTime = '';
+    if (startTime) {
+      const dateObj = new Date(startTime);
+      formattedDate = dateObj.toLocaleDateString(userLocale, {
+        month: 'long',
+        day: 'numeric',
+      });
+      formattedTime = dateObj.toLocaleTimeString(userLocale, {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      });
+    }
 
     return (
       <>
@@ -131,6 +141,7 @@ const SwitchboardTile = () => {
           code="Switchboard-QueueSwitchboardedStatus"
           queueName={queueName || ''}
           supervisorName={supervisorName || ''}
+          startDate={formattedDate}
           startTime={formattedTime}
         />
       </>

--- a/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
+++ b/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
@@ -182,10 +182,15 @@ const SwitchboardTile = () => {
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <Template code="Switchboard-NoQueuesSwitchboarded" />
               <Tooltip title="Learn more about switchboarding">
-                <Box style={{ display: 'flex', marginLeft: '8px', cursor: 'pointer' }}>
-                  <InfoIcon style={{ fontSize: '16px', marginRight: '2px' }} />
-                  <OpenInNewIcon style={{ fontSize: '16px' }} />
-                </Box>
+                <a 
+                  href="https://aselo-support.freshdesk.com/en/support/solutions/articles/151000202559-switchboarding" 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  style={{ display: 'flex', marginLeft: '8px', cursor: 'pointer', color: 'inherit', textDecoration: 'none' }}
+                >
+                  <InfoIcon style={{ fontSize: '18px', marginRight: '2px' }} />
+                  <OpenInNewIcon style={{ fontSize: '14px' }} />
+                </a>
               </Tooltip>
             </div>
           )}

--- a/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
+++ b/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
@@ -182,11 +182,17 @@ const SwitchboardTile = () => {
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <Template code="Switchboard-NoQueuesSwitchboarded" />
               <Tooltip title="Learn more about switchboarding">
-                <a 
-                  href="https://aselo-support.freshdesk.com/en/support/solutions/articles/151000202559-switchboarding" 
-                  target="_blank" 
+                <a
+                  href="https://aselo-support.freshdesk.com/en/support/solutions/articles/151000202559-switchboarding"
+                  target="_blank"
                   rel="noopener noreferrer"
-                  style={{ display: 'flex', marginLeft: '8px', cursor: 'pointer', color: 'inherit', textDecoration: 'none' }}
+                  style={{
+                    display: 'flex',
+                    marginLeft: '8px',
+                    cursor: 'pointer',
+                    color: 'inherit',
+                    textDecoration: 'none',
+                  }}
                 >
                   <InfoIcon style={{ fontSize: '18px', marginRight: '2px' }} />
                   <OpenInNewIcon style={{ fontSize: '14px' }} />

--- a/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
+++ b/plugin-hrm-form/src/components/queuesView/SwitchboardTile.tsx
@@ -117,9 +117,8 @@ const SwitchboardTile = () => {
     startTime: string | null,
     supervisorName: string | null,
   ) => {
-    
-    const userLocale = (currentlocale==='fr')?'fr-FR':'en-US';
-    
+    const userLocale = currentlocale || 'en-US';
+
     let formattedDate = '';
     let formattedTime = '';
     if (startTime) {

--- a/plugin-hrm-form/src/translations/locales/en.json
+++ b/plugin-hrm-form/src/translations/locales/en.json
@@ -587,6 +587,7 @@
   "Switchboard-SelectQueueModalTitle": "Select queue to switchboard",
   "Switchboard-StatusActive": "Switchboarding: In Progress",
   "Switchboard-StatusInactive": "Switchboarding: Off",
-  "Switchboard-ConfirmTurnOffSwitchboard": "Are you sure you want to turn off switchboarding?"
-
+  "Switchboard-ConfirmTurnOffSwitchboard": "Are you sure you want to turn off switchboarding?",
+  "Switchboard-ActivateSwitchboarding": "Activate switchboarding",
+  "Switchboard-PleaseSelectQueue": "Please select a queue first"
 }

--- a/plugin-hrm-form/src/translations/locales/en.json
+++ b/plugin-hrm-form/src/translations/locales/en.json
@@ -583,8 +583,10 @@
   "MainHeader-Translator-MenuTitle": "Language Preference",
 
   "Switchboard-NoQueuesSwitchboarded": "No queues are currently being switchboarded",
-  "Switchboard-QueueSwitchboardedStatus": "<strong>{{queueName}}</strong> queue is currently being switchboarded by <strong>{{supervisorName}}</strong> since <strong>{{startTime}}</strong>",
+  "Switchboard-QueueSwitchboardedStatus": "<strong>{{queueName}}</strong> queue is currently being switchboarded by <strong>{{supervisorName}}</strong> since <strong>{{startDate}} at {{startTime}}</strong>",
   "Switchboard-SelectQueueModalTitle": "Select queue to switchboard",
   "Switchboard-StatusActive": "Switchboarding: In Progress",
-  "Switchboard-StatusInactive": "Switchboarding: Off"
+  "Switchboard-StatusInactive": "Switchboarding: Off",
+  "Switchboard-ConfirmTurnOffSwitchboard": "Are you sure you want to turn off switchboarding?"
+
 }

--- a/plugin-hrm-form/src/translations/locales/fr.json
+++ b/plugin-hrm-form/src/translations/locales/fr.json
@@ -669,5 +669,7 @@
 "Switchboard-StatusActive": "Commutation : en cours",
 "Switchboard-StatusInactive": "Commutation : désactivé",
 "Switchboard-ModalTitleTurnOffSwitchboard": "Êtes-vous sûr de vouloir désactiver la commutation?",
-"Switchboard-ButtonTurnOffSwitchboard": "Désactiver"
+"Switchboard-ButtonTurnOffSwitchboard": "Désactiver",
+"Switchboard-ActivateSwitchboarding": "Activer la commutation",
+"Switchboard-PleaseSelectQueue": "Veuillez d'abord sélectionner une file d'attente"
 }

--- a/plugin-hrm-form/src/translations/locales/fr.json
+++ b/plugin-hrm-form/src/translations/locales/fr.json
@@ -661,5 +661,13 @@
 "UnholdCustomerTooltip": "Décoller",
 "HoldAgentTooltip": "Mettre en attente",
 "UnholdAgentTooltip": "Décoller",
-"NewChatMessageNotificationTitle": "Nouveau message de {{lastMessage.authorName}}"
+"NewChatMessageNotificationTitle": "Nouveau message de {{lastMessage.authorName}}",
+
+"Switchboard-NoQueuesSwitchboarded": "aucune file d'attente n'est commutée",
+"Switchboard-QueueSwitchboardedStatus": "{{queueName}} est en cours de changement par {{supervisorName}} depuis {{startDate}} à {{startTime}}",
+"Switchboard-SelectQueueModalTitle": "Sélectionner la file d'attente pour changer",
+"Switchboard-StatusActive": "Commutation : en cours",
+"Switchboard-StatusInactive": "Commutation : désactivé",
+"Switchboard-ModalTitleTurnOffSwitchboard": "Êtes-vous sûr de vouloir désactiver la commutation?",
+"Switchboard-ButtonTurnOffSwitchboard": "Désactiver"
 }


### PR DESCRIPTION
## Description
This PR 
- adds missing translation strings for switchboarding actions, prompts, and statuses.
- Updates status messages to show both date and time for when a queue is switchboarded.
- Adds a help link with improved icon display in the switchboard status UI.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3374)
- [ ] New tests added
- [ ] Feature flags added
- [x] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P