### PR TITLE
CHI-3592: Improve pause recording errors to reduce spam

### DIFF
--- a/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
+++ b/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
@@ -18,7 +18,7 @@ import {
   ConferenceStatusEventHandler,
   registerTaskRouterEventHandler,
 } from './conferenceStatusCallback';
-import RestException from 'twilio/lib/base/RestException';
+import type RestException from 'twilio/lib/base/RestException';
 
 const handler: ConferenceStatusEventHandler = async (event, _accountSid, client) => {
   if (event.StatusCallbackEvent !== 'participant-leave') {
@@ -93,11 +93,8 @@ const handler: ConferenceStatusEventHandler = async (event, _accountSid, client)
             );
           }
         } catch (error) {
-          if (
-            error instanceof RestException &&
-            error.status === 400 &&
-            error.code === 21220
-          ) {
+          const restError = error as RestException;
+          if (restError.status === 400 && restError.code === 21220) {
             // Often errors of this type are thrown but the recording appears to pause at the correct point.
             console.debug(
               `An error was thrown pausing recording ${recording.sid} for call ${recording.callSid} on conference ${conferenceSid}, but the pause operation would normally be successful or redundant when this type or error is thrown`,


### PR DESCRIPTION
## Description

- Reduces the common, harmless error type to a debug log rather than an error log to prevent spamming error level logs

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
None

### Verification steps

Deploy a version with Twilio lambda in and monitor the error logs, they should no longer have spam about recordings in them

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P