### PR TITLE
Enable lambda conferencing flag for all staging, disable for all production

### DIFF
--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -24,6 +24,7 @@
             "enable_voice_recordings": true,
             "enable_lex_v2": true,
             "enable_select_agents_teams_view": true,
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "multipleOfficeSupport": true,

--- a/twilio-iac/helplines/br/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/br/configs/service-configuration/staging.json
@@ -3,6 +3,7 @@
         "assets_bucket_url": "https://s3.amazonaws.com/assets-staging.tl.techmatters.org",
         "feature_flags": {
             "enable_external_transcripts": false,
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -4,6 +4,7 @@
     "feature_flags": {
       "enable_resouorces_updates": true,
       "enable_switchboarding_move_tasks": true,
+      "use_twilio_lambda_for_conference_functions": true,
       "use_twilio_lambda_for_task_assignment": true
     },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",

--- a/twilio-iac/helplines/cl/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": { 
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "pdfImagesSource": "https://tl-public-chat-cl-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/clhs/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/clhs/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",

--- a/twilio-iac/helplines/co/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/co/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/configs/service-configuration/defaults.json
+++ b/twilio-iac/helplines/configs/service-configuration/defaults.json
@@ -74,8 +74,7 @@
             "enable_transfers": true,
             "enable_twilio_transcripts": false,
             "enable_upload_documents": true,
-            "enable_voice_recordings": false,
-            "use_twilio_lambda_for_conference_functions": true
+            "enable_voice_recordings": false
         },
         "multipleOfficeSupport": false,
         "WARNING": "These attributes are set using a tool in the twilio-iac repo. If you are seeing this message anywhere else, please stop and use the process described here: https://github.com/techmatters/flex-plugins/blob/master/twilio-iac/docs/service_configuration.md"

--- a/twilio-iac/helplines/et/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/et/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {   
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true     
         },
         "previous_ui_version": {

--- a/twilio-iac/helplines/eumc/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/eumc/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
   "attributes": {
       "feature_flags": {
+        "use_twilio_lambda_for_conference_functions": true,
         "use_twilio_lambda_for_task_assignment": true      
       },
       "previous_ui_version": {

--- a/twilio-iac/helplines/hu/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/hu/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": { 
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true        
         },
         "hrm_base_url": "https://hrm-staging-eu.tl.techmatters.org",

--- a/twilio-iac/helplines/in/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/in/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {  
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true  
         },
         "helplineLanguage": "en-IN",

--- a/twilio-iac/helplines/jm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/jm/configs/service-configuration/staging.json
@@ -4,6 +4,7 @@
     "feature_flags": {
       "enable_voice_recordings": true,
       "enable_client_profiles": true,
+      "use_twilio_lambda_for_conference_functions": true,
       "use_twilio_lambda_for_task_assignment": true
     },
     "pdfImagesSource": "https://tl-public-chat-jm-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/mt/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mt/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",

--- a/twilio-iac/helplines/mw/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mw/configs/service-configuration/staging.json
@@ -2,6 +2,7 @@
     "attributes": {
         "feature_flags": {
             "enable_external_transcripts": false,
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "pdfImagesSource": "https://tl-public-chat-mw-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/nz/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/nz/configs/service-configuration/staging.json
@@ -3,6 +3,7 @@
         "system_down" : false,
         "definitionVersion": "nz-v1",
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/ph/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ph/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/sg/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/sg/configs/service-configuration/staging.json
@@ -4,6 +4,7 @@
         "enableConferencing": true,
         "feature_flags": {
             "enable_conferencing": true,
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "helpline_code": "sg",

--- a/twilio-iac/helplines/th/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/th/configs/service-configuration/staging.json
@@ -2,6 +2,7 @@
     "attributes": {
         "feature_flags": {
             "enable_client_profiles": true,
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true        
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/tz/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/tz/configs/service-configuration/staging.json
@@ -4,6 +4,7 @@
         "resources_base_url": "",
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png",
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         }
     }

--- a/twilio-iac/helplines/ukmh/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ukmh/configs/service-configuration/staging.json
@@ -11,6 +11,7 @@
             "enable_post_survey": true,
             "enable_lambda_post_survey_processing": true,
             "use_prepopulate_mappings": true,
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         }
     }

--- a/twilio-iac/helplines/usch/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/usch/configs/service-configuration/staging.json
@@ -5,6 +5,7 @@
         "resources_base_url": "https://hrm-staging.tl.techmatters.org",
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png",
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         }
     }

--- a/twilio-iac/helplines/uscr/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/uscr/configs/service-configuration/staging.json
@@ -5,6 +5,7 @@
         "resources_base_url": "",
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png",
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         }
     }

--- a/twilio-iac/helplines/usvc/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/usvc/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
         "resources_base_url": "",
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png",
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         }
     }

--- a/twilio-iac/helplines/za/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/za/configs/service-configuration/staging.json
@@ -1,6 +1,7 @@
 {
     "attributes": {
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "previous_ui_version": {

--- a/twilio-iac/helplines/zm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zm/configs/service-configuration/staging.json
@@ -3,6 +3,7 @@
         "system_down" : false,
         "feature_flags": {
             "enable_client_profiles": true,
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png",

--- a/twilio-iac/helplines/zw/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zw/configs/service-configuration/staging.json
@@ -10,6 +10,7 @@
             "line"
         ],
         "feature_flags": {
+            "use_twilio_lambda_for_conference_functions": true,
             "use_twilio_lambda_for_task_assignment": true
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",


### PR DESCRIPTION
## Description
Enable use_twilio_lambda_for_conference_functions for all staging accounts, but disable for all production while Steve is looking into this bug: https://tech-matters.atlassian.net/browse/CHI-3666

See Slack thread: https://tech-matters.slack.com/archives/C06G61NK44E/p1768494821305439?thread_ts=1768447120.482019&cid=C06G61NK44E

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P