### PR TITLE
CHI-3759: Fix resource pagination

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/resources/search.test.ts
@@ -22,8 +22,8 @@ import { searchResources } from '../../../services/ResourceService';
 import { getHrmConfig } from '../../../hrmConfig';
 import {
   changeResultPageAction,
-  getCurrentPageResults,
-  getPageCount,
+  selectResourceSearchCurrentPageResults,
+  selectResourceSearchPageCount,
   initialState,
   ReferrableResourceResult,
   ReferrableResourceSearchState,
@@ -36,6 +36,7 @@ import {
   updateSearchFormAction,
 } from '../../../states/resources/search';
 import { initialFilterOptions } from '../../../states/resources/filterSelectionState/khp';
+import { namespace } from '../../../states/storeNamespaces';
 
 jest.mock('../../../services/ResourceService');
 jest.mock('../../../hrmConfig');
@@ -84,6 +85,14 @@ const nonInitialState: ReferrableResourceSearchState = {
     cityOptions: [],
     provinceOptions: [],
     regionOptions: [],
+  },
+};
+
+const fullNonInitialState = {
+  [namespace]: {
+    referrableResources: {
+      search: nonInitialState,
+    },
   },
 };
 
@@ -459,31 +468,49 @@ describe('actions', () => {
   });
 });
 
-describe('getCurrentPageResults', () => {
+const patchSearchState = (patch: Partial<ReferrableResourceSearchState>) => ({
+  ...fullNonInitialState,
+  [namespace]: {
+    ...fullNonInitialState[namespace],
+    referrableResources: {
+      ...fullNonInitialState[namespace].referrableResources,
+      search: {
+        ...nonInitialState,
+        ...patch,
+      },
+    },
+  },
+});
+
+describe('selectResourceSearchCurrentPageResults', () => {
   test('Returns a subset of the results from the current resources results, calculated based on the page and limit', () => {
-    const results = getCurrentPageResults(nonInitialState);
+    const results = selectResourceSearchCurrentPageResults(fullNonInitialState);
     expect(results).toStrictEqual([
       { name: '5', id: '5', attributes: {} },
       { name: '6', id: '6', attributes: {} },
     ]);
   });
   test('Current page out of range - Returns empty array', () => {
-    const results = getCurrentPageResults({ ...nonInitialState, currentPage: 20 });
+    const results = selectResourceSearchCurrentPageResults(patchSearchState({ currentPage: 20 }));
     expect(results).toStrictEqual([]);
   });
 });
 
-describe('getPageCount', () => {
+describe('selectResourceSearchPageCount', () => {
   test('Calculates number of result pages based on specified page size and total number of results', () => {
-    expect(getPageCount(nonInitialState)).toBe(3);
+    expect(selectResourceSearchPageCount(fullNonInitialState)).toBe(3);
   });
   test('Rounds up', () => {
-    expect(getPageCount({ ...nonInitialState, parameters: { ...nonInitialState.parameters, pageSize: 5 } })).toBe(2);
+    expect(
+      selectResourceSearchPageCount(patchSearchState({ parameters: { ...nonInitialState.parameters, pageSize: 5 } })),
+    ).toBe(2);
   });
   test('Counts nulls', () => {
-    expect(getPageCount({ ...nonInitialState, results: [null, null, null, null, null, null, null] })).toBe(4);
+    expect(
+      selectResourceSearchPageCount(patchSearchState({ results: [null, null, null, null, null, null, null] })),
+    ).toBe(4);
   });
   test('Returns zero for empty array', () => {
-    expect(getPageCount({ ...nonInitialState, results: [] })).toBe(0);
+    expect(selectResourceSearchPageCount(patchSearchState({ results: [] }))).toBe(0);
   });
 });

--- a/plugin-hrm-form/src/components/resources/search/SearchResourcesResults.tsx
+++ b/plugin-hrm-form/src/components/resources/search/SearchResourcesResults.tsx
@@ -14,12 +14,11 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AnyAction } from 'redux';
 import { Template } from '@twilio/flex-ui';
 
-import { RootState } from '../../../states';
 import { Box, Column, SearchFormTopRule } from '../../../styles';
 import SearchResultsBackButton from '../../search/SearchResults/SearchResultsBackButton';
 import {
@@ -30,35 +29,47 @@ import {
   ResourcesSearchTitle,
   ResourceTitle,
 } from '../styles';
+import type { RootState } from '../../../states';
 import {
   changeResultPageAction,
-  getCurrentPageResults,
-  getPageCount,
+  selectResourceSearchCurrentPageResults,
   returnToSearchFormAction,
   searchResourceAsyncAction,
-  SearchSettings,
+  selectResourceSearchCurrentPage,
+  selectResourceSearchParameters,
+  selectResourceSearchResultsTotal,
+  selectResourceSearchPageCount,
+  selectResourceSearchError,
+  selectFilterSelections,
 } from '../../../states/resources/search';
 import { viewResourceAction } from '../../../states/resources';
 import Pagination from '../../pagination';
 import asyncDispatch from '../../../states/asyncDispatch';
 import ResourcePreview from './ResourcePreview';
-import { namespace, referrableResourcesBase } from '../../../states/storeNamespaces';
 import { ResourcesSearchResultsDescriptionDetails } from '../mappingComponents';
 
 const SearchResourcesResults: React.FC = () => {
   const dispatch = useDispatch();
 
-  const searchState = useSelector((state: RootState) => state[namespace][referrableResourcesBase].search);
-  const { error, status, currentPage, parameters } = searchState;
-  const currentPageResults = getCurrentPageResults(searchState);
-  const resultPageCount = getPageCount(searchState);
-  const resultCount = searchState.results.length;
+  const error = useSelector(selectResourceSearchError);
+  const currentPage = useSelector(selectResourceSearchCurrentPage);
+  const filterSelections = useSelector(selectFilterSelections);
+  const pageSize = useSelector((state: RootState) => selectResourceSearchParameters(state).pageSize);
+  const generalSearchTerm = useSelector((state: RootState) => selectResourceSearchParameters(state).generalSearchTerm);
+  const currentPageResults = useSelector(selectResourceSearchCurrentPageResults);
+  const resultPageCount = useSelector(selectResourceSearchPageCount);
+  const resultCount = useSelector(selectResourceSearchResultsTotal);
   // If any results for the current page are undefined (i.e. expected to exist given the total result count but not in  redux yet) query the back end
+  useEffect(() => {
+    if (!currentPageResults.every(res => res)) {
+      asyncDispatch<AnyAction>(dispatch)(
+        searchResourceAsyncAction({ pageSize, filterSelections, generalSearchTerm }, currentPage, false),
+      );
+    }
+  }, [currentPage, currentPageResults, dispatch, filterSelections, generalSearchTerm, pageSize]);
   if (!currentPageResults.every(res => res)) {
-    asyncDispatch<AnyAction>(dispatch)(searchResourceAsyncAction(parameters, currentPage, false));
     return null;
   }
-
   return (
     <ResourcesSearchArea>
       <Column>
@@ -76,10 +87,10 @@ const SearchResourcesResults: React.FC = () => {
           </ResourcesSearchTitle>
           <ResourcesSearchResultsDescription>
             <Template code="Resources-Search-ResultsDescription" count={resultCount} />
-            {parameters.generalSearchTerm && (
+            {generalSearchTerm && (
               <Template
                 code="Resources-Search-ResultsDescription-GeneralSearchTerm"
-                generalSearchTerm={parameters.generalSearchTerm}
+                generalSearchTerm={generalSearchTerm}
               />
             )}
             <ResourcesSearchResultsDescriptionDetails />

--- a/plugin-hrm-form/src/states/resources/search.ts
+++ b/plugin-hrm-form/src/states/resources/search.ts
@@ -21,7 +21,7 @@ import { loadReferenceLocationsAsyncAction, ReferenceLocationState } from './ref
 import { FilterOption } from './types';
 import { getFilterSelectionState } from '../../components/resources/mappingComponents';
 import { RootState } from '..';
-import { namespace, referrableResourcesBase } from '../storeNamespaces';
+import { namespace } from '../storeNamespaces';
 
 export type SearchSettings = Omit<Partial<ReferrableResourceSearchState['parameters']>, 'filterSelections'> & {
   filterSelections?: Partial<ReferrableResourceSearchState['parameters']['filterSelections']>;
@@ -244,14 +244,30 @@ export const resourceSearchReducer = createReducer(initialState, handleAction =>
   ),
 ]);
 
-export const getCurrentPageResults = ({
-  results,
-  currentPage,
-  parameters: { pageSize },
-}: ReferrableResourceSearchState) => results.slice(currentPage * pageSize, (currentPage + 1) * pageSize);
+const selectSearchState = (state: RootState): ReferrableResourceSearchState =>
+  state[namespace].referrableResources.search;
 
-export const getPageCount = ({ results, parameters: { pageSize } }: ReferrableResourceSearchState) =>
-  Math.ceil(results.length / pageSize);
+export const selectResourceSearchCurrentPageResults = (state: RootState) => {
+  const {
+    results,
+    currentPage,
+    parameters: { pageSize },
+  } = state[namespace].referrableResources.search;
+  return results.slice(currentPage * pageSize, (currentPage + 1) * pageSize);
+};
 
-export const selectFilterSelections = <T extends FilterSelections>(state: RootState): T =>
-  state[namespace][referrableResourcesBase].search.parameters.filterSelections as T;
+export const selectFilterSelections = (state: RootState): FilterSelections =>
+  selectSearchState(state).parameters.filterSelections;
+
+export const selectResourceSearchPageCount = (state: RootState) => {
+  const {
+    results,
+    parameters: { pageSize },
+  } = selectSearchState(state);
+  return Math.ceil(results.length / pageSize);
+};
+
+export const selectResourceSearchError = (state: RootState) => selectSearchState(state).error;
+export const selectResourceSearchCurrentPage = (state: RootState) => selectSearchState(state).currentPage;
+export const selectResourceSearchParameters = (state: RootState) => selectSearchState(state).parameters;
+export const selectResourceSearchResultsTotal = (state: RootState) => selectSearchState(state).results.length;


### PR DESCRIPTION
## Description

The refactored redux hooks caused an infinite rerender loop

To fix this 2 changes were made

- More granular redux selectors to prevent unstable comparisons
- Putting the search request action trigger in a useEffect block to prevent it firing every rerender

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P