### PR TITLE
CHI-3544: Fix feature flag logic in new task pane buttons

### DIFF
--- a/plugin-hrm-form/src/utils/setUpComponents.tsx
+++ b/plugin-hrm-form/src/utils/setUpComponents.tsx
@@ -192,12 +192,10 @@ export const setUpAddButtons = (featureFlags: FeatureFlags) => {
   // setup for offline contact tasks
   setUpOfflineContact();
 
-  // add UI
-  if (featureFlags.enable_manual_pulling)
-    Flex.TaskList.Content.add(addButtonsUI(featureFlags), {
-      sortOrder: Infinity,
-      align: 'start',
-    });
+  Flex.TaskList.Content.add(addButtonsUI(featureFlags), {
+    sortOrder: Infinity,
+    align: 'start',
+  });
 
   // replace UI for task information
   Flex.TaskCanvas.Content.replace(<TaskCanvasOverride key="TaskCanvas-empty" />, {


### PR DESCRIPTION
## Description

Fixed issue where some previously UI was gated to appear if manual pulling OR offline contacts were enabled. It was changed to be just enabled when manual pulling was enabled, whereas really the gate should just be removed, because offline contacts are now always 'on''

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [x] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Ensure that the bug in the ticket is fixed when helplines have manual pulling configured on or off

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P