### PR TITLE
Chi 3394 see timeline fix

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseHome.tsx
+++ b/plugin-hrm-form/src/components/case/CaseHome.tsx
@@ -20,7 +20,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { DefinitionVersion } from 'hrm-form-definitions';
 
 import { CaseContainer, CaseDetailsBorder } from './styles';
-import { BottomButtonBar, Box, DestructiveButton, TertiaryButton } from '../../styles';
+import { BottomButtonBar, Box, DestructiveButton, Flex, TertiaryButton } from '../../styles';
 import CaseOverviewHeader from './caseOverview/CaseOverviewHeader';
 import CaseOverview from './caseOverview';
 import Timeline from './timeline/Timeline';
@@ -164,9 +164,11 @@ const CaseHome: React.FC<CaseHomeProps> = ({ task, handlePrintCase, handleClose,
               titleCode={hasMoreActivities ? 'Case-Timeline-RecentTitle' : 'Case-Timeline-Title'}
             />
             {hasMoreActivities && (
-              <TertiaryButton style={{ marginTop: '10px' }} onClick={onViewFullTimelineClick}>
-                <Template code="Case-Timeline-OpenFullTimelineButton" />
-              </TertiaryButton>
+              <Flex flexDirection="column" width="100%">
+                <TertiaryButton style={{ marginTop: '10px' }} onClick={onViewFullTimelineClick}>
+                  <Template code="Case-Timeline-OpenFullTimelineButton" />
+                </TertiaryButton>
+              </Flex>
             )}
           </CaseDetailsBorder>
         </Box>

--- a/plugin-hrm-form/src/states/case/timeline.ts
+++ b/plugin-hrm-form/src/states/case/timeline.ts
@@ -81,6 +81,7 @@ export const loadTimelineIntoRedux = (
   if (timeline.length !== timelineResult.count) {
     timeline = [];
     timeline.length = timelineResult.count;
+    timeline.fill(null, 0, timelineResult.count);
   }
   timelineResult.activities.forEach((timelineActivity, index) => {
     if (isCaseSectionTimelineActivity(timelineActivity)) {
@@ -146,6 +147,7 @@ export const selectTimeline = (
   const timelineWindow = timeline.slice(offset, offset + limit);
   return timelineWindow
     .map(timelineActivity => {
+      if (!timelineActivity) return timelineActivity;
       if (isCaseSectionIdentifierTimelineActivity(timelineActivity)) {
         const { activity } = timelineActivity;
         const section = sections?.[activity.sectionType]?.[activity.sectionId];

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -80,10 +80,10 @@ export type TimelineActivity<T> = GenericTimelineActivity<T, Date>;
 
 export const isCaseSectionTimelineActivity = (
   activity: TimelineActivity<any>,
-): activity is TimelineActivity<FullCaseSection> => activity.activityType === 'case-section';
+): activity is TimelineActivity<FullCaseSection> => activity?.activityType === 'case-section';
 
 export const isContactTimelineActivity = (activity: TimelineActivity<any>): activity is TimelineActivity<Contact> =>
-  activity.activityType === 'contact';
+  activity?.activityType === 'contact';
 
 export type ContactIdentifierTimelineActivity = TimelineActivity<{ contactId: Contact['id'] }> & {
   activityType: 'contact-id';
@@ -91,7 +91,7 @@ export type ContactIdentifierTimelineActivity = TimelineActivity<{ contactId: Co
 
 export const isContactIdentifierTimelineActivity = (
   activity: TimelineActivity<any>,
-): activity is CaseSectionIdentifierTimelineActivity => activity.activityType === 'contact-id';
+): activity is CaseSectionIdentifierTimelineActivity => activity?.activityType === 'contact-id';
 
 export type CaseSectionIdentifierTimelineActivity = TimelineActivity<{
   sectionType: string;
@@ -102,7 +102,7 @@ export type CaseSectionIdentifierTimelineActivity = TimelineActivity<{
 
 export const isCaseSectionIdentifierTimelineActivity = (
   activity: TimelineActivity<any>,
-): activity is CaseSectionIdentifierTimelineActivity => activity.activityType === 'case-section-id';
+): activity is CaseSectionIdentifierTimelineActivity => activity?.activityType === 'case-section-id';
 
 export type CaseSummaryWorkingCopy = {
   status: string;


### PR DESCRIPTION
## Description

The logic for showing the button was based on checking the length of an array that could have empty indexes. This worked ok until the array we checked had a .filter prepass added. .filter removes empty array slots even if the filter condition is () => true, so this broke the check, causing the button not to be shown

Update timeline logic to prefill timeline indexes without activities with nulls to prevent issues where .filter removes them

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Feature flags added
- [N/A] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P