### PR TITLE
CHI-3408: Update node version for E2E test lambda

### DIFF
--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 
 ARG TARGETARCH
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y \
         nodejs \
         autoconf \

--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /app
 
 RUN apt-get update && \
     apt-get install -y curl wget gpg && \
-    curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     # move npm cache to /tmp for use in lambda
     npm config set cache /tmp --global && \


### PR DESCRIPTION
## Description

Updates container setup for E2E lambdas so it uses node 22

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [n/a] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P