### PR TITLE
CHI-3423: Move webchat serverless functions into twilio lambda and fix translations lookups

### DIFF
--- a/.github/workflows/webchat-ci.yml
+++ b/.github/workflows/webchat-ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ env.IP_FIND_API_KEY }}';
-          export const SERVERLESS_URL = '${{ env.SERVERLESS_URL }}';
+          export const SERVERLESS_URL = 'https://hrm-development.tl.techmatters.org/lambda/twilio/account-scoped/${{ env.ACCOUNT_SID }}';
           export const RECAPTCHA_KEY = '${{ env.RECAPTCHA_KEY }}';
           export const RECAPTCHA_VERIFY_URL = 'https://hrm-development.tl.techmatters.org/lambda/recaptchaVerify'
           EOT

--- a/lambdas/account-scoped/package.json
+++ b/lambdas/account-scoped/package.json
@@ -28,6 +28,7 @@
     "@twilio-labs/serverless-runtime-types": "^4.0.1",
     "date-fns": "^4.1.0",
     "lodash": "^4.17.21",
+    "moment-timezone": "^0.6.0",
     "twilio": "^5.4.0",
     "twilio-flex-token-validator": "^1.6.0"
   }

--- a/lambdas/account-scoped/src/conversation/chatChannelJanitor.ts
+++ b/lambdas/account-scoped/src/conversation/chatChannelJanitor.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/**
+ * In order to make post surveys work, we need to disable the Channel Janitor (see https://www.twilio.com/docs/flex/developer/messaging/manage-flows#channel-janitor).
+ * However, once the post survey is finished we want to mimic this feature to clear the channel and the proxy session, to enable future conversations from the same customer
+ * Ths file exposes functionalities to achieve this. chatChannelJanitor will:
+ * - Label the chat channel as INACTIVE.
+ * - Delete the associated proxy session if there is one.
+ */
+
+// eslint-disable-next-line prettier/prettier
+import {AccountSID, ChatChannelSID, ConversationSID} from '../twilioTypes';
+import {
+  getChatServiceSid,
+  getFlexProxyServiceSid,
+  getTwilioClient,
+} from '../configuration/twilioConfiguration';
+
+export type Event =
+  | {
+      channelSid?: ChatChannelSID;
+      conversationSid: ConversationSID;
+    }
+  | {
+      channelSid: ChatChannelSID;
+      conversationSid?: ConversationSID;
+    };
+
+const deleteProxySession = async (accountSid: AccountSID, proxySession: string) => {
+  try {
+    const client = await getTwilioClient(accountSid);
+    const ps = await client.proxy.v1.services
+      .get(await getFlexProxyServiceSid(accountSid))
+      .sessions.get(proxySession)
+      .fetch();
+
+    if (!ps) {
+      // eslint-disable-next-line no-console
+      console.log(`Tried to remove proxy session ${proxySession} but couldn't find it.`);
+      return false;
+    }
+
+    return await ps.remove();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log('deleteProxySession error: ', err);
+    return false;
+  }
+};
+
+const deactivateChannel = async (accountSid: AccountSID, channelSid: ChatChannelSID) => {
+  const client = await getTwilioClient(accountSid);
+  const serviceSid = await getChatServiceSid(accountSid);
+  const channel = await client.chat.v2.services
+    .get(serviceSid)
+    .channels.get(channelSid)
+    .fetch();
+
+  const attributes = JSON.parse(channel.attributes);
+
+  if (attributes.status !== 'INACTIVE') {
+    if (attributes.proxySession) {
+      await deleteProxySession(accountSid, attributes.proxySession);
+    }
+
+    const newAttributes = { ...attributes, status: 'INACTIVE' };
+    const updated = await channel.update({
+      attributes: JSON.stringify(newAttributes),
+      xTwilioWebhookEnabled: 'true',
+    });
+
+    return { message: 'Channel deactivated', updated };
+  }
+
+  return { message: 'Channel already INACTIVE, event ignored' };
+};
+
+const deactivateConversation = async (
+  accountSid: AccountSID,
+  conversationSid: ConversationSID,
+) => {
+  const client = await getTwilioClient(accountSid);
+  const conversation = await client.conversations.v1.conversations
+    .get(conversationSid)
+    .fetch();
+  const attributes = JSON.parse(conversation.attributes);
+
+  if (conversation.state !== 'closed') {
+    if (attributes.proxySession) {
+      await deleteProxySession(accountSid, attributes.proxySession);
+    }
+    console.log('Attempting to deactivate active conversation', conversationSid);
+    const updated = await conversation.update({
+      state: 'closed',
+      xTwilioWebhookEnabled: 'true',
+    });
+
+    return { message: 'Conversation deactivated', updated };
+  }
+
+  return { message: 'Conversation already closed, event ignored' };
+};
+
+export const chatChannelJanitor = async (
+  accountSid: AccountSID,
+  { channelSid, conversationSid }: Event,
+) => {
+  if (conversationSid) {
+    const result = await deactivateConversation(accountSid, conversationSid);
+
+    return {
+      message: `Deactivation attempted for conversation ${conversationSid}`,
+      result,
+    };
+  }
+  const result = await deactivateChannel(accountSid, channelSid);
+
+  return { message: `Deactivation attempted for channel ${channelSid}`, result };
+};

--- a/lambdas/account-scoped/src/conversation/endChat.ts
+++ b/lambdas/account-scoped/src/conversation/endChat.ts
@@ -1,0 +1,235 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
+import '@twilio-labs/serverless-runtime-types';
+
+import type { TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
+import { ChatChannelSID, ConversationSID } from '../twilioTypes';
+import { AccountScopedHandler, HttpError } from '../httpTypes';
+import { AccountSID } from '../twilioTypes';
+import { newErr, newOk, Result } from '../Result';
+import {
+  getChatServiceSid,
+  getTwilioClient,
+  getTwilioWorkspaceSid,
+} from '../configuration/twilioConfiguration';
+import { lookupCustomMessage } from '../hrm/formDefinitionsCache';
+import { chatChannelJanitor } from './chatChannelJanitor';
+
+export type EndChatRequestBody = {
+  channelSid?: ChatChannelSID;
+  conversationSid?: ConversationSID;
+  language?: string;
+};
+
+const getEndChatMessage = async (
+  accountSid: AccountSID,
+  event: EndChatRequestBody,
+): Promise<string> => {
+  // Retrieve the EndChatMsg for appropriate language
+  const { language: locale } = event;
+
+  if (locale) {
+    try {
+      const customMessage = await lookupCustomMessage(accountSid, locale, 'EndChatMsg');
+      if (customMessage) {
+        return customMessage;
+      }
+      // We would typically look up 'standard translations' here, but none are currently set up
+      // The message is always set as a custom message for the helpline
+      console.info(`No custom EndChatMsg message set for ${locale} on ${accountSid}`);
+    } catch (err) {
+      console.warn(`Couldn't retrieve EndChatMsg message translation for ${locale}`, err);
+    }
+  }
+  return 'User left the conversation';
+};
+
+/**
+ * End a task by updating their assignment status.
+ *
+ * It also sends a message indicating that the user has left the conversation
+ * if appropriate.
+ *
+ * @returns channelCleanupRequired
+ */
+const updateTaskAssignmentStatus = async (
+  accountSid: AccountSID,
+  taskSid: string,
+  channelSid: string,
+  event: EndChatRequestBody,
+) => {
+  try {
+    const client = await getTwilioClient(accountSid);
+    const workspaceSid = await getTwilioWorkspaceSid(accountSid);
+    // Fetch the Task to 'cancel' or 'wrapup'
+    const task = await client.taskrouter.v1.workspaces
+      .get(workspaceSid)
+      .tasks(taskSid)
+      .fetch();
+
+    // Send a Message indicating user left the conversation
+    if (task.assignmentStatus === 'assigned') {
+      const endChatMessage = await getEndChatMessage(accountSid, event);
+      await client.chat.v2
+        .services(await getChatServiceSid(accountSid))
+        .channels(channelSid)
+        .messages.create({
+          body: endChatMessage,
+          from: 'Bot',
+          xTwilioWebhookEnabled: 'true',
+        });
+    }
+
+    // Update the task assignmentStatus
+    const updateAssignmentStatus = (assignmentStatus: TaskInstance['assignmentStatus']) =>
+      client.taskrouter.v1
+        .workspaces(workspaceSid)
+        .tasks(taskSid)
+        .update({ assignmentStatus });
+
+    switch (task.assignmentStatus) {
+      case 'reserved':
+      case 'pending': {
+        await updateAssignmentStatus('canceled');
+        return 'cleanup'; // indicate that there's cleanup needed
+      }
+      case 'assigned': {
+        await updateAssignmentStatus('wrapping');
+        return 'keep-alive'; // keep the channel alive for post survey
+      }
+      default:
+    }
+
+    return 'noop'; // no action needed
+  } catch (err) {
+    console.warn(`Unable to end task ${taskSid}:`, err);
+    return 'noop'; // no action needed
+  }
+};
+
+/**
+ * End contact task or post-survey task associated to the given channel.
+ *
+ * @returns channelCleanupRequired
+ */
+const endContactOrPostSurvey = async (
+  accountSid: AccountSID,
+  channelAttributes: any,
+  event: EndChatRequestBody,
+) => {
+  const { tasksSids, surveyTaskSid } = channelAttributes;
+
+  const { channelSid } = event;
+  const actionsOnChannel = await Promise.allSettled(
+    [...tasksSids, surveyTaskSid]
+      .filter(Boolean)
+      .map(tSid =>
+        updateTaskAssignmentStatus(accountSid, tSid, channelSid as string, event),
+      ),
+  );
+
+  // Cleanup the channel if there's no keep-alive and at least one cleanup
+  return (
+    !actionsOnChannel.some(p => p.status === 'fulfilled' && p.value === 'keep-alive') &&
+    actionsOnChannel.some(p => p.status === 'fulfilled' && p.value === 'cleanup')
+  );
+};
+
+export const handleEndChat: AccountScopedHandler = async (
+  { body },
+  accountSid: AccountSID,
+): Promise<Result<HttpError, any>> => {
+  try {
+    const client = await getTwilioClient(accountSid);
+
+    const { conversationSid, channelSid, language } = body as EndChatRequestBody;
+
+    if (channelSid === undefined && conversationSid === undefined) {
+      return newErr({
+        message: 'Either a ChannelSid or ConversationSid parameter is required',
+        error: { statusCode: 400 },
+      });
+    }
+    if (language === undefined) {
+      return newErr({
+        message: 'language parameter is missing',
+        error: { statusCode: 400 },
+      });
+    }
+
+    let channelCleanupRequired = false;
+
+    if (conversationSid) {
+      const { attributes, participants } = await client.conversations.v1.conversations
+        .get(conversationSid)
+        .fetch();
+      const conversationAttributes = JSON.parse(attributes);
+      channelCleanupRequired = await endContactOrPostSurvey(
+        accountSid,
+        conversationAttributes,
+        body,
+      );
+      const participantsList = await participants().list();
+      await Promise.all(
+        participantsList.map(async (p): Promise<boolean> => {
+          if (JSON.parse(p.attributes).member_type !== 'guest') {
+            return p.remove();
+          }
+          return false;
+        }),
+      );
+    } else {
+      const { members, attributes } = await client.chat.v2
+        .services(await getChatServiceSid(accountSid))
+        .channels(channelSid!)
+        .fetch();
+      // Use the channelSid to fetch task that needs to be closed
+      const channelAttributes = JSON.parse(attributes);
+
+      channelCleanupRequired = await endContactOrPostSurvey(
+        accountSid,
+        channelAttributes,
+        body,
+      );
+
+      const channelMembers = await members().list();
+      await Promise.all(
+        channelMembers.map(m => {
+          if (JSON.parse(m.attributes).member_type !== 'guest') {
+            return m.remove();
+          }
+
+          return Promise.resolve();
+        }),
+      );
+    }
+
+    if (channelCleanupRequired) {
+      // Deactivate channel and proxy
+      await chatChannelJanitor(accountSid, {
+        channelSid,
+        conversationSid: conversationSid!,
+      });
+    }
+
+    return newOk({ message: 'End Chat OK!' });
+  } catch (error: any) {
+    return newErr({ message: error.message, error: { statusCode: 500, cause: error } });
+  }
+};

--- a/lambdas/account-scoped/src/operatingHours.ts
+++ b/lambdas/account-scoped/src/operatingHours.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import '@twilio-labs/serverless-runtime-types';
+import moment from 'moment-timezone';
+import { AccountScopedHandler, HttpError } from './httpTypes';
+import { AccountSID } from './twilioTypes';
+import { newErr, newOk, Result } from './Result';
+import { lookupCustomMessage } from './hrm/formDefinitionsCache';
+import {
+  areOperatingHoursEnforced,
+  getOperatingInfoKey,
+} from './configuration/twilioConfiguration';
+
+type OperatingShift = { open: number; close: number };
+
+enum DaysOfTheWeek {
+  Monday = 1,
+  Tuesday = 2,
+  Wednesday = 3,
+  Thursday = 4,
+  Friday = 5,
+  Saturday = 6,
+  Sunday = 7,
+}
+
+type OfficeOperatingInfo = {
+  timezone: string; // the timezone the helpline uses
+  holidays: { [date: string]: string }; // a date (in MM/DD/YYYY format) - holiday name object to specify which days are holidays for the helpline
+  operatingHours: { [channel: string]: { [day in DaysOfTheWeek]: OperatingShift[] } }; // object that pairs numbers representing weekdays to open and close shifts
+};
+
+// The root contains OfficeOperatingInfo info (default, support legacy) plus an "offices" entry, which maps OfficeOperatingInfo to a particular office
+type OperatingInfo = OfficeOperatingInfo & {
+  offices: {
+    [office: string]: OfficeOperatingInfo;
+  };
+};
+
+export type Body = {
+  channel?: string;
+  office?: string;
+  includeMessageTextInResponse?: string;
+  language?: string;
+};
+
+const isOpen =
+  (timeOfDay: number) =>
+  (shift: OperatingShift): boolean =>
+    timeOfDay >= shift.open && timeOfDay < shift.close;
+
+const getStatusFromEntry = (
+  officeOperatingInfo: OfficeOperatingInfo,
+  channel: string,
+) => {
+  if (!officeOperatingInfo || !officeOperatingInfo.operatingHours[channel]) {
+    throw new Error(
+      `Operating Info not found for channel ${channel}. Check OPERATING_INFO_KEY env vars and a matching OperatingInfo json file for it.`,
+    );
+  }
+
+  const { timezone, holidays, operatingHours } = officeOperatingInfo;
+
+  const timeOfDay = parseInt(
+    moment().tz(timezone).format('Hmm'), // e.g 123 for 1hs 23m, 1345 for 13hs 45m
+    10,
+  );
+  const dayOfWeek = moment().tz(timezone).isoWeekday() as DaysOfTheWeek;
+  const currentDate = moment().tz(timezone).format('MM/DD/YYYY');
+
+  if (currentDate in holidays) {
+    return 'holiday';
+  }
+
+  const isInOpenShift = isOpen(timeOfDay);
+  const isOpenNow = operatingHours[channel][dayOfWeek].some(isInOpenShift);
+
+  if (isOpenNow) {
+    return 'open';
+  }
+
+  return 'closed';
+};
+
+const getOperatingStatus = (
+  operatingInfo: OperatingInfo,
+  channel: string,
+  office?: string,
+) => {
+  const { offices, ...operatingInfoRoot } = operatingInfo;
+
+  if (office) {
+    try {
+      const officeEntry = offices[office];
+
+      return getStatusFromEntry(officeEntry, channel);
+    } catch (err) {
+      console.warn(`Error trying to access entry for office ${office}`, err);
+    }
+  }
+
+  // If no office was provided, or the channel is missing in the office entry, return root info
+  return getStatusFromEntry(operatingInfoRoot, channel);
+};
+
+const getClosedMessage = async (
+  accountSid: AccountSID,
+  status: 'closed' | 'holiday',
+  locale: string = 'en-US',
+): Promise<string> => {
+  const messageKey = status === 'closed' ? 'ClosedOutOfShift' : 'ClosedHolidays';
+
+  // Try to get the translated message
+  try {
+    const customMessage = await lookupCustomMessage(accountSid, locale, messageKey);
+    if (customMessage) {
+      return customMessage;
+    }
+    // We would typically look up 'standard translations' here, but none are currently set up
+    // The message is always set as a custom message for the helpline
+    console.info(`No custom ${messageKey} message set for ${locale} on ${accountSid}`);
+  } catch {
+    console.warn(`Couldn't retrieve EndChatMsg message translation for ${locale}`);
+  }
+
+  // Return default strings if can't retrieve the translation
+  return {
+    ClosedOutOfShift: 'The helpline is out of shift, please reach us later.',
+    ClosedHolidays: 'The helpline is closed due to a holiday.',
+  }[messageKey];
+};
+
+const flagIsTrue = (s?: string) => s?.toLowerCase() === 'true';
+
+export const handleOperatingHours: AccountScopedHandler = async (
+  { body },
+  accountSid: AccountSID,
+): Promise<Result<HttpError, any>> => {
+  try {
+    const operatingInfoKey = await getOperatingInfoKey(accountSid);
+
+    const { channel, office, language, includeMessageTextInResponse } = body;
+
+    if (await areOperatingHoursEnforced(accountSid)) {
+      if (!flagIsTrue(includeMessageTextInResponse)) {
+        return newOk('open');
+      }
+
+      const response = {
+        status: 'open',
+        message: undefined,
+      };
+
+      return newOk(response);
+    }
+
+    if (channel === undefined) {
+      return newErr({
+        message: 'channel parameter is missing',
+        error: { statusCode: 400 },
+      });
+    }
+
+    const operatingInfo: OperatingInfo = JSON.parse(
+      Runtime.getAssets()[`/operatingInfo/${operatingInfoKey}.json`].open(),
+    );
+
+    const status = getOperatingStatus(operatingInfo, channel, office);
+
+    // Support legacy function to avoid braking changes
+    // TODO: remove once every account has been migrated
+    if (!flagIsTrue(includeMessageTextInResponse)) {
+      return newOk({});
+    }
+
+    // Return a the status and, if closed, the appropriate message
+    const response = {
+      status,
+      message:
+        status === 'open'
+          ? undefined
+          : await getClosedMessage(accountSid, status, language),
+    };
+
+    return newOk(response);
+  } catch (error: any) {
+    return newErr({ message: error.message, error: { statusCode: 500, cause: error } });
+  }
+};

--- a/lambdas/account-scoped/src/router.ts
+++ b/lambdas/account-scoped/src/router.ts
@@ -32,6 +32,8 @@ import { getParticipantHandler } from './conference/getParticipant';
 import { updateParticipantHandler } from './conference/updateParticipant';
 import { removeParticipantHandler } from './conference/removeParticipant';
 import { statusCallbackHandler } from './conference/statusCallback';
+import { handleOperatingHours } from './operatingHours';
+import { handleEndChat } from './conversation/endChat';
 
 /**
  * Super simple router sufficient for directly ported Twilio Serverless functions
@@ -89,6 +91,14 @@ const ROUTES: Record<string, FunctionRoute> = {
   toggleSwitchboardQueue: {
     requestPipeline: [validateFlexTokenRequest({ tokenMode: 'supervisor' })],
     handler: handleToggleSwitchboardQueue,
+  },
+  endChat: {
+    requestPipeline: [validateFlexTokenRequest({ tokenMode: 'guest' })],
+    handler: handleEndChat,
+  },
+  operatingHours: {
+    requestPipeline: [validateFlexTokenRequest({ tokenMode: 'guest' })],
+    handler: handleOperatingHours,
   },
 };
 

--- a/lambdas/account-scoped/src/twilioTypes.ts
+++ b/lambdas/account-scoped/src/twilioTypes.ts
@@ -22,6 +22,9 @@ export type TaskSID = `WT${string}`;
 export type ChatServiceSID = `IS${string}`;
 export type WorkflowSID = `WW${string}`;
 
+export type ConversationSID = `CH${string}`;
+export type ChatChannelSID = ConversationSID;
+
 export const isAccountSID = (value: string): value is AccountSID =>
   // This regex could be stricter if we only wanted to catch 'real' account SIDs, but our test account sids have non hexadecimal characters
   /^AC[0-9a-zA-Z_]+$/.test(value);

--- a/lambdas/account-scoped/src/validation/flexToken.ts
+++ b/lambdas/account-scoped/src/validation/flexToken.ts
@@ -32,9 +32,9 @@ const isSupervisor = (tokenResult: TokenValidatorResponse) =>
 export const validateFlexTokenRequest: ({
   tokenMode,
 }: {
-  tokenMode: 'supervisor' | 'worker';
+  tokenMode: 'supervisor' | 'worker' | 'guest';
 }) => HttpRequestPipelineStep =
-  ({ tokenMode }: { tokenMode: 'supervisor' | 'worker' }) =>
+  ({ tokenMode }: { tokenMode: 'supervisor' | 'worker' | 'guest' }) =>
   async (request, { accountSid }) => {
     const { Token: token } = request.body;
     if (!token) {
@@ -47,7 +47,7 @@ export const validateFlexTokenRequest: ({
         await getAccountAuthToken(accountSid),
       )) as TokenValidatorResponse;
       const isGuestToken = !isWorker(tokenResult) || isGuest(tokenResult);
-      if (isGuestToken) {
+      if (isGuestToken && tokenMode !== 'guest') {
         return newErr({
           message: 'Guest tokens are not authorized for this endpoint',
           error: { statusCode: 403 },

--- a/lambdas/package-lock.json
+++ b/lambdas/package-lock.json
@@ -62,6 +62,7 @@
         "@twilio-labs/serverless-runtime-types": "^4.0.1",
         "date-fns": "^4.1.0",
         "lodash": "^4.17.21",
+        "moment-timezone": "^0.6.0",
         "twilio": "^5.4.0",
         "twilio-flex-token-validator": "^1.6.0"
       },
@@ -15340,6 +15341,27 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.0.tgz",
+      "integrity": "sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -27047,6 +27069,7 @@
         "jest-each": "^29.5.0",
         "lodash": "^4.17.21",
         "mockttp": "^3.15.5",
+        "moment-timezone": "^0.6.0",
         "ts-node": "^10.9.1",
         "twilio": "^5.4.0",
         "twilio-flex-token-validator": "^1.6.0",
@@ -33016,6 +33039,19 @@
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
           "dev": true
         }
+      }
+    },
+    "moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
+    },
+    "moment-timezone": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.0.tgz",
+      "integrity": "sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==",
+      "requires": {
+        "moment": "^2.29.4"
       }
     },
     "ms": {

--- a/webchat/configurations/as-development.ts
+++ b/webchat/configurations/as-development.ts
@@ -165,4 +165,5 @@ export const config: Configuration = {
   blockedEmojis,
   memberDisplayOptions,
   enableRecaptcha,
+  twilioServicesUrl: new URL(`https://hrm-development.tl.techmatters.org/lambda/twilio/account-scoped/${accountSid}`),
 };

--- a/webchat/src/end-chat/end-chat-service.ts
+++ b/webchat/src/end-chat/end-chat-service.ts
@@ -14,6 +14,9 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+// eslint-disable-next-line import/no-unresolved
+import { config } from '../config';
+
 type Token = string;
 type ChannelSid = string;
 type Language = string;
@@ -30,7 +33,7 @@ export const finishChatTask = async (channelSid: ChannelSid, token: Token, langu
   };
   // eslint-disable-next-line global-require
   const { SERVERLESS_URL } = require('../../private/secret');
-  const response = await fetch(`${SERVERLESS_URL}/endChat`, options);
+  const response = await fetch(`${config.twilioServicesUrl ?? SERVERLESS_URL}/endChat`, options);
   const responseJson = await response.json();
 
   if (response.status === 403) {

--- a/webchat/src/operating-hours.ts
+++ b/webchat/src/operating-hours.ts
@@ -18,6 +18,7 @@ import { Manager } from '@twilio/flex-webchat-ui';
 
 import { Configuration, OperatingHoursResponse } from '../types';
 import { setFormDefinition } from './pre-engagement-form/state';
+import { config } from "./config";
 
 const getOperatingHours = async (language: string): Promise<OperatingHoursResponse> => {
   const body = {
@@ -35,7 +36,7 @@ const getOperatingHours = async (language: string): Promise<OperatingHoursRespon
   };
 
   const { SERVERLESS_URL } = require('../private/secret'); // eslint-disable-line global-require
-  const response = await fetch(`${SERVERLESS_URL}/operatingHours`, options);
+  const response = await fetch(`${config.twilioServicesUrl ?? SERVERLESS_URL}/operatingHours`, options);
 
   if (response.status === 403) {
     throw new Error('Server responded with 403 status (Forbidden)');

--- a/webchat/types.ts
+++ b/webchat/types.ts
@@ -42,6 +42,7 @@ export type Configuration = {
   showEmojiPicker?: boolean;
   blockedEmojis?: string[];
   enableRecaptcha?: boolean;
+  twilioServicesUrl?: URL;
 };
 
 type OperatingHoursStatus = 'open' | 'closed' | 'holiday';


### PR DESCRIPTION
## Description

- Move the serverless endpoints endChat and operatingHours to twilio lambda
- The operating hours override is now set via an optional SSM parameter: /{environment}/twilio/{accountSid}/operating_hours_enforced_override - 'true' or 'false', remove it to use default, true for prod, false elsewhere
- Webchat is configured to use the twilio lambda via the config file, where you can set a `twilioServicesUrl` which overrides the SERVERLESS_URL set via the build.
- Custom messages are looked up from the form definition in both cases
- Support for guest tokens on endpoint verification added to Twilio LAmbda

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [x] Feature flags added
- [n/a] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Deploy this branch of the Twilio Lambda
Reconfigure webchat as above
Ensure that correct messages are sent for end chat and operating hours checks

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P