### PR TITLE
feat: Support customized color for Aselo Webchat widget [CHI-3837]

### DIFF
--- a/aselo-webchat-react-app/src/components/styles/EntryPoint.styles.ts
+++ b/aselo-webchat-react-app/src/components/styles/EntryPoint.styles.ts
@@ -32,7 +32,7 @@ export const containerStyles: BoxStyleProps = {
   outline: '0px',
   padding: 'space0',
   _hover: {
-    backgroundColor: 'colorBackgroundPrimaryStronger',
+    opacity: 0.5,
   },
   _focusVisible: {
     backgroundColor: 'colorBackgroundPrimaryStronger',

--- a/aselo-webchat-react-app/src/components/styles/Header.styles.ts
+++ b/aselo-webchat-react-app/src/components/styles/Header.styles.ts
@@ -21,7 +21,7 @@ export const containerStyles: BoxStyleProps = {
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  backgroundColor: 'colorBackgroundPrimaryStronger',
+  backgroundColor: 'colorBackgroundPrimary',
   padding: 'space20',
   paddingTop: 'space40',
   paddingBottom: 'space40',

--- a/aselo-webchat-react-app/src/components/styles/MessageBubble.styles.ts
+++ b/aselo-webchat-react-app/src/components/styles/MessageBubble.styles.ts
@@ -43,7 +43,7 @@ export const getInnerContainerStyles = (belongToCurrentUser: boolean): BoxStyleP
   paddingBottom: 'space30',
   paddingLeft: 'space40',
   paddingRight: 'space40',
-  backgroundColor: belongToCurrentUser ? 'colorBackgroundPrimaryStronger' : 'colorBackground',
+  backgroundColor: belongToCurrentUser ? 'colorBackgroundPrimary' : 'colorBackground',
   color: belongToCurrentUser ? 'colorTextWeakest' : 'colorText',
   borderRadius: 'borderRadius30',
   marginLeft: belongToCurrentUser ? 'auto' : 'space0',

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -29,6 +29,8 @@ export const initChat = () => {
   const scriptEl = document.currentScript;
   const theme = urlParams.get('theme') ?? scriptEl?.getAttribute('theme');
   const isLightTheme = theme !== 'dark';
+  const color = urlParams.get('color') || scriptEl?.getAttribute('data-color');
+  const backgroundColor = urlParams.get('backgroundColor') || scriptEl?.getAttribute('data-background-color');
   const alwaysOpen = urlParams.get('alwaysOpen');
   const defaultLocale = urlParams.get('locale');
   const configUrl = urlParams.get('configUrl') ?? scriptEl?.getAttribute('config-url') ?? undefined;
@@ -44,7 +46,15 @@ export const initChat = () => {
 
   window.Twilio.initLogger('info');
   window.Twilio.initWebchat(configUrl, {
-    theme: { isLight: isLightTheme },
+    theme: {
+      isLight: isLightTheme,
+      overrides: {
+        backgroundColors: {
+          ...(backgroundColor && { colorBackgroundPrimary: backgroundColor }),
+        },
+        textColors: { ...(color && { colorTextWeakest: color }) },
+      },
+    },
     ...(alwaysOpen ? { alwaysOpen: alwaysOpen.toLowerCase() === 'true' } : {}),
     ...(defaultLocale ? { defaultLocale: defaultLocale as LocaleString } : {}),
   });


### PR DESCRIPTION
## Description
This PR adds support for color and background color customization for aselo webchat.
This is done either via the legacy `data-color` and `data-background-color` HTML attributes (used in existing webchat) or via url parameters `color` and `backgroundColor` - you can test this changes adding `?backgroundColor=%23FF7606&color=%23000000` to the end of the aselo webchat URL.

This approach seemed like most solid one since we are not changing the behavior of individual, but the theme, which means future components using the same styling theme will also get this applied.

Affected components:
- [x] Open/close bubble (`backgroundColor`).
- [x] Close carat color (`color`).
- [x] Hover state for bubble decreased opacity.
- [x] Title bar (`backgroundColor` + `color`).
- [x] Let’s Chat / Start Chat button (`backgroundColor`).
- [x] Message bubble - sent by user (`backgroundColor` + `color`).
- [x] Start Another Chat button (`backgroundColor`).

[Screencast from 29-04-26 15:48:11.webm](https://github.com/user-attachments/assets/a3aa795b-3a3c-496f-98ae-5b3d3720a13f)


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3837)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P