### PR TITLE
fix: aselo webchat EndChat behavior [CHI-3810]

### DIFF
--- a/aselo-webchat-react-app/src/components/MessageInput.tsx
+++ b/aselo-webchat-react-app/src/components/MessageInput.tsx
@@ -39,6 +39,7 @@ import {
 import { useSanitizer } from '../utils/useSanitizer';
 import { selectCurrentLocale } from '../store/config.reducer';
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export const MessageInput = () => {
   const dispatch = useDispatch();
   const [text, setText] = useState('');

--- a/aselo-webchat-react-app/src/components/MessageList.tsx
+++ b/aselo-webchat-react-app/src/components/MessageList.tsx
@@ -114,6 +114,8 @@ export const MessageList = () => {
       }
     };
 
+    if (conversation?.status !== 'joined') return () => undefined;
+
     conversation?.addListener('messageAdded', messageListener);
 
     return () => {
@@ -123,21 +125,28 @@ export const MessageList = () => {
 
   useEffect(() => {
     const checkIfAllMessagesLoaded = async () => {
-      if (!messages) return;
+      try {
+        if (!messages) return;
 
-      await noop(200);
+        if (conversation?.status !== 'joined') return;
 
-      const totalMessagesCount = await conversation?.getMessagesCount();
-      if (totalMessagesCount) {
-        setHasLoadedAllMessages(totalMessagesCount === messages.length);
-      }
+        await noop(200);
 
-      // if messages were added to state, loading is complete
-      if (messages && oldMessagesLength.current < messages?.length) {
-        isLoadingMessages.current = false;
-        oldMessagesLength.current = messages.length;
+        const totalMessagesCount = await conversation?.getMessagesCount();
+        if (totalMessagesCount) {
+          setHasLoadedAllMessages(totalMessagesCount === messages.length);
+        }
+
+        // if messages were added to state, loading is complete
+        if (messages && oldMessagesLength.current < messages?.length) {
+          isLoadingMessages.current = false;
+          oldMessagesLength.current = messages.length;
+        }
+      } catch (err) {
+        console.error('checkIfAllMessagesLoaded', err);
       }
     };
+
     checkIfAllMessagesLoaded();
   }, [messages, conversation]);
 
@@ -145,6 +154,8 @@ export const MessageList = () => {
     const element = event.target as HTMLDivElement;
     const hasReachedTop =
       element.scrollHeight + element.scrollTop - MESSAGES_SPINNER_BOX_HEIGHT <= element.clientHeight;
+
+    if (conversation?.status !== 'joined') return;
 
     // When reaching the top of all messages, load the next chunk
     if (hasReachedTop && conversation && messages && !hasLoadedAllMessages && !isLoadingMessages.current) {

--- a/aselo-webchat-react-app/src/components/MessagingCanvasPhase.tsx
+++ b/aselo-webchat-react-app/src/components/MessagingCanvasPhase.tsx
@@ -35,7 +35,7 @@ const DEFAULT_AUTO_FIRST_MESSAGE = 'Incoming webchat contact from';
 const DEFAULT_CUSTOMER_DEFAULT_NAME = 'Anonymous';
 
 const sendInitialUserQuery = async (conv?: Conversation, query?: string): Promise<void> => {
-  if (!query || !conv) return;
+  if (!query || !conv || conv.status !== 'joined') return;
 
   const totalMessagesCount = await conv.getMessagesCount();
 
@@ -76,7 +76,7 @@ export const MessagingCanvasPhase = () => {
       <CloseChatButtons />
       <NotificationBar />
       <MessageList />
-      {conversationState === 'active' ? <MessageInput /> : <ConversationEnded />}
+      {conversationState === 'active' && conversation?.status === 'joined' ? <MessageInput /> : <ConversationEnded />}
     </Wrapper>
   );
 };

--- a/aselo-webchat-react-app/src/components/__tests__/MessageList.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/MessageList.test.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { resetMockRedux } from '../../__mocks__/redux/mockRedux';
@@ -48,6 +48,7 @@ const message2 = {
 const defaultChatState = {
   conversation: {
     dateCreated: message1.dateCreated,
+    status: 'joined',
     getMessagesCount: jest.fn(),
     addListener: jest.fn(),
     removeListener: jest.fn(),
@@ -178,6 +179,31 @@ describe('Message List', () => {
       expect(getMessagesCountSpy).toHaveBeenCalled();
       expect(queryByTitle('Spinner')).not.toBeInTheDocument();
     });
+  });
+
+  it('does not call getMessagesCount and does not render loading spinner when conversation is not joined', async () => {
+    const getMessagesCountMock = jest.fn().mockResolvedValue(4);
+    resetMockRedux({
+      chat: {
+        ...defaultChatState,
+        conversation: {
+          ...defaultChatState.conversation,
+          status: 'notParticipating',
+          getMessagesCount: getMessagesCountMock,
+        },
+      },
+    });
+
+    let queryByTitle: ReturnType<typeof render>['queryByTitle'];
+    await act(async () => {
+      const result = render(<MessageList />);
+      queryByTitle = result.queryByTitle;
+      // Wait longer than the 200ms noop delay in checkIfAllMessagesLoaded to ensure effects ran
+      await new Promise(resolve => setTimeout(resolve, 300));
+    });
+
+    expect(getMessagesCountMock).not.toHaveBeenCalled();
+    expect(queryByTitle!('Spinner')).not.toBeInTheDocument();
   });
 
   it('correctly loads more messages when scrolled to top', async () => {

--- a/aselo-webchat-react-app/src/components/__tests__/MessageList.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/MessageList.test.tsx
@@ -194,16 +194,14 @@ describe('Message List', () => {
       },
     });
 
-    let queryByTitle: ReturnType<typeof render>['queryByTitle'];
+    const { queryByTitle } = render(<MessageList />);
+    // Wait longer than the 200ms noop delay in checkIfAllMessagesLoaded to ensure effects ran
     await act(async () => {
-      const result = render(<MessageList />);
-      queryByTitle = result.queryByTitle;
-      // Wait longer than the 200ms noop delay in checkIfAllMessagesLoaded to ensure effects ran
       await new Promise(resolve => setTimeout(resolve, 300));
     });
 
     expect(getMessagesCountMock).not.toHaveBeenCalled();
-    expect(queryByTitle!('Spinner')).not.toBeInTheDocument();
+    expect(queryByTitle('Spinner')).not.toBeInTheDocument();
   });
 
   it('correctly loads more messages when scrolled to top', async () => {

--- a/aselo-webchat-react-app/src/components/__tests__/MessagingCanvasPhase.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/MessagingCanvasPhase.test.tsx
@@ -53,6 +53,7 @@ const messageMock = {
   send: jest.fn(),
 };
 const conversationMock = {
+  status: 'joined',
   getMessagesCount: jest.fn(),
   prepareMessage: jest.fn(),
 };
@@ -118,13 +119,32 @@ describe('Messaging Canvas Phase', () => {
   });
 
   it('renders message input (and file drop area wrapper) when conversation state is active', () => {
-    resetMockRedux({ ...baseReduxState, chat: { conversationState: 'active', ...baseReduxState } });
+    resetMockRedux({
+      ...baseReduxState,
+      chat: { ...baseReduxState.chat, conversationState: 'active', conversation: conversationMock },
+    });
 
     const { queryByTitle } = render(<MessagingCanvasPhase />);
 
     expect(queryByTitle('AttachFileDropArea')).toBeInTheDocument();
     expect(queryByTitle('MessageInput')).toBeInTheDocument();
     expect(queryByTitle('ConversationEnded')).not.toBeInTheDocument();
+  });
+
+  it('renders conversation ended when conversation state is active but conversation is not joined', () => {
+    resetMockRedux({
+      ...baseReduxState,
+      chat: {
+        ...baseReduxState.chat,
+        conversationState: 'active',
+        conversation: { ...conversationMock, status: 'notParticipating' },
+      },
+    });
+
+    const { queryByTitle } = render(<MessagingCanvasPhase />);
+
+    expect(queryByTitle('ConversationEnded')).toBeInTheDocument();
+    expect(queryByTitle('MessageInput')).not.toBeInTheDocument();
   });
 
   it('renders conversation ended when conversation state is closed', () => {

--- a/aselo-webchat-react-app/src/components/endChat/EndChat.tsx
+++ b/aselo-webchat-react-app/src/components/endChat/EndChat.tsx
@@ -59,8 +59,6 @@ export default function EndChat(props: Props) {
             setDisabled(true);
             await configuredBackend('/endChat', { channelSid, token, language });
             sessionDataHandler.clear();
-            dispatch(updatePreEngagementData({}));
-            dispatch(changeEngagementPhase({ phase: EngagementPhase.PreEngagementForm }));
           } catch (error) {
             console.error(error);
           } finally {

--- a/aselo-webchat-react-app/src/store/actions/listeners/__tests__/conversationListener.test.ts
+++ b/aselo-webchat-react-app/src/store/actions/listeners/__tests__/conversationListener.test.ts
@@ -16,29 +16,33 @@
 
 import { Conversation } from '../../../../__mocks__/@twilio/conversations/conversation';
 import { initConversationListener } from '../conversationListener';
+import { ACTION_UPDATE_CONVERSATION_ATTRIBUTES } from '../../actionTypes';
+
+const buildConversation = () =>
+  new Conversation(
+    {
+      channel: 'chat',
+      entityName: '',
+      uniqueName: '',
+      attributes: {},
+      lastConsumedMessageIndex: 0,
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    },
+    'sid',
+    {
+      self: '',
+      messages: '',
+      participants: '',
+    },
+    {} as any,
+    {} as any,
+  );
 
 describe('initConversationListener', () => {
   it('adds a listener for the "update" event subset', () => {
     const dispatch = jest.fn();
-    const conversation = new Conversation(
-      {
-        channel: 'chat',
-        entityName: '',
-        uniqueName: '',
-        attributes: {},
-        lastConsumedMessageIndex: 0,
-        dateCreated: new Date(),
-        dateUpdated: new Date(),
-      },
-      'sid',
-      {
-        self: '',
-        messages: '',
-        participants: '',
-      },
-      {} as any,
-      {} as any,
-    );
+    const conversation = buildConversation();
 
     initConversationListener(conversation, dispatch);
     conversation.emit('updated', {
@@ -53,5 +57,19 @@ describe('initConversationListener', () => {
       updateReasons: ['status'],
     });
     expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches ACTION_UPDATE_CONVERSATION_ATTRIBUTES upon "removed" event', () => {
+    const dispatch = jest.fn();
+    const conversation = buildConversation();
+
+    initConversationListener(conversation, dispatch);
+    conversation.emit('removed', conversation);
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: ACTION_UPDATE_CONVERSATION_ATTRIBUTES,
+      payload: { conversation },
+    });
   });
 });

--- a/aselo-webchat-react-app/src/store/actions/listeners/conversationListener.ts
+++ b/aselo-webchat-react-app/src/store/actions/listeners/conversationListener.ts
@@ -35,4 +35,11 @@ export const initConversationListener = (conversation: Conversation, dispatch: D
       });
     }
   });
+
+  conversation.addListener('removed', payload => {
+    dispatch({
+      type: ACTION_UPDATE_CONVERSATION_ATTRIBUTES,
+      payload: { conversation: payload },
+    });
+  });
 };


### PR DESCRIPTION
## Description
This PR fixes the behavior of end chat button. Now, when the chat is ended, the widget does not resets the chat (stays in message list rather than navigating to pre engagement).
Most of the changes in this PR are to handle the case where message list components attempt calls to conversation services, which are no longer valid after the user is not a participant anymore.


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3810)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P