### PR TITLE
feat: teamsview - select multiple workers for bulks skill UI

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -117,6 +117,7 @@ const setUpComponents = (featureFlags: FeatureFlags, setupObject: ReturnType<typ
   if (featureFlags.enable_emoji_picker) Components.setupEmojiPicker();
   if (featureFlags.enable_canned_responses) Components.setupCannedResponses();
 
+  TeamsView.setUpSelectAgentColumn();
   TeamsView.setUpAgentColumn();
   TeamsView.setUpStatusColumn();
   TeamsView.setUpSkillsColumn();

--- a/plugin-hrm-form/src/___tests__/states/teamsView/actions.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/teamsView/actions.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import each from 'jest-each';
+
+import * as types from '../../../states/teamsView/types';
+import * as actions from '../../../states/teamsView/actions';
+
+describe('test action creators', () => {
+  each([
+    {
+      workerSids: ['WK-123'],
+      description: 'single worker',
+    },
+    {
+      workerSids: ['WK-123', 'WK-999'],
+      description: 'multiple workers',
+    },
+  ]).test('teamsViewSelectWorkers - $description', async ({ workerSids }) => {
+    expect(actions.teamsViewSelectWorkers(workerSids)).toStrictEqual({
+      type: types.TEAMSVIEW_SELECT_WORKERS,
+      payload: workerSids,
+    });
+  });
+
+  each([
+    {
+      workerSids: ['WK-123'],
+      description: 'single worker',
+    },
+    {
+      workerSids: ['WK-123', 'WK-999'],
+      description: 'multiple workers',
+    },
+  ]).test('teamsViewUnselectWorkers - $description', async ({ workerSids }) => {
+    expect(actions.teamsViewUnselectWorkers(workerSids)).toStrictEqual({
+      type: types.TEAMSVIEW_UNSELECT_WORKERS,
+      payload: workerSids,
+    });
+  });
+});

--- a/plugin-hrm-form/src/___tests__/states/teamsView/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/teamsView/reducer.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import each from 'jest-each';
+
+import * as types from '../../../states/teamsView/types';
+import * as actions from '../../../states/teamsView/actions';
+import { reduce } from '../../../states/teamsView/reducer';
+
+describe('test reducer', () => {
+  test('empty state with unrelated action - should return initial state', async () => {
+    const state = undefined;
+    const expected = {
+      selectedWorkers: new Set(),
+    };
+
+    const result = reduce(state, {} as any);
+    expect(result).toStrictEqual(expected);
+  });
+
+  test('existing state with unrelated action - should return same state', async () => {
+    const state = {
+      selectedWorkers: new Set(['WK-123']),
+    };
+    const expected = state;
+
+    const result = reduce(state, {} as any);
+    expect(result).toStrictEqual(expected);
+  });
+
+  each([
+    {
+      state: {
+        selectedWorkers: new Set(),
+      },
+      workersSids: ['WK-123'],
+      expected: {
+        selectedWorkers: new Set(['WK-123']),
+      },
+      description: 'add single worker to blank state',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      workersSids: ['WK-123'],
+      expected: {
+        selectedWorkers: new Set(['WK-xxx', 'WK-123']),
+      },
+      description: 'add single worker to existing state merges them',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      workersSids: ['WK-xxx'],
+      expected: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      description: 'add single worker already selected does nothing',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(),
+      },
+      workersSids: ['WK-123', 'WK-999'],
+      expected: {
+        selectedWorkers: new Set(['WK-123', 'WK-999']),
+      },
+      description: 'add multiple workers to blank state',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      workersSids: ['WK-123', 'WK-999'],
+      expected: {
+        selectedWorkers: new Set(['WK-xxx', 'WK-123', 'WK-999']),
+      },
+      description: 'add multiple workers to existing state merges them',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx', 'WK-yyy']),
+      },
+      workersSids: ['WK-xxx', 'WK-yyy'],
+      expected: {
+        selectedWorkers: new Set(['WK-xxx', 'WK-yyy']),
+      },
+      description: 'add multiple workers already selected does nothing',
+    },
+  ]).test('TEAMSVIEW_SELECT_WORKERS - $description', async ({ state, workersSids, expected }) => {
+    const result = reduce(state, actions.teamsViewSelectWorkers(workersSids));
+    expect(result).toStrictEqual(expected);
+  });
+
+  each([
+    {
+      state: {
+        selectedWorkers: new Set(),
+      },
+      workersSids: ['WK-123'],
+      expected: {
+        selectedWorkers: new Set(),
+      },
+      description: 'remove single worker to blank state does nothing',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      workersSids: ['WK-123'],
+      expected: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      description: 'remove missing worker to existing state does nothing',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      workersSids: ['WK-xxx'],
+      expected: {
+        selectedWorkers: new Set(),
+      },
+      description: 'remove selected worker to existing state results in blank state',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(),
+      },
+      workersSids: ['WK-123', 'WK-999'],
+      expected: {
+        selectedWorkers: new Set(),
+      },
+      description: 'remove multiple workers to blank state does nothing',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      workersSids: ['WK-123', 'WK-999'],
+      expected: {
+        selectedWorkers: new Set(['WK-xxx']),
+      },
+      description: 'remove multiple missing workers to existing state does nothing',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx', 'WK-yyy']),
+      },
+      workersSids: ['WK-xxx', 'WK-yyy'],
+      expected: {
+        selectedWorkers: new Set(),
+      },
+      description: 'remove all selected workers to existing state results in blank state',
+    },
+    {
+      state: {
+        selectedWorkers: new Set(['WK-xxx', 'WK-yyy', 'WK-zzz']),
+      },
+      workersSids: ['WK-xxx', 'WK-zzz'],
+      expected: {
+        selectedWorkers: new Set(['WK-yyy']),
+      },
+      description: 'remove multiple selected workers to existing state results in partial state',
+    },
+  ]).test('TEAMSVIEW_UNSELECT_WORKERS - $description', async ({ state, workersSids, expected }) => {
+    const result = reduce(state, actions.teamsViewUnselectWorkers(workersSids));
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -26,8 +26,6 @@ import SearchIcon from '@material-ui/icons/Search';
 
 import {
   Box,
-  FormCheckbox,
-  FormCheckBoxWrapper,
   FormDateInput,
   FormError,
   FormFieldset,
@@ -47,7 +45,8 @@ import {
 } from '../../../styles';
 import type { HTMLElementRef } from './types';
 import UploadFileInput from './UploadFileInput';
-import { getTemplateStrings } from '../../../hrmConfig';
+import { StyledFormCheckbox } from '../../forms/components/FormCheckbox/styles';
+import { FormCheckBoxWrapper } from '../../forms/components/styles';
 
 const ConnectForm: React.FC<{
   children: <P extends ReturnType<typeof useFormContext>>(args: P) => JSX.Element;
@@ -396,7 +395,7 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
                       <FormListboxMultiselectOption role="option">
                         <FormListboxMultiselectOptionLabel htmlFor={`${path}-${value}`}>
                           <Box marginRight="5px">
-                            <FormCheckbox
+                            <StyledFormCheckbox
                               id={`${path}-${value}`}
                               data-testid={`listbox-multiselect-option-${path}-${value}`}
                               name={path}
@@ -431,48 +430,6 @@ export const getInputType = (parents: string[], updateCallback: () => void, cust
                   </FormError>
                 )}
               </FormListboxMultiselect>
-            );
-          }}
-        </ConnectForm>
-      );
-    case FormInputType.CopyTo:
-    case FormInputType.Checkbox:
-      return (
-        <ConnectForm key={path}>
-          {({ errors, register }) => {
-            const error = get(errors, path);
-            return (
-              <FormLabel htmlFor={path}>
-                <FormCheckBoxWrapper error={Boolean(error)}>
-                  <Box marginRight="5px">
-                    <FormCheckbox
-                      id={path}
-                      data-testid={path}
-                      name={path}
-                      type="checkbox"
-                      aria-invalid={Boolean(error)}
-                      aria-describedby={`${path}-error`}
-                      onChange={updateCallback}
-                      ref={ref => {
-                        if (htmlElRef) {
-                          htmlElRef.current = ref;
-                        }
-
-                        register(rules)(ref);
-                      }}
-                      defaultChecked={initialValue}
-                      disabled={!isEnabled}
-                    />
-                  </Box>
-                  {labelTextComponent}
-                  {rules.required && path !== 'ageVerified' && <RequiredAsterisk />}
-                </FormCheckBoxWrapper>
-                {error && (
-                  <FormError>
-                    <Template id={`${path}-error`} code={error.message} />
-                  </FormError>
-                )}
-              </FormLabel>
             );
           }}
         </ConnectForm>

--- a/plugin-hrm-form/src/components/forms/components/FormCheckbox/FormCheckbox.tsx
+++ b/plugin-hrm-form/src/components/forms/components/FormCheckbox/FormCheckbox.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import { Template } from '@twilio/flex-ui';
+import { get } from 'lodash';
+import { useFormContext } from 'react-hook-form';
+
+import { Box } from '../../../../styles';
+import { FormCheckBoxWrapper, FormError, FormLabel, RequiredAsterisk } from '../styles';
+import { FormInputBaseProps } from '../types';
+import { StyledFormCheckbox } from './styles';
+
+type FormCheckboxUIProps = {
+  inputId: string;
+  updateCallback: () => void;
+  refFunction: (ref: any) => void;
+  defaultValue: boolean;
+  labelTextComponent: JSX.Element;
+  required: boolean;
+  disabled: boolean;
+  isErrorState: boolean;
+  errorId: string;
+  errorTextComponent: JSX.Element;
+};
+
+const FormCheckboxUI: React.FC<FormCheckboxUIProps> = ({
+  inputId,
+  updateCallback,
+  refFunction,
+  defaultValue,
+  labelTextComponent,
+  required,
+  disabled,
+  isErrorState,
+  errorId,
+  errorTextComponent,
+}) => {
+  return (
+    <FormLabel htmlFor={inputId} data-testid={`FormCheckbox-${inputId}`}>
+      <FormCheckBoxWrapper error={isErrorState}>
+        <Box marginRight="5px">
+          <StyledFormCheckbox
+            id={inputId}
+            data-testid={inputId}
+            name={inputId}
+            type="checkbox"
+            aria-invalid={isErrorState}
+            aria-required={required}
+            aria-errormessage={isErrorState ? errorId : undefined}
+            onChange={updateCallback}
+            ref={refFunction}
+            defaultChecked={defaultValue}
+            disabled={disabled}
+          />
+        </Box>
+        {labelTextComponent}
+        {required && <RequiredAsterisk />}
+      </FormCheckBoxWrapper>
+      {isErrorState && <FormError>{errorTextComponent}</FormError>}
+    </FormLabel>
+  );
+};
+
+type Props = FormInputBaseProps;
+
+const FormCheckbox: React.FC<Props> = ({
+  inputId,
+  label,
+  initialValue,
+  registerOptions,
+  updateCallback,
+  htmlElRef,
+  isEnabled,
+}) => {
+  // TODO factor out into a custom hook to make easier sharing this chunk of code
+  const { errors, register } = useFormContext();
+  const error = get(errors, inputId);
+  const labelTextComponent = React.useMemo(() => <Template code={`${label}`} className=".fullstory-unmask" />, [label]);
+  const errorId = `${inputId}-error`;
+  const errorTextComponent = React.useMemo(() => (error ? <Template id={errorId} code={error.message} /> : null), [
+    error,
+    errorId,
+  ]);
+  const refFunction = React.useCallback(
+    ref => {
+      if (htmlElRef && ref) {
+        htmlElRef.current = ref;
+      }
+
+      register(registerOptions)(ref);
+    },
+    [htmlElRef, register, registerOptions],
+  );
+  // ====== //
+
+  const defaultValue = Boolean(initialValue);
+  const disabled = !isEnabled;
+
+  return (
+    <FormCheckboxUI
+      inputId={inputId}
+      updateCallback={updateCallback}
+      refFunction={refFunction}
+      defaultValue={defaultValue}
+      labelTextComponent={labelTextComponent}
+      required={Boolean(registerOptions.required)}
+      disabled={disabled}
+      isErrorState={Boolean(error)}
+      errorId={errorId}
+      errorTextComponent={errorTextComponent}
+    />
+  );
+};
+
+export default FormCheckbox;

--- a/plugin-hrm-form/src/components/forms/components/FormCheckbox/styles.tsx
+++ b/plugin-hrm-form/src/components/forms/components/FormCheckbox/styles.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { styled } from '@twilio/flex-ui';
+
+import { CheckboxBase } from '../styles';
+
+export const StyledFormCheckbox = styled(CheckboxBase)`
+  &[type='checkbox']:checked::before {
+    border-color: #1976d2;
+    background: #1976d2;
+  }
+  &[type='checkbox']:checked::after {
+    font-family: 'Font Awesome 5 Free';
+    content: '\\f00c';
+    color: #ffffff;
+    font-weight: 900;
+  }
+
+  &[type='checkbox']:focus:not(:focus-visible) {
+    outline: auto;
+  }
+`;
+StyledFormCheckbox.displayName = 'FormCheckbox';

--- a/plugin-hrm-form/src/components/forms/components/styles.tsx
+++ b/plugin-hrm-form/src/components/forms/components/styles.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import HrmTheme from '../../../styles/HrmTheme';
+import { Row } from '../../../styles';
 
 export const FormLabel = styled('label')`
   display: flex;
@@ -72,3 +73,45 @@ export const FormInputBase = styled('input')<FormInputBaseProps>`
   }
 `;
 FormInputBase.displayName = 'FormInputBase';
+
+export type FormInputProps = { error?: boolean; width?: number | string; fullWidth?: boolean };
+
+export const FormCheckBoxWrapper = styled(Row)<FormInputProps>`
+  align-items: flex-start;
+  box-sizing: border-box; /* Tells the browser to account for any border and padding in the values you specify for an element's width and height. https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing*/
+  height: 36px;
+  border-radius: 4px;
+  border: ${props => (props.error ? '1px solid #CB3232' : 'none')};
+  box-shadow: ${props => (props.error ? '0px 0px 0px 2px rgba(234,16,16,0.2)' : 'none')};
+`;
+FormCheckBoxWrapper.displayName = 'FormCheckBoxWrapper';
+
+export const CheckboxBase = styled.input<FormInputProps>`
+  &[type='checkbox'] {
+    display: inline-block;
+    position: relative;
+    padding-left: 1.4em;
+    cursor: default;
+    margin-right: 5px;
+  }
+  &[type='checkbox']::before,
+  &[type='checkbox']::after {
+    position: absolute;
+    top: 50%;
+    left: 7px;
+    transform: translate(-50%, -50%);
+    content: '';
+    font-weight: 900;
+  }
+  &[type='checkbox']::before {
+    width: 13px;
+    height: 13px;
+    border: 1px solid hsl(0, 0%, 66%);
+    border-radius: 0.2em;
+    background-image: linear-gradient(to bottom, hsl(300, 3%, 93%), #fff 30%);
+  }
+  &[type='checkbox']:active::before {
+    background-image: linear-gradient(to bottom, hsl(300, 3%, 73%), hsl(300, 3%, 93%) 30%);
+  }
+`;
+CheckboxBase.displayName = 'CheckboxBase';

--- a/plugin-hrm-form/src/components/forms/inputGenerator.tsx
+++ b/plugin-hrm-form/src/components/forms/inputGenerator.tsx
@@ -27,6 +27,7 @@ import FormTextArea from './components/FormTextArea/FormTextArea';
 import { TaskSID } from '../../types/twilio';
 import FormSelect from './components/FormSelect/FormSelect';
 import DependentFormSelect from './components/FormSelect/DependentFormSelect';
+import FormCheckbox from './components/FormCheckbox/FormCheckbox';
 
 const getRegisterOptions = (formItemDefinition: FormItemDefinition): RegisterOptions =>
   pick(formItemDefinition, ['max', 'maxLength', 'min', 'minLength', 'pattern', 'required', 'validate']);
@@ -122,6 +123,21 @@ export const createInput = ({
           dependsOn={formItemDefinition.dependsOn}
           dependentOptions={formItemDefinition.options}
           defaultOption={formItemDefinition.defaultOption}
+        />
+      );
+    }
+    case FormInputType.CopyTo:
+    case FormInputType.Checkbox: {
+      return (
+        <FormCheckbox
+          key={inputId}
+          inputId={inputId}
+          initialValue={initialValue}
+          updateCallback={updateCallback}
+          label={formItemDefinition.label}
+          registerOptions={registerOptions}
+          isEnabled={isEnabled}
+          htmlElRef={htmlElRef}
         />
       );
     }

--- a/plugin-hrm-form/src/components/search/SearchForm/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.tsx
@@ -23,16 +23,7 @@ import { Template } from '@twilio/flex-ui';
 import FieldText from '../../FieldText';
 import FieldSelect from '../../FieldSelect';
 import FieldDate from '../../FieldDate';
-import {
-  Bold,
-  BottomButtonBar,
-  Box,
-  Container,
-  FormCheckbox,
-  FormCheckBoxWrapper,
-  FormLabel,
-  Row,
-} from '../../../styles';
+import { Bold, BottomButtonBar, Box, Container, FormLabel, Row } from '../../../styles';
 import { PrimaryButton } from '../../../styles/buttons';
 import { getContactValueTemplate, getFormattedNumberFromTask, getNumberFromTask } from '../../../utils/task';
 import {
@@ -50,6 +41,8 @@ import { selectCounselorsList } from '../../../states/configuration/selectCounse
 import { selectCurrentDefinitionVersion } from '../../../states/configuration/selectDefinitions';
 import { CustomITask } from '../../../types/types';
 import selectContextContactId from '../../../states/contacts/selectContextContactId';
+import { FormCheckBoxWrapper } from '../../forms/components/styles';
+import { StyledFormCheckbox } from '../../forms/components/FormCheckbox/styles';
 
 const getField = value => ({
   value,
@@ -239,7 +232,7 @@ const SearchForm: React.FC<Props> = ({
               <FormLabel htmlFor="Search_PreviousContacts">
                 <FormCheckBoxWrapper data-testid="Search-PreviousContactsCheckbox">
                   <Box marginRight="5px">
-                    <FormCheckbox
+                    <StyledFormCheckbox
                       id="Search_PreviousContacts"
                       type="checkbox"
                       defaultChecked={Boolean(contactNumber)}

--- a/plugin-hrm-form/src/components/teamsView/SelectAgentColumn.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SelectAgentColumn.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import { WorkersDataTable, ColumnDefinition } from '@twilio/flex-ui';
+
+import { StyledFormCheckbox } from '../forms/components/FormCheckbox/styles';
+
+const SelectAllCheckbox: React.FC = () => {
+  return (
+    <StyledFormCheckbox
+      type="checkbox"
+      defaultChecked={false}
+      disabled={false}
+      required={false}
+      onChange={e => {
+        console.log('>>>>>>>>>> SELECT ALL CLICKED');
+      }}
+      onClick={e => {
+        e.stopPropagation();
+      }}
+    />
+  );
+};
+
+const SelectWorkerCheckbox: React.FC<{ item: { worker: { sid: string; fullName: string } } }> = ({
+  children,
+  ...props
+}) => {
+  const { worker } = props.item;
+
+  return (
+    <StyledFormCheckbox
+      type="checkbox"
+      defaultChecked={false}
+      disabled={false}
+      required={false}
+      onChange={e => {
+        console.log('>>>>>>>>>>', props, worker);
+      }}
+      onClick={e => {
+        e.stopPropagation();
+      }}
+    />
+  );
+};
+
+// eslint-disable-next-line import/no-unused-modules
+export const setUpSelectAgentColumn = () => {
+  WorkersDataTable.Content.add(
+    <ColumnDefinition
+      key="select-worker"
+      header={<SelectAllCheckbox />}
+      // sortingFn={sortSkills}
+      style={{ width: '30px', padding: '0px' }}
+      content={(item: any) => <SelectWorkerCheckbox item={item} />}
+    />,
+    { sortOrder: 0 },
+  );
+};

--- a/plugin-hrm-form/src/components/teamsView/SelectAgentColumn.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SelectAgentColumn.tsx
@@ -15,20 +15,32 @@
  */
 
 import React from 'react';
-import { WorkersDataTable, ColumnDefinition } from '@twilio/flex-ui';
+import { WorkersDataTable, ColumnDefinition, useFlexSelector } from '@twilio/flex-ui';
+import { useDispatch, useSelector } from 'react-redux';
+import type { SupervisorState } from '@twilio/flex-ui/src/state/Supervisor/SupervisorState';
 
+import { namespace, teamsviewBase } from '../../states/storeNamespaces';
+import { teamsViewSelectWorkers, teamsViewUnselectWorkers } from '../../states/teamsView/actions';
 import { StyledFormCheckbox } from '../forms/components/FormCheckbox/styles';
+import { RootState } from '../../states';
 
-const SelectAllCheckbox: React.FC = () => {
+const SelectAllCheckbox: React.FC<{}> = () => {
+  const dispatch = useDispatch();
+  const { selectedWorkers } = useSelector((state: RootState) => state[namespace][teamsviewBase]);
+  const { workers } =
+    useFlexSelector((state: RootState) => state.flex.supervisor) || ({ workers: [] } as SupervisorState);
+
+  const workersSids = workers.map(w => w.worker.sid);
+  const allChecked = workersSids.length && workersSids.every(w => selectedWorkers?.has(w));
+
+  const toggleAllWorkers = () =>
+    allChecked ? dispatch(teamsViewUnselectWorkers(workersSids)) : dispatch(teamsViewSelectWorkers(workersSids));
+
   return (
     <StyledFormCheckbox
       type="checkbox"
-      defaultChecked={false}
-      disabled={false}
-      required={false}
-      onChange={e => {
-        console.log('>>>>>>>>>> SELECT ALL CLICKED');
-      }}
+      checked={allChecked}
+      onChange={toggleAllWorkers}
       onClick={e => {
         e.stopPropagation();
       }}
@@ -36,21 +48,21 @@ const SelectAllCheckbox: React.FC = () => {
   );
 };
 
-const SelectWorkerCheckbox: React.FC<{ item: { worker: { sid: string; fullName: string } } }> = ({
-  children,
-  ...props
-}) => {
-  const { worker } = props.item;
+const SelectWorkerCheckbox: React.FC<{
+  item: { worker: { sid: string; fullName: string } };
+}> = ({ item }) => {
+  const dispatch = useDispatch();
+  const { selectedWorkers } = useSelector((state: RootState) => state[namespace][teamsviewBase]);
+  const { worker } = item;
+  const isSelected = selectedWorkers?.has(worker.sid);
+  const toggleSingleWorker = () =>
+    isSelected ? dispatch(teamsViewUnselectWorkers([worker.sid])) : dispatch(teamsViewSelectWorkers([worker.sid]));
 
   return (
     <StyledFormCheckbox
       type="checkbox"
-      defaultChecked={false}
-      disabled={false}
-      required={false}
-      onChange={e => {
-        console.log('>>>>>>>>>>', props, worker);
-      }}
+      checked={isSelected}
+      onChange={toggleSingleWorker}
       onClick={e => {
         e.stopPropagation();
       }}
@@ -58,13 +70,11 @@ const SelectWorkerCheckbox: React.FC<{ item: { worker: { sid: string; fullName: 
   );
 };
 
-// eslint-disable-next-line import/no-unused-modules
 export const setUpSelectAgentColumn = () => {
   WorkersDataTable.Content.add(
     <ColumnDefinition
       key="select-worker"
       header={<SelectAllCheckbox />}
-      // sortingFn={sortSkills}
       style={{ width: '30px', padding: '0px' }}
       content={(item: any) => <SelectWorkerCheckbox item={item} />}
     />,

--- a/plugin-hrm-form/src/components/teamsView/index.ts
+++ b/plugin-hrm-form/src/components/teamsView/index.ts
@@ -13,6 +13,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
+import { setUpSelectAgentColumn } from './SelectAgentColumn';
 import { setUpAgentColumn } from './AgentColumn';
 import { setUpSkillsColumn } from './SkillsColumn';
 import { setUpStatusColumn } from './StatusColumn';
@@ -20,6 +21,7 @@ import { setUpTeamsViewSorting } from './teamsViewSorting';
 import { setUpTeamsViewFilters, setUpWorkerDirectoryFilters } from './teamsViewFilters';
 
 const TeamsView = {
+  setUpSelectAgentColumn,
   setUpAgentColumn,
   setUpStatusColumn,
   setUpSkillsColumn,

--- a/plugin-hrm-form/src/states/index.ts
+++ b/plugin-hrm-form/src/states/index.ts
@@ -30,6 +30,7 @@ import { reduce as ReferrableResourcesReducer } from './resources';
 import { reduce as ConferencingReducer } from './conferencing';
 import { reduce as ProfileReducer } from './profile/reducer';
 import { reduce as SwitchboardReducer } from './switchboard/reducer';
+import { reduce as TeamsViewReducer } from './teamsView/reducer';
 import { CaseState } from './case/types';
 import { ContactsState } from './contacts/types';
 import {
@@ -46,6 +47,7 @@ import {
   referrableResourcesBase,
   routingBase,
   switchboardBase,
+  teamsviewBase,
 } from './storeNamespaces';
 import { reduce as CaseMergingBannersReducer } from './case/caseBanners';
 import { customIntegrationsReducer } from './customIntegrations';
@@ -63,6 +65,7 @@ const reducers = {
   [caseMergingBannersBase]: CaseMergingBannersReducer,
   [profileBase]: ProfileReducer,
   [switchboardBase]: SwitchboardReducer,
+  [teamsviewBase]: TeamsViewReducer,
 
   /*
    * [csamClcReportBase]: CSAMCLCReportReducer,

--- a/plugin-hrm-form/src/states/storeNamespaces.ts
+++ b/plugin-hrm-form/src/states/storeNamespaces.ts
@@ -29,3 +29,4 @@ export const conferencingBase = 'conferencing';
 export const caseMergingBannersBase = 'caseMergingBanners';
 export const profileBase = 'profile';
 export const switchboardBase = 'switchboard';
+export const teamsviewBase = 'teamsview';

--- a/plugin-hrm-form/src/states/teamsView/actions.ts
+++ b/plugin-hrm-form/src/states/teamsView/actions.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  TEAMSVIEW_SELECT_WORKERS,
+  TEAMSVIEW_UNSELECT_WORKERS,
+  TeamsViewSelectWorkersAction,
+  TeamsViewUnselectWorkersAction,
+} from './types';
+
+export const teamsViewSelectWorkers = (workers: string[]): TeamsViewSelectWorkersAction => ({
+  type: TEAMSVIEW_SELECT_WORKERS,
+  payload: workers,
+});
+
+export const teamsViewUnselectWorkers = (workers: string[]): TeamsViewUnselectWorkersAction => ({
+  type: TEAMSVIEW_UNSELECT_WORKERS,
+  payload: workers,
+});

--- a/plugin-hrm-form/src/states/teamsView/reducer.ts
+++ b/plugin-hrm-form/src/states/teamsView/reducer.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  TeamsViewState,
+  TeamsViewActionTypes,
+  TEAMSVIEW_SELECT_WORKERS,
+  TEAMSVIEW_UNSELECT_WORKERS,
+  initialState,
+} from './types';
+
+export const reduce = (state = initialState, action: TeamsViewActionTypes): TeamsViewState => {
+  switch (action.type) {
+    case TEAMSVIEW_SELECT_WORKERS: {
+      const selectedWorkers = new Set([...Array.from(state.selectedWorkers), ...action.payload]);
+      return {
+        ...state,
+        selectedWorkers,
+      };
+    }
+    case TEAMSVIEW_UNSELECT_WORKERS: {
+      const removeSet = new Set(action.payload);
+      const selectedWorkers = new Set(Array.from(state.selectedWorkers).filter(w => !removeSet.has(w)));
+      return {
+        ...state,
+        selectedWorkers,
+      };
+    }
+    default:
+      return state;
+  }
+};

--- a/plugin-hrm-form/src/states/teamsView/types.ts
+++ b/plugin-hrm-form/src/states/teamsView/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export type TeamsViewState = {
+  selectedWorkers: Set<string>;
+};
+
+export const initialState: TeamsViewState = {
+  selectedWorkers: new Set(),
+};
+
+// Action types
+export const TEAMSVIEW_SELECT_WORKERS = 'TEAMSVIEW_SELECT_WORKERS';
+export const TEAMSVIEW_UNSELECT_WORKERS = 'TEAMSVIEW_UNSELECT_WORKERS';
+
+export type TeamsViewSelectWorkersAction = {
+  type: typeof TEAMSVIEW_SELECT_WORKERS;
+  payload: string[];
+};
+
+export type TeamsViewUnselectWorkersAction = {
+  type: typeof TEAMSVIEW_UNSELECT_WORKERS;
+  payload: string[];
+};
+
+export type TeamsViewActionTypes = TeamsViewSelectWorkersAction | TeamsViewUnselectWorkersAction;

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -16,11 +16,12 @@
 
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { Input, MenuItem, MenuList, Select } from '@material-ui/core';
+import { Input, MenuItem, Select } from '@material-ui/core';
 import { styled } from '@twilio/flex-ui';
 
-import { Row, Flex } from './layout';
+import { Flex } from './layout';
 import HrmTheme from './HrmTheme';
+import { CheckboxBase, FormInputProps } from '../components/forms/components/styles';
 
 const StyledInput = styled(Input)`
   display: flex;
@@ -224,8 +225,6 @@ export const FormError = styled('span')`
 `;
 FormError.displayName = 'FormError';
 
-type FormInputProps = { error?: boolean; width?: number | string; fullWidth?: boolean };
-
 export const FormInput = styled('input')<FormInputProps>`
   /* ---------- Input ---------- */
   & {
@@ -361,64 +360,6 @@ export const FormTextArea = styled('textarea')<FormInputProps>`
     border: 1px solid rgba(0, 59, 129, 0.37);
   }
 `;
-
-export const FormCheckBoxWrapper = styled(Row)<FormInputProps>`
-  align-items: flex-start;
-  box-sizing: border-box; /* Tells the browser to account for any border and padding in the values you specify for an element's width and height. https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing*/
-  height: 36px;
-  border-radius: 4px;
-  border: ${props => (props.error ? '1px solid #CB3232' : 'none')};
-  box-shadow: ${props => (props.error ? '0px 0px 0px 2px rgba(234,16,16,0.2)' : 'none')};
-`;
-FormCheckBoxWrapper.displayName = 'FormCheckBoxWrapper';
-
-const CheckboxBase = styled.input<FormInputProps>`
-  &[type='checkbox'] {
-    display: inline-block;
-    position: relative;
-    padding-left: 1.4em;
-    cursor: default;
-    margin-right: 5px;
-  }
-  &[type='checkbox']::before,
-  &[type='checkbox']::after {
-    position: absolute;
-    top: 50%;
-    left: 7px;
-    transform: translate(-50%, -50%);
-    content: '';
-    font-weight: 900;
-  }
-  &[type='checkbox']::before {
-    width: 13px;
-    height: 13px;
-    border: 1px solid hsl(0, 0%, 66%);
-    border-radius: 0.2em;
-    background-image: linear-gradient(to bottom, hsl(300, 3%, 93%), #fff 30%);
-  }
-  &[type='checkbox']:active::before {
-    background-image: linear-gradient(to bottom, hsl(300, 3%, 73%), hsl(300, 3%, 93%) 30%);
-  }
-`;
-CheckboxBase.displayName = 'CheckboxBase';
-
-export const FormCheckbox = styled(CheckboxBase)`
-  &[type='checkbox']:checked::before {
-    border-color: #1976d2;
-    background: #1976d2;
-  }
-  &[type='checkbox']:checked::after {
-    font-family: 'Font Awesome 5 Free';
-    content: '\\f00c';
-    color: #ffffff;
-    font-weight: 900;
-  }
-
-  &[type='checkbox']:focus:not(:focus-visible) {
-    outline: auto;
-  }
-`;
-FormCheckbox.displayName = 'FormCheckbox';
 
 export const FormMixedCheckbox = styled(CheckboxBase)`
   &[class~='mixed-checkbox'][type='checkbox'][aria-checked='false']::before {


### PR DESCRIPTION
## Description
This PR
- Refactors form generators, moving `checkbox` input type to the newer input generator format.
- Adds `teamsView` reducer to keep track of selected workers in Redux state.
- Adds UI to TeamsView page to allow a supervisor select workers, according to the requirements in the linked ticket below.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3400)
- [x] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P