### PR TITLE
CHI-366: Return 404 when participant not found in conferencing endpoints

### DIFF
--- a/lambdas/account-scoped/src/conference/getParticipant.ts
+++ b/lambdas/account-scoped/src/conference/getParticipant.ts
@@ -17,7 +17,8 @@
 import { AccountScopedHandler } from '../httpTypes';
 import { newMissingParameterResult } from '../httpErrors';
 import { getTwilioClient } from '@tech-matters/twilio-configuration';
-import { newOk } from '../Result';
+import { newErr, newOk } from '../Result';
+import type RestException from 'twilio/lib/base/RestException';
 
 export type Body = {
   callSid: string;
@@ -34,10 +35,26 @@ export const getParticipantHandler: AccountScopedHandler = async (
   if (!callSid) return newMissingParameterResult('callSid');
   if (!conferenceSid) return newMissingParameterResult('conferenceSid');
   const client = await getTwilioClient(accountSid);
-  const participant = await client.conferences
-    .get(conferenceSid)
-    .participants.get(callSid)
-    .fetch();
-
-  return newOk({ participant });
+  try {
+    const participant = await client.conferences
+      .get(conferenceSid)
+      .participants.get(callSid)
+      .fetch();
+    return newOk({ participant });
+  } catch (error) {
+    const restError = error as RestException;
+    if (restError.status === 404) {
+      const message = `Participant with call sid ${callSid} not found on ${accountSid}/${conferenceSid}`;
+      // Often errors of this type are thrown but the recording appears to pause at the correct point.
+      console.warn(message, error);
+      return newErr({
+        message,
+        error: {
+          cause: restError,
+          statusCode: 404,
+        },
+      });
+    }
+    throw error;
+  }
 };


### PR DESCRIPTION
## Description

Return 404 when we can't find the participant we are trying to read / remove / update in the conference endpoints. This is more correct and will prevent spurious pages

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Deploy patch and hope we don't get paged for these

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P