### PR TITLE
CHI-3617: Remove close chat buttons from pre-engagement

### DIFF
--- a/aselo-webchat-react-app/package-lock.json
+++ b/aselo-webchat-react-app/package-lock.json
@@ -87,7 +87,7 @@
       "license": "AGPL",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.23"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.5",
@@ -31414,6 +31414,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
+++ b/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
@@ -32,7 +32,6 @@ import { notifications } from '../notifications';
 import { NotificationBar } from './NotificationBar';
 import { introStyles, fieldStyles, titleStyles, formStyles } from './styles/PreEngagementFormPhase.styles';
 import { useSanitizer } from '../utils/useSanitizer';
-import CloseChatButtons from './endChat/CloseChatButtons';
 
 export const PreEngagementFormPhase = () => {
   const { name, email, query } = useSelector((state: AppState) => state.session.preEngagementData) || {};
@@ -72,7 +71,6 @@ export const PreEngagementFormPhase = () => {
   return (
     <>
       <Header />
-      <CloseChatButtons />
       <NotificationBar />
       <Box as="form" data-test="pre-engagement-chat-form" onSubmit={handleSubmit} {...formStyles}>
         <Text {...titleStyles} as="h3">


### PR DESCRIPTION
## Description
Run aselo webchat npm install after dependabot updates. 
Remove close chat buttons from pre-engagement

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P