### PR TITLE
chore: USCH resources - move default option to head of options list [CHI-3767]

### DIFF
--- a/plugin-hrm-form/src/states/resources/filterSelectionState/usch/index.ts
+++ b/plugin-hrm-form/src/states/resources/filterSelectionState/usch/index.ts
@@ -142,6 +142,33 @@ export const handlerUpdateSearchFormAction = (
   };
 };
 
+const moveDefaultOptionToHead = ({
+  options,
+  defaultOptionValue,
+}: {
+  options: FilterOption<string>[];
+  defaultOptionValue: string;
+}) => {
+  const defaultOptionIndex = options.findIndex(o => o.value === defaultOptionValue);
+  const containsDefaultOption = defaultOptionIndex > 0;
+  if (!containsDefaultOption) {
+    return { sortedOptions: options, containsDefaultOption };
+  }
+
+  const defaultOption = options[defaultOptionIndex];
+  const sortedOptions = [defaultOption];
+
+  options.forEach((option, index) => {
+    if (index === defaultOptionIndex) {
+      return;
+    }
+
+    sortedOptions.push(option);
+  });
+
+  return { sortedOptions, containsDefaultOption };
+};
+
 export const handleLoadReferenceLocationsAsyncActionFulfilled = (
   state: ReferrableResourceSearchState,
   { payload }: { payload: { list: string; options: FilterOption[] } },
@@ -152,9 +179,17 @@ export const handleLoadReferenceLocationsAsyncActionFulfilled = (
 
   switch (list) {
     case USCHReferenceLocationList.Country:
-      referenceLocations = { ...referenceLocations, countryOptions: options };
       const defaultCountryTarget = 'United States';
-      if (options.some(o => o.value === defaultCountryTarget)) {
+
+      // sort the list, moving defaultCountryTarget to the top, if present
+      const { sortedOptions, containsDefaultOption } = moveDefaultOptionToHead({
+        options,
+        defaultOptionValue: defaultCountryTarget,
+      });
+      referenceLocations = { ...referenceLocations, countryOptions: sortedOptions };
+
+      // select defaultCountryTarget filter upon load
+      if (containsDefaultOption) {
         defaultFilterSelection = { ...defaultFilterSelection, country: defaultCountryTarget };
       }
       break;


### PR DESCRIPTION
## Description
This PR refactors `plugin-hrm-form/src/states/resources/filterSelectionState/usch/index.ts` to move "default option" (`United States`) to the top of the country filter options list.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3767)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
Since `USCH` is currently configured for Aselo development account:
- `npm run dev`.
- Navigate to resources page and confirm `United States` appears at the top of the country filter list.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P