### PR TITLE
fix: force switchboard card refresh after toggling [CHI-3393]

### DIFF
--- a/plugin-hrm-form/src/states/switchboard/useSwitchboard.ts
+++ b/plugin-hrm-form/src/states/switchboard/useSwitchboard.ts
@@ -33,7 +33,7 @@ const useSwitchboardState = (): SwitchboardState => {
  * Hook to subscribe to the switchboard state from the Twilio Sync service and update the Redux store
  * @returns Cleanup function to unsubscribe from updates
  */
-const useSubscribeSwitchboardNotify = (): void => {
+const useSubscribeSwitchboardNotify = () => {
   const dispatch = useDispatch();
 
   const handleError = useCallback(
@@ -46,7 +46,7 @@ const useSubscribeSwitchboardNotify = (): void => {
     [dispatch],
   );
 
-  const onUpdate = useCallback(async () => {
+  const refreshSwitchboardState = useCallback(async () => {
     dispatch(setSwitchboardLoading(true));
     const switchboardStateResult = await getSwitchboardState();
 
@@ -67,10 +67,11 @@ const useSubscribeSwitchboardNotify = (): void => {
     const switchboardSubscribe = async () => {
       try {
         dispatch(setSwitchboardLoading(true));
-
-        onUpdate();
+        // initial state load
+        refreshSwitchboardState();
+        // subscribe to live updates
         const subscribeResult = await subscribeSwitchboardNotify({
-          onUpdate,
+          onUpdate: refreshSwitchboardState,
         });
 
         if (isErr(subscribeResult)) {
@@ -91,7 +92,9 @@ const useSubscribeSwitchboardNotify = (): void => {
         unsubscribe();
       }
     };
-  }, [dispatch, handleError, onUpdate]);
+  }, [dispatch, handleError, refreshSwitchboardState]);
+
+  return { refreshSwitchboardState };
 };
 
 /**
@@ -101,7 +104,7 @@ const useSubscribeSwitchboardNotify = (): void => {
 export const useSwitchboard = () => {
   const dispatch = useDispatch();
   const state = useSwitchboardState();
-  useSubscribeSwitchboardNotify();
+  const { refreshSwitchboardState } = useSubscribeSwitchboardNotify();
 
   const toggleSwitchboard = useCallback(
     async ({
@@ -119,18 +122,7 @@ export const useSwitchboard = () => {
 
         const response = await toggleSwitchboardingForQueue({ queueSid, supervisorWorkerSid, operation });
 
-        if (response && typeof response === 'object') {
-          const newState = {
-            isSwitchboardingActive: response.isSwitchboardingActive,
-            queueSid: response.queueSid,
-            queueName: response.queueName,
-            startTime: response.startTime,
-            supervisorWorkerSid: response.supervisorWorkerSid,
-          };
-
-          dispatch(updateSwitchboardState(newState));
-        }
-
+        refreshSwitchboardState();
         dispatch(setSwitchboardLoading(false));
       } catch (error) {
         const errorMessage = 'Failed to activate switchboarding. Please try again or contact support.';
@@ -139,7 +131,7 @@ export const useSwitchboard = () => {
         throw error;
       }
     },
-    [dispatch],
+    [dispatch, refreshSwitchboardState],
   );
 
   return { state, toggleSwitchboard };

--- a/plugin-hrm-form/src/states/switchboard/useSwitchboard.ts
+++ b/plugin-hrm-form/src/states/switchboard/useSwitchboard.ts
@@ -121,14 +121,12 @@ export const useSwitchboard = () => {
         dispatch(setSwitchboardError(null));
 
         const response = await toggleSwitchboardingForQueue({ queueSid, supervisorWorkerSid, operation });
-
-        refreshSwitchboardState();
-        dispatch(setSwitchboardLoading(false));
       } catch (error) {
         const errorMessage = 'Failed to activate switchboarding. Please try again or contact support.';
         dispatch(setSwitchboardError(errorMessage));
-        dispatch(setSwitchboardLoading(false));
-        throw error;
+        // throw error;
+      } finally {
+        refreshSwitchboardState();
       }
     },
     [dispatch, refreshSwitchboardState],


### PR DESCRIPTION
## Description
This PR fixes an issue where switchboarding state is not immediately refreshed after toggling, specially seen after turning it on.
The fix is achieved by forcing a state refresh after attempting to toggle switchboard.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3393)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P