### PR TITLE
fix: remove SWITCHBOARD_STATE_DOCUMENT ttl [CHI-3386]

### DIFF
--- a/lambdas/account-scoped/src/hrm/toggleSwitchboardQueue.ts
+++ b/lambdas/account-scoped/src/hrm/toggleSwitchboardQueue.ts
@@ -60,7 +60,6 @@ async function createSwitchboardStateDocument({
     await client.sync.v1.services(syncServiceSid).documents.create({
       uniqueName: SWITCHBOARD_STATE_DOCUMENT,
       data: state,
-      ttl: 48 * 60 * 60, // 48 hours
     });
 
     // update or create the notify document to emit a notification


### PR DESCRIPTION
## Description
This PR fixes a bug where tasks were assigned to Switchboard Queue when switchboarding was turned off.
To recap
- Switchboard enabled/disabled is determined by the existence of `SWITCHBOARD_STATE_DOCUMENT`. If it does exists, the clients understand it's enabled. If it's missing, then clients understand it's disabled. This document also acts as a "semaphore", so that only one queue can be switch-boarded at a given time.
- When switchboard is disabled, some cleanup is done:
  - Workflow filters are adjusted to it's original state (removing all the switchboard clones).
  - The `SWITCHBOARD_STATE_DOCUMENT` is removed to indicate it's now disabled.
The bug was caused because the document had a TTL of 48 hours. After this period, the document would be deleted, hence "switchboard was disabled", but the workflow filters were not cleared, causing tasks to be redirected to switchboard queue.
The fix is to simply remove the TTL from the `SWITCHBOARD_STATE_DOCUMENT` document. Now, switchboard will be kept enable until manually disabled.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3386)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P