### PR TITLE
CHI-3855: Capture data attributes from the current script so they can be used in event handlers

### DIFF
--- a/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
+++ b/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
@@ -135,10 +135,11 @@ jobs:
           cat >> aselo-chat-uncompressed.js << 'INIT_SCRIPT'
           ;
           (function () {
+            const scriptTagData = document.currentScript.element.dataset;
             if (document.readyState === 'loading') {
-              document.addEventListener('DOMContentLoaded', function () { window.Twilio.initChat(); });
+              document.addEventListener('DOMContentLoaded', function () { window.Twilio.initChat(scriptTagData); });
             } else {
-              window.Twilio.initChat();
+              window.Twilio.initChat(scriptTagData);
             }
           })();
           INIT_SCRIPT

--- a/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
+++ b/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
@@ -135,7 +135,7 @@ jobs:
           cat >> aselo-chat-uncompressed.js << 'INIT_SCRIPT'
           ;
           (function () {
-            const scriptTagData = document.currentScript.element.dataset;
+            const scriptTagData = document.currentScript.dataset;
             if (document.readyState === 'loading') {
               document.addEventListener('DOMContentLoaded', function () { window.Twilio.initChat(scriptTagData); });
             } else {

--- a/aselo-webchat-react-app/public/app.js
+++ b/aselo-webchat-react-app/public/app.js
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-
+const scriptTagData = document.currentScript.element.dataset;
 window.addEventListener('DOMContentLoaded', () => {
-  Twilio.initChat();
+  Twilio.initChat(scriptTagData);
 });

--- a/aselo-webchat-react-app/public/app.js
+++ b/aselo-webchat-react-app/public/app.js
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-const scriptTagData = document.currentScript.element.dataset;
+const scriptTagData = document.currentScript.dataset;
 window.addEventListener('DOMContentLoaded', () => {
   Twilio.initChat(scriptTagData);
 });

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -28,8 +28,8 @@ export const initChat = (scriptTagData: Record<string, string | undefined>) => {
   const urlParams = new URLSearchParams(window.location.search);
   const theme = urlParams.get('theme') ?? scriptTagData.theme;
   const isLightTheme = theme !== 'dark';
-  const color = urlParams.get('color') || scriptEl?.getAttribute('data-color');
-  const backgroundColor = urlParams.get('backgroundColor') || scriptEl?.getAttribute('data-background-color');
+  const color = urlParams.get('color') || scriptTagData.color;
+  const backgroundColor = urlParams.get('backgroundColor') || scriptTagData.backgroundColor;
   const alwaysOpen = urlParams.get('alwaysOpen');
   const defaultLocale =
     // data-language attribute is supported for backwards compatibility, remove once webchat is fully migrated

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -24,18 +24,17 @@ import { LocaleString } from './store/definitions';
  * standard app.js bootstrap and the aselo-chat.min.js wrapper used for legacy URL
  * compatibility deploys.
  */
-export const initChat = () => {
+export const initChat = (scriptTagData: Record<string, string | undefined>) => {
   const urlParams = new URLSearchParams(window.location.search);
-  const scriptEl = document.currentScript;
-  const theme = urlParams.get('theme') ?? scriptEl?.getAttribute('theme');
+  const theme = urlParams.get('theme') ?? scriptTagData.theme;
   const isLightTheme = theme !== 'dark';
   const color = urlParams.get('color') || scriptEl?.getAttribute('data-color');
   const backgroundColor = urlParams.get('backgroundColor') || scriptEl?.getAttribute('data-background-color');
   const alwaysOpen = urlParams.get('alwaysOpen');
   const defaultLocale =
     // data-language attribute is supported for backwards compatibility, remove once webchat is fully migrated
-    urlParams.get('locale') || scriptEl?.getAttribute('data-locale') || scriptEl?.getAttribute('data-language');
-  const configUrl = urlParams.get('configUrl') ?? scriptEl?.getAttribute('data-config-url') ?? undefined;
+    urlParams.get('locale') || scriptTagData.locale || scriptTagData.language;
+  const configUrl = urlParams.get('configUrl') ?? scriptTagData.configUrl ?? undefined;
 
   const themeEl = document.querySelector('[data-theme-pref]');
   themeEl?.setAttribute('data-theme-pref', isLightTheme ? 'light-theme' : 'dark-theme');


### PR DESCRIPTION
## Description

Aselo Webchat runs code from window event handlers rather than directly from the script, which means document.currentScript is null, because it's fired on an event, not a script

This PR captures the data attributes on the script tag ahead of time so they can still be used to override configurations in code running in event handlers

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P