### PR TITLE
fix: avoid pages upon attempt of switchboard when enabled [CHI-3430]

### DIFF
--- a/lambdas/account-scoped/src/hrm/toggleSwitchboardQueue.ts
+++ b/lambdas/account-scoped/src/hrm/toggleSwitchboardQueue.ts
@@ -422,6 +422,12 @@ export const handleToggleSwitchboardQueue: AccountScopedHandler = async (
         supervisorWorkerSid,
       });
       if (isErr(enableResult)) {
+        if (enableResult.error.message?.includes('Unique name already exists')) {
+          return newErr({
+            message: enableResult.message,
+            error: { statusCode: 400, cause: enableResult.error },
+          });
+        }
         return newErr({
           message: enableResult.message,
           error: { statusCode: 500, cause: enableResult.error },


### PR DESCRIPTION
## Description
This PR captures the "enable switchboard" logic in scenarios where it is already enabled, to prevent it from paging, returning a `400` error status code instead of a `500`. 
A follow up PR updates the UI to this state should be unreachable.


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3430)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P