### PR TITLE
refactor: move conversationJoined subscriptions - afterAcceptTask > beforeAcceptTask [CHI-3543]

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.tsx
+++ b/plugin-hrm-form/src/HrmFormPlugin.tsx
@@ -155,6 +155,7 @@ const setUpActions = (
   // bind setupObject to the functions that requires some initialization
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject, getMessage);
 
+  Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.beforeAcceptTask(setupObject, getMessage));
   Flex.Actions.addListener('afterAcceptTask', ActionFunctions.afterAcceptTask(featureFlags, setupObject, getMessage));
 
   setUpTransferActions(setupObject);

--- a/plugin-hrm-form/src/utils/setUpActions.ts
+++ b/plugin-hrm-form/src/utils/setUpActions.ts
@@ -140,6 +140,21 @@ const sendWelcomeMessageOnConversationJoined = (
   manager.conversationsClient.once('conversationJoined', (c: Conversation) => trySendWelcomeMessage(c, 0, 0));
 };
 
+export const beforeAcceptTask = (setupObject: SetupObject, getMessage: GetMessage) => async (
+  payload: ActionPayload,
+) => {
+  const { task } = payload;
+
+  if (TaskHelper.isChatBasedTask(task)) {
+    subscribeAlertOnConversationJoined(task);
+  }
+
+  // If this is the first counsellor that gets the task, say hi
+  if (TaskHelper.isChatBasedTask(task) && !TransferHelpers.hasTransferStarted(task)) {
+    sendWelcomeMessageOnConversationJoined(setupObject, getMessage, payload);
+  }
+};
+
 export const afterAcceptTask = (featureFlags: FeatureFlags, setupObject: SetupObject, getMessage: GetMessage) => async (
   payload: ActionPayload,
 ) => {
@@ -158,14 +173,6 @@ export const afterAcceptTask = (featureFlags: FeatureFlags, setupObject: SetupOb
       }
     }
   });
-  if (TaskHelper.isChatBasedTask(task)) {
-    subscribeAlertOnConversationJoined(task);
-  }
-
-  // If this is the first counsellor that gets the task, say hi
-  if (TaskHelper.isChatBasedTask(task) && !TransferHelpers.hasTransferStarted(task)) {
-    sendWelcomeMessageOnConversationJoined(setupObject, getMessage, payload);
-  }
 
   if (TransferHelpers.hasTransferStarted(task)) {
     await handleTransferredTask(task);


### PR DESCRIPTION
## Description
This PR is a cherry pick of the latest commit of https://github.com/techmatters/flex-plugins/pull/3644, which fixes the bug reported by USCH (https://tech-matters.atlassian.net/browse/CHI-3543).

The fix consist of moving the `conversationJoined` event subscriptions to be done during `beforeAcceptTask` event, rather than `afterAcceptTask`, to avoid a race condition on events ordering.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3543)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P