### PR TITLE
fix: expandable component leading to excessive set state calls [CHI-3817]

### DIFF
--- a/lambdas/packages/hrm-form-definitions/form-definitions/as/v1/tabbedForms/CallerInformationTab.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/as/v1/tabbedForms/CallerInformationTab.json
@@ -3,7 +3,11 @@
     "name": "firstName",
     "label": "First Name",
     "type": "input",
-    "isPII": true
+    "isPII": true,
+    "description": {
+      "title": "AsV1-ChildInformationTab-FirstName-Title",
+      "content": "AsV1-ChildInformationTab-FirstName-Content"
+    }
   },
   {
     "name": "lastName",

--- a/plugin-hrm-form/src/components/ExpandableBlocks/ExpandableComponent.tsx
+++ b/plugin-hrm-form/src/components/ExpandableBlocks/ExpandableComponent.tsx
@@ -56,18 +56,18 @@ const ExpandableComponent: React.FC<ExpandableComponentProps & Partial<StyledPro
   return (
     <div
       className={`${classes.join(' ')}`}
-      style={{ display: 'flex', flexFlow: 'row', justifyContent: 'stretch', textOverflow: 'ellipsis', ...style }}
-      ref={overflowingRef}
+      style={{ display: 'flex', flexFlow: 'row', justifyContent: 'stretch', ...style }}
     >
       <div
         style={{
-          textOverflow: 'inherit',
+          textOverflow: 'hidden',
           whiteSpace: isOverflowing && !isExpanded ? 'nowrap' : 'inherit',
           overflow: isOverflowing && !isExpanded ? 'hidden' : 'inherit',
           height: isExpanded ? 'inherit' : '1.6em',
           lineHeight: '1.5em',
           wordBreak: isExpanded ? 'break-word' : 'inherit',
         }}
+        ref={overflowingRef}
       >
         {children}
         <StyledLink

--- a/plugin-hrm-form/src/components/ExpandableBlocks/ExpandableText.tsx
+++ b/plugin-hrm-form/src/components/ExpandableBlocks/ExpandableText.tsx
@@ -66,10 +66,6 @@ const ExpandableText: React.FC<ExpandableTextProps & Partial<StyledProps>> = ({
   } = useExpandableOnOverflow({});
   const collapsedStyles = { ...defaultCollapsedStyles, ...collapsedOverrides };
 
-  React.useLayoutEffect(() => {
-    triggerOverflowing();
-  });
-
   return (
     <div
       style={{
@@ -77,7 +73,6 @@ const ExpandableText: React.FC<ExpandableTextProps & Partial<StyledProps>> = ({
         display: 'flex',
         flexFlow: 'row',
         justifyContent: 'stretch',
-        textOverflow: 'ellipsis',
         ...style,
       }}
     >

--- a/plugin-hrm-form/src/components/search/CasePreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/CasePreview/index.tsx
@@ -143,7 +143,7 @@ const CasePreview: React.FC<Props> = ({ currentCase, onClickViewCase, counselors
         />
         <PreviewRow>
           {summary && (
-            <PreviewDescription expandLinkText="ReadMore" collapseLinkText="ReadLess">
+            <PreviewDescription expandLinkText="ReadMore" collapseLinkText="ReadLess" style={{ width: '100%' }}>
               {summary}
             </PreviewDescription>
           )}

--- a/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/index.tsx
@@ -111,7 +111,7 @@ const ContactPreview: React.FC<ContactPreviewProps> = ({ contact, handleViewDeta
         />
         {callSummary && (
           <PreviewRow>
-            <PreviewDescription expandLinkText="ReadMore" collapseLinkText="ReadLess">
+            <PreviewDescription expandLinkText="ReadMore" collapseLinkText="ReadLess" style={{ width: '100%' }}>
               {callSummary}
             </PreviewDescription>
           </PreviewRow>

--- a/plugin-hrm-form/src/components/search/PreviewDescription.tsx
+++ b/plugin-hrm-form/src/components/search/PreviewDescription.tsx
@@ -24,7 +24,6 @@ export const PreviewDescription = styled(ExpandableText)<ExpandableTextProps>`
   color: #000000;
   font-family: Open Sans, serif;
   text-align: left;
-  width: 100%;
 `;
 
 PreviewDescription.displayName = 'PreviewDescription';

--- a/plugin-hrm-form/src/components/search/styles.tsx
+++ b/plugin-hrm-form/src/components/search/styles.tsx
@@ -112,11 +112,13 @@ export const SummaryText = styled(FontOpenSans)`
 `;
 
 export const PreviewRow = styled(Row)<Partial<BannerContainerProps>>`
+  width: 100%;
   ${({ color }) => (color ? `background-color: ${colors.background[color]}` : '')};
   ${({ color }) => (color ? `border-bottom: 2px solid ${colors.border[color]}` : '')};
   margin-top: 10px;
   padding: 0 20px 5px 20px;
 `;
+PreviewRow.displayName = 'PreviewRow';
 
 export const SubtitleValue = styled(SummaryText)`
   padding-inline-end: 10px;

--- a/plugin-hrm-form/src/hooks/useExpandableOnOverflow.ts
+++ b/plugin-hrm-form/src/hooks/useExpandableOnOverflow.ts
@@ -25,21 +25,26 @@ export const useExpandableOnOverflow = ({ callback }: { callback?: (isOverflowin
   const expandButtonElementRef = React.useRef<HTMLButtonElement>(undefined);
   const collapseButtonElementRef = React.useRef<HTMLButtonElement>(undefined);
 
-  const handleExpand = () => {
+  const handleExpand = React.useCallback(() => {
     setExpanded(true);
-  };
+  }, [setExpanded]);
 
-  const handleCollapse = () => {
+  const handleCollapse = React.useCallback(() => {
     setExpanded(false);
-  };
+  }, [setExpanded]);
 
   React.useEffect(() => {
+    // Recompute when component is collapsed
+    if (!isExpanded) {
+      trigger();
+    }
+
     if (isExpanded) {
       collapseButtonElementRef.current?.focus();
     } else {
       expandButtonElementRef.current?.focus();
     }
-  }, [isExpanded]);
+  }, [isExpanded, trigger]);
 
   return {
     overflowingRef,

--- a/plugin-hrm-form/src/hooks/useIsOverflowing.ts
+++ b/plugin-hrm-form/src/hooks/useIsOverflowing.ts
@@ -20,7 +20,8 @@ import React from 'react';
 // Walks up the DOM tree and returns all ancestors that have display:none
 const getHiddenAncestors = (node: Element): Element[] => {
   const hiddenAncestors: Element[] = [];
-  let current = node.parentElement;
+
+  let current = node?.parentElement;
 
   while (current) {
     if (getComputedStyle(current).display === 'none') {

--- a/plugin-hrm-form/src/hooks/useIsOverflowing.ts
+++ b/plugin-hrm-form/src/hooks/useIsOverflowing.ts
@@ -15,11 +15,31 @@
  */
 
 // https://www.robinwieruch.de/react-custom-hook-check-if-overflow/
-import { debounce } from 'lodash';
 import React from 'react';
 
+// Walks up the DOM tree and returns all ancestors that have display:none
+const getHiddenAncestors = (node: Element): Element[] => {
+  const hiddenAncestors: Element[] = [];
+  let current = node.parentElement;
+
+  while (current) {
+    if (getComputedStyle(current).display === 'none') {
+      hiddenAncestors.push(current);
+    }
+    current = current.parentElement;
+  }
+
+  return hiddenAncestors;
+};
+
+/**
+ * Computes if a given component (via ref) has overflow, i.e. if it's child content does not fit within the component.
+ *
+ * **IMPORTANT:** if a callback is given, it **MUST** be a stable reference (e.g. wrapped within React.useCallback).
+ */
 export const useIsOverflowing = ({ ref, callback }: { ref: any; callback?: (isOverflowing: boolean) => void }) => {
   const [isOverflow, setOverflow] = React.useState(undefined);
+  const mutationObserversRef = React.useRef<MutationObserver[]>([]);
 
   const trigger = React.useCallback(() => {
     if (!ref.current) {
@@ -37,9 +57,46 @@ export const useIsOverflowing = ({ ref, callback }: { ref: any; callback?: (isOv
     }
   }, [callback, ref]);
 
+  const cleanupMutationObservers = React.useCallback(() => {
+    mutationObserversRef.current.forEach(obs => obs.disconnect());
+    mutationObserversRef.current = [];
+  }, []);
+
+  const setupObservers = React.useCallback(() => {
+    // Check if any ancestor is hidden — if so, we need MutationObservers as a fallback
+    const hiddenAncestors = getHiddenAncestors(ref.current);
+
+    if (hiddenAncestors.length > 0) {
+      hiddenAncestors.forEach(ancestor => {
+        const mutationObserver = new MutationObserver(() => {
+          // Once the ancestor is no longer hidden, check overflow and clean up
+          // mutation observers since ResizeObserver will take over from here
+          if (getComputedStyle(ancestor).display !== 'none') {
+            trigger();
+          }
+        });
+
+        mutationObserver.observe(ancestor, {
+          attributes: true,
+          attributeFilter: ['style', 'class'], // only watch style/class changes since those are what typically toggle display
+        });
+
+        mutationObserversRef.current.push(mutationObserver);
+      });
+    }
+  }, [trigger, ref]);
+
   React.useLayoutEffect(() => {
     trigger();
   }, [trigger, ref]);
+
+  React.useEffect(() => {
+    setupObservers();
+
+    return () => {
+      cleanupMutationObservers();
+    };
+  }, [ref, setupObservers, cleanupMutationObservers]);
 
   return { trigger, isOverflowing: isOverflow };
 };


### PR DESCRIPTION
## Description
This PR fixes the bug linked below, where search page would result in an unhandled error. The bug was introduced in https://github.com/techmatters/flex-plugins/pull/4143 and it caused because the "trigger compute overflow" function was invoked too many times, causing excessive set state function calls.

To fix the issue:
- `useLayoutEffect` is removed from `plugin-hrm-form/src/components/ExpandableBlocks/ExpandableText.tsx`. This fixes the bug introduced in the above linked PR.
- `MutationObserver`s are set for components using the `useIsOverflow` hook, if they are a descendant of a component that is "hidden" (`display: none` CSS attribute) when it is mounted. The observers trigger a compute overflow when the hidden ancestors become visible, fixing the bug attempted in the above linked PR.
- `useExpandableOnOverflow` triggers a compute overflow when the component is collapsed, to fix a potential bug that occurs when a component is hidden after it was expanded, but never unmounted (e.g. tabbing in contact forms).
- Some minor UI adjustments for case and contact preview (search results) to make the rest of the component relying on above hooks behave as expected.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3817)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
Confirm that the behavior is the expected in the following components:
- Field descriptions.
- Search results
  - Case preview when summary text is too long to fit the card.
  - Contact preview when summary text is too long to fit the card.
  - Case tags when they are too long to fit the card.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P