### PR TITLE
chore: USCH Configure United States as default for Resources "Countries" dropdown [CHI-3583]

### DIFF
--- a/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceSearchFilters.tsx
+++ b/plugin-hrm-form/src/components/resources/mappingComponents/uschMappings/ResourceSearchFilters.tsx
@@ -52,16 +52,13 @@ const ResourceSearchFilters: React.FC<{}> = () => {
   const { country, province, city } = (filterOptions || {}) as USCHFilterOptions;
   const filterSelections: USCHFilterSelections = useSelector(selectFilterSelections);
 
-  const updateFilterSelection = useCallback(
-    (filterName: FilterName, filterValue: string | number | boolean | string[]) => {
-      let reduxFilterValue = filterValue;
-      if (filterName === 'country' || filterName === 'province' || filterName === 'city') {
-        reduxFilterValue = filterValue === NO_LOCATION_SELECTED ? undefined : filterValue;
-      }
-      dispatch(updateSearchFormAction({ filterSelections: { [filterName]: reduxFilterValue } }));
-    },
-    [dispatch],
-  );
+  const updateFilterSelection = (filterName: FilterName, filterValue: string | number | boolean | string[]) => {
+    let reduxFilterValue = filterValue;
+    if (filterName === 'country' || filterName === 'province' || filterName === 'city') {
+      reduxFilterValue = filterValue === NO_LOCATION_SELECTED ? undefined : filterValue;
+    }
+    dispatch(updateSearchFormAction({ filterSelections: { [filterName]: reduxFilterValue } }));
+  };
 
   useEffect(() => {
     const loadReferenceLocations = (referenceLocations: ReferenceLocationState) => {

--- a/plugin-hrm-form/src/states/resources/filterSelectionState/usch/index.ts
+++ b/plugin-hrm-form/src/states/resources/filterSelectionState/usch/index.ts
@@ -148,14 +148,14 @@ export const handleLoadReferenceLocationsAsyncActionFulfilled = (
 ): ReferrableResourceSearchState => {
   const { list, options } = payload;
   let { referenceLocations } = state;
-  let defaultFilterSelection: Partial<USCHFilterSelections> = {};
+  let defaultFilterSelection: Partial<USCHFilterSelections> = state.parameters.filterSelections;
 
   switch (list) {
     case USCHReferenceLocationList.Country:
       referenceLocations = { ...referenceLocations, countryOptions: options };
       const defaultCountryTarget = 'United States';
       if (options.some(o => o.value === defaultCountryTarget)) {
-        defaultFilterSelection = { country: defaultCountryTarget };
+        defaultFilterSelection = { ...defaultFilterSelection, country: defaultCountryTarget };
       }
       break;
     case USCHReferenceLocationList.Provinces:


### PR DESCRIPTION
## Description
This PR:
- Updates USCH resources mapping to set "country" filter drop-down to `United States` value as default.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3583)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- `npm run dev`.
- Go to resources page.
- Wait for the "country" drop-down filter to load, and confirm `United States` is set as default value.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P