### PR TITLE
chore: Hide trigger message in aselo-webchat-react-app [CHI-3753]

### DIFF
--- a/.github/workflows/aselo-webchat-react-app-ci.yml
+++ b/.github/workflows/aselo-webchat-react-app-ci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: '22.x'
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
         working-directory: ./aselo-webchat-react-app
       - name: Create Temp Files
         run: |
@@ -46,7 +46,7 @@ jobs:
       with:
         node-version: '22.x'
     - name: Install dependencies
-      run: npm ci --legacy-peer-deps
+      run: npm ci
       working-directory: ./aselo-webchat-react-app
     - name: Run aselo-webchat-react-app tests
       run: npm run test
@@ -68,7 +68,7 @@ jobs:
       with:
         node-version: '22.x'
     - name: Install dependencies
-      run: npm ci --legacy-peer-deps
+      run: npm ci
       working-directory: ./aselo-webchat-react-app
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v6

--- a/aselo-webchat-react-app/package-lock.json
+++ b/aselo-webchat-react-app/package-lock.json
@@ -31454,6 +31454,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",

--- a/aselo-webchat-react-app/src/components/MessageList.tsx
+++ b/aselo-webchat-react-app/src/components/MessageList.tsx
@@ -70,6 +70,7 @@ export const MessageList = () => {
     conversation: state.chat.conversation,
     conversationsClient: state.chat.conversationsClient,
   }));
+
   const dispatch = useDispatch();
   const messageListRef = useRef<HTMLDivElement>(null);
   const isLoadingMessages = useRef(false);
@@ -77,6 +78,11 @@ export const MessageList = () => {
   const [hasLoadedAllMessages, setHasLoadedAllMessages] = useState(true);
   const [focusIndex, setFocusIndex] = useState(messages && messages.length ? messages[messages?.length - 1].index : -1);
   const [shouldFocusLatest, setShouldFocusLatest] = useState(false);
+
+  useEffect(() => {
+    console.log('>>>>> messages', messages);
+    console.log('>>>>> hasLoadedAllMessages', hasLoadedAllMessages);
+  }, [messages, hasLoadedAllMessages]);
 
   const updateFocus = (newFocus: number) => {
     if (newFocus < 0 || !messages || !messages.length || newFocus > messages[messages.length - 1].index) {
@@ -223,8 +229,15 @@ export const MessageList = () => {
           </Box>
         );
       }
+
       // Discount loading spinner from indices
       i -= 1;
+
+      const belongsToCurrentUser = message.author === conversationsClient?.user.identity;
+      // Remove the auto first message sent in MessagingCanvasPhase
+      if (message.index === 0 && hasLoadedAllMessages && belongsToCurrentUser) {
+        return null;
+      }
 
       return (
         <Box data-test="all-message-bubbles" key={message.index}>

--- a/aselo-webchat-react-app/src/components/MessageList.tsx
+++ b/aselo-webchat-react-app/src/components/MessageList.tsx
@@ -79,11 +79,6 @@ export const MessageList = () => {
   const [focusIndex, setFocusIndex] = useState(messages && messages.length ? messages[messages?.length - 1].index : -1);
   const [shouldFocusLatest, setShouldFocusLatest] = useState(false);
 
-  useEffect(() => {
-    console.log('>>>>> messages', messages);
-    console.log('>>>>> hasLoadedAllMessages', hasLoadedAllMessages);
-  }, [messages, hasLoadedAllMessages]);
-
   const updateFocus = (newFocus: number) => {
     if (newFocus < 0 || !messages || !messages.length || newFocus > messages[messages.length - 1].index) {
       return;

--- a/aselo-webchat-react-app/src/components/MessagingCanvasPhase.tsx
+++ b/aselo-webchat-react-app/src/components/MessagingCanvasPhase.tsx
@@ -28,6 +28,11 @@ import { removeNotification } from '../store/actions/genericActions';
 import { notifications } from '../notifications';
 import { AttachFileDropArea } from './AttachFileDropArea';
 import CloseChatButtons from './endChat/CloseChatButtons';
+import { selectCurrentTranslations } from '../store/config.reducer';
+import { localizeKey } from '../localization/localizeKey';
+
+const DEFAULT_AUTO_FIRST_MESSAGE = 'Incoming webchat contact from';
+const DEFAULT_CUSTOMER_DEFAULT_NAME = 'Anonymous';
 
 const sendInitialUserQuery = async (conv?: Conversation, query?: string): Promise<void> => {
   if (!query || !conv) return;
@@ -42,6 +47,16 @@ const sendInitialUserQuery = async (conv?: Conversation, query?: string): Promis
 export const MessagingCanvasPhase = () => {
   const dispatch = useDispatch();
 
+  const { currentTranslations } = useSelector((state: AppState) => ({
+    currentTranslations: selectCurrentTranslations(state),
+  }));
+  const autoFirstMessage = localizeKey(currentTranslations)('AutoFirstMessage') || DEFAULT_AUTO_FIRST_MESSAGE;
+  // TODO: fill contact contactIdentifier with ip once that is ported
+  // const message = `${autoFirstMessage} ${contactIdentifier}`;
+  const contactIdentifier =
+    localizeKey(currentTranslations)('Conversation-Participants-CustomerDefaultName') || DEFAULT_CUSTOMER_DEFAULT_NAME;
+  const message = `${autoFirstMessage} ${contactIdentifier}`;
+
   const { conversation, conversationState, preEngagmentData } = useSelector((state: AppState) => ({
     conversationState: state.chat.conversationState,
     conversation: state.chat?.conversation,
@@ -50,8 +65,8 @@ export const MessagingCanvasPhase = () => {
 
   useEffect(() => {
     dispatch(removeNotification(notifications.failedToInitSessionNotification('ds').id));
-    sendInitialUserQuery(conversation as Conversation, 'TODO: trigger message');
-  }, [dispatch, conversation, preEngagmentData]);
+    sendInitialUserQuery(conversation as Conversation, message);
+  }, [dispatch, conversation, preEngagmentData, message]);
 
   const Wrapper = conversationState === 'active' ? AttachFileDropArea : Fragment;
 

--- a/aselo-webchat-react-app/src/components/__tests__/MessageList.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/MessageList.test.tsx
@@ -84,12 +84,34 @@ describe('Message List', () => {
     expect(container).toBeInTheDocument();
   });
 
-  it('renders a message bubble for each message', () => {
+  it('renders a message bubble for each visible message', () => {
     const { queryAllByTestId, queryByText } = render(<MessageList />);
 
-    expect(queryAllByTestId(messageBubbleTestId)).toHaveLength(2);
-    expect(queryByText(message1.body)).toBeInTheDocument();
+    // message1 is at index 0 and belongs to the current user, so it is hidden as the auto trigger message
+    expect(queryAllByTestId(messageBubbleTestId)).toHaveLength(1);
+    expect(queryByText(message1.body)).not.toBeInTheDocument();
     expect(queryByText(message2.body)).toBeInTheDocument();
+  });
+
+  it('hides the first message (auto trigger) when it belongs to the current user at index 0', () => {
+    const { queryByText, queryAllByTestId } = render(<MessageList />);
+
+    expect(queryByText(message1.body)).not.toBeInTheDocument();
+    expect(queryAllByTestId(messageBubbleTestId)).toHaveLength(1);
+  });
+
+  it('does not hide the first message when it belongs to another user', () => {
+    resetMockRedux({
+      chat: {
+        ...defaultChatState,
+        messages: [{ ...message1, author: user2.identity }, message2],
+      },
+    });
+
+    const { queryByText, queryAllByTestId } = render(<MessageList />);
+
+    expect(queryByText(message1.body)).toBeInTheDocument();
+    expect(queryAllByTestId(messageBubbleTestId)).toHaveLength(2);
   });
 
   it('does not render any chat items if no messages object', () => {
@@ -436,7 +458,8 @@ describe('Message List', () => {
       const messageBubbles = queryAllByTestId(messageBubbleTestId);
       fireEvent.focus(messagesContainer);
 
-      expect(messageBubbles[1]).toHaveFocus();
+      // message1 (index 0, current user) is hidden; only message2 (index 1) is visible
+      expect(messageBubbles[0]).toHaveFocus();
     });
 
     it('message list container is focusable when there are no messages', () => {
@@ -463,13 +486,24 @@ describe('Message List', () => {
     it('starts with focus on the most recent message when rendering with messages already in the store', () => {
       const { queryAllByTestId } = render(<MessageList />);
 
-      const [, bottomBubble] = queryAllByTestId(messageBubbleTestId);
+      // message1 (index 0, current user) is hidden; only message2 (index 1) is visible
+      const [bottomBubble] = queryAllByTestId(messageBubbleTestId);
 
       expect(bottomBubble.tabIndex).toBe(0);
       expect(bottomBubble).toHaveFocus();
     });
 
     it('focuses previous message on up key press', () => {
+      // Use messages starting at index 1 to avoid the auto-trigger message hiding (index 0)
+      const msgA = { index: 1, author: user1.identity, dateCreated: new Date(), body: 'message A' };
+      const msgB = { index: 2, author: user2.identity, dateCreated: new Date(), body: 'message B' };
+      resetMockRedux({
+        chat: {
+          ...defaultChatState,
+          messages: [msgA, msgB],
+        },
+      });
+
       const { queryAllByTestId } = render(<MessageList />);
 
       const [topBubble, bottomBubble] = queryAllByTestId(messageBubbleTestId);
@@ -483,6 +517,16 @@ describe('Message List', () => {
     });
 
     it('focuses next message on down key press', () => {
+      // Use messages starting at index 1 to avoid the auto-trigger message hiding (index 0)
+      const msgA = { index: 1, author: user1.identity, dateCreated: new Date(), body: 'message A' };
+      const msgB = { index: 2, author: user2.identity, dateCreated: new Date(), body: 'message B' };
+      resetMockRedux({
+        chat: {
+          ...defaultChatState,
+          messages: [msgA, msgB],
+        },
+      });
+
       const { queryAllByTestId } = render(<MessageList />);
 
       const [topBubble, bottomBubble] = queryAllByTestId(messageBubbleTestId);
@@ -500,8 +544,11 @@ describe('Message List', () => {
     });
 
     it('does not focus if triggered by a click', async () => {
-      const message3 = { ...message2, index: 2 };
-      const messages = [message1, message2, message3];
+      // Use messages starting at index 1 to avoid the auto-trigger message hiding (index 0)
+      const msgA = { index: 1, author: user2.identity, dateCreated: new Date(), body: 'message A' };
+      const msgB = { index: 2, author: user2.identity, dateCreated: new Date(), body: 'message B' };
+      const msgC = { index: 3, author: user2.identity, dateCreated: new Date(), body: 'message C' };
+      const messages = [msgA, msgB, msgC];
       resetMockRedux({
         chat: {
           ...defaultChatState,

--- a/aselo-webchat-react-app/src/components/__tests__/MessagingCanvasPhase.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/MessagingCanvasPhase.test.tsx
@@ -56,9 +56,20 @@ const conversationMock = {
   getMessagesCount: jest.fn(),
   prepareMessage: jest.fn(),
 };
-const TEST_QUERY = 'TODO: trigger message';
+const TEST_AUTO_FIRST_MESSAGE = 'Incoming webchat contact from';
+const TEST_CUSTOMER_DEFAULT_NAME = 'Anonymous';
+const TEST_QUERY = `${TEST_AUTO_FIRST_MESSAGE} ${TEST_CUSTOMER_DEFAULT_NAME}`;
 const baseReduxState = {
   chat: { conversationState: 'closed', ...BASE_MOCK_REDUX.chat },
+  config: {
+    ...BASE_MOCK_REDUX.config,
+    translations: {
+      'ut-UT': {
+        AutoFirstMessage: TEST_AUTO_FIRST_MESSAGE,
+        'Conversation-Participants-CustomerDefaultName': TEST_CUSTOMER_DEFAULT_NAME,
+      },
+    },
+  },
   session: { token: 'token', ...BASE_MOCK_REDUX.session },
   task: { tasksSids: ['tasksSids'], ...BASE_MOCK_REDUX.task },
 };

--- a/aselo-webchat-react-app/translationsSrc/en.json
+++ b/aselo-webchat-react-app/translationsSrc/en.json
@@ -1,4 +1,5 @@
 {
+  "AutoFirstMessage": "Incoming webchat contact from",
   "Conversation-Participants-CustomerDefaultName": "Anonymous",
   "Header-CloseChatButtons-EndChatButtonLabel": "End Chat",
   "Header-CloseChatButtons-EndChatConfirmDialogMessageFromChat": "End the current chat? Your messages will be lost.",


### PR DESCRIPTION
## Description
This PR:
- Configures the auto first message for `aselo-webchat-react-app`.
  - TODO: we have to consume the ip where the message is originated from once https://tech-matters.atlassian.net/jira/software/c/projects/CHI/boards/7?selectedIssue=CHI-3630 is addressed.
- Remove the auto first message from the UI for the client.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3753)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P