### PR TITLE
fix: field input description translatable [CHI-3685]

### DIFF
--- a/lambdas/packages/hrm-form-definitions/form-definitions/as/v1/tabbedForms/ChildInformationTab.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/as/v1/tabbedForms/ChildInformationTab.json
@@ -5,8 +5,8 @@
     "type": "input",
     "isPII": true,
     "description": {
-      "title": "First Name desc",
-      "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+      "title": "AsV1-ChildInformationTab-FirstName-Title",
+      "content": "AsV1-ChildInformationTab-FirstName-Content"
     }
   },
   {

--- a/plugin-hrm-form/src/components/forms/components/FormInputDescription/FormInputDescription.tsx
+++ b/plugin-hrm-form/src/components/forms/components/FormInputDescription/FormInputDescription.tsx
@@ -15,6 +15,7 @@
  */
 import React from 'react';
 import { FormItemDefinition } from 'hrm-form-definitions';
+import { Template } from '@twilio/flex-ui';
 
 import {
   BACKROUND_COLOR,
@@ -35,13 +36,17 @@ export const FormInputDescription: React.FC<Props> = ({ definition }) => {
 
   return (
     <FieldInputDescriptionContainer>
-      <FieldInputDescriptionTitle>{definition.description.title}</FieldInputDescriptionTitle>
+      <FieldInputDescriptionTitle>
+        <Template code={definition.description.title} />
+      </FieldInputDescriptionTitle>
       <FieldInputDescriptionExpandableText
         expandLinkText="ReadMore"
         collapseLinkText="ReadLess"
         collapsedOverrides={{ whiteSpace: 'wrap', linesPreview: 2, backgroundColor: BACKROUND_COLOR }}
       >
-        <FieldInputDescriptionText>{definition.description.content}</FieldInputDescriptionText>
+        <FieldInputDescriptionText>
+          <Template code={definition.description.content} />
+        </FieldInputDescriptionText>
       </FieldInputDescriptionExpandableText>
     </FieldInputDescriptionContainer>
   );

--- a/plugin-hrm-form/src/translations/en.json
+++ b/plugin-hrm-form/src/translations/en.json
@@ -661,5 +661,8 @@
   "Modals-ConfirmDialog-ConfirmButton": "OK",
   "Modals-CloseDialog-CancelButton": "Cancel",
   "Modals-CloseDialog-DiscardButton": "Discard",
-  "BrowserNotification-ChatMessage-MaskedTitle": "New message"
+  "BrowserNotification-ChatMessage-MaskedTitle": "New message",
+
+  "AsV1-ChildInformationTab-FirstName-Title": "First Name description",
+  "AsV1-ChildInformationTab-FirstName-Content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 }


### PR DESCRIPTION
## Description
This PR fixes a missed requirement in field input descriptions, making them "translatable strings" (label and content).

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P