### PR TITLE
fix: replace "childName" sort by "label" in case search [CHI-3367]

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/CaseService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/CaseService.test.ts
@@ -117,9 +117,9 @@ describe('createCase()', () => {
           ...baselineContact.rawJson.childInformation,
           firstName: 'first',
           lastName: 'last',
-        }
-      }
-    }
+        },
+      },
+    };
 
     const response = await createCase(contact, 'creating worker', 'as-v1');
 

--- a/plugin-hrm-form/src/___tests__/services/CaseService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/CaseService.test.ts
@@ -99,6 +99,42 @@ describe('createCase()', () => {
           definitionVersion: 'as-v1',
         },
         definitionVersion: 'as-v1',
+        label: null,
+      }),
+    };
+    expect(fetchHrmApi).toHaveBeenCalledWith(expectedUrl, expectedOptions);
+    expect(response).toStrictEqual(baselineResponse);
+  });
+
+  test('No createdOnBehalfOf set - label uses childs first and last name if present', async () => {
+    mockFetchHrmAPi.mockResolvedValue(baselineResponse);
+
+    const contact = {
+      ...baselineContact,
+      rawJson: {
+        ...baselineContact.rawJson,
+        childInformation: {
+          ...baselineContact.rawJson.childInformation,
+          firstName: 'first',
+          lastName: 'last',
+        }
+      }
+    }
+
+    const response = await createCase(contact, 'creating worker', 'as-v1');
+
+    const expectedUrl = `/cases`;
+    const expectedOptions = {
+      method: 'POST',
+      body: expect.jsonStringToParseAs({
+        twilioWorkerId: 'creating worker',
+        status: 'open',
+        helpline: 'a helpline',
+        info: {
+          definitionVersion: 'as-v1',
+        },
+        definitionVersion: 'as-v1',
+        label: 'first last',
       }),
     };
     expect(fetchHrmApi).toHaveBeenCalledWith(expectedUrl, expectedOptions);
@@ -140,6 +176,7 @@ describe('createCase()', () => {
           offlineContactCreator: 'creating worker',
         },
         definitionVersion: 'as-v1',
+        label: null,
       }),
     };
     expect(fetchHrmApi).toHaveBeenCalledWith(expectedUrl, expectedOptions);

--- a/plugin-hrm-form/src/components/caseList/CaseListTableHead.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTableHead.tsx
@@ -16,7 +16,7 @@
 
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { TableHead, TableRow } from '@material-ui/core';
+import { TableRow } from '@material-ui/core';
 
 import CaseListTableHeadCell from './CaseListTableHeadCell';
 import { ListCasesSortBy, SortDirection } from '../../types/types';
@@ -32,9 +32,9 @@ const CaseListTableHead = () => {
           localizedText="CaseList-THCase"
         />
         <CaseListTableHeadCell
-          column={ListCasesSortBy.CHILD_NAME}
+          column={ListCasesSortBy.LABEL}
           defaultSortDirection={SortDirection.ASC}
-          localizedText="CaseList-THChildName"
+          localizedText="CaseList-THLabel"
         />
         <CaseListTableHeadCell localizedText="CaseList-THCounselor" />
         <CaseListTableHeadCell localizedText="CaseList-THSummary" width="20%" />

--- a/plugin-hrm-form/src/components/caseList/CaseListTableHead.tsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTableHead.tsx
@@ -34,7 +34,7 @@ const CaseListTableHead = () => {
         <CaseListTableHeadCell
           column={ListCasesSortBy.LABEL}
           defaultSortDirection={SortDirection.ASC}
-          localizedText="CaseList-THLabel"
+          localizedText="CaseList-THChildName"
         />
         <CaseListTableHeadCell localizedText="CaseList-THCounselor" />
         <CaseListTableHeadCell localizedText="CaseList-THSummary" width="20%" />

--- a/plugin-hrm-form/src/services/CaseService.ts
+++ b/plugin-hrm-form/src/services/CaseService.ts
@@ -30,7 +30,8 @@ const convertApiCaseToFlexCase = (apiCase: Case): Case => ({
 });
 export const getCasePayload = (contact: Contact, creatingWorkerSid: string, definitionVersion: string) => {
   const { helpline, rawJson: contactForm } = contact;
-  const label = `${contactForm.childInformation.firstName || ''} ${contactForm.childInformation.lastName || ''}`.trim() || null;
+  const label =
+    `${contactForm.childInformation.firstName || ''} ${contactForm.childInformation.lastName || ''}`.trim() || null;
 
   return contactForm.contactlessTask?.createdOnBehalfOf
     ? {

--- a/plugin-hrm-form/src/services/CaseService.ts
+++ b/plugin-hrm-form/src/services/CaseService.ts
@@ -30,6 +30,7 @@ const convertApiCaseToFlexCase = (apiCase: Case): Case => ({
 });
 export const getCasePayload = (contact: Contact, creatingWorkerSid: string, definitionVersion: string) => {
   const { helpline, rawJson: contactForm } = contact;
+  const label = `${contactForm.childInformation.firstName} ${contactForm.childInformation.lastName}`.trim() || null;
 
   return contactForm.contactlessTask?.createdOnBehalfOf
     ? {
@@ -38,6 +39,7 @@ export const getCasePayload = (contact: Contact, creatingWorkerSid: string, defi
         twilioWorkerId: contactForm.contactlessTask.createdOnBehalfOf,
         info: { definitionVersion, offlineContactCreator: creatingWorkerSid },
         definitionVersion,
+        label,
       }
     : {
         helpline,
@@ -45,6 +47,7 @@ export const getCasePayload = (contact: Contact, creatingWorkerSid: string, defi
         twilioWorkerId: creatingWorkerSid,
         info: { definitionVersion },
         definitionVersion,
+        label,
       };
 };
 

--- a/plugin-hrm-form/src/services/CaseService.ts
+++ b/plugin-hrm-form/src/services/CaseService.ts
@@ -30,7 +30,7 @@ const convertApiCaseToFlexCase = (apiCase: Case): Case => ({
 });
 export const getCasePayload = (contact: Contact, creatingWorkerSid: string, definitionVersion: string) => {
   const { helpline, rawJson: contactForm } = contact;
-  const label = `${contactForm.childInformation.firstName} ${contactForm.childInformation.lastName}`.trim() || null;
+  const label = `${contactForm.childInformation.firstName || ''} ${contactForm.childInformation.lastName || ''}`.trim() || null;
 
   return contactForm.contactlessTask?.createdOnBehalfOf
     ? {

--- a/plugin-hrm-form/src/translations/en.json
+++ b/plugin-hrm-form/src/translations/en.json
@@ -270,6 +270,7 @@
   "CaseList-Filters-CaseCount-Plural": "{{count}} cases",
   "CaseList-THCase": "Case",
   "CaseList-THChildName": "Child",
+  "CaseList-THLabel": "Label",
   "CaseList-THSummary": "Summary",
   "CaseList-THCounselor": "Counsellor",
   "CaseList-THOpened": "Opened",

--- a/plugin-hrm-form/src/translations/en.json
+++ b/plugin-hrm-form/src/translations/en.json
@@ -270,7 +270,6 @@
   "CaseList-Filters-CaseCount-Plural": "{{count}} cases",
   "CaseList-THCase": "Case",
   "CaseList-THChildName": "Child",
-  "CaseList-THLabel": "Label",
   "CaseList-THSummary": "Summary",
   "CaseList-THCounselor": "Counsellor",
   "CaseList-THOpened": "Opened",

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -177,7 +177,7 @@ export enum ListCasesSortBy {
   ID = 'id',
   CREATED_AT = 'createdAt',
   UPDATED_AT = 'updatedAt',
-  CHILD_NAME = 'childName',
+  LABEL = 'label',
   FOLLOW_UP_DATE = 'info.followUpDate',
 }
 


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/hrm/pull/921.

## Description
This PR
- Adjusts case list to use `label` as a sort direction property.
- Populates `label` field upon case creation using contact's child info first and last names (if any).

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3367)
- [x] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
See linked PR.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P