### PR TITLE
Enable use_twilio_lambda_for_conference_functions for all helplines

### DIFF
--- a/twilio-iac/helplines/configs/service-configuration/defaults.json
+++ b/twilio-iac/helplines/configs/service-configuration/defaults.json
@@ -75,7 +75,7 @@
             "enable_twilio_transcripts": false,
             "enable_upload_documents": true,
             "enable_voice_recordings": false,
-            "use_twilio_lambda_for_conference_functions": false
+            "use_twilio_lambda_for_conference_functions": true
         },
         "multipleOfficeSupport": false,
         "WARNING": "These attributes are set using a tool in the twilio-iac repo. If you are seeing this message anywhere else, please stop and use the process described here: https://github.com/techmatters/flex-plugins/blob/master/twilio-iac/docs/service_configuration.md"


### PR DESCRIPTION
## Description
Enable use_twilio_lambda_for_conference_functions for all helplines (staging and production)

Since we have now QAed in staging with this flag on, we're ready to turn on the flag in production :)

Right now, use_twilio_lambda_for_conference_functions is set to False in the code. However, because of previous applies, the current state of applied feature flags looks like this:
- All production helplines : this flag is False
- All staging helplines except KHP Stg: this flag is True
- KHP Staging: this flag is False

To summarize, this PR will enable a TF apply with these changes:
- KHP Staging : turn flag on
- all production helplines : turn flag on

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P