### PR TITLE
CHI-3857: Hide validation errors until submit attempted

### DIFF
--- a/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
+++ b/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
@@ -52,30 +52,38 @@ export const PreEngagementFormPhase = () => {
   const [wasSubmitAttempted, setSubmitAttempted] = useState(false);
   const [fieldsTouched, setFieldsTouched] = useState(new Set<string>());
 
-  const setPreEngagementDataFromDom = useCallback(() => {
-    const form = formRef.current;
-    if (!form) return;
-    // Collect current DOM values for all form fields and sync them to Redux in a
-    // single dispatch before validation runs. This ensures fields that have been
-    // filled but not yet blurred are still captured.
-    const domFieldValues = (preEngagementFormDefinition?.fields ?? []).reduce<
-      { name: string; value: string | boolean }[]
-    >((accum, field) => {
-      const element = form.querySelector<HTMLInputElement | HTMLSelectElement>(`#${field.name}`);
-      if (!element) return accum;
-      const value = field.type === FormInputType.Checkbox ? (element as HTMLInputElement).checked : element.value;
-      return [...accum, { name: field.name, value }];
-    }, []);
+  const setPreEngagementDataFromDom = useCallback(
+    (updates: Record<string, string | boolean> = {}) => {
+      const form = formRef.current;
+      if (!form) return;
+      // Collect current DOM values for all form fields and sync them to Redux in a
+      // single dispatch before validation runs. This ensures fields that have been
+      // filled but not yet blurred are still captured.
+      const domFieldValues = (preEngagementFormDefinition?.fields ?? []).reduce<
+        { name: string; value: string | boolean }[]
+      >((accum, field) => {
+        const element = form.querySelector<HTMLInputElement | HTMLSelectElement>(`#${field.name}`);
+        if (!element) return accum;
+        let value: string | boolean;
+        if (updates[field.name]) {
+          value = updates[field.name];
+        } else {
+          value = field.type === FormInputType.Checkbox ? (element as HTMLInputElement).checked : element.value;
+        }
+        return [...accum, { name: field.name, value }];
+      }, []);
 
-    if (domFieldValues.length > 0) {
-      dispatch(updatePreEngagementDataFields(domFieldValues) as any);
-    }
-  }, [dispatch, preEngagementFormDefinition?.fields]);
+      if (domFieldValues.length > 0) {
+        dispatch(updatePreEngagementDataFields(domFieldValues) as any);
+      }
+    },
+    [dispatch, preEngagementFormDefinition?.fields],
+  );
 
   const getItem = (inputName: string) => preEngagementData[inputName] ?? {};
-  const setItemValue = ({ name }: { name: string }) => {
+  const setItemValue = ({ name, value }: { name: string; value: string | boolean }) => {
     setFieldsTouched(fieldsTouched.add(name));
-    setPreEngagementDataFromDom();
+    setPreEngagementDataFromDom({ name, value });
   };
   const handleChange = setItemValue;
 

--- a/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
+++ b/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
@@ -49,6 +49,7 @@ export const PreEngagementFormPhase = () => {
   const dispatch = useDispatch();
 
   const [isRecaptchaVerifyPending, setRecaptchaVerifyPending] = useState(false);
+  const [wasSubmitAttempted, setSubmitAttempted] = useState(false);
 
   const setPreEngagementDataFromDom = useCallback(() => {
     const form = formRef.current;
@@ -79,7 +80,7 @@ export const PreEngagementFormPhase = () => {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setPreEngagementDataFromDom();
-
+    setSubmitAttempted(true);
     await dispatch(submitAndInitChatThunk() as any);
   };
 
@@ -100,7 +101,13 @@ export const PreEngagementFormPhase = () => {
           <LocalizedTemplate code={titleText} />
         </Text>
         <Box {...fieldStyles}>
-          {generateForm({ form: preEngagementFormDefinition.fields, handleChange, getItem, setItemValue })}
+          {generateForm({
+            form: preEngagementFormDefinition.fields,
+            handleChange,
+            getItem,
+            setItemValue,
+            showError: wasSubmitAttempted,
+          })}
         </Box>
 
         {enableRecaptcha && recaptchaSiteKey && (

--- a/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
+++ b/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
@@ -82,7 +82,11 @@ export const PreEngagementFormPhase = () => {
 
   const getItem = (inputName: string) => preEngagementData[inputName] ?? {};
   const setItemValue = ({ name, value }: { name: string; value: string | boolean }) => {
-    setFieldsTouched(fieldsTouched.add(name));
+    setFieldsTouched(prevFieldsTouched => {
+      const nextFieldsTouched = new Set(prevFieldsTouched);
+      nextFieldsTouched.add(name);
+      return nextFieldsTouched;
+    });
     setPreEngagementDataFromDom({ name, value });
   };
   const handleChange = setItemValue;

--- a/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
+++ b/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
@@ -65,7 +65,7 @@ export const PreEngagementFormPhase = () => {
         const element = form.querySelector<HTMLInputElement | HTMLSelectElement>(`#${field.name}`);
         if (!element) return accum;
         let value: string | boolean;
-        if (updates[field.name]) {
+        if (field.name in updates) {
           value = updates[field.name];
         } else {
           value = field.type === FormInputType.Checkbox ? (element as HTMLInputElement).checked : element.value;
@@ -87,7 +87,7 @@ export const PreEngagementFormPhase = () => {
       nextFieldsTouched.add(name);
       return nextFieldsTouched;
     });
-    setPreEngagementDataFromDom({ name, value });
+    setPreEngagementDataFromDom({ [name]: value });
   };
   const handleChange = setItemValue;
 

--- a/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
+++ b/aselo-webchat-react-app/src/components/PreEngagementFormPhase.tsx
@@ -50,6 +50,7 @@ export const PreEngagementFormPhase = () => {
 
   const [isRecaptchaVerifyPending, setRecaptchaVerifyPending] = useState(false);
   const [wasSubmitAttempted, setSubmitAttempted] = useState(false);
+  const [fieldsTouched, setFieldsTouched] = useState(new Set<string>());
 
   const setPreEngagementDataFromDom = useCallback(() => {
     const form = formRef.current;
@@ -72,7 +73,8 @@ export const PreEngagementFormPhase = () => {
   }, [dispatch, preEngagementFormDefinition?.fields]);
 
   const getItem = (inputName: string) => preEngagementData[inputName] ?? {};
-  const setItemValue = () => {
+  const setItemValue = ({ name }: { name: string }) => {
+    setFieldsTouched(fieldsTouched.add(name));
     setPreEngagementDataFromDom();
   };
   const handleChange = setItemValue;
@@ -106,7 +108,7 @@ export const PreEngagementFormPhase = () => {
             handleChange,
             getItem,
             setItemValue,
-            showError: wasSubmitAttempted,
+            showError: name => wasSubmitAttempted || fieldsTouched.has(name),
           })}
         </Box>
 

--- a/aselo-webchat-react-app/src/components/__tests__/PreEngagementFormPhase.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/PreEngagementFormPhase.test.tsx
@@ -604,6 +604,64 @@ describe('Pre Engagement Form Phase - validation', () => {
     );
     expect(initAction.initSession).toHaveBeenCalled();
   });
+
+  it('validation errors are hidden before the first submit attempt even when the Redux state has an error', () => {
+    // Pre-populate the store with a field that already has a validation error
+    const store = createValidationStore(
+      [{ name: 'name', type: FormInputType.Input, label: 'Name', required: true } as PreEngagementFormItem],
+      { name: { value: '', error: 'RequiredFieldError', dirty: true } },
+    );
+    const { queryByText } = render(
+      <Provider store={store}>
+        <PreEngagementFormPhase />
+      </Provider>,
+    );
+    // showError is false before any submit or field touch, so the error span must not render
+    expect(queryByText('RequiredFieldError')).not.toBeInTheDocument();
+  });
+
+  it('validation errors become visible after the first submit attempt', async () => {
+    const store = createValidationStore([
+      { name: 'name', type: FormInputType.Input, label: 'Name', required: true } as PreEngagementFormItem,
+    ]);
+    const { container, queryByText } = render(
+      <Provider store={store}>
+        <PreEngagementFormPhase />
+      </Provider>,
+    );
+    // No error visible before submit
+    expect(queryByText('RequiredFieldError')).not.toBeInTheDocument();
+    // Submit with the required field empty — validation fails and wasSubmitAttempted becomes true
+    await submitForm(container);
+    // showError is now true for all fields, so the error span must be rendered
+    expect(queryByText('RequiredFieldError')).toBeInTheDocument();
+  });
+
+  it('validation error for a field becomes visible after that field is touched without a submit', async () => {
+    const namePlaceholder = 'Enter name';
+    const store = createValidationStore([
+      {
+        name: 'name',
+        type: FormInputType.Input,
+        label: 'Name',
+        required: true,
+        placeholder: namePlaceholder,
+      } as PreEngagementFormItem,
+    ]);
+    const { getByPlaceholderText, queryByText } = render(
+      <Provider store={store}>
+        <PreEngagementFormPhase />
+      </Provider>,
+    );
+    // No error visible before any interaction
+    expect(queryByText('RequiredFieldError')).not.toBeInTheDocument();
+    // Blur the empty required field — this adds it to fieldsTouched and syncs the empty value to Redux
+    await act(async () => {
+      fireEvent.blur(getByPlaceholderText(namePlaceholder));
+    });
+    // showError is now true for this field (fieldsTouched.has('name')), so the error must be rendered
+    expect(queryByText('RequiredFieldError')).toBeInTheDocument();
+  });
 });
 
 describe('Pre Engagement Form Phase - ReCaptcha', () => {

--- a/aselo-webchat-react-app/src/components/forms/formInputs/Checkbox.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/Checkbox.tsx
@@ -27,11 +27,12 @@ type OwnProps = {
   getItem: (inptuName: string) => PreEngagementDataItem;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
   defaultValue?: string;
+  showError?: boolean;
 };
 
 type Props = OwnProps;
 
-const Checkbox: React.FC<Props> = ({ definition, getItem, handleChange, defaultValue }) => {
+const Checkbox: React.FC<Props> = ({ definition, getItem, handleChange, defaultValue, showError = true }) => {
   const { required, name, label, initialChecked } = definition;
   const { error } = getItem(name);
 
@@ -40,7 +41,7 @@ const Checkbox: React.FC<Props> = ({ definition, getItem, handleChange, defaultV
       <Label htmlFor={name} data-testid={`${name}-label`}>
         <CheckboxInput
           id={name}
-          hasError={Boolean(error)}
+          hasError={Boolean(error && showError)}
           onClick={e => {
             handleChange({ name, value: (e.target as HTMLInputElement).checked });
           }}
@@ -51,7 +52,7 @@ const Checkbox: React.FC<Props> = ({ definition, getItem, handleChange, defaultV
           {Boolean(required) && '*'}
         </CheckboxInput>
       </Label>
-      {error && (
+      {error && showError && (
         <span style={{ color: 'rgb(203, 50, 50)' }}>
           <LocalizedTemplate code={error} />
         </span>

--- a/aselo-webchat-react-app/src/components/forms/formInputs/DependentSelect.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/DependentSelect.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021-2023 Technology Matters
+ * Copyright (C) 2021-2026 Technology Matters
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
@@ -31,11 +31,12 @@ type OwnProps = {
   setItemValue: (payload: { name: string; value: string | boolean }) => void;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
   defaultValue?: string;
+  showError?: boolean;
 };
 
 type Props = OwnProps;
 
-const DependentSelect: React.FC<Props> = ({ getItem, setItemValue, definition, handleChange }) => {
+const DependentSelect: React.FC<Props> = ({ getItem, setItemValue, definition, handleChange, showError = true }) => {
   const currentTranslations = useSelector(selectCurrentTranslations);
   const configuredLocalizeKey = localizeKey(currentTranslations);
   const { dependsOn, name, label, required, options } = definition;
@@ -74,7 +75,7 @@ const DependentSelect: React.FC<Props> = ({ getItem, setItemValue, definition, h
         </span>
         <SelectInput
           id={name}
-          hasError={Boolean(error)}
+          hasError={Boolean(error && showError)}
           onChange={e => handleChange({ name, value: e.target.value })}
           disabled={!dependsOnValue}
           value={value as string}
@@ -82,7 +83,7 @@ const DependentSelect: React.FC<Props> = ({ getItem, setItemValue, definition, h
           {buildOptions()}
         </SelectInput>
       </Label>
-      {error && (
+      {error && showError && (
         <span style={{ color: 'rgb(203, 50, 50)' }}>
           <LocalizedTemplate code={error} />
         </span>

--- a/aselo-webchat-react-app/src/components/forms/formInputs/Input.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/Input.tsx
@@ -32,11 +32,12 @@ type OwnProps = {
   getItem: (inptuName: string) => PreEngagementDataItem;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
   defaultValue?: string;
+  showError?: boolean;
 };
 
 type Props = OwnProps;
 
-const InputText: React.FC<Props> = ({ definition, handleChange, getItem }) => {
+const InputText: React.FC<Props> = ({ definition, handleChange, getItem, showError = true }) => {
   const currentTranslations = useSelector(selectCurrentTranslations);
   const configuredLocalizeKey = localizeKey(currentTranslations);
   const { name, label, placeholder, required } = definition;
@@ -60,12 +61,12 @@ const InputText: React.FC<Props> = ({ definition, handleChange, getItem }) => {
           type="text"
           id={name}
           placeholder={placeholder === undefined ? undefined : configuredLocalizeKey(placeholder)}
-          hasError={Boolean(error)}
+          hasError={Boolean(error && showError)}
           onBlur={e => handleChange({ name, value: e.target.value })}
           onChange={e => debouncedHandleChange({ name, value: e.target.value })}
         />
       </Label>
-      {error && (
+      {error && showError && (
         <span style={{ color: 'rgb(203, 50, 50)' }}>
           <LocalizedTemplate code={error} />
         </span>

--- a/aselo-webchat-react-app/src/components/forms/formInputs/Select.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/Select.tsx
@@ -30,11 +30,12 @@ type OwnProps = {
   getItem: (inptuName: string) => PreEngagementDataItem;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
   defaultValue?: string;
+  showError?: boolean;
 };
 
 type Props = OwnProps;
 
-const Select: React.FC<Props> = ({ definition, getItem, defaultValue, handleChange }) => {
+const Select: React.FC<Props> = ({ definition, getItem, defaultValue, handleChange, showError = true }) => {
   const currentTranslations = useSelector(selectCurrentTranslations);
   const configuredLocalizeKey = localizeKey(currentTranslations);
   const { name, label, required, options } = definition;
@@ -54,14 +55,14 @@ const Select: React.FC<Props> = ({ definition, getItem, defaultValue, handleChan
         </span>
         <SelectInput
           id={name}
-          hasError={Boolean(error)}
+          hasError={Boolean(error && showError)}
           onChange={e => handleChange({ name, value: e.target.value })}
           defaultValue={defaultValue}
         >
           {buildOptions()}
         </SelectInput>
       </Label>
-      {error && (
+      {error && showError && (
         <span style={{ color: 'rgb(203, 50, 50)' }}>
           <LocalizedTemplate code={error} />
         </span>

--- a/aselo-webchat-react-app/src/components/forms/formInputs/index.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/index.tsx
@@ -27,19 +27,37 @@ const generateFormItem = ({
   handleChange,
   getItem,
   setItemValue,
+  showError,
 }: {
   definition: PreEngagementFormItem;
   defaultValue?: string | boolean;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
   getItem: (inptuName: string) => PreEngagementDataItem;
   setItemValue: (payload: { name: string; value: string | boolean }) => void;
+  showError?: boolean;
 }) => {
   switch (definition.type) {
     case FormInputType.Input:
     case FormInputType.Email:
-      return <InputText key={definition.name} definition={definition} handleChange={handleChange} getItem={getItem} />;
+      return (
+        <InputText
+          key={definition.name}
+          definition={definition}
+          handleChange={handleChange}
+          getItem={getItem}
+          showError={showError}
+        />
+      );
     case FormInputType.Select:
-      return <Select key={definition.name} definition={definition} handleChange={handleChange} getItem={getItem} />;
+      return (
+        <Select
+          key={definition.name}
+          definition={definition}
+          handleChange={handleChange}
+          getItem={getItem}
+          showError={showError}
+        />
+      );
     case FormInputType.DependentSelect:
       return (
         <DependentSelect
@@ -48,10 +66,19 @@ const generateFormItem = ({
           handleChange={handleChange}
           getItem={getItem}
           setItemValue={setItemValue}
+          showError={showError}
         />
       );
     case FormInputType.Checkbox:
-      return <Checkbox key={definition.name} definition={definition} handleChange={handleChange} getItem={getItem} />;
+      return (
+        <Checkbox
+          key={definition.name}
+          definition={definition}
+          handleChange={handleChange}
+          getItem={getItem}
+          showError={showError}
+        />
+      );
     default:
       return <div>Invalid form definition: {JSON.stringify(definition)}</div>;
   }
@@ -77,16 +104,25 @@ export const generateForm = ({
   handleChange,
   getItem,
   setItemValue,
+  showError = true,
 }: {
   form: PreEngagementForm['fields'];
   handleChange: (payload: { name: string; value: string | boolean }) => void;
   getItem: (inptuName: string) => PreEngagementDataItem;
   setItemValue: (payload: { name: string; value: string | boolean }) => void;
+  showError?: boolean;
 }) => {
   return (
     form &&
     form.map(definition =>
-      generateFormItem({ definition, handleChange, defaultValue: getDefaultValue(definition), getItem, setItemValue }),
+      generateFormItem({
+        definition,
+        handleChange,
+        defaultValue: getDefaultValue(definition),
+        getItem,
+        setItemValue,
+        showError,
+      }),
     )
   );
 };

--- a/aselo-webchat-react-app/src/components/forms/formInputs/index.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/index.tsx
@@ -104,13 +104,13 @@ export const generateForm = ({
   handleChange,
   getItem,
   setItemValue,
-  showError = true,
+  showError = () => true,
 }: {
   form: PreEngagementForm['fields'];
   handleChange: (payload: { name: string; value: string | boolean }) => void;
   getItem: (inptuName: string) => PreEngagementDataItem;
   setItemValue: (payload: { name: string; value: string | boolean }) => void;
-  showError?: boolean;
+  showError?: (name: string) => boolean;
 }) => {
   return (
     form &&
@@ -121,7 +121,7 @@ export const generateForm = ({
         defaultValue: getDefaultValue(definition),
         getItem,
         setItemValue,
-        showError,
+        showError: showError(definition.name),
       }),
     )
   );


### PR DESCRIPTION
## Description

Pre engagement form was showing validation errors too early. Now only shows them after a submit is attempted or after that specific field has been touched

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P