### PR TITLE
CHI-3438: Add 'Assigned Skills' & 'Unassigned Skills' Teams View filters

### DIFF
--- a/plugin-hrm-form/src/components/contact/IssueCategorizationSectionForm.tsx
+++ b/plugin-hrm-form/src/components/contact/IssueCategorizationSectionForm.tsx
@@ -68,10 +68,7 @@ const IssueCategorizationSectionForm: React.FC<Props> = ({ display, definition, 
   const selectedCount = Object.values(selectedCategories).reduce((acc, curr) => acc + curr.length, 0);
 
   const { clearErrors, register } = useFormContext();
-  const maxSelections =
-    (getAseloFeatureFlags().enable_configurable_max_categories
-      ? definition.maxSelections
-      : DEFAULT_MAXIMUM_SELECTIONS) ?? DEFAULT_MAXIMUM_SELECTIONS;
+  const maxSelections = definition.maxSelections ?? DEFAULT_MAXIMUM_SELECTIONS;
 
   // Add invisible field that errors if no category is selected (triggered by validation)
   React.useEffect(() => {

--- a/plugin-hrm-form/src/components/teamsView/teamsViewFilters.ts
+++ b/plugin-hrm-form/src/components/teamsView/teamsViewFilters.ts
@@ -88,12 +88,17 @@ const filterInputExpressionStrings: Record<string, string> = {};
  * We re-evaluate the relevant entry each time the factory function is run, reading the current filter selections for the filter from redux state and generating the livequery snippet using the provided generator function
  * We then add all these filter expressions with AND logic to the hiddenFilter, which implements the filter
  */
-const generateFilterDefinitionFactoryForInputExpression = (
-  id: string,
-  queryGenerator: (selectionsString: string[]) => string,
-  titleKey: string,
-  fieldName: string = id.toLowerCase().replace('.', '_'),
-): FilterDefinitionFactory => (state, teamsViewProps) => {
+const generateFilterDefinitionFactoryForInputExpression = ({
+  id,
+  queryGenerator,
+  titleKey,
+  fieldName = id.toLowerCase().replace('.', '_'),
+}: {
+  id: string;
+  queryGenerator: (selectionsString: string[]) => string;
+  titleKey: string;
+  fieldName?: string;
+}): FilterDefinitionFactory => (state, teamsViewProps) => {
   const values = state.flex.supervisor.appliedFilters.find(af => af.name === id)?.values ?? [];
   const selections = Array.isArray(values) ? values : [values];
   if (selections.length) {
@@ -113,27 +118,26 @@ const generateFilterDefinitionFactoryForInputExpression = (
   };
 };
 
-const assignedSkillsFilterDefinition: FilterDefinitionFactory = generateFilterDefinitionFactoryForInputExpression(
-  `data.attributes.dummy_assigned_skills`,
-  selections => {
+const assignedSkillsFilterDefinition: FilterDefinitionFactory = generateFilterDefinitionFactoryForInputExpression({
+  id: `data.attributes.dummy_assigned_skills`,
+  queryGenerator: selections => {
     const selectionsString = selections.map(s => `\"${s}\"`).join(', ');
     return `(data.attributes.routing.skills IN [${selectionsString}] OR data.attributes.disabled_skills.skills IN [${selectionsString}])`;
   },
-  'Assigned Skills',
-);
+  titleKey: 'Assigned Skills',
+});
 
-const unassignedSkillsFilterDefinition: FilterDefinitionFactory = generateFilterDefinitionFactoryForInputExpression(
-  `data.attributes.dummy_unassigned_skills`,
-  selections =>
+const unassignedSkillsFilterDefinition: FilterDefinitionFactory = generateFilterDefinitionFactoryForInputExpression({
+  id: `data.attributes.dummy_unassigned_skills`,
+  queryGenerator: selections =>
     `(${selections
       .map(
         selection =>
           `(data.attributes.routing.skills NOT_IN [\"${selection}\"] AND data.attributes.disabled_skills.skills NOT_IN [\"${selection}\"])`,
       )
       .join(' OR ')})`,
-
-  'Unassigned Skills',
-);
+  titleKey: 'Unassigned Skills',
+});
 
 /**
  * This function sets up filters for the TeamsView component

--- a/plugin-hrm-form/src/components/teamsView/teamsViewFilters.ts
+++ b/plugin-hrm-form/src/components/teamsView/teamsViewFilters.ts
@@ -19,6 +19,7 @@ import { Manager, FiltersListItemType, TeamsView, WorkerDirectoryTabs } from '@t
 import sortBy from 'lodash/sortBy';
 
 const activityNoOfflineByDefault: FilterDefinitionFactory = (appState, _teamFiltersPanelProps) => {
+  const title = 'Activities';
   const activitiesArray = Array.from(appState.flex.worker.activities.values());
 
   const options = activitiesArray.map(activity => ({
@@ -31,7 +32,7 @@ const activityNoOfflineByDefault: FilterDefinitionFactory = (appState, _teamFilt
     id: 'data.activity_name',
     fieldName: 'activity',
     type: FiltersListItemType.multiValue,
-    title: 'Activities',
+    title: Manager.getInstance().strings[title] ?? title,
     options,
   };
 };
@@ -45,9 +46,10 @@ const skillsOptions = Manager.getInstance().serviceConfiguration.taskrouter_skil
  * This function returns a list of skills defined in the taskrouter_skills configuration
  */
 const skillsFilterDefinition: FilterDefinitionFactory = () => {
+  const title = 'Enabled Skills';
   return {
     id: 'data.attributes.routing.skills',
-    title: 'Enabled Skills',
+    title: Manager.getInstance().strings[title] ?? title,
     fieldName: 'skills',
     type: FiltersListItemType.multiValue,
     options: skillsOptions ? sortBy(skillsOptions, ['label']) : [],
@@ -56,9 +58,10 @@ const skillsFilterDefinition: FilterDefinitionFactory = () => {
 };
 
 const disabledSkillsFilterDefinition: FilterDefinitionFactory = () => {
+  const title = 'Disabled Skills';
   return {
     id: 'data.attributes.disabled_skills.skills',
-    title: 'Disabled Skills',
+    title: Manager.getInstance().strings[title] ?? title,
     fieldName: 'disabled_skills',
     type: FiltersListItemType.multiValue,
     options: skillsOptions ? sortBy(skillsOptions, ['label']) : [],

--- a/plugin-hrm-form/src/components/teamsView/teamsViewFilters.ts
+++ b/plugin-hrm-form/src/components/teamsView/teamsViewFilters.ts
@@ -18,6 +18,8 @@ import type { FilterDefinitionFactory } from '@twilio/flex-ui/src/components/vie
 import { Manager, FiltersListItemType, TeamsView, WorkerDirectoryTabs } from '@twilio/flex-ui';
 import sortBy from 'lodash/sortBy';
 
+import { getAseloFeatureFlags } from '../../hrmConfig';
+
 const activityNoOfflineByDefault: FilterDefinitionFactory = (appState, _teamFiltersPanelProps) => {
   const title = 'Activities';
   const activitiesArray = Array.from(appState.flex.worker.activities.values());
@@ -139,13 +141,15 @@ const unassignedSkillsFilterDefinition: FilterDefinitionFactory = generateFilter
  * The skills filter is included if the feature flag is enabled.
  */
 export const setUpTeamsViewFilters = () => {
-  TeamsView.defaultProps.filters = [
-    activityNoOfflineByDefault,
-    skillsFilterDefinition,
-    disabledSkillsFilterDefinition,
-    assignedSkillsFilterDefinition,
-    unassignedSkillsFilterDefinition,
-  ];
+  TeamsView.defaultProps.filters = getAseloFeatureFlags().enable_assigned_skill_teams_view_filters
+    ? [
+        activityNoOfflineByDefault,
+        skillsFilterDefinition,
+        disabledSkillsFilterDefinition,
+        assignedSkillsFilterDefinition,
+        unassignedSkillsFilterDefinition,
+      ]
+    : [activityNoOfflineByDefault, skillsFilterDefinition, disabledSkillsFilterDefinition];
 };
 
 export const setUpWorkerDirectoryFilters = () => {

--- a/plugin-hrm-form/src/components/teamsView/teamsViewFilters.ts
+++ b/plugin-hrm-form/src/components/teamsView/teamsViewFilters.ts
@@ -36,9 +36,9 @@ const activityNoOfflineByDefault: FilterDefinitionFactory = (appState, _teamFilt
   };
 };
 
-const getSkillsArray = Manager.getInstance().serviceConfiguration.taskrouter_skills?.map(skill => ({
-  value: skill.name,
-  label: skill.name,
+const skillsOptions = Manager.getInstance().serviceConfiguration.taskrouter_skills?.map(({ name }) => ({
+  value: name,
+  label: name,
 }));
 
 /**
@@ -50,7 +50,7 @@ const skillsFilterDefinition: FilterDefinitionFactory = () => {
     title: 'Enabled Skills',
     fieldName: 'skills',
     type: FiltersListItemType.multiValue,
-    options: getSkillsArray ? sortBy(getSkillsArray, ['label']) : [],
+    options: skillsOptions ? sortBy(skillsOptions, ['label']) : [],
     condition: 'IN',
   };
 };
@@ -61,10 +61,74 @@ const disabledSkillsFilterDefinition: FilterDefinitionFactory = () => {
     title: 'Disabled Skills',
     fieldName: 'disabled_skills',
     type: FiltersListItemType.multiValue,
-    options: getSkillsArray ? sortBy(getSkillsArray, ['label']) : [],
+    options: skillsOptions ? sortBy(skillsOptions, ['label']) : [],
     condition: 'IN',
   };
 };
+
+const filterInputExpressionStrings: Record<string, string> = {};
+
+/**
+ * This function will generate a FilterDefinitionFactory that can be passed livequery expression to determine how to evaluate filter selections to generate a filtered list of workers
+ * e.g. data.attributes.routing.skills IN [{...selections}] OR data.attributes.disabled_skills.skills IN [{...selections}]
+ * to return any workers with the selected skills present in their enabled or disabled list
+ *
+ * The Twilio FilterDefinition does not support expression inputs like this, only references to a single data field, e.g. data.attributes.routing.skills
+ * To work around this, this function creates a dummy FilterDefinition which only renders the UI and updates the current filter selections in the redux state
+ * The query the FilterDefinition generates is always a NOT_IN vs an attribute that doesn't exist, so should always return everything.
+ * This is why the id property is usually prefixed with 'dummy_' to ensure it doesn't point at real data and indicate it isn't supposed to
+ *
+ * The 'real' filtering is implemented by setting the hiddenFilter property on teamsView.
+ * We maintain a map of filter strings, with an entry for each 'expression backed filter'.
+ * We re-evaluate the relevant entry each time the factory function is run, reading the current filter selections for the filter from redux state and generating the livequery snippet using the provided generator function
+ * We then add all these filter expressions with AND logic to the hiddenFilter, which implements the filter
+ */
+const generateFilterDefinitionFactoryForInputExpression = (
+  id: string,
+  queryGenerator: (selectionsString: string[]) => string,
+  titleKey: string,
+  fieldName: string = id.toLowerCase().replace('.', '_'),
+): FilterDefinitionFactory => (state, teamsViewProps) => {
+  const values = state.flex.supervisor.appliedFilters.find(af => af.name === id)?.values ?? [];
+  const selections = Array.isArray(values) ? values : [values];
+  if (selections.length) {
+    filterInputExpressionStrings[id] = queryGenerator(selections);
+  } else {
+    // Assume nothing is selected if no values are set in the state, therefore we don't apply any filtering for this filter
+    delete filterInputExpressionStrings[id];
+  }
+  teamsViewProps.hiddenFilter = Object.values(filterInputExpressionStrings).join(' AND ');
+  return {
+    id,
+    title: Manager.getInstance().strings[titleKey] ?? titleKey,
+    fieldName,
+    type: FiltersListItemType.multiValue,
+    options: skillsOptions ? sortBy(skillsOptions, ['label']) : [],
+    condition: `NOT_IN`,
+  };
+};
+
+const assignedSkillsFilterDefinition: FilterDefinitionFactory = generateFilterDefinitionFactoryForInputExpression(
+  `data.attributes.dummy_assigned_skills`,
+  selections => {
+    const selectionsString = selections.map(s => `\"${s}\"`).join(', ');
+    return `(data.attributes.routing.skills IN [${selectionsString}] OR data.attributes.disabled_skills.skills IN [${selectionsString}])`;
+  },
+  'Assigned Skills',
+);
+
+const unassignedSkillsFilterDefinition: FilterDefinitionFactory = generateFilterDefinitionFactoryForInputExpression(
+  `data.attributes.dummy_unassigned_skills`,
+  selections =>
+    `(${selections
+      .map(
+        selection =>
+          `(data.attributes.routing.skills NOT_IN [\"${selection}\"] AND data.attributes.disabled_skills.skills NOT_IN [\"${selection}\"])`,
+      )
+      .join(' OR ')})`,
+
+  'Unassigned Skills',
+);
 
 /**
  * This function sets up filters for the TeamsView component
@@ -72,7 +136,13 @@ const disabledSkillsFilterDefinition: FilterDefinitionFactory = () => {
  * The skills filter is included if the feature flag is enabled.
  */
 export const setUpTeamsViewFilters = () => {
-  TeamsView.defaultProps.filters = [activityNoOfflineByDefault, skillsFilterDefinition, disabledSkillsFilterDefinition];
+  TeamsView.defaultProps.filters = [
+    activityNoOfflineByDefault,
+    skillsFilterDefinition,
+    disabledSkillsFilterDefinition,
+    assignedSkillsFilterDefinition,
+    unassignedSkillsFilterDefinition,
+  ];
 };
 
 export const setUpWorkerDirectoryFilters = () => {
@@ -81,6 +151,7 @@ export const setUpWorkerDirectoryFilters = () => {
   const activitiesArray = Array.from(managerInstance.store.getState().flex.worker.activities.values());
   const availableActivities = activitiesArray.filter(a => a.available).map(a => a.name);
 
-  const activitiesFilter = `data.activity_name IN ${JSON.stringify(availableActivities)}`;
-  WorkerDirectoryTabs.defaultProps.hiddenWorkerFilter = `(${activitiesFilter})`;
+  WorkerDirectoryTabs.defaultProps.hiddenWorkerFilter = `(data.activity_name IN ${JSON.stringify(
+    availableActivities,
+  )})`;
 };

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -256,10 +256,9 @@ export type FeatureFlags = {
   enable_llm_summary: boolean; // Enables generation of suggested contact summaries via an LLM
   use_prepopulate_mappings: boolean; // Use PrepopulateMappings.json instead of PrepopulateKeys.json
   enable_language_selector: boolean // Enables the language of the UI to be changed by the user via a dropdown menu
-  use_twilio_lambda_for_conference_functions: boolean; // Use PrepopulateMappings.json instead of PrepopulateKeys.json
-  enable_configurable_max_categories: boolean;
+  use_twilio_lambda_for_conference_functions: boolean; // Use the twilio account scoped lambda for conferencing functions
   enable_conference_status_event_handler: boolean; // Enable conference status event handling. This needs to be set up from flex when accepting a task
-  
+  enable_assigned_skill_teams_view_filters: boolean; // Enable the 'Assigned Skill' and 'Unassigned Skill' filters on the teams view
   // TODO remove once this changes are enabled
   enable_resouorces_updates: boolean;
 };


### PR DESCRIPTION
## Description

- Add support for expression based team view filtering 
- Use this to add 'Assigned Skills' & 'Unassigned Skills' Teams View filters
- Make teams view filter headings translatable

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P