### PR TITLE
CHI-3534: Refactor test client to use dynamoDB client directly to retrieve webhook requests

### DIFF
--- a/lambdas/integrationTestRunner/src/webhookReceiver/handler.ts
+++ b/lambdas/integrationTestRunner/src/webhookReceiver/handler.ts
@@ -19,10 +19,9 @@ import {
   WebhookResponse,
   WebhookRecord,
   WebhookRecordResponse,
-  WebhookDeleteResponse,
   ISO8601UTCDateString,
 } from './types';
-import { recordWebhook, retrieveWebhooks, deleteWebhooks } from './dynamoDbClient';
+import { recordWebhook } from './dynamoDbClient';
 
 const createResponse = (statusCode: number, body: WebhookResponse): ALBResult => {
   return {
@@ -59,10 +58,29 @@ const getSessionIdFromRequest = (event: ALBEvent): string | null => {
   return null;
 };
 
-const handleRecordOperation = async (
-  event: ALBEvent,
-  sessionId: string,
-): Promise<ALBResult> => {
+/**
+ * Main handler for webhook receiver operations
+ * Determines operation based on HTTP method and request body
+ */
+export const handleWebhookReceiver = async (event: ALBEvent): Promise<ALBResult> => {
+  console.info('Webhook receiver event:', JSON.stringify(event, null, 2));
+
+  // Handle OPTIONS for CORS preflight
+  if (event.httpMethod === 'OPTIONS') {
+    return createResponse(200, {
+      message: 'CORS preflight',
+    });
+  }
+
+  const sessionId = getSessionIdFromRequest(event);
+
+  if (!sessionId) {
+    return createErrorResponse(
+      400,
+      'sessionId is required. Provide it via X-List-Id header, query parameter, or request body',
+    );
+  }
+
   try {
     const timestamp = new Date().toISOString() as ISO8601UTCDateString;
     const headers: Record<string, string | undefined> = event.headers ?? {};
@@ -89,77 +107,5 @@ const handleRecordOperation = async (
   } catch (error: any) {
     console.error('Error recording webhook:', error);
     return createErrorResponse(500, `Failed to record webhook: ${error.message}`);
-  }
-};
-
-const handleRetrieveOperation = async (sessionId: string): Promise<ALBResult> => {
-  try {
-    const records = await retrieveWebhooks(sessionId);
-
-    const response: WebhookRecord[] = records;
-
-    return createResponse(200, response);
-  } catch (error: any) {
-    console.error('Error retrieving webhooks:', error);
-    return createErrorResponse(500, `Failed to retrieve webhooks: ${error.message}`);
-  }
-};
-
-const handleDeleteOperation = async (sessionId: string): Promise<ALBResult> => {
-  try {
-    const deletedCount = await deleteWebhooks(sessionId);
-
-    const response: WebhookDeleteResponse = {
-      message: `Successfully deleted ${deletedCount} webhook record(s)`,
-      deletedCount,
-    };
-
-    return createResponse(200, response);
-  } catch (error: any) {
-    console.error('Error deleting webhooks:', error);
-    return createErrorResponse(500, `Failed to delete webhooks: ${error.message}`);
-  }
-};
-
-/**
- * Main handler for webhook receiver operations
- * Determines operation based on HTTP method and request body
- */
-export const handleWebhookReceiver = async (event: ALBEvent): Promise<ALBResult> => {
-  console.info('Webhook receiver event:', JSON.stringify(event, null, 2));
-
-  // Handle OPTIONS for CORS preflight
-  if (event.httpMethod === 'OPTIONS') {
-    return createResponse(200, {
-      message: 'CORS preflight',
-    });
-  }
-
-  const sessionId = getSessionIdFromRequest(event);
-
-  if (!sessionId) {
-    return createErrorResponse(
-      400,
-      'sessionId is required. Provide it via X-List-Id header, query parameter, or request body',
-    );
-  }
-
-  // Determine operation from request body or HTTP method
-  let operation =
-    event.headers?.['x-webhook-receiver-operation'] ??
-    event.queryStringParameters?.webhookReceiverOperation ??
-    'RECORD';
-
-  console.log(`Processing ${operation} operation for sessionId: ${sessionId}`);
-
-  switch (operation) {
-    case 'RECORD':
-      return handleRecordOperation(event, sessionId);
-    case 'RETRIEVE':
-      return handleRetrieveOperation(sessionId);
-    case 'DELETE':
-      return handleDeleteOperation(sessionId);
-    default:
-      return createErrorResponse(400, `Unknown operation: ${operation}`);
   }
 };


### PR DESCRIPTION
## Description

Removes the pointless round trip of retrieving webhook requests via REST for the request runner

Removes the delete endpoint for requests since we set a TTL on all the data anyway and keeping it for 7 days can be useful for debugging

We could reintroduce the endpoints if they turn out to be useful for maintenance, but it looks like it's easier to just use the AWS console to eyeball / delete the data

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [ ] Tested for chat contacts
- [n/a] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Verify integration tests still pass after this version of the integration test lambda is deployed

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P