### PR TITLE
Correcting a mistake - wrong flag in BR Stg

### DIFF
--- a/twilio-iac/helplines/br/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/br/configs/service-configuration/staging.json
@@ -4,8 +4,8 @@
         "feature_flags": {
             "enable_external_transcripts": false,
             "use_twilio_lambda_adjust_capacity": false,
-            "use_twilio_lambda_for_conference_functions": true,
-            "use_twilio_lambda_for_conversation_duration": false,
+            "use_twilio_lambda_for_conference_functions": false,
+            "use_twilio_lambda_for_conversation_duration": true,
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,


### PR DESCRIPTION
## Description
Correcting a mistake where I turned off the wrong flag in an unused staging account (BR Stg)


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P