### PR TITLE
chore: change bulk skills action button to skills column

### DIFF
--- a/plugin-hrm-form/src/components/teamsView/SelectAgentColumn.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SelectAgentColumn.tsx
@@ -15,123 +15,23 @@
  */
 
 import React from 'react';
-import { createPortal } from 'react-dom';
-import { WorkersDataTable, ColumnDefinition, useFlexSelector, Template, styled } from '@twilio/flex-ui';
+import { WorkersDataTable, ColumnDefinition, useFlexSelector } from '@twilio/flex-ui';
 import { useDispatch, useSelector } from 'react-redux';
 import type { SupervisorState } from '@twilio/flex-ui/src/state/Supervisor/SupervisorState';
-import { ArrowDropDown, ArrowDropUp, KeyboardArrowRight } from '@material-ui/icons';
 
 import { getAseloFeatureFlags } from '../../hrmConfig';
+import type { RootState } from '../../states';
 import { namespace, teamsViewBase } from '../../states/storeNamespaces';
-import {
-  newTeamsViewSelectOperation,
-  newTeamsViewSelectWorkers,
-  TeamsViewState,
-  newTeamsViewUnselectWorkers,
-} from '../../states/teamsView';
-import { newOpenModalAction } from '../../states/routing/actions';
+import { newTeamsViewSelectWorkers, newTeamsViewUnselectWorkers } from '../../states/teamsView';
 import { StyledFormCheckbox } from '../forms/components/FormCheckbox/styles';
-import { RootState } from '../../states';
-import { Column, Flex, Row } from '../../styles';
-import { MultiSelectButton } from '../../styles/filters';
 import { UpdateWorkersSkillsModal } from './UpdateWorkersSkillsModal';
 import { standaloneTask } from '../../types/types';
-
-const StyledButton = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 8px 12px;
-  background: white;
-  border: none;
-  text-align: left;
-  cursor: pointer;
-  font-family: sans-serif;
-  transition: background 0.2s ease,
-
-  &:hover {
-    background: #f8f8f8;
-  }
-`;
-const DropDownButton: React.FC<{ onClick: () => void }> = ({ onClick, children }) => {
-  return (
-    <StyledButton type="button" onClick={onClick}>
-      {children}
-    </StyledButton>
-  );
-};
-
-const DropdownPortal: React.FC<{
-  anchorRef: any;
-  boxHeight: number;
-  open: boolean;
-  onClickAction: (operation: TeamsViewState['operation']) => () => void;
-}> = ({ anchorRef, boxHeight, open, onClickAction }) => {
-  const [coords, setCoords] = React.useState(null);
-
-  // Update dropdown position when opened or resized
-  React.useLayoutEffect(() => {
-    if (open && anchorRef.current) {
-      const rect = anchorRef.current.getBoundingClientRect();
-
-      setCoords({
-        top: rect.bottom,
-        left: rect.left,
-      });
-    }
-  }, [anchorRef, boxHeight, open]);
-
-  if (!open || !coords) return null;
-
-  return createPortal(
-    <div
-      style={{
-        position: 'fixed',
-        top: coords.top,
-        left: coords.left,
-        marginTop: '5px',
-        background: 'white',
-        boxSizing: 'border-box',
-        width: '230px',
-        border: '1px solid lightgray',
-        zIndex: 9999,
-      }}
-      role="dialog"
-      aria-labelledby="dialog-title"
-    >
-      <Column>
-        <DropDownButton onClick={onClickAction('enable')}>
-          <Template code="Enable Skills" />
-          <KeyboardArrowRight style={{ marginLeft: '20px' }} />
-        </DropDownButton>
-        <DropDownButton onClick={onClickAction('disable')}>
-          <Template code="Disable Skills" />
-          <KeyboardArrowRight style={{ marginLeft: '20px' }} />
-        </DropDownButton>
-      </Column>
-    </div>,
-    document.body,
-  );
-};
 
 const SelectAllCheckbox: React.FC<{}> = () => {
   const dispatch = useDispatch();
   const { selectedWorkers } = useSelector((state: RootState) => state[namespace][teamsViewBase]);
   const { workers } =
     useFlexSelector((state: RootState) => state.flex.supervisor) || ({ workers: [] } as SupervisorState);
-
-  const [isOpen, setIsOpen] = React.useState(false);
-  const buttonRef = React.useRef(null);
-
-  const boxRef = React.useRef(null);
-  const [boxHeight, setBoxHeight] = React.useState(0);
-
-  React.useEffect(() => {
-    if (boxRef.current) {
-      setBoxHeight(boxRef.current.clientHeight);
-    }
-  }, []);
 
   const workersSids = workers.map(w => w.worker.sid);
   const allChecked = workersSids.length && workersSids.every(w => selectedWorkers?.has(w));
@@ -141,44 +41,14 @@ const SelectAllCheckbox: React.FC<{}> = () => {
 
   return (
     <>
-      <Row ref={boxRef}>
-        <StyledFormCheckbox
-          type="checkbox"
-          checked={allChecked}
-          onChange={toggleAllWorkers}
-          onClick={e => {
-            e.stopPropagation();
-          }}
-        />
-        <MultiSelectButton
-          isOpened={isOpen}
-          isActive={selectedWorkers.size > 0}
-          disabled={selectedWorkers.size === 0}
-          type="button"
-          onClick={() => {
-            setIsOpen(prev => !prev);
-          }}
-          ref={buttonRef}
-        >
-          <Template code="Actions" />
-          <Flex marginLeft="15px">
-            {isOpen && <ArrowDropUp />}
-            {!isOpen && <ArrowDropDown />}
-          </Flex>
-        </MultiSelectButton>
-        <DropdownPortal
-          anchorRef={buttonRef}
-          boxHeight={boxHeight}
-          open={isOpen}
-          onClickAction={operation => () => {
-            dispatch(newTeamsViewSelectOperation(operation));
-            // dispatch(changeRoute({ route: 'teams' }, standaloneTask.taskSid));
-            dispatch(newOpenModalAction({ route: 'teams', subroute: 'select-skills' }, standaloneTask.taskSid));
-            setIsOpen(false);
-            // setOpenModal(true);
-          }}
-        />
-      </Row>
+      <StyledFormCheckbox
+        type="checkbox"
+        checked={allChecked}
+        onChange={toggleAllWorkers}
+        onClick={e => {
+          e.stopPropagation();
+        }}
+      />
       <UpdateWorkersSkillsModal task={standaloneTask} />
     </>
   );
@@ -216,7 +86,7 @@ export const setUpSelectAgentColumn = () => {
     <ColumnDefinition
       key="select-worker"
       header={<SelectAllCheckbox />}
-      style={{ width: '150px', padding: '0px', position: 'relative' }}
+      style={{ width: '40px', padding: '0px' }}
       content={(item: any) => <SelectWorkerCheckbox item={item} />}
     />,
     { sortOrder: 0 },

--- a/plugin-hrm-form/src/components/teamsView/SkillsColumn.tsx
+++ b/plugin-hrm-form/src/components/teamsView/SkillsColumn.tsx
@@ -15,20 +15,77 @@
  */
 
 import React from 'react';
-import { WorkersDataTable, ColumnDefinition, Template } from '@twilio/flex-ui';
+import { createPortal } from 'react-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { WorkersDataTable, ColumnDefinition, Template, styled } from '@twilio/flex-ui';
 import { Tooltip } from '@material-ui/core';
+import { ArrowDropDown, ArrowDropUp, KeyboardArrowRight } from '@material-ui/icons';
 
-import { OpaqueText } from '../../styles';
+import { Flex, Column, OpaqueText, Row, Box } from '../../styles';
+import { MultiSelectButton } from '../../styles/filters';
 import { SkillsList, StyledChip } from './styles';
 import { sortSkills } from './teamsViewSorting';
+import { newTeamsViewSelectOperation, TeamsViewState } from '../../states/teamsView';
+import { newOpenModalAction } from '../../states/routing/actions';
+import type { RootState } from '../../states';
+import { namespace, teamsViewBase } from '../../states/storeNamespaces';
+import { standaloneTask } from '../../types/types';
 
 const MAX_SKILL_LENGTH = 12;
+
+const SkillsColumnHeader: React.FC = () => {
+  const dispatch = useDispatch();
+  const { selectedWorkers } = useSelector((state: RootState) => state[namespace][teamsViewBase]);
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const buttonRef = React.useRef(null);
+
+  const boxRef = React.useRef(null);
+
+  return (
+    <>
+      <Row ref={boxRef}>
+        <Template code="Skills" />
+        <Box marginLeft="10px" style={{ ...(!selectedWorkers.size && { opactity: 0, visibility: 'hidden' }) }}>
+          <MultiSelectButton
+            isOpened={isOpen}
+            isActive={Boolean(selectedWorkers.size)}
+            disabled={!selectedWorkers.size}
+            type="button"
+            onClick={e => {
+              e.stopPropagation();
+              setIsOpen(prev => !prev);
+            }}
+            ref={buttonRef}
+            style={{ textDecorationLine: 'none' }}
+          >
+            <Template code="Actions" />
+            <Flex marginLeft="15px">
+              {isOpen && <ArrowDropUp />}
+              {!isOpen && <ArrowDropDown />}
+            </Flex>
+          </MultiSelectButton>
+        </Box>
+      </Row>
+      <DropdownPortal
+        anchorRef={buttonRef}
+        open={isOpen}
+        onClickAction={operation => e => {
+          e.stopPropagation();
+          dispatch(newTeamsViewSelectOperation(operation));
+          dispatch(newOpenModalAction({ route: 'teams', subroute: 'select-skills' }, standaloneTask.taskSid));
+          setIsOpen(false);
+        }}
+      />
+    </>
+  );
+};
 
 export const setUpSkillsColumn = () => {
   WorkersDataTable.Content.add(
     <ColumnDefinition
       key="skills"
-      header="Skills"
+      header={<SkillsColumnHeader />}
       sortingFn={sortSkills}
       style={{ width: 'auto !important' }}
       content={item => <SkillsCell item={item} />}
@@ -67,5 +124,81 @@ const SkillsCell = ({ item }) => {
         ),
       )}
     </SkillsList>
+  );
+};
+
+const StyledButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 12px;
+  background: white;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: sans-serif;
+  transition: background 0.2s ease,
+
+  &:hover {
+    background: #f8f8f8;
+  }
+`;
+const DropDownButton: React.FC<{ onClick: React.MouseEventHandler<HTMLButtonElement> }> = ({ onClick, children }) => {
+  return (
+    <StyledButton type="button" onClick={onClick}>
+      {children}
+    </StyledButton>
+  );
+};
+const DropdownPortal: React.FC<{
+  anchorRef: any;
+  open: boolean;
+  onClickAction: (operation: TeamsViewState['operation']) => React.MouseEventHandler<HTMLButtonElement>;
+}> = ({ anchorRef, open, onClickAction }) => {
+  const [coords, setCoords] = React.useState(null);
+
+  // Update dropdown position when opened or resized
+  React.useLayoutEffect(() => {
+    if (open && anchorRef.current) {
+      const rect = anchorRef.current.getBoundingClientRect();
+
+      setCoords({
+        top: rect.bottom,
+        left: rect.left,
+      });
+    }
+  }, [anchorRef, open]);
+
+  if (!open || !coords) return null;
+
+  return createPortal(
+    <div
+      style={{
+        position: 'fixed',
+        top: coords.top,
+        left: coords.left,
+        marginTop: '5px',
+        background: 'white',
+        boxSizing: 'border-box',
+        width: '230px',
+        border: '1px solid lightgray',
+        zIndex: 9999,
+      }}
+      role="dialog"
+      aria-labelledby="dialog-title"
+    >
+      <Column>
+        <DropDownButton onClick={onClickAction('enable')}>
+          <Template code="Enable Skills" />
+          <KeyboardArrowRight style={{ marginLeft: '20px' }} />
+        </DropDownButton>
+        <DropDownButton onClick={onClickAction('disable')}>
+          <Template code="Disable Skills" />
+          <KeyboardArrowRight style={{ marginLeft: '20px' }} />
+        </DropDownButton>
+      </Column>
+    </div>,
+    document.body,
   );
 };


### PR DESCRIPTION
## Description
This PR refactors the "actions" button used to trigger bulk skills, repositioning it from "checkbox column" into "skills column", as described in the linked ticket.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3558)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P