### PR TITLE
CHI 3457 Normalise SIP Caller Address

### DIFF
--- a/twilio-iac/helplines/sg/templates/studio-flows/voice-no-chatbot-operating-hours-lambda.tftpl
+++ b/twilio-iac/helplines/sg/templates/studio-flows/voice-no-chatbot-operating-hours-lambda.tftpl
@@ -274,7 +274,7 @@ ${
             {
               "friendly_name": "If value does_not_start_with +65",
               "arguments": [
-                "{{trigger.call.From}}"
+                "{{trigger.call.From | replace: 'sip:', '' | split: '@' | first}}"
               ],
               "type": "does_not_start_with",
               "value": "+65"
@@ -283,7 +283,7 @@ ${
         }
       ],
       "properties": {
-        "input": "{{trigger.call.From}}",
+        "input": "{{trigger.call.From | replace: 'sip:', '' | split: '@' | first}}",
         "offset": {
           "x": 500,
           "y": 180


### PR DESCRIPTION
Normalise the “sip:” prefix from incoming caller address in Voice studio flows using SIP. 

The address in SIP calls is usually “sip:+2787654321@twilio.dcthosted.net”. This change aims to remove the “sip:” prefix and the suffix domain name keeping only the phone number using the below 

"name": "trigger.call.From | replace: 'sip:', '' | split: '@' | first"