### PR TITLE
feat: update search UX to support USCH [CHI-3448]

### DIFF
--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -14,7 +14,7 @@
     "dev:local-form-definition-server": "npx http-server ../lambdas/packages/hrm-form-definitions/form-definitions -p 8090 --cors -c-1",
     "dev": "cross-env UNBUNDLED_REACT=true NO_MONITORING=true REACT_APP_FORM_DEFINITIONS_BASE_URL=http://localhost:8090 run-p dev:local-form-definition-server start",
     "dev:s3-forms": "cross-env UNBUNDLED_REACT=true NO_MONITORING=true npm start",
-    "dev:local": " cross-env REACT_APP_HRM_BASE_URL=http://localhost:8080 run-s env:local dev",
+    "dev:local": " cross-env REACT_APP_RESOURCES_BASE_URL=http://localhost:8080 REACT_APP_HRM_BASE_URL=http://localhost:8080 run-s env:local dev",
     "dev:local:docker": "cross-env REACT_APP_HRM_BASE_URL=http://localhost:8081 npm run dev",
     "dev:local:e2e": "npm run ssm:local:appConfig:e2e && cross-env REACT_APP_SERVERLESS_BASE_URL=http://localhost:3030 REACT_APP_HRM_BASE_URL=http://localhost:8080 npm run dev",
     "dev:local:serverless": "cross-env REACT_APP_SERVERLESS_BASE_URL=http://localhost:3030 npm run dev:local",

--- a/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
@@ -19,6 +19,7 @@ import promiseMiddleware from 'redux-promise-middleware';
 import each from 'jest-each';
 
 import { searchResources } from '../../../services/ResourceService';
+import { getHrmConfig } from '../../../hrmConfig';
 import {
   changeResultPageAction,
   getCurrentPageResults,
@@ -36,7 +37,12 @@ import {
 } from '../../../states/resources/search';
 
 jest.mock('../../../services/ResourceService');
+jest.mock('../../../hrmConfig');
 
+const mockGetHrmConfig = getHrmConfig as jest.MockedFunction<typeof getHrmConfig>;
+mockGetHrmConfig.mockReturnValue({
+  helplineCode: 'E2E',
+} as any);
 const mockSearchResources = searchResources as jest.Mock<
   Promise<{ results: ReferrableResourceResult[]; totalCount: number }>
 >;

--- a/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
@@ -35,6 +35,7 @@ import {
   SearchSettings,
   updateSearchFormAction,
 } from '../../../states/resources/search';
+import { initialFilterOptions } from '../../../components/resources/mappingComponents/khpMappings/filterSelectionState';
 
 jest.mock('../../../services/ResourceService');
 jest.mock('../../../hrmConfig');
@@ -59,7 +60,7 @@ const testStore = (stateChanges: Partial<ReferrableResourceSearchState> = {}) =>
 
 const nonInitialState: ReferrableResourceSearchState = {
   filterOptions: {
-    ...initialState.filterOptions,
+    ...initialFilterOptions,
     region: [{ label: '', value: undefined }],
     city: [{ label: '', value: undefined }],
   },

--- a/plugin-hrm-form/src/components/resources/mappingComponents/index.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/index.tsx
@@ -25,12 +25,12 @@ import KHPResourcePreviewAttributes from './khpMappings/ResourcePreviewAttribute
 import KHPResourceViewAttributes from './khpMappings/ResourceViewAttributes';
 import KHPResourceSearchFilters from './khpMappings/ResourceSearchFilters';
 import KHPResourcesSearchResultsDescriptionDetails from './khpMappings/ResourcesSearchResultsDescriptionDetails';
-import * as khpFilterSelectionState from './khpMappings/filterSelectionState';
+import * as khpFilterSelectionState from '../../../states/resources/filterSelectionState/khp';
 import USCHResourcePreviewAttributes from './uschMappings/ResourcePreviewAttributes';
 import USCHResourceViewAttributes from './uschMappings/ResourceViewAttributes';
 import USCHResourceSearchFilters from './uschMappings/ResourceSearchFilters';
 import USCHResourcesSearchResultsDescriptionDetails from './uschMappings/ResourcesSearchResultsDescriptionDetails';
-import * as uschFilterSelectionState from './uschMappings/filterSelectionState';
+import * as uschFilterSelectionState from '../../../states/resources/filterSelectionState/usch';
 
 type FilterSelectionState = {
   loadReferenceActionFunction: (list: string) => LoadReferenceActionFunction;

--- a/plugin-hrm-form/src/components/resources/mappingComponents/index.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/index.tsx
@@ -14,13 +14,37 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import React from 'react';
+import type { Handler } from 'redux-promise-middleware-actions/lib/reducers';
 
+import type { LoadReferenceActionFunction } from '../../../states/resources/referenceLocations';
+import type { FilterOption } from '../../../states/resources/types';
+import type { ReferrableResourceSearchState, SearchSettings } from '../../../states/resources/search';
 import type { ReferrableResource } from '../../../services/ResourceService';
 import { getHrmConfig } from '../../../hrmConfig';
 import KHPResourcePreviewAttributes from './khpMappings/ResourcePreviewAttributes';
 import KHPResourceViewAttributes from './khpMappings/ResourceViewAttributes';
+import KHPResourceSearchFilters from './khpMappings/ResourceSearchFilters';
+import KHPResourcesSearchResultsDescriptionDetails from './khpMappings/ResourcesSearchResultsDescriptionDetails';
+import * as khpFilterSelectionState from './khpMappings/filterSelectionState';
 import USCHResourcePreviewAttributes from './uschMappings/ResourcePreviewAttributes';
 import USCHResourceViewAttributes from './uschMappings/ResourceViewAttributes';
+import USCHResourceSearchFilters from './uschMappings/ResourceSearchFilters';
+import USCHResourcesSearchResultsDescriptionDetails from './uschMappings/ResourcesSearchResultsDescriptionDetails';
+import * as uschFilterSelectionState from './uschMappings/filterSelectionState';
+
+type FilterSelectionState = {
+  loadReferenceActionFunction: (list: string) => LoadReferenceActionFunction;
+  handlerUpdateSearchFormAction: Handler<
+    ReferrableResourceSearchState,
+    { type: string; payload: SearchSettings },
+    ReferrableResourceSearchState
+  >;
+  handleLoadReferenceLocationsAsyncActionFulfilled: Handler<
+    ReferrableResourceSearchState,
+    { type: string; payload: { list: string; options: FilterOption[] } },
+    ReferrableResourceSearchState
+  >;
+};
 
 type MappingComponents = {
   ResourcePreviewAttributes: React.FC<{
@@ -29,16 +53,25 @@ type MappingComponents = {
   ResourceViewAttributes: React.FC<{
     resource: ReferrableResource;
   }>;
+  ResourceSearchFilters: React.FC<{}>;
+  ResourcesSearchResultsDescriptionDetails: React.FC<{}>;
+  filterSelectionState: FilterSelectionState;
 };
 
 const khpMappingComponents: MappingComponents = {
   ResourcePreviewAttributes: KHPResourcePreviewAttributes,
   ResourceViewAttributes: KHPResourceViewAttributes,
+  ResourceSearchFilters: KHPResourceSearchFilters,
+  ResourcesSearchResultsDescriptionDetails: KHPResourcesSearchResultsDescriptionDetails,
+  filterSelectionState: khpFilterSelectionState,
 };
 
 const uschMappingComponents: MappingComponents = {
   ResourcePreviewAttributes: USCHResourcePreviewAttributes,
   ResourceViewAttributes: USCHResourceViewAttributes,
+  ResourceSearchFilters: USCHResourceSearchFilters,
+  ResourcesSearchResultsDescriptionDetails: USCHResourcesSearchResultsDescriptionDetails,
+  filterSelectionState: uschFilterSelectionState,
 };
 
 const getMappingComponents = (): MappingComponents => {
@@ -58,7 +91,8 @@ const getMappingComponents = (): MappingComponents => {
   }
 };
 
-// eslint-disable-next-line import/no-unused-modules
+export const getFilterSelectionState = (): FilterSelectionState => getMappingComponents().filterSelectionState;
+
 export const ResourcePreviewAttributes: React.FC<{ resource: ReferrableResource }> = ({ resource }) => {
   return React.useMemo(() => {
     const mappingComponents = getMappingComponents();
@@ -66,10 +100,23 @@ export const ResourcePreviewAttributes: React.FC<{ resource: ReferrableResource 
   }, [resource]);
 };
 
-// eslint-disable-next-line import/no-unused-modules
 export const ResourceViewAttributes: React.FC<{ resource: ReferrableResource }> = ({ resource }) => {
   return React.useMemo(() => {
     const mappingComponents = getMappingComponents();
     return <mappingComponents.ResourceViewAttributes resource={resource} />;
   }, [resource]);
+};
+
+export const ResourceSearchFilters: React.FC<{}> = () => {
+  return React.useMemo(() => {
+    const mappingComponents = getMappingComponents();
+    return <mappingComponents.ResourceSearchFilters />;
+  }, []);
+};
+
+export const ResourcesSearchResultsDescriptionDetails: React.FC<{}> = () => {
+  return React.useMemo(() => {
+    const mappingComponents = getMappingComponents();
+    return <mappingComponents.ResourcesSearchResultsDescriptionDetails />;
+  }, []);
 };

--- a/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourceSearchFilters.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourceSearchFilters.tsx
@@ -1,0 +1,290 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AnyAction } from 'redux';
+import { Template } from '@twilio/flex-ui';
+import { Grid } from '@material-ui/core';
+
+import { RootState } from '../../../../states';
+import {
+  Box,
+  Column,
+  FiltersCheckbox,
+  FormLabel,
+  FormOption,
+  FormSelect,
+  FormSelectWrapper,
+  Row,
+} from '../../../../styles';
+import { ResourcesSearchFormFilterHeader, ResourcesSearchFormSettingBox } from '../../styles';
+import { updateSearchFormAction } from '../../../../states/resources/search';
+import { FilterOption } from '../../../../states/resources/types';
+import { getAseloFeatureFlags } from '../../../../hrmConfig';
+import { namespace, referrableResourcesBase } from '../../../../states/storeNamespaces';
+import {
+  loadReferenceLocationsAsyncAction,
+  ReferenceLocationState,
+} from '../../../../states/resources/referenceLocations';
+import {
+  KHPFilterOptions,
+  KHPFilterSelections,
+  KHPReferenceLocationList,
+  loadReferenceActionFunction,
+} from './filterSelectionState';
+import asyncDispatch from '../../../../states/asyncDispatch';
+
+const NO_AGE_SELECTED = -1;
+const NO_LOCATION_SELECTED = '__NO_LOCATION_SELECTED__';
+
+type FilterName = keyof KHPFilterSelections;
+type LocationFilterName = Extract<keyof KHPFilterSelections, 'province' | 'region' | 'city'>;
+// This type definition is a bit convoluted but it self checks if the option names change in the state;
+type CheckboxFilterName = keyof Pick<KHPFilterSelections, 'howServiceIsOffered' | 'feeStructure'>;
+
+const ResourceSearchFilters: React.FC<{}> = () => {
+  const dispatch = useDispatch();
+  const searchAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
+
+  const { enable_region_resource_search: enableRegionResourceSearch } = getAseloFeatureFlags();
+  const { referenceLocations, filterOptions, parameters } = useSelector(
+    (state: RootState) => state[namespace][referrableResourcesBase].search,
+  );
+  const { province, city, region, maxEligibleAge, minEligibleAge, ...checkboxOptions } = (filterOptions ||
+    {}) as KHPFilterOptions;
+  const filterSelections = (parameters.filterSelections || {}) as KHPFilterSelections;
+
+  useEffect(() => {
+    const loadReferenceLocations = (referenceLocations: ReferenceLocationState) => {
+      if (!referenceLocations.provinceOptions?.length) {
+        searchAsyncDispatch(
+          loadReferenceLocationsAsyncAction({
+            loadReferenceActionFunction: loadReferenceActionFunction(KHPReferenceLocationList.Provinces),
+          }),
+        );
+      }
+      if (!referenceLocations.regionOptions?.length) {
+        searchAsyncDispatch(
+          loadReferenceLocationsAsyncAction({
+            loadReferenceActionFunction: loadReferenceActionFunction(KHPReferenceLocationList.Regions),
+          }),
+        );
+      }
+      if (!referenceLocations.cityOptions?.length) {
+        searchAsyncDispatch(
+          loadReferenceLocationsAsyncAction({
+            loadReferenceActionFunction: loadReferenceActionFunction(KHPReferenceLocationList.Cities),
+          }),
+        );
+      }
+    };
+
+    loadReferenceLocations(referenceLocations);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const updateFilterSelection = (filterName: FilterName, filterValue: string | number | boolean | string[]) => {
+    let reduxFilterValue = filterValue;
+    if (filterName === 'maxEligibleAge' || filterName === 'minEligibleAge') {
+      reduxFilterValue = filterValue === NO_AGE_SELECTED ? undefined : filterValue;
+    } else if (filterName === 'province' || filterName === 'region' || filterName === 'city') {
+      reduxFilterValue = filterValue === NO_LOCATION_SELECTED ? undefined : filterValue;
+    }
+    dispatch(updateSearchFormAction({ filterSelections: { [filterName]: reduxFilterValue } }));
+  };
+
+  const locationDropdown = (locationFilterName: LocationFilterName, optionList: FilterOption[]) => {
+    const capitalizedLocationFilterName = locationFilterName.charAt(0).toUpperCase() + locationFilterName.slice(1);
+    return (
+      <FormSelectWrapper style={{ width: '100%' }}>
+        <FormSelect
+          id={`location-${locationFilterName}`}
+          data-testid={`Resources-Search-Location-${capitalizedLocationFilterName}`}
+          name={`location-${locationFilterName}`}
+          onChange={({ target: { value } }) => updateFilterSelection(locationFilterName, value)}
+          value={filterSelections[locationFilterName] ?? NO_LOCATION_SELECTED}
+          style={{ width: '100%' }}
+        >
+          {(optionList || []).map(({ value, label }) => (
+            <FormOption key={value ?? NO_LOCATION_SELECTED} value={value ?? NO_LOCATION_SELECTED}>
+              {label ?? value}
+            </FormOption>
+          ))}
+        </FormSelect>
+      </FormSelectWrapper>
+    );
+  };
+
+  const ageRangeDropDown = (dropdown: 'Min' | 'Max', optionList: FilterOption<number>[]) => {
+    const currentSelection =
+      (dropdown === 'Min' ? filterSelections.minEligibleAge : filterSelections.maxEligibleAge) ?? NO_AGE_SELECTED;
+    return (
+      <Row>
+        <FormSelectWrapper style={{ width: '80px' }}>
+          <FormSelect
+            style={{ width: '80px' }}
+            id={`age-range-${dropdown.toLowerCase()}`}
+            data-testid={`Resources-Search-Age-Range-${dropdown}`}
+            name={dropdown === 'Min' ? 'minEligibleAge' : 'maxEligibleAge'}
+            onChange={({ target: { value } }) =>
+              updateFilterSelection(
+                dropdown === 'Min' ? 'minEligibleAge' : 'maxEligibleAge',
+                value ? parseInt(value, 10) : undefined,
+              )
+            }
+            value={currentSelection}
+          >
+            {(optionList || []).map(({ value, label }) => (
+              <FormOption key={value ?? NO_AGE_SELECTED} value={value ?? NO_AGE_SELECTED}>
+                {label ?? value}
+              </FormOption>
+            ))}
+          </FormSelect>
+        </FormSelectWrapper>
+        &nbsp;
+        <FormLabel htmlFor={`age-range-${dropdown.toLowerCase()}`} style={{ marginLeft: '4px', flexDirection: 'row' }}>
+          <Template code={`Resources-Search-Age-Range-${dropdown}`} />
+        </FormLabel>
+      </Row>
+    );
+  };
+
+  const checkboxSet = (optionSet: CheckboxFilterName, options: FilterOption[]) => {
+    const selectedOptions = filterSelections[optionSet] ?? [];
+    return (
+      <ResourcesSearchFormSettingBox>
+        <ResourcesSearchFormFilterHeader>
+          <Template code={`Resources-Search-${optionSet}`} />
+        </ResourcesSearchFormFilterHeader>
+        <Grid container>
+          {options.map(({ value, label }) => (
+            <Grid key={value} xs={4} item>
+              <FormLabel htmlFor={value} style={{ flexDirection: 'row' }}>
+                <FiltersCheckbox
+                  id={value}
+                  name={value}
+                  type="checkbox"
+                  checked={selectedOptions.includes(value)}
+                  onChange={({ target: { checked } }) => {
+                    const newSelections = checked
+                      ? [...selectedOptions, value]
+                      : selectedOptions.filter(option => option !== value);
+                    updateFilterSelection(
+                      optionSet as CheckboxFilterName,
+                      newSelections.length ? newSelections : undefined,
+                    );
+                  }}
+                />
+                &nbsp;&nbsp;{label ?? value}
+              </FormLabel>
+            </Grid>
+          ))}
+        </Grid>
+      </ResourcesSearchFormSettingBox>
+    );
+  };
+
+  return (
+    <Column>
+      <ResourcesSearchFormSettingBox>
+        <ResourcesSearchFormFilterHeader>
+          <Template code="Resources-Search-Location" />
+        </ResourcesSearchFormFilterHeader>
+        <Row key="location" style={{ marginTop: '10px', marginBottom: '10px', gap: '60px' }}>
+          <Column
+            style={{
+              width: enableRegionResourceSearch ? '33%' : '50%',
+              maxWidth: enableRegionResourceSearch ? '166px' : '250px',
+              gap: '4px',
+            }}
+          >
+            <FormLabel htmlFor="location-province">
+              <Template code="Resources-Search-Location-Province" />
+            </FormLabel>
+            {locationDropdown('province', province)}
+          </Column>
+          {enableRegionResourceSearch && (
+            <Column
+              style={{
+                width: '33%',
+                maxWidth: '166px',
+                // opacity: filterSelections?.province ? 1 : 0.2,
+                gap: '4px',
+              }}
+            >
+              <FormLabel htmlFor="location-region">
+                <Template code="Resources-Search-Location-Region" />
+              </FormLabel>
+              {locationDropdown('region', region)}
+            </Column>
+          )}
+          <Column
+            style={{
+              width: enableRegionResourceSearch ? '33%' : '50%',
+              maxWidth: enableRegionResourceSearch ? '166px' : '250px',
+              // opacity: filterSelections?.province ? 1 : 0.2,
+              gap: '4px',
+            }}
+          >
+            <FormLabel htmlFor="location-city">
+              <Template code="Resources-Search-Location-City" />
+            </FormLabel>
+            {locationDropdown('city', city)}
+          </Column>
+        </Row>
+      </ResourcesSearchFormSettingBox>
+      <Row key="age-range" style={{ alignItems: 'stretch', justifyContent: 'stretch', gap: '4px' }}>
+        <ResourcesSearchFormSettingBox key="age-range" style={{ flexShrink: 1 }}>
+          <ResourcesSearchFormFilterHeader>
+            <Template code="Resources-Search-Age-Range" />
+          </ResourcesSearchFormFilterHeader>
+          <Row style={{ alignItems: 'baseline', justifyContent: 'space-between' }}>
+            {ageRangeDropDown('Min', minEligibleAge)}
+            <Box>&mdash;</Box>
+            {ageRangeDropDown('Max', maxEligibleAge)}
+          </Row>
+        </ResourcesSearchFormSettingBox>
+        <ResourcesSearchFormSettingBox style={{ flexShrink: 1, marginLeft: '4px' }}>
+          <Column>
+            <ResourcesSearchFormFilterHeader>
+              <Template code="Resources-Search-InterpretationTranslationServicesAvailable" />
+            </ResourcesSearchFormFilterHeader>
+            <FormLabel htmlFor="interpretationTranslationServicesAvailable" style={{ flexDirection: 'row' }}>
+              <FiltersCheckbox
+                id="interpretationTranslationServicesAvailable"
+                name="interpretationTranslationServicesAvailable"
+                type="checkbox"
+                checked={Boolean(filterSelections.interpretationTranslationServicesAvailable)}
+                onChange={({ target: { checked } }) => {
+                  updateFilterSelection('interpretationTranslationServicesAvailable', checked || undefined);
+                }}
+              />
+              &nbsp;&nbsp;
+              <Template code="Resources-Search-InterpretationTranslationServicesAvailable-Checkbox" />
+            </FormLabel>
+          </Column>
+        </ResourcesSearchFormSettingBox>
+      </Row>
+      <Grid container>
+        {Object.entries(checkboxOptions).map(([optionSet, options]) =>
+          checkboxSet(optionSet as CheckboxFilterName, options),
+        )}
+      </Grid>
+    </Column>
+  );
+};
+
+export default ResourceSearchFilters;

--- a/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourceSearchFilters.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourceSearchFilters.tsx
@@ -43,9 +43,9 @@ import {
   KHPFilterOptions,
   KHPFilterSelections,
   KHPReferenceLocationList,
-  loadReferenceActionFunction,
 } from '../../../../states/resources/filterSelectionState/khp';
 import asyncDispatch from '../../../../states/asyncDispatch';
+import { getFilterSelectionState } from '..';
 
 const NO_AGE_SELECTED = -1;
 const NO_LOCATION_SELECTED = '__NO_LOCATION_SELECTED__';
@@ -58,6 +58,7 @@ type CheckboxFilterName = keyof Pick<KHPFilterSelections, 'howServiceIsOffered' 
 const ResourceSearchFilters: React.FC<{}> = () => {
   const dispatch = useDispatch();
   const searchAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
+  const { loadReferenceActionFunction } = getFilterSelectionState();
 
   const { enable_region_resource_search: enableRegionResourceSearch } = getAseloFeatureFlags();
   const { referenceLocations, filterOptions, parameters } = useSelector(

--- a/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourceSearchFilters.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourceSearchFilters.tsx
@@ -44,7 +44,7 @@ import {
   KHPFilterSelections,
   KHPReferenceLocationList,
   loadReferenceActionFunction,
-} from './filterSelectionState';
+} from '../../../../states/resources/filterSelectionState/khp';
 import asyncDispatch from '../../../../states/asyncDispatch';
 
 const NO_AGE_SELECTED = -1;

--- a/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourcesSearchResultsDescriptionDetails.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourcesSearchResultsDescriptionDetails.tsx
@@ -20,7 +20,7 @@ import { useSelector } from 'react-redux';
 import type { RootState } from '../../../../states';
 import { ResourcesSearchResultsDescriptionItem } from '../../styles';
 import { namespace, referrableResourcesBase } from '../../../../states/storeNamespaces';
-import { KHPFilterSelections } from './filterSelectionState';
+import { KHPFilterSelections } from '../../../../states/resources/filterSelectionState/khp';
 
 const ResourcesSearchResultsDescriptionDetails: React.FC<{}> = () => {
   const { filterOptions, parameters } = useSelector(

--- a/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourcesSearchResultsDescriptionDetails.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/ResourcesSearchResultsDescriptionDetails.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import React from 'react';
+import { Template } from '@twilio/flex-ui';
+import { useSelector } from 'react-redux';
+
+import type { RootState } from '../../../../states';
+import { ResourcesSearchResultsDescriptionItem } from '../../styles';
+import { namespace, referrableResourcesBase } from '../../../../states/storeNamespaces';
+import { KHPFilterSelections } from './filterSelectionState';
+
+const ResourcesSearchResultsDescriptionDetails: React.FC<{}> = () => {
+  const { filterOptions, parameters } = useSelector(
+    (state: RootState) => state[namespace][referrableResourcesBase].search,
+  );
+
+  const filterSelections = (parameters.filterSelections || {}) as KHPFilterSelections;
+
+  const ageRangeDescription = () => {
+    const { minEligibleAge, maxEligibleAge } = filterSelections;
+    if (minEligibleAge && maxEligibleAge) {
+      return (
+        <ResourcesSearchResultsDescriptionItem>
+          <Template
+            code="Resources-Search-ResultsDescription-AgeRange"
+            minEligibleAge={minEligibleAge}
+            maxEligibleAge={maxEligibleAge}
+          />
+        </ResourcesSearchResultsDescriptionItem>
+      );
+    } else if (minEligibleAge) {
+      return (
+        <ResourcesSearchResultsDescriptionItem>
+          <Template code="Resources-Search-ResultsDescription-MinimumAge" minEligibleAge={minEligibleAge} />
+        </ResourcesSearchResultsDescriptionItem>
+      );
+    } else if (maxEligibleAge) {
+      return (
+        <ResourcesSearchResultsDescriptionItem>
+          <Template code="Resources-Search-ResultsDescription-MaximumAge" maxEligibleAge={maxEligibleAge} />
+        </ResourcesSearchResultsDescriptionItem>
+      );
+    }
+    return null;
+  };
+
+  const locationDescription = () => {
+    const { province, city, region } = filterSelections;
+    const location = [
+      filterOptions.city.find(({ value }) => value === city)?.label,
+      filterOptions.region.find(({ value }) => value === region)?.label,
+      filterOptions.province.find(({ value }) => value === province)?.label,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    if (location) {
+      return (
+        <ResourcesSearchResultsDescriptionItem>
+          <Template code="Resources-Search-ResultsDescription-Location" location={location} />
+        </ResourcesSearchResultsDescriptionItem>
+      );
+    }
+    return null;
+  };
+
+  const filterDescription = (code: string, selections: string[]) => {
+    const selectionsText = (selections ?? []).join(', ');
+    if (selectionsText) {
+      return (
+        <ResourcesSearchResultsDescriptionItem>
+          <Template code={code} selections={selectionsText} />
+        </ResourcesSearchResultsDescriptionItem>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <>
+      {locationDescription()}
+      {filterSelections.interpretationTranslationServicesAvailable && (
+        <ResourcesSearchResultsDescriptionItem>
+          <Template code="Resources-Search-ResultsDescription-InterpretationTranslationServicesAvailable" />
+        </ResourcesSearchResultsDescriptionItem>
+      )}
+      {ageRangeDescription()}
+      {filterDescription('Resources-Search-ResultsDescription-FeeStructure', filterSelections.feeStructure)}
+      {filterDescription(
+        'Resources-Search-ResultsDescription-HowServiceIsOffered',
+        filterSelections.howServiceIsOffered,
+      )}
+    </>
+  );
+};
+
+export default ResourcesSearchResultsDescriptionDetails;

--- a/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/filterSelectionState.ts
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/filterSelectionState.ts
@@ -62,7 +62,8 @@ export type KHPFilterOptions = {
   maxEligibleAge: FilterOption<number>[];
 };
 
-const initialFilterOptions: KHPFilterOptions = {
+// Exported for testing
+export const initialFilterOptions: KHPFilterOptions = {
   feeStructure: [
     { value: 'Free' },
     { value: 'Cost Unknown' },

--- a/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/filterSelectionState.ts
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/khpMappings/filterSelectionState.ts
@@ -1,0 +1,210 @@
+/* eslint-disable import/no-unused-modules */
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { getReferenceAttributeList, ReferenceAttributeStringValue } from '../../../../services/ResourceService';
+import type { ReferrableResourceSearchState } from '../../../../states/resources/search';
+import type { FilterOption } from '../../../../states/resources/types';
+import {
+  dedupAndSort,
+  LoadReferenceActionFunction,
+  ReferenceLocationState,
+} from '../../../../states/resources/referenceLocations';
+
+export type KHPReferenceLocationState = {
+  provinceOptions: FilterOption[];
+  regionOptions: FilterOption[];
+  cityOptions: FilterOption[];
+};
+
+export const referenceLocationsInitialState: KHPReferenceLocationState = {
+  provinceOptions: [],
+  regionOptions: [],
+  cityOptions: [],
+};
+
+export const enum KHPReferenceLocationList {
+  Provinces = 'provinces',
+  Regions = 'country/province/region',
+  Cities = 'country/province/region/city',
+}
+
+const minAgeOptions: FilterOption<number>[] = [
+  { label: '0', value: undefined },
+  ...Array.from({ length: 30 }, (_, i) => i + 1).map(age => ({ value: age })),
+];
+
+const maxAgeOptions: FilterOption<number>[] = [
+  ...Array.from({ length: 30 }, (_, i) => i).map(age => ({ value: age })),
+  { value: undefined, label: '30+' },
+];
+
+export type KHPFilterOptions = {
+  feeStructure: FilterOption[];
+  howServiceIsOffered: FilterOption[];
+  province: FilterOption[];
+  region?: FilterOption[];
+  city?: FilterOption[];
+  minEligibleAge: FilterOption<number>[];
+  maxEligibleAge: FilterOption<number>[];
+};
+
+const initialFilterOptions: KHPFilterOptions = {
+  feeStructure: [
+    { value: 'Free' },
+    { value: 'Cost Unknown' },
+    { value: 'Membership Fee' },
+    { value: 'Cost for Service' },
+    { value: 'Sliding Scale' },
+    { value: 'One Time Small Fee' },
+    { value: 'Covered by Health Insurance' },
+  ],
+  howServiceIsOffered: [{ value: 'In-person Support' }, { value: 'Online Support' }, { value: 'Phone Support' }],
+  province: [{ label: '', value: undefined }],
+  region: [],
+  city: [],
+  minEligibleAge: minAgeOptions,
+  maxEligibleAge: maxAgeOptions,
+};
+
+export type KHPFilterSelections = {
+  city?: string;
+  region?: string;
+  province?: string;
+  interpretationTranslationServicesAvailable?: true;
+  minEligibleAge?: number;
+  maxEligibleAge?: number;
+  feeStructure?: string[];
+  howServiceIsOffered?: string[];
+};
+
+const getFilterOptionsBasedOnSelections = (
+  filterSelections: KHPFilterSelections = {},
+  { provinceOptions, regionOptions, cityOptions }: ReferenceLocationState = {},
+): KHPFilterOptions => {
+  return {
+    ...initialFilterOptions,
+    minEligibleAge: minAgeOptions.filter(opt => {
+      const maxSelection = filterSelections.maxEligibleAge ?? 1000;
+      return opt.value === undefined || opt.value <= maxSelection;
+    }),
+    maxEligibleAge: maxAgeOptions.filter(opt => {
+      const minSelection = filterSelections.minEligibleAge ?? 0;
+      return opt.value === undefined || opt.value >= minSelection;
+    }),
+    province: [{ label: '', value: undefined }, ...(provinceOptions || [])],
+    region: [
+      { label: '', value: undefined },
+      ...(regionOptions || []).filter(
+        ({ value }) => filterSelections.province && (!value || value.startsWith(filterSelections.province)),
+      ),
+    ],
+    city: [
+      { label: '', value: undefined },
+      ...(cityOptions || []).filter(({ value }) => {
+        const { region, province } = filterSelections;
+        if (!province) {
+          return false;
+        }
+        const startPrefix = region?.startsWith(province) ? region : province;
+        return !value || value.startsWith(startPrefix);
+      }),
+    ],
+  };
+};
+
+const ensureFilterSelectionsAreValid = (
+  filterSelections: KHPFilterSelections = {},
+  filterOptions: KHPFilterOptions = initialFilterOptions,
+): KHPFilterSelections => {
+  return {
+    // Don't add undefined values to the filter selections
+    ...Object.fromEntries(
+      Object.entries({
+        ...filterSelections,
+        minEligibleAge: filterOptions.minEligibleAge.find(opt => opt.value === filterSelections.minEligibleAge)?.value,
+        maxEligibleAge: filterOptions.maxEligibleAge.find(opt => opt.value === filterSelections.maxEligibleAge)?.value,
+        province: filterOptions.province.find(opt => opt.value === filterSelections.province)?.value,
+        region: filterOptions.region.find(opt => opt.value === filterSelections.region)?.value,
+        city: filterOptions.city.find(opt => opt.value === filterSelections.city)?.value,
+      }).filter(([, value]) => value !== undefined),
+    ),
+  };
+};
+
+export const loadReferenceActionFunction: (list: string) => LoadReferenceActionFunction = (
+  list: string,
+) => async () => {
+  const apiAttributes = await getReferenceAttributeList(list, 'en');
+  const unsortedOptions = apiAttributes.map(({ value, info }: ReferenceAttributeStringValue) => ({
+    label: info?.name ?? value,
+    value,
+  }));
+  return { list, options: dedupAndSort(unsortedOptions) };
+};
+
+export const handlerUpdateSearchFormAction = (state: ReferrableResourceSearchState, { payload }) => {
+  const updatedFilterOptions = getFilterOptionsBasedOnSelections(
+    {
+      ...state.parameters.filterSelections,
+      ...(payload.filterSelections ?? {}),
+    },
+    state.referenceLocations,
+  );
+  const validatedFilterSelections = ensureFilterSelectionsAreValid(
+    { ...state.parameters.filterSelections, ...payload.filterSelections },
+    updatedFilterOptions,
+  );
+  return {
+    ...state,
+    filterOptions: updatedFilterOptions,
+    parameters: {
+      ...state.parameters,
+      ...payload,
+      filterSelections: validatedFilterSelections,
+    },
+  };
+};
+
+export const handleLoadReferenceLocationsAsyncActionFulfilled = (state: ReferrableResourceSearchState, { payload }) => {
+  const { list, options } = payload;
+  let { referenceLocations } = state;
+  switch (list) {
+    case KHPReferenceLocationList.Provinces:
+      referenceLocations = { ...referenceLocations, provinceOptions: options };
+      break;
+    case KHPReferenceLocationList.Regions:
+      referenceLocations = { ...referenceLocations, regionOptions: options };
+      break;
+    case KHPReferenceLocationList.Cities:
+      referenceLocations = { ...referenceLocations, cityOptions: options };
+      break;
+    default:
+  }
+
+  const updatedFilterOptions = getFilterOptionsBasedOnSelections(state.parameters.filterSelections, referenceLocations);
+  const validatedFilterSelections = ensureFilterSelectionsAreValid(
+    state.parameters.filterSelections,
+    updatedFilterOptions,
+  );
+
+  return {
+    ...state,
+    filterOptions: updatedFilterOptions,
+    filterSelections: validatedFilterSelections,
+    referenceLocations,
+  };
+};

--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceSearchFilters.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceSearchFilters.tsx
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AnyAction } from 'redux';
+import { Template } from '@twilio/flex-ui';
+
+import { RootState } from '../../../../states';
+import { Column, FormLabel, FormOption, FormSelect, FormSelectWrapper, Row } from '../../../../styles';
+import { ResourcesSearchFormFilterHeader, ResourcesSearchFormSettingBox } from '../../styles';
+import { updateSearchFormAction } from '../../../../states/resources/search';
+import { FilterOption } from '../../../../states/resources/types';
+import { namespace, referrableResourcesBase } from '../../../../states/storeNamespaces';
+import {
+  loadReferenceLocationsAsyncAction,
+  ReferenceLocationState,
+} from '../../../../states/resources/referenceLocations';
+import {
+  USCHFilterOptions,
+  USCHFilterSelections,
+  USCHReferenceLocationList,
+  loadReferenceActionFunction,
+} from './filterSelectionState';
+import asyncDispatch from '../../../../states/asyncDispatch';
+
+const NO_LOCATION_SELECTED = '__NO_LOCATION_SELECTED__';
+
+type FilterName = keyof USCHFilterSelections;
+type LocationFilterName = Extract<keyof USCHFilterSelections, 'country' | 'province' | 'city'>;
+
+const ResourceSearchFilters: React.FC<{}> = () => {
+  const dispatch = useDispatch();
+  const searchAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
+
+  const { referenceLocations, filterOptions, parameters } = useSelector(
+    (state: RootState) => state[namespace][referrableResourcesBase].search,
+  );
+  const { country, province, city } = (filterOptions || {}) as USCHFilterOptions;
+  const filterSelections = (parameters.filterSelections || {}) as USCHFilterSelections;
+
+  useEffect(() => {
+    const loadReferenceLocations = (referenceLocations: ReferenceLocationState) => {
+      if (!referenceLocations.countryOptions?.length) {
+        searchAsyncDispatch(
+          loadReferenceLocationsAsyncAction({
+            loadReferenceActionFunction: loadReferenceActionFunction(USCHReferenceLocationList.Country),
+          }),
+        );
+      }
+      if (!referenceLocations.provinceOptions?.length) {
+        searchAsyncDispatch(
+          loadReferenceLocationsAsyncAction({
+            loadReferenceActionFunction: loadReferenceActionFunction(USCHReferenceLocationList.Provinces),
+          }),
+        );
+      }
+      if (!referenceLocations.cityOptions?.length) {
+        searchAsyncDispatch(
+          loadReferenceLocationsAsyncAction({
+            loadReferenceActionFunction: loadReferenceActionFunction(USCHReferenceLocationList.Cities),
+          }),
+        );
+      }
+    };
+
+    loadReferenceLocations(referenceLocations);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const updateFilterSelection = (filterName: FilterName, filterValue: string | number | boolean | string[]) => {
+    let reduxFilterValue = filterValue;
+    if (filterName === 'country' || filterName === 'province' || filterName === 'city') {
+      reduxFilterValue = filterValue === NO_LOCATION_SELECTED ? undefined : filterValue;
+    }
+    dispatch(updateSearchFormAction({ filterSelections: { [filterName]: reduxFilterValue } }));
+  };
+
+  const locationDropdown = (locationFilterName: LocationFilterName, optionList: FilterOption[]) => {
+    const capitalizedLocationFilterName = locationFilterName.charAt(0).toUpperCase() + locationFilterName.slice(1);
+    return (
+      <FormSelectWrapper style={{ width: '100%' }}>
+        <FormSelect
+          id={`location-${locationFilterName}`}
+          data-testid={`Resources-Search-Location-${capitalizedLocationFilterName}`}
+          name={`location-${locationFilterName}`}
+          onChange={({ target: { value } }) => updateFilterSelection(locationFilterName, value)}
+          value={filterSelections[locationFilterName] ?? NO_LOCATION_SELECTED}
+          style={{ width: '100%' }}
+        >
+          {(optionList || []).map(({ value, label }) => (
+            <FormOption key={value ?? NO_LOCATION_SELECTED} value={value ?? NO_LOCATION_SELECTED}>
+              {label ?? value}
+            </FormOption>
+          ))}
+        </FormSelect>
+      </FormSelectWrapper>
+    );
+  };
+
+  return (
+    <Column>
+      <ResourcesSearchFormSettingBox>
+        <ResourcesSearchFormFilterHeader>
+          <Template code="Resources-Search-Location" />
+        </ResourcesSearchFormFilterHeader>
+        <Row key="location" style={{ marginTop: '10px', marginBottom: '10px', gap: '60px' }}>
+          <Column
+            style={{
+              width: '33%',
+              maxWidth: '166px',
+              gap: '4px',
+            }}
+          >
+            <FormLabel htmlFor="location-region">
+              <Template code="Country" />
+            </FormLabel>
+            {locationDropdown('country', country)}
+          </Column>
+          <Column
+            style={{
+              width: '33%',
+              maxWidth: '166px',
+              gap: '4px',
+            }}
+          >
+            <FormLabel htmlFor="location-province">
+              <Template code="Province" />
+            </FormLabel>
+            {locationDropdown('province', province)}
+          </Column>
+          <Column
+            style={{
+              width: '33%',
+              maxWidth: '166px',
+              gap: '4px',
+            }}
+          >
+            <FormLabel htmlFor="location-city">
+              <Template code="City" />
+            </FormLabel>
+            {locationDropdown('city', city)}
+          </Column>
+        </Row>
+      </ResourcesSearchFormSettingBox>
+    </Column>
+  );
+};
+
+export default ResourceSearchFilters;

--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceSearchFilters.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceSearchFilters.tsx
@@ -33,7 +33,7 @@ import {
   USCHFilterSelections,
   USCHReferenceLocationList,
   loadReferenceActionFunction,
-} from './filterSelectionState';
+} from '../../../../states/resources/filterSelectionState/usch';
 import asyncDispatch from '../../../../states/asyncDispatch';
 
 const NO_LOCATION_SELECTED = '__NO_LOCATION_SELECTED__';

--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceSearchFilters.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceSearchFilters.tsx
@@ -32,9 +32,9 @@ import {
   USCHFilterOptions,
   USCHFilterSelections,
   USCHReferenceLocationList,
-  loadReferenceActionFunction,
 } from '../../../../states/resources/filterSelectionState/usch';
 import asyncDispatch from '../../../../states/asyncDispatch';
+import { getFilterSelectionState } from '..';
 
 const NO_LOCATION_SELECTED = '__NO_LOCATION_SELECTED__';
 
@@ -44,6 +44,7 @@ type LocationFilterName = Extract<keyof USCHFilterSelections, 'country' | 'provi
 const ResourceSearchFilters: React.FC<{}> = () => {
   const dispatch = useDispatch();
   const searchAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
+  const { loadReferenceActionFunction } = getFilterSelectionState();
 
   const { referenceLocations, filterOptions, parameters } = useSelector(
     (state: RootState) => state[namespace][referrableResourcesBase].search,

--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourcesSearchResultsDescriptionDetails.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourcesSearchResultsDescriptionDetails.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import React from 'react';
+import { Template } from '@twilio/flex-ui';
+import { useSelector } from 'react-redux';
+
+import type { RootState } from '../../../../states';
+import { ResourcesSearchResultsDescriptionItem } from '../../styles';
+import { namespace, referrableResourcesBase } from '../../../../states/storeNamespaces';
+import { USCHFilterSelections } from './filterSelectionState';
+
+const ResourcesSearchResultsDescriptionDetails: React.FC<{}> = () => {
+  const { filterOptions, parameters } = useSelector(
+    (state: RootState) => state[namespace][referrableResourcesBase].search,
+  );
+
+  const filterSelections = (parameters.filterSelections || {}) as USCHFilterSelections;
+
+  const locationDescription = () => {
+    const { country, province, city } = filterSelections;
+    const location = [
+      country && filterOptions.country.find(({ value }) => value === country)?.label,
+      province && filterOptions.province.find(({ value }) => value === province)?.label,
+      city && filterOptions.city.find(({ value }) => value === city)?.label,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    if (location) {
+      return (
+        <ResourcesSearchResultsDescriptionItem>
+          <Template code="Resources-Search-ResultsDescription-Location" location={location} />
+        </ResourcesSearchResultsDescriptionItem>
+      );
+    }
+    return null;
+  };
+
+  return <>{locationDescription()}</>;
+};
+
+export default ResourcesSearchResultsDescriptionDetails;

--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourcesSearchResultsDescriptionDetails.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourcesSearchResultsDescriptionDetails.tsx
@@ -20,7 +20,7 @@ import { useSelector } from 'react-redux';
 import type { RootState } from '../../../../states';
 import { ResourcesSearchResultsDescriptionItem } from '../../styles';
 import { namespace, referrableResourcesBase } from '../../../../states/storeNamespaces';
-import { USCHFilterSelections } from './filterSelectionState';
+import { USCHFilterSelections } from '../../../../states/resources/filterSelectionState/usch';
 
 const ResourcesSearchResultsDescriptionDetails: React.FC<{}> = () => {
   const { filterOptions, parameters } = useSelector(

--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/filterSelectionState.ts
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/filterSelectionState.ts
@@ -1,0 +1,166 @@
+/* eslint-disable import/no-unused-modules */
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import type { ReferrableResourceSearchState, SearchSettings } from '../../../../states/resources/search';
+import type { FilterOption } from '../../../../states/resources/types';
+import {
+  dedupAndSort,
+  LoadReferenceActionFunction,
+  ReferenceLocationState,
+} from '../../../../states/resources/referenceLocations';
+import { getDistinctStringAttributes } from '../../../../services/ResourceService';
+
+export type USCHReferenceLocationState = {
+  countryOptions: FilterOption[];
+  provinceOptions: FilterOption[];
+  cityOptions: FilterOption[];
+};
+
+export const referenceLocationsInitialState: USCHReferenceLocationState = {
+  countryOptions: [],
+  provinceOptions: [],
+  cityOptions: [],
+};
+
+export const enum USCHReferenceLocationList {
+  Country = 'address/country',
+  Provinces = 'address/province',
+  Cities = 'address/city',
+}
+
+export type USCHFilterOptions = {
+  // feeStructure: FilterOption[];
+  country: FilterOption[];
+  province: FilterOption[];
+  city?: FilterOption[];
+};
+
+const initialFilterOptions: USCHFilterOptions = {
+  // feeStructure: [
+  //   { value: 'Free' },
+  // ],
+  country: [],
+  province: [{ label: '', value: undefined }],
+  city: [],
+};
+
+export type USCHFilterSelections = {
+  country?: string;
+  province?: string;
+  city?: string;
+  // feeStructure?: string[];
+};
+
+const getFilterOptionsBasedOnSelections = ({
+  countryOptions,
+  provinceOptions,
+  cityOptions,
+}: ReferenceLocationState = {}): USCHFilterOptions => {
+  return {
+    ...initialFilterOptions,
+    country: [{ label: '', value: undefined }, ...(countryOptions || [])],
+    province: [{ label: '', value: undefined }, ...(provinceOptions || [])],
+    city: [{ label: '', value: undefined }, ...(cityOptions || [])],
+  };
+};
+
+const ensureFilterSelectionsAreValid = (
+  filterSelections: USCHFilterSelections = {},
+  filterOptions: USCHFilterOptions = initialFilterOptions,
+): USCHFilterSelections => {
+  return {
+    // Don't add undefined values to the filter selections
+    ...Object.fromEntries(
+      Object.entries({
+        ...filterSelections,
+        country: filterOptions.country.find(opt => opt.value === filterSelections.country)?.value,
+        province: filterOptions.province.find(opt => opt.value === filterSelections.province)?.value,
+        city: filterOptions.city.find(opt => opt.value === filterSelections.city)?.value,
+      }).filter(([, value]) => value !== undefined),
+    ),
+  };
+};
+
+export const loadReferenceActionFunction: (list: string) => LoadReferenceActionFunction = (
+  list: string,
+) => async () => {
+  const apiAttributes = await getDistinctStringAttributes({ key: list });
+  const unsortedOptions = apiAttributes.map(({ value }) => ({
+    label: value,
+    value,
+  }));
+  return { list, options: dedupAndSort(unsortedOptions) };
+};
+
+export const handlerUpdateSearchFormAction = (
+  state: ReferrableResourceSearchState,
+  { payload }: { payload: SearchSettings },
+) => {
+  const updatedFilterOptions = getFilterOptionsBasedOnSelections(state.referenceLocations);
+  const validatedFilterSelections = ensureFilterSelectionsAreValid(
+    { ...state.parameters.filterSelections, ...payload.filterSelections },
+    updatedFilterOptions,
+  );
+
+  console.log('>>>>>>>>>>> payload', payload);
+  console.log('>>>>>>>>>>> referenceLocations', state.referenceLocations);
+  console.log('>>>>>>>>>>> updatedFilterOptions', updatedFilterOptions);
+  console.log('>>>>>>>>>>> validatedFilterSelections', validatedFilterSelections);
+
+  return {
+    ...state,
+    filterOptions: updatedFilterOptions,
+    parameters: {
+      ...state.parameters,
+      ...payload,
+      filterSelections: validatedFilterSelections,
+    },
+  };
+};
+
+export const handleLoadReferenceLocationsAsyncActionFulfilled = (
+  state: ReferrableResourceSearchState,
+  { payload }: { payload: { list: string; options: FilterOption[] } },
+) => {
+  const { list, options } = payload;
+  let { referenceLocations } = state;
+  switch (list) {
+    case USCHReferenceLocationList.Country:
+      referenceLocations = { ...referenceLocations, countryOptions: options };
+      break;
+    case USCHReferenceLocationList.Provinces:
+      referenceLocations = { ...referenceLocations, provinceOptions: options };
+      break;
+    case USCHReferenceLocationList.Cities:
+      referenceLocations = { ...referenceLocations, cityOptions: options };
+      break;
+    default:
+  }
+
+  const updatedFilterOptions = getFilterOptionsBasedOnSelections(referenceLocations);
+  const validatedFilterSelections = ensureFilterSelectionsAreValid(
+    state.parameters.filterSelections,
+    updatedFilterOptions,
+  );
+
+  return {
+    ...state,
+    filterOptions: updatedFilterOptions,
+    filterSelections: validatedFilterSelections,
+    referenceLocations,
+  };
+};

--- a/plugin-hrm-form/src/components/resources/search/SearchAutoComplete.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchAutoComplete.tsx
@@ -18,12 +18,12 @@
 import React from 'react';
 
 import { AutoCompleteDropdown, AutoCompleteDropdownRow } from '../styles';
-import { sanitizeInputForSuggestions, TaxonomyLevelNameCompletion } from '../../../states/resources/search';
+import { sanitizeInputForSuggestions, SuggestSearch } from '../../../states/resources/search';
 
 type OwnProps = {
   generalSearchTermBoxText: string;
   setGeneralSearchTermBoxText: (event: string) => void;
-  suggestSearch: TaxonomyLevelNameCompletion;
+  suggestSearch: SuggestSearch;
 };
 
 type Props = OwnProps;
@@ -40,26 +40,27 @@ const SearchAutoComplete: React.FC<Props> = ({
     setGeneralSearchTermBoxText(`"${searchTerm}"`);
   };
 
+  const suggestions = (Object.values(suggestSearch.suggestions).flatMap(s => s) || [])
+    .filter(item => {
+      const text = item.text.toLocaleLowerCase();
+      return searchTermLength && text.includes(searchTerm) && text !== searchTerm;
+    })
+    .slice(0, 9);
+
   return (
     <div style={{ position: 'relative', width: '100%' }}>
       <AutoCompleteDropdown>
-        {(suggestSearch.taxonomyLevelNameCompletion || [])
-          .filter(item => {
-            const text = item.text.toLocaleLowerCase();
-            return searchTermLength && text.includes(searchTerm) && text !== searchTerm;
-          })
-          .slice(0, 9)
-          .map((item, index) => {
-            const regex = new RegExp(searchTerm, 'gi');
-            const modifiedItem = item.text.replace(regex, match => `<span style="font-weight: bold">${match}</span>`);
-            return (
-              <AutoCompleteDropdownRow
-                onClick={() => onSearch(item.text)}
-                key={index}
-                dangerouslySetInnerHTML={{ __html: modifiedItem }}
-              />
-            );
-          })}
+        {suggestions.map((item, index) => {
+          const regex = new RegExp(searchTerm, 'gi');
+          const modifiedItem = item.text.replace(regex, match => `<span style="font-weight: bold">${match}</span>`);
+          return (
+            <AutoCompleteDropdownRow
+              onClick={() => onSearch(item.text)}
+              key={index}
+              dangerouslySetInnerHTML={{ __html: modifiedItem }}
+            />
+          );
+        })}
       </AutoCompleteDropdown>
     </div>
   );

--- a/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchResourcesForm.tsx
@@ -19,27 +19,13 @@ import React, { Dispatch, useEffect, useRef } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { AnyAction } from 'redux';
 import { Template } from '@twilio/flex-ui';
-import { Grid } from '@material-ui/core';
 import debounce from 'lodash/debounce';
 
-import { RootState } from '../../../states';
-import {
-  BottomButtonBar,
-  Box,
-  Column,
-  FiltersCheckbox,
-  FormLabel,
-  FormOption,
-  FormSelect,
-  FormSelectWrapper,
-  Row,
-  SearchFormTopRule,
-  PrimaryButton,
-} from '../../../styles';
+import type { RootState } from '../../../states';
+import { BottomButtonBar, Box, Column, SearchFormTopRule, PrimaryButton } from '../../../styles';
 import {
   ResourcesSearchFormArea,
   ResourcesSearchFormContainer,
-  ResourcesSearchFormFilterHeader,
   ResourcesSearchFormSectionHeader,
   ResourcesSearchFormSettingBox,
   ResourcesSearchTitle,
@@ -52,63 +38,33 @@ import {
   suggestSearchAsyncAction,
   updateSearchFormAction,
 } from '../../../states/resources/search';
-import { FilterOption } from '../../../states/resources/types';
 import SearchInput from '../../caseList/filters/SearchInput';
-import { getAseloFeatureFlags, getTemplateStrings } from '../../../hrmConfig';
+import { getTemplateStrings } from '../../../hrmConfig';
 import asyncDispatch from '../../../states/asyncDispatch';
 import SearchAutoComplete from './SearchAutoComplete';
 import { namespace, referrableResourcesBase } from '../../../states/storeNamespaces';
-import {
-  loadReferenceLocationsAsyncAction,
-  ReferenceLocationList,
-  ReferenceLocationState,
-} from '../../../states/resources/referenceLocations';
-
-const NO_AGE_SELECTED = -1;
-const NO_LOCATION_SELECTED = '__NO_LOCATION_SELECTED__';
+import { ResourceSearchFilters } from '../mappingComponents';
 
 type OwnProps = {};
-type FilterName = keyof ReferrableResourceSearchState['parameters']['filterSelections'];
-type LocationFilterName = Extract<
-  keyof ReferrableResourceSearchState['parameters']['filterSelections'],
-  'province' | 'region' | 'city'
->;
-// This type definition is a bit convoluted but it self checks if the option names change in the state;
-type CheckboxFilterName = keyof Pick<
-  ReferrableResourceSearchState['parameters']['filterSelections'],
-  'howServiceIsOffered' | 'feeStructure'
->;
 
 const mapStateToProps = (state: RootState) => {
   const {
     parameters: { generalSearchTerm, pageSize, filterSelections },
-    filterOptions,
-    referenceLocations,
   } = state[namespace][referrableResourcesBase].search;
   const { suggestSearch } = state[namespace][referrableResourcesBase];
   return {
     generalSearchTerm,
     pageSize,
     filterSelections,
-    filterOptions,
     suggestSearch,
-    referenceLocations,
   };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
   const searchAsyncDispatch = asyncDispatch<AnyAction>(dispatch);
   return {
+    searchAsyncDispatch,
     updateGeneralSearchTerm: (generalSearchTerm: string) => dispatch(updateSearchFormAction({ generalSearchTerm })),
-    updateFilterSelection: (filterName: FilterName, filterValue: string | number | boolean | string[]) => {
-      let reduxFilterValue = filterValue;
-      if (filterName === 'maxEligibleAge' || filterName === 'minEligibleAge') {
-        reduxFilterValue = filterValue === NO_AGE_SELECTED ? undefined : filterValue;
-      } else if (filterName === 'province' || filterName === 'region' || filterName === 'city') {
-        reduxFilterValue = filterValue === NO_LOCATION_SELECTED ? undefined : filterValue;
-      }
-      dispatch(updateSearchFormAction({ filterSelections: { [filterName]: reduxFilterValue } }));
-    },
     submitSearch: (
       generalSearchTerm: string,
       filterSelections: ReferrableResourceSearchState['parameters']['filterSelections'],
@@ -119,17 +75,6 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
       leading: true,
       trailing: true,
     }),
-    loadReferenceLocations: (referenceLocations: ReferenceLocationState) => {
-      if (!referenceLocations.provinceOptions?.length) {
-        searchAsyncDispatch(loadReferenceLocationsAsyncAction(ReferenceLocationList.Provinces));
-      }
-      if (!referenceLocations.regionOptions?.length) {
-        searchAsyncDispatch(loadReferenceLocationsAsyncAction(ReferenceLocationList.Regions));
-      }
-      if (!referenceLocations.cityOptions?.length) {
-        searchAsyncDispatch(loadReferenceLocationsAsyncAction(ReferenceLocationList.Cities));
-      }
-    },
   };
 };
 
@@ -141,20 +86,15 @@ const SearchResourcesForm: React.FC<Props> = ({
   generalSearchTerm,
   pageSize,
   updateGeneralSearchTerm,
-  updateFilterSelection,
   submitSearch,
   resetSearch,
-  filterOptions,
   filterSelections,
   suggestSearch,
   updateSuggestSearch,
-  loadReferenceLocations,
-  referenceLocations,
+  searchAsyncDispatch,
 }) => {
   const firstElement = useRef(null);
   const strings = getTemplateStrings();
-  const { enable_region_resource_search: enableRegionResourceSearch } = getAseloFeatureFlags();
-  const { province, city, region, maxEligibleAge, minEligibleAge, ...checkboxOptions } = filterOptions;
   const [generalSearchTermBoxText, setGeneralSearchTermBoxText] = React.useState(generalSearchTerm);
 
   const hasValidSearchSettings = () =>
@@ -175,102 +115,6 @@ const SearchResourcesForm: React.FC<Props> = ({
   useEffect(() => {
     setGeneralSearchTermBoxText(generalSearchTerm);
   }, [generalSearchTerm, setGeneralSearchTermBoxText]);
-
-  useEffect(() => {
-    loadReferenceLocations(referenceLocations);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const locationDropdown = (locationFilterName: LocationFilterName, optionList: FilterOption[]) => {
-    const capitalizedLocationFilterName = locationFilterName.charAt(0).toUpperCase() + locationFilterName.slice(1);
-    return (
-      <FormSelectWrapper style={{ width: '100%' }}>
-        <FormSelect
-          id={`location-${locationFilterName}`}
-          data-testid={`Resources-Search-Location-${capitalizedLocationFilterName}`}
-          name={`location-${locationFilterName}`}
-          onChange={({ target: { value } }) => updateFilterSelection(locationFilterName, value)}
-          value={filterSelections[locationFilterName] ?? NO_LOCATION_SELECTED}
-          style={{ width: '100%' }}
-        >
-          {optionList.map(({ value, label }) => (
-            <FormOption key={value ?? NO_LOCATION_SELECTED} value={value ?? NO_LOCATION_SELECTED}>
-              {label ?? value}
-            </FormOption>
-          ))}
-        </FormSelect>
-      </FormSelectWrapper>
-    );
-  };
-
-  const ageRangeDropDown = (dropdown: 'Min' | 'Max', optionList: FilterOption<number>[]) => {
-    const currentSelection =
-      (dropdown === 'Min' ? filterSelections.minEligibleAge : filterSelections.maxEligibleAge) ?? NO_AGE_SELECTED;
-    return (
-      <Row>
-        <FormSelectWrapper style={{ width: '80px' }}>
-          <FormSelect
-            style={{ width: '80px' }}
-            id={`age-range-${dropdown.toLowerCase()}`}
-            data-testid={`Resources-Search-Age-Range-${dropdown}`}
-            name={dropdown === 'Min' ? 'minEligibleAge' : 'maxEligibleAge'}
-            onChange={({ target: { value } }) =>
-              updateFilterSelection(
-                dropdown === 'Min' ? 'minEligibleAge' : 'maxEligibleAge',
-                value ? parseInt(value, 10) : undefined,
-              )
-            }
-            value={currentSelection}
-          >
-            {optionList.map(({ value, label }) => (
-              <FormOption key={value ?? NO_AGE_SELECTED} value={value ?? NO_AGE_SELECTED}>
-                {label ?? value}
-              </FormOption>
-            ))}
-          </FormSelect>
-        </FormSelectWrapper>
-        &nbsp;
-        <FormLabel htmlFor={`age-range-${dropdown.toLowerCase()}`} style={{ marginLeft: '4px', flexDirection: 'row' }}>
-          <Template code={`Resources-Search-Age-Range-${dropdown}`} />
-        </FormLabel>
-      </Row>
-    );
-  };
-
-  const checkboxSet = (optionSet: CheckboxFilterName, options: FilterOption[]) => {
-    const selectedOptions = filterSelections[optionSet] ?? [];
-    return (
-      <ResourcesSearchFormSettingBox>
-        <ResourcesSearchFormFilterHeader>
-          <Template code={`Resources-Search-${optionSet}`} />
-        </ResourcesSearchFormFilterHeader>
-        <Grid container>
-          {options.map(({ value, label }) => (
-            <Grid key={value} xs={4} item>
-              <FormLabel htmlFor={value} style={{ flexDirection: 'row' }}>
-                <FiltersCheckbox
-                  id={value}
-                  name={value}
-                  type="checkbox"
-                  checked={selectedOptions.includes(value)}
-                  onChange={({ target: { checked } }) => {
-                    const newSelections = checked
-                      ? [...selectedOptions, value]
-                      : selectedOptions.filter(option => option !== value);
-                    updateFilterSelection(
-                      optionSet as CheckboxFilterName,
-                      newSelections.length ? newSelections : undefined,
-                    );
-                  }}
-                />
-                &nbsp;&nbsp;{label ?? value}
-              </FormLabel>
-            </Grid>
-          ))}
-        </Grid>
-      </ResourcesSearchFormSettingBox>
-    );
-  };
 
   return (
     <ResourcesSearchFormContainer>
@@ -315,92 +159,7 @@ const SearchResourcesForm: React.FC<Props> = ({
           <ResourcesSearchFormSectionHeader data-testid="Resources-Search-FilterHeader">
             <Template code="Resources-Search-FilterHeader" />
           </ResourcesSearchFormSectionHeader>
-          <Column>
-            <ResourcesSearchFormSettingBox>
-              <ResourcesSearchFormFilterHeader>
-                <Template code="Resources-Search-Location" />
-              </ResourcesSearchFormFilterHeader>
-              <Row key="location" style={{ marginTop: '10px', marginBottom: '10px', gap: '60px' }}>
-                <Column
-                  style={{
-                    width: enableRegionResourceSearch ? '33%' : '50%',
-                    maxWidth: enableRegionResourceSearch ? '166px' : '250px',
-                    gap: '4px',
-                  }}
-                >
-                  <FormLabel htmlFor="location-province">
-                    <Template code="Resources-Search-Location-Province" />
-                  </FormLabel>
-                  {locationDropdown('province', province)}
-                </Column>
-                {enableRegionResourceSearch && (
-                  <Column
-                    style={{
-                      width: '33%',
-                      maxWidth: '166px',
-                      opacity: filterSelections.province ? 1 : 0.2,
-                      gap: '4px',
-                    }}
-                  >
-                    <FormLabel htmlFor="location-region">
-                      <Template code="Resources-Search-Location-Region" />
-                    </FormLabel>
-                    {locationDropdown('region', region)}
-                  </Column>
-                )}
-                <Column
-                  style={{
-                    width: enableRegionResourceSearch ? '33%' : '50%',
-                    maxWidth: enableRegionResourceSearch ? '166px' : '250px',
-                    opacity: filterSelections.province ? 1 : 0.2,
-                    gap: '4px',
-                  }}
-                >
-                  <FormLabel htmlFor="location-city">
-                    <Template code="Resources-Search-Location-City" />
-                  </FormLabel>
-                  {locationDropdown('city', city)}
-                </Column>
-              </Row>
-            </ResourcesSearchFormSettingBox>
-            <Row key="age-range" style={{ alignItems: 'stretch', justifyContent: 'stretch', gap: '4px' }}>
-              <ResourcesSearchFormSettingBox key="age-range" style={{ flexShrink: 1 }}>
-                <ResourcesSearchFormFilterHeader>
-                  <Template code="Resources-Search-Age-Range" />
-                </ResourcesSearchFormFilterHeader>
-                <Row style={{ alignItems: 'baseline', justifyContent: 'space-between' }}>
-                  {ageRangeDropDown('Min', minEligibleAge)}
-                  <Box>&mdash;</Box>
-                  {ageRangeDropDown('Max', maxEligibleAge)}
-                </Row>
-              </ResourcesSearchFormSettingBox>
-              <ResourcesSearchFormSettingBox style={{ flexShrink: 1, marginLeft: '4px' }}>
-                <Column>
-                  <ResourcesSearchFormFilterHeader>
-                    <Template code="Resources-Search-InterpretationTranslationServicesAvailable" />
-                  </ResourcesSearchFormFilterHeader>
-                  <FormLabel htmlFor="interpretationTranslationServicesAvailable" style={{ flexDirection: 'row' }}>
-                    <FiltersCheckbox
-                      id="interpretationTranslationServicesAvailable"
-                      name="interpretationTranslationServicesAvailable"
-                      type="checkbox"
-                      checked={Boolean(filterSelections.interpretationTranslationServicesAvailable)}
-                      onChange={({ target: { checked } }) => {
-                        updateFilterSelection('interpretationTranslationServicesAvailable', checked || undefined);
-                      }}
-                    />
-                    &nbsp;&nbsp;
-                    <Template code="Resources-Search-InterpretationTranslationServicesAvailable-Checkbox" />
-                  </FormLabel>
-                </Column>
-              </ResourcesSearchFormSettingBox>
-            </Row>
-            <Grid container>
-              {Object.entries(checkboxOptions).map(([optionSet, options]) =>
-                checkboxSet(optionSet as CheckboxFilterName, options),
-              )}
-            </Grid>
-          </Column>
+          <ResourceSearchFilters />
         </ResourcesSearchFormArea>
       </Box>
       <BottomButtonBar>

--- a/plugin-hrm-form/src/components/resources/search/SearchResourcesResults.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchResourcesResults.tsx
@@ -25,7 +25,6 @@ import SearchResultsBackButton from '../../search/SearchResults/SearchResultsBac
 import {
   ResourcesSearchArea,
   ResourcesSearchResultsDescription,
-  ResourcesSearchResultsDescriptionItem,
   ResourcesSearchResultsHeader,
   ResourcesSearchResultsList,
   ResourcesSearchTitle,
@@ -44,16 +43,16 @@ import Pagination from '../../pagination';
 import asyncDispatch from '../../../states/asyncDispatch';
 import ResourcePreview from './ResourcePreview';
 import { namespace, referrableResourcesBase } from '../../../states/storeNamespaces';
+import { ResourcesSearchResultsDescriptionDetails } from '../mappingComponents';
 
 type OwnProps = {};
 
 const mapStateToProps = (state: RootState) => {
   const searchState = state[namespace][referrableResourcesBase].search;
-  const { error, status, currentPage, parameters, filterOptions } = searchState;
+  const { error, status, currentPage, parameters } = searchState;
   const currentPageResults = getCurrentPageResults(searchState);
   return {
     parameters,
-    filterOptions,
     currentPageResults,
     currentPage,
     error,
@@ -89,76 +88,12 @@ const SearchResourcesResults: React.FC<Props> = ({
   retrievePageResults,
   returnToForm,
   viewResource,
-  filterOptions,
 }) => {
   // If any results for the current page are undefined (i.e. expected to exist given the total result count but not in  redux yet) query the back end
   if (!currentPageResults.every(res => res)) {
     retrievePageResults(parameters, currentPage);
     return null;
   }
-
-  const ageRangeDescription = () => {
-    const {
-      filterSelections: { minEligibleAge, maxEligibleAge },
-    } = parameters;
-    if (minEligibleAge && maxEligibleAge) {
-      return (
-        <ResourcesSearchResultsDescriptionItem>
-          <Template
-            code="Resources-Search-ResultsDescription-AgeRange"
-            minEligibleAge={minEligibleAge}
-            maxEligibleAge={maxEligibleAge}
-          />
-        </ResourcesSearchResultsDescriptionItem>
-      );
-    } else if (minEligibleAge) {
-      return (
-        <ResourcesSearchResultsDescriptionItem>
-          <Template code="Resources-Search-ResultsDescription-MinimumAge" minEligibleAge={minEligibleAge} />
-        </ResourcesSearchResultsDescriptionItem>
-      );
-    } else if (maxEligibleAge) {
-      return (
-        <ResourcesSearchResultsDescriptionItem>
-          <Template code="Resources-Search-ResultsDescription-MaximumAge" maxEligibleAge={maxEligibleAge} />
-        </ResourcesSearchResultsDescriptionItem>
-      );
-    }
-    return null;
-  };
-
-  const locationDescription = () => {
-    const {
-      filterSelections: { province, city, region },
-    } = parameters;
-    const location = [
-      filterOptions.city.find(({ value }) => value === city)?.label,
-      filterOptions.region.find(({ value }) => value === region)?.label,
-      filterOptions.province.find(({ value }) => value === province)?.label,
-    ]
-      .filter(Boolean)
-      .join(', ');
-    if (location) {
-      return (
-        <ResourcesSearchResultsDescriptionItem>
-          <Template code="Resources-Search-ResultsDescription-Location" location={location} />
-        </ResourcesSearchResultsDescriptionItem>
-      );
-    }
-    return null;
-  };
-
-  const filterDescription = (code: string, selections: string[]) => {
-    const selectionsText = (selections ?? []).join(', ');
-    if (selectionsText) {
-      return (
-        <ResourcesSearchResultsDescriptionItem>
-          <Template code={code} selections={selectionsText} />
-        </ResourcesSearchResultsDescriptionItem>
-      );
-    }
-    return null;
-  };
 
   return (
     <ResourcesSearchArea>
@@ -183,21 +118,7 @@ const SearchResourcesResults: React.FC<Props> = ({
                 generalSearchTerm={parameters.generalSearchTerm}
               />
             )}
-            {locationDescription()}
-            {parameters.filterSelections.interpretationTranslationServicesAvailable && (
-              <ResourcesSearchResultsDescriptionItem>
-                <Template code="Resources-Search-ResultsDescription-InterpretationTranslationServicesAvailable" />
-              </ResourcesSearchResultsDescriptionItem>
-            )}
-            {ageRangeDescription()}
-            {filterDescription(
-              'Resources-Search-ResultsDescription-FeeStructure',
-              parameters.filterSelections.feeStructure,
-            )}
-            {filterDescription(
-              'Resources-Search-ResultsDescription-HowServiceIsOffered',
-              parameters.filterSelections.howServiceIsOffered,
-            )}
+            <ResourcesSearchResultsDescriptionDetails />
           </ResourcesSearchResultsDescription>
         </ResourcesSearchResultsHeader>
         {error && ( // TODO: translation / friendlyisation layer

--- a/plugin-hrm-form/src/services/ResourceService.ts
+++ b/plugin-hrm-form/src/services/ResourceService.ts
@@ -82,3 +82,15 @@ export const getReferenceAttributeList = async (
   // Lists can contain slashes, but we only want them as one path section
   return fetchResourceApi(`reference-attributes/${encodeURIComponent(list)}?${queryString}`);
 };
+
+export const getDistinctStringAttributes = async ({
+  key,
+  language,
+}: {
+  key: string;
+  language?: string;
+}): Promise<{ value: string }[]> => {
+  const queryItems = Object.entries({ key, language }).filter(([, value]) => value);
+  const queryString = queryItems.map(([k, v]) => `${k}=${v}`).join('&');
+  return fetchResourceApi(`list-string-attributes?${queryString}`);
+};

--- a/plugin-hrm-form/src/services/ResourceService.ts
+++ b/plugin-hrm-form/src/services/ResourceService.ts
@@ -17,7 +17,7 @@
  */
 import fetchResourceApi from './fetchResourcesApi';
 import { getReferrableResourceConfig } from '../hrmConfig';
-import { TaxonomyLevelNameCompletion } from '../states/resources/search';
+import { SuggestSearch } from '../states/resources/search';
 
 export type AttributeData<T = any> = {
   language?: string;
@@ -68,7 +68,7 @@ export const searchResources = async (
   };
 };
 
-export const suggestSearch = async (prefix: string): Promise<TaxonomyLevelNameCompletion> => {
+export const suggestSearch = async (prefix: string): Promise<SuggestSearch['suggestions']> => {
   return fetchResourceApi(`suggest?prefix=${prefix}`);
 };
 

--- a/plugin-hrm-form/src/states/resources/filterSelectionState/khp/index.ts
+++ b/plugin-hrm-form/src/states/resources/filterSelectionState/khp/index.ts
@@ -1,0 +1,206 @@
+/* eslint-disable import/no-unused-modules */
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { getReferenceAttributeList, ReferenceAttributeStringValue } from '../../../../services/ResourceService';
+import type { ReferrableResourceSearchState } from '../../search';
+import type { FilterOption } from '../../types';
+import { dedupAndSort, LoadReferenceActionFunction, ReferenceLocationState } from '../../referenceLocations';
+
+export type KHPReferenceLocationState = {
+  provinceOptions: FilterOption[];
+  regionOptions: FilterOption[];
+  cityOptions: FilterOption[];
+};
+
+export const referenceLocationsInitialState: KHPReferenceLocationState = {
+  provinceOptions: [],
+  regionOptions: [],
+  cityOptions: [],
+};
+
+export const enum KHPReferenceLocationList {
+  Provinces = 'provinces',
+  Regions = 'country/province/region',
+  Cities = 'country/province/region/city',
+}
+
+const minAgeOptions: FilterOption<number>[] = [
+  { label: '0', value: undefined },
+  ...Array.from({ length: 30 }, (_, i) => i + 1).map(age => ({ value: age })),
+];
+
+const maxAgeOptions: FilterOption<number>[] = [
+  ...Array.from({ length: 30 }, (_, i) => i).map(age => ({ value: age })),
+  { value: undefined, label: '30+' },
+];
+
+export type KHPFilterOptions = {
+  feeStructure: FilterOption[];
+  howServiceIsOffered: FilterOption[];
+  province: FilterOption[];
+  region?: FilterOption[];
+  city?: FilterOption[];
+  minEligibleAge: FilterOption<number>[];
+  maxEligibleAge: FilterOption<number>[];
+};
+
+const initialFilterOptions: KHPFilterOptions = {
+  feeStructure: [
+    { value: 'Free' },
+    { value: 'Cost Unknown' },
+    { value: 'Membership Fee' },
+    { value: 'Cost for Service' },
+    { value: 'Sliding Scale' },
+    { value: 'One Time Small Fee' },
+    { value: 'Covered by Health Insurance' },
+  ],
+  howServiceIsOffered: [{ value: 'In-person Support' }, { value: 'Online Support' }, { value: 'Phone Support' }],
+  province: [{ label: '', value: undefined }],
+  region: [],
+  city: [],
+  minEligibleAge: minAgeOptions,
+  maxEligibleAge: maxAgeOptions,
+};
+
+export type KHPFilterSelections = {
+  city?: string;
+  region?: string;
+  province?: string;
+  interpretationTranslationServicesAvailable?: true;
+  minEligibleAge?: number;
+  maxEligibleAge?: number;
+  feeStructure?: string[];
+  howServiceIsOffered?: string[];
+};
+
+const getFilterOptionsBasedOnSelections = (
+  filterSelections: KHPFilterSelections = {},
+  { provinceOptions, regionOptions, cityOptions }: ReferenceLocationState = {},
+): KHPFilterOptions => {
+  return {
+    ...initialFilterOptions,
+    minEligibleAge: minAgeOptions.filter(opt => {
+      const maxSelection = filterSelections.maxEligibleAge ?? 1000;
+      return opt.value === undefined || opt.value <= maxSelection;
+    }),
+    maxEligibleAge: maxAgeOptions.filter(opt => {
+      const minSelection = filterSelections.minEligibleAge ?? 0;
+      return opt.value === undefined || opt.value >= minSelection;
+    }),
+    province: [{ label: '', value: undefined }, ...(provinceOptions || [])],
+    region: [
+      { label: '', value: undefined },
+      ...(regionOptions || []).filter(
+        ({ value }) => filterSelections.province && (!value || value.startsWith(filterSelections.province)),
+      ),
+    ],
+    city: [
+      { label: '', value: undefined },
+      ...(cityOptions || []).filter(({ value }) => {
+        const { region, province } = filterSelections;
+        if (!province) {
+          return false;
+        }
+        const startPrefix = region?.startsWith(province) ? region : province;
+        return !value || value.startsWith(startPrefix);
+      }),
+    ],
+  };
+};
+
+const ensureFilterSelectionsAreValid = (
+  filterSelections: KHPFilterSelections = {},
+  filterOptions: KHPFilterOptions = initialFilterOptions,
+): KHPFilterSelections => {
+  return {
+    // Don't add undefined values to the filter selections
+    ...Object.fromEntries(
+      Object.entries({
+        ...filterSelections,
+        minEligibleAge: filterOptions.minEligibleAge.find(opt => opt.value === filterSelections.minEligibleAge)?.value,
+        maxEligibleAge: filterOptions.maxEligibleAge.find(opt => opt.value === filterSelections.maxEligibleAge)?.value,
+        province: filterOptions.province.find(opt => opt.value === filterSelections.province)?.value,
+        region: filterOptions.region.find(opt => opt.value === filterSelections.region)?.value,
+        city: filterOptions.city.find(opt => opt.value === filterSelections.city)?.value,
+      }).filter(([, value]) => value !== undefined),
+    ),
+  };
+};
+
+export const loadReferenceActionFunction: (list: string) => LoadReferenceActionFunction = (
+  list: string,
+) => async () => {
+  const apiAttributes = await getReferenceAttributeList(list, 'en');
+  const unsortedOptions = apiAttributes.map(({ value, info }: ReferenceAttributeStringValue) => ({
+    label: info?.name ?? value,
+    value,
+  }));
+  return { list, options: dedupAndSort(unsortedOptions) };
+};
+
+export const handlerUpdateSearchFormAction = (state: ReferrableResourceSearchState, { payload }) => {
+  const updatedFilterOptions = getFilterOptionsBasedOnSelections(
+    {
+      ...state.parameters.filterSelections,
+      ...(payload.filterSelections ?? {}),
+    },
+    state.referenceLocations,
+  );
+  const validatedFilterSelections = ensureFilterSelectionsAreValid(
+    { ...state.parameters.filterSelections, ...payload.filterSelections },
+    updatedFilterOptions,
+  );
+  return {
+    ...state,
+    filterOptions: updatedFilterOptions,
+    parameters: {
+      ...state.parameters,
+      ...payload,
+      filterSelections: validatedFilterSelections,
+    },
+  };
+};
+
+export const handleLoadReferenceLocationsAsyncActionFulfilled = (state: ReferrableResourceSearchState, { payload }) => {
+  const { list, options } = payload;
+  let { referenceLocations } = state;
+  switch (list) {
+    case KHPReferenceLocationList.Provinces:
+      referenceLocations = { ...referenceLocations, provinceOptions: options };
+      break;
+    case KHPReferenceLocationList.Regions:
+      referenceLocations = { ...referenceLocations, regionOptions: options };
+      break;
+    case KHPReferenceLocationList.Cities:
+      referenceLocations = { ...referenceLocations, cityOptions: options };
+      break;
+    default:
+  }
+
+  const updatedFilterOptions = getFilterOptionsBasedOnSelections(state.parameters.filterSelections, referenceLocations);
+  const validatedFilterSelections = ensureFilterSelectionsAreValid(
+    state.parameters.filterSelections,
+    updatedFilterOptions,
+  );
+
+  return {
+    ...state,
+    filterOptions: updatedFilterOptions,
+    filterSelections: validatedFilterSelections,
+    referenceLocations,
+  };
+};

--- a/plugin-hrm-form/src/states/resources/filterSelectionState/usch/index.ts
+++ b/plugin-hrm-form/src/states/resources/filterSelectionState/usch/index.ts
@@ -15,13 +15,9 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import type { ReferrableResourceSearchState, SearchSettings } from '../../../../states/resources/search';
-import type { FilterOption } from '../../../../states/resources/types';
-import {
-  dedupAndSort,
-  LoadReferenceActionFunction,
-  ReferenceLocationState,
-} from '../../../../states/resources/referenceLocations';
+import type { ReferrableResourceSearchState, SearchSettings } from '../../search';
+import type { FilterOption } from '../../types';
+import { dedupAndSort, LoadReferenceActionFunction, ReferenceLocationState } from '../../referenceLocations';
 import { getDistinctStringAttributes } from '../../../../services/ResourceService';
 
 export type USCHReferenceLocationState = {

--- a/plugin-hrm-form/src/states/resources/index.ts
+++ b/plugin-hrm-form/src/states/resources/index.ts
@@ -25,7 +25,7 @@ import {
   suggestSearchInitialState,
   suggestSearchReducer,
   resourceSearchReducer,
-  TaxonomyLevelNameCompletion,
+  SuggestSearch,
 } from './search';
 
 export const enum ResourcePage {
@@ -73,7 +73,7 @@ export type ReferrableResourcesState = {
     )
   >;
   search: ReferrableResourceSearchState;
-  suggestSearch: TaxonomyLevelNameCompletion;
+  suggestSearch: SuggestSearch;
 };
 
 const initialState: ReferrableResourcesState = {

--- a/plugin-hrm-form/src/states/resources/referenceLocations.ts
+++ b/plugin-hrm-form/src/states/resources/referenceLocations.ts
@@ -16,10 +16,9 @@
 import { createAsyncAction } from 'redux-promise-middleware-actions';
 
 import { FilterOption } from './types';
-import { getReferenceAttributeList, ReferenceAttributeStringValue } from '../../services/ResourceService';
 
 // Deduplicate based on value and sort by label
-const dedupAndSort = (arr: FilterOption[]) => {
+export const dedupAndSort = (arr: FilterOption[]) => {
   const mapped = arr.reduce((optionMap: Record<string, FilterOption>, option: FilterOption) => {
     optionMap[option.value] = option;
     return optionMap;
@@ -29,34 +28,19 @@ const dedupAndSort = (arr: FilterOption[]) => {
 };
 
 export type ReferenceLocationState = {
-  provinceOptions: FilterOption[];
-  regionOptions: FilterOption[];
-  cityOptions: FilterOption[];
-};
-
-export const referenceLocationsInitialState: ReferenceLocationState = {
-  provinceOptions: [],
-  regionOptions: [],
-  cityOptions: [],
+  [input: string]: FilterOption[];
 };
 
 const LOAD_REFERENCE_LOCATIONS_LIST_ACTION = 'resource-action/reference-locations/load-all';
 
-export const enum ReferenceLocationList {
-  Provinces = 'provinces',
-  Regions = 'country/province/region',
-  Cities = 'country/province/region/city',
-}
+export type LoadReferenceActionFunction = () => Promise<{ list: string; options: FilterOption[] }>;
 
 export const loadReferenceLocationsAsyncAction = createAsyncAction(
   LOAD_REFERENCE_LOCATIONS_LIST_ACTION,
-  async (list: ReferenceLocationList): Promise<{ list: ReferenceLocationList; options: FilterOption[] }> => {
-    const apiAttributes = await getReferenceAttributeList(list, 'en');
-    const unsortedOptions = apiAttributes.map(({ value, info }: ReferenceAttributeStringValue) => ({
-      label: info?.name ?? value,
-      value,
-    }));
-    return { list, options: dedupAndSort(unsortedOptions) };
-  },
+  async ({
+    loadReferenceActionFunction,
+  }: {
+    loadReferenceActionFunction: LoadReferenceActionFunction;
+  }): Promise<{ list: string; options: FilterOption[] }> => loadReferenceActionFunction(),
   // { promiseTypeDelimiter: '/' }, // Doesn't work :-(
 );

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -44,7 +44,7 @@ export enum ResourceSearchStatus {
   Error,
 }
 
-export type FilterSelections = {
+type FilterSelections = {
   [filter: string]: number | string | boolean | string[];
 };
 

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -89,15 +89,19 @@ export type ReferrableResourceSearchState = {
   error?: Error;
 };
 
-export type TaxonomyLevelNameCompletion = {
-  taxonomyLevelNameCompletion: Array<{
-    text: string;
-    score: number;
-  }>;
+export type SuggestSearch = {
+  status: ResourceSearchStatus;
+  suggestions: {
+    [completionKey: string]: Array<{
+      text: string;
+      score: number;
+    }>;
+  };
 };
 
-export const suggestSearchInitialState: TaxonomyLevelNameCompletion = {
-  taxonomyLevelNameCompletion: [],
+export const suggestSearchInitialState: SuggestSearch = {
+  status: ResourceSearchStatus.NotSearched,
+  suggestions: {},
 };
 
 export const initialState: ReferrableResourceSearchState = {
@@ -255,7 +259,7 @@ export const suggestSearchReducer = createReducer(suggestSearchInitialState, han
   handleAction(suggestSearchAsyncAction.pending, state => {
     return {
       ...state,
-      taxonomyLevelNameCompletion: [],
+      suggestions: {},
       status: ResourceSearchStatus.ResultPending,
     };
   }),
@@ -263,7 +267,10 @@ export const suggestSearchReducer = createReducer(suggestSearchInitialState, han
   handleAction(suggestSearchAsyncAction.fulfilled, (state, { payload }) => {
     return {
       ...state,
-      taxonomyLevelNameCompletion: payload.taxonomyLevelNameCompletion,
+      suggestions: {
+        ...state.suggestions,
+        ...payload,
+      },
       status: ResourceSearchStatus.ResultReceived,
     };
   }),


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/hrm/pull/934.

## Description
This PR
- Extends src/components/resources/mappingComponents/
  - Each account that supports resources must expose the customizable parts of the UI, depending on how they interact with the custom resource mappings.
  - `FilterSelectionState` defines behavior in different parts of the Redux resources search state:
    - `loadReferenceActionFunction`: specifies how to lookup the reference resources.
    - `handleLoadReferenceLocationsAsyncActionFulfilled`: specifies how to handle the above action.
    - `handlerUpdateSearchFormAction`: specifies how to handle the form updates upong changing search filters.
  - `ResourceSearchFilters` defines the custom component that adds filters to the search page (below the omnisearch bar).
  - `ResourcesSearchResultsDescriptionDetails` defines the custom component that informs the user of the selected filters after a search.
- As part of the above change, parts of the search resource state are refactored to support dynamic shapes, as well as dynamic ways to update it (defined as part of the mapping components, under `FilterSelectionState`).
- Refactors `SearchResourcesForm` and `SearchResourcesResults` components to use the above mentioned custom components (`ResourceSearchFilters` and `ResourcesSearchResultsDescriptionDetails` respectively).
- Refactors KHP mapping components accordingly.
- Introduces USCH mapping components.
  - Filters are only location based (`country`, `province`, `city`).
- Previously `TaxonomyLevelNameCompletion` type has been made more abstracted into `SuggestSearch`, which supports different "keys" corresponding to the suggest fields of the EalasticSearch mappings.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3448)
- [ ] New tests added
- [ ] Feature flags added
- [x] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- Deploy HRM and Lambdas using the above linked PR.
  - Delete resources from DB, and corresponding index from ElasticSearch.
  - Trigger a reindex using USCH resources.
- `npm run dev` to start local server.
- Confirm the resources search page and results now display the appropriate filters, and that the onmisearch suggester appropriately uses the categories field from ElasticSearch resources.
- KHP QA to make sure no bug is being introduced.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P