### PR TITLE
fix: usch - Resource DB Description field should be appear instead of shortDescription [CHI-3502]

### DIFF
--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceViewAttributes.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceViewAttributes.tsx
@@ -50,11 +50,7 @@ const ResourceAttributes: React.FC<{ resource: ReferrableResource }> = ({ resour
           <ResourceAttributesColumn style={{ flexGrow: 3, paddingLeft: 0, marginLeft: '1px' }}>
             {[
               {
-                subtitle: 'Short Description',
-                attributeToDisplay: resourceAttributes.shortDescription,
-              },
-              {
-                subtitle: 'Details',
+                subtitle: 'Description',
                 attributeToDisplay: resourceAttributes.description,
               },
               {

--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/convertUSCHResourceAttributes.ts
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/convertUSCHResourceAttributes.ts
@@ -52,11 +52,6 @@ const extractCoverage = (coverage: Attributes): string => {
     .join('\n');
 };
 
-const extractDescriptionInfo = (description, language: Language) => {
-  const descriptionByLanguage = description?.find(item => item.language === language || item.language === '');
-  return descriptionByLanguage && descriptionByLanguage.info ? descriptionByLanguage.info.text : null;
-};
-
 const extractPhoneNumbers = (attributes: Attributes, language: Language) => {
   return Object.entries(attributes.phone || {})
     .map(([type, p]) => {
@@ -99,6 +94,7 @@ export const convertUSCHResourceAttributes = (
   const hoursOfOperation = getAttributeValue(attributes, language, 'hoursOfOperation');
   const hoursFormatted = getAttributeValue(attributes, language, 'hoursFormatted');
   const phoneFax = getAttributeValue(attributes, language, 'phoneFax');
+  const description = getAttributeValue(attributes, language, 'description');
   const shortDescription = getAttributeValue(attributes, language, 'shortDescription');
   const emailAddress = getAttributeValue(attributes, language, 'emailAddress');
   const websiteAddress = getAttributeValue(attributes, language, 'websiteAddress');
@@ -109,7 +105,7 @@ export const convertUSCHResourceAttributes = (
     categories,
     comment,
     coverage: extractCoverage(coverage),
-    description: extractDescriptionInfo(attributes.description, language),
+    description,
     emailAddress,
     feeStructure,
     hoursFormatted,


### PR DESCRIPTION
## Description
This PR
- Fixes a bug where resources' description attribute was not displaying. The reason is that we were looking in the wrong place - description is stored in attribute's value, not within "info" object.
- Removes short description attribute as indicated in the ticket.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3502)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
- `npm run dev` to start development server.
- Navigate to resources page.
- Perform a resources search, and open some of them.
- Confirm the description field is appropriately populated and displayed.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P