### PR TITLE
Add Follow Up button to CallTypeButtons.json

### DIFF
--- a/lambdas/packages/hrm-form-definitions/form-definitions/uscr/v1/CallTypeButtons.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/uscr/v1/CallTypeButtons.json
@@ -12,6 +12,12 @@
         "category": "data"
     },
     {
+        "name": "followUp",
+        "label": "Follow Up (Case ID Provided)",
+        "type": "button",
+        "category": "non-data"
+    },
+    {
         "name": "test",
         "label": "Test/Informational",
         "type": "button",


### PR DESCRIPTION
Adding Follow Up non-data call type for follow up dispatch in Beacon