### PR TITLE
Clean up default conversation channel attributes

### DIFF
--- a/twilio-iac/helplines/templates/channel-attributes/default-conversations.tftpl
+++ b/twilio-iac/helplines/templates/channel-attributes/default-conversations.tftpl
@@ -1,7 +1,5 @@
 {
   "name": "{{trigger.conversation.ChannelAttributes.from}}",
-  "ip": "{{trigger.conversation.ChannelAttributes.pre_engagement_data.ip}}",
-  "firstName": "{{trigger.conversation.ChannelAttributes.pre_engagement_data.friendlyName}}",
   "channelType": "{% if trigger.conversation.ChannelAttributes.channel_type %}{{trigger.conversation.ChannelAttributes.channel_type}}{% else %}{{trigger.conversation.Source | downcase}}{% endif %}",
   "customChannelType": "{{trigger.conversation.ChannelAttributes.channelType}}", 
   "channelSid": "{{trigger.conversation.ChannelSid}}",
@@ -10,6 +8,5 @@
   "helpline":"${helpline}",
   "language":"${task_language}",
   "transferTargetType": "",
-  "preEngagementData": {{trigger.conversation.ChannelAttributes.pre_engagement_data | to_json}},
   "memory": {{trigger.conversation.ChannelAttributes.memory | to_json}}
 }


### PR DESCRIPTION
Removed webchat fields from conversation attributes, will replace with new chat-conversation file

## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P