### PR TITLE
fix: capture channel cleanup failing [CHI-3569]

### DIFF
--- a/lambdas/account-scoped/src/channelCapture/chatbotCallbackCleanup.ts
+++ b/lambdas/account-scoped/src/channelCapture/chatbotCallbackCleanup.ts
@@ -54,6 +54,7 @@ export const chatbotCallbackCleanup = async ({
 }: ChatbotCallbackCleanupParams) => {
   const memory = lexMemory || {};
 
+  // we use undefined as default for capturedChannelAttributes, as it falsy value is used to skip handleChannelRelease step
   const capturedChannelAttributes =
     channelAttributes.capturedChannelAttributes as CapturedChannelAttributes;
 
@@ -110,7 +111,7 @@ export const chatbotCallbackCleanup = async ({
     environment,
     helplineCode,
     userId,
-  } = capturedChannelAttributes;
+  } = capturedChannelAttributes || {};
 
   const shouldDeleteSession =
     botLanguage && botSuffix && environment && helplineCode && userId;


### PR DESCRIPTION
## Description
This PR fixes the issue described in the linked ticket, where `chatbotCallbackCleanup` function fails after a failed execution of `captureChannelWithBot`.
The reason of the failure is 
```
ERROR handleChatbotCallbackCleanup TypeError: Cannot destructure property 'botLanguage' of 'capturedChannelAttributes' as it is undefined at chatbotCallbackCleanup......
```
which indicates that the function fails running because `capturedChannelAttributes` property of the channel attributes is undefined. [Example can be found here](https://app.datadoghq.com/logs?query=env%3Aproduction%20%22handleChatbotCallbackCleanup%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZtA3Ze_7tHZcAAAABhBWnRBM2JUMEFBQjBTcWwtM3c5X3FnQUcAAAAkMTE5YjQxYTMtOWE3MC00NDUxLTkxYjQtNzg3NzFkZTEzMTIxAAYkrw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1763824128200&to_ts=1766416128200&live=true).
This can happen if the channel capture fails updating the channel where `capturedChannelAttributes` is set.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3569)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P