### PR TITLE
CHI-3862: Use fetchLater to ensure endChat call is sent

### DIFF
--- a/aselo-webchat-react-app/public/index.html
+++ b/aselo-webchat-react-app/public/index.html
@@ -34,7 +34,6 @@
   <noscript>
     You need to enable JavaScript to run this app.
   </noscript>
-  <div id="aselo-webchat-widget-root"></div>
   <script defer src="./app.js"></script>
 </body>
 

--- a/aselo-webchat-react-app/src/__tests__/sessionDataHandler.test.ts
+++ b/aselo-webchat-react-app/src/__tests__/sessionDataHandler.test.ts
@@ -119,6 +119,42 @@ describe('session data handler', () => {
         `${TEST_CONFIG_STATE.aseloBackendUrl}/lambda/twilio/account-scoped/XX/Webchat/Tokens/Refresh`,
       );
     });
+
+    describe('deferredRequest', () => {
+      afterEach(() => {
+        delete (window as any).fetchLater;
+      });
+
+      it('should use fetchLater when available and not call fetch', async () => {
+        const fetchLaterMock = jest.fn();
+        (window as any).fetchLater = fetchLaterMock;
+
+        await contactBackend(TEST_CONFIG_STATE).deferredRequest('/endChat', {
+          channelSid: 'CH123',
+          token: 'token',
+        });
+
+        expect(fetchLaterMock).toHaveBeenCalledWith(
+          `${TEST_CONFIG_STATE.aseloBackendUrl}/lambda/twilio/account-scoped/XX/endChat`,
+          expect.objectContaining({ method: 'POST' }),
+        );
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      it('should fall back to fetch when fetchLater is not available', async () => {
+        fetchMock.mockResolvedValue(okFetchResponse({}));
+
+        await contactBackend(TEST_CONFIG_STATE).deferredRequest('/endChat', {
+          channelSid: 'CH123',
+          token: 'token',
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          `${TEST_CONFIG_STATE.aseloBackendUrl}/lambda/twilio/account-scoped/XX/endChat`,
+          expect.objectContaining({ method: 'POST' }),
+        );
+      });
+    });
   });
 
   describe('fetch and store new session', () => {

--- a/aselo-webchat-react-app/src/__tests__/sessionDataHandler.test.ts
+++ b/aselo-webchat-react-app/src/__tests__/sessionDataHandler.test.ts
@@ -97,7 +97,10 @@ describe('session data handler', () => {
     it('should call correct stage url', async () => {
       fetchMock.mockResolvedValue(okFetchResponse({}));
       sessionDataHandler.setRegion('stage');
-      await contactBackend(TEST_CONFIG_STATE)('/Webchat/Tokens/Refresh', { DeploymentKey: 'dk', token: 'token' });
+      await contactBackend(TEST_CONFIG_STATE).request('/Webchat/Tokens/Refresh', {
+        DeploymentKey: 'dk',
+        token: 'token',
+      });
       expect(fetchMock.mock.calls[0][0]).toEqual(
         `${TEST_CONFIG_STATE.aseloBackendUrl}/lambda/twilio/account-scoped/XX/Webchat/Tokens/Refresh`,
       );
@@ -108,7 +111,10 @@ describe('session data handler', () => {
       const fetchSpy = jest
         .spyOn(window, 'fetch')
         .mockImplementation(async (): Promise<never> => mockFetch as Promise<never>);
-      await contactBackend(TEST_CONFIG_STATE)('/Webchat/Tokens/Refresh', { DeploymentKey: 'dk', token: 'token' });
+      await contactBackend(TEST_CONFIG_STATE).request('/Webchat/Tokens/Refresh', {
+        DeploymentKey: 'dk',
+        token: 'token',
+      });
       expect(fetchSpy.mock.calls[0][0]).toEqual(
         `${TEST_CONFIG_STATE.aseloBackendUrl}/lambda/twilio/account-scoped/XX/Webchat/Tokens/Refresh`,
       );

--- a/aselo-webchat-react-app/src/components/endChat/EndChat.tsx
+++ b/aselo-webchat-react-app/src/components/endChat/EndChat.tsx
@@ -57,7 +57,7 @@ export default function EndChat(props: Props) {
           try {
             const { token, channelSid, language } = props;
             setDisabled(true);
-            await configuredBackend('/endChat', { channelSid, token, language });
+            await configuredBackend.request('/endChat', { channelSid, token, language });
             sessionDataHandler.clear();
           } catch (error) {
             console.error(error);

--- a/aselo-webchat-react-app/src/components/endChat/QuickExit.tsx
+++ b/aselo-webchat-react-app/src/components/endChat/QuickExit.tsx
@@ -45,20 +45,21 @@ export default function QuickExit(props: Props) {
 
   const configuredBackend = contactBackend(config);
   const handleExit = async () => {
-    // Clear chat history and open a new location
-    sessionDataHandler.clear();
-    dispatch(updatePreEngagementData({}));
-    dispatch(changeEngagementPhase({ phase: EngagementPhase.PreEngagementForm }));
     if (props.action === 'finishTask') {
       // Only if we started a task
       try {
         // Fire and forget end chat request, don't delay blanking the page waiting for the response
-        configuredBackend('/endChat', props).then(() => null);
+        configuredBackend.deferredRequest('/endChat', props).then(() => null);
       } catch (error) {
         // Only errors synchronously making the request will be caught, not errors from the service
         console.error(error);
       }
     }
+    // Clear chat history and open a new location
+    sessionDataHandler.clear();
+    dispatch(updatePreEngagementData({}));
+    dispatch(changeEngagementPhase({ phase: EngagementPhase.PreEngagementForm }));
+
     window.location.replace(config.quickExitUrl);
   };
 

--- a/aselo-webchat-react-app/src/sessionDataHandler.ts
+++ b/aselo-webchat-react-app/src/sessionDataHandler.ts
@@ -95,8 +95,9 @@ export const contactBackend = ({ aseloBackendUrl, helplineCode }: ConfigState) =
 
     if (!response.ok) {
       const body = await response.text();
-      logger.error(`Request to backend failed (status ${response.status})`, body);
-      throw new Error(`Request to backend failed (status ${response.status}). ${body}`);
+      const errorMessage = `Request to backend failed (status ${response.status}). ${body}`;
+      logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     return response.json();

--- a/aselo-webchat-react-app/src/sessionDataHandler.ts
+++ b/aselo-webchat-react-app/src/sessionDataHandler.ts
@@ -57,7 +57,7 @@ export const contactBackend = ({ aseloBackendUrl, helplineCode }: ConfigState) =
     body: InitWebchatAPIPayload | RefreshTokenAPIPayload | EndChatPayload,
     attemptToDefer: boolean,
   ): Promise<T | undefined> => {
-    const securityHeaders = await generateSecurityHeaders();
+    const securityHeaders = generateSecurityHeaders();
     const mixpanelHeaders = generateMixPanelHeaders();
     const logger = window.Twilio.getLogger('SessionDataHandler');
     const urlEncodedBody = new URLSearchParams();

--- a/aselo-webchat-react-app/src/sessionDataHandler.ts
+++ b/aselo-webchat-react-app/src/sessionDataHandler.ts
@@ -52,10 +52,11 @@ export const getAccountScopedBaseUrl = (aseloBackendUrl: string, helplineCode: s
 
 export const contactBackend = ({ aseloBackendUrl, helplineCode }: ConfigState) => {
   const lambdaUrl = getAccountScopedBaseUrl(aseloBackendUrl, helplineCode);
-  return async <T>(
+  const doRequest = async <T>(
     endpointRoute: string,
     body: InitWebchatAPIPayload | RefreshTokenAPIPayload | EndChatPayload,
-  ): Promise<T> => {
+    attemptToDefer: boolean,
+  ): Promise<T | undefined> => {
     const securityHeaders = await generateSecurityHeaders();
     const mixpanelHeaders = generateMixPanelHeaders();
     const logger = window.Twilio.getLogger('SessionDataHandler');
@@ -65,23 +66,47 @@ export const contactBackend = ({ aseloBackendUrl, helplineCode }: ConfigState) =
         urlEncodedBody.append(key, (body as Record<string, string>)[key].toString());
       }
     }
-    const response = await fetch(lambdaUrl + endpointRoute, {
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...securityHeaders,
+      ...mixpanelHeaders,
+    };
+    const fullUrl = lambdaUrl + endpointRoute;
+    if (attemptToDefer) {
+      // eslint-disable-next-line dot-notation
+      const { fetchLater } = window as any;
+      if (fetchLater) {
+        console.info(`fetchLater support detected, using that.`);
+        fetchLater(fullUrl, {
+          method: 'POST',
+          headers,
+          body: urlEncodedBody.toString(),
+        });
+        return undefined;
+      }
+      console.info(`No fetchLater support detected, falling back to fetch`);
+    }
+    const response = await fetch(fullUrl, {
       method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded',
-        ...securityHeaders,
-        ...mixpanelHeaders,
-      },
+      headers,
       body: urlEncodedBody.toString(),
     });
 
     if (!response.ok) {
-      logger.error('Request to backend failed');
-      throw new Error('Request to backend failed');
+      const body = await response.text();
+      logger.error(`Request to backend failed (status ${response.status})`, body);
+      throw new Error(`Request to backend failed (status ${response.status}). ${body}`);
     }
 
     return response.json();
+  };
+  return {
+    request: <T>(endpointRoute: string, body: InitWebchatAPIPayload | RefreshTokenAPIPayload | EndChatPayload) =>
+      doRequest(endpointRoute, body, false) as Promise<T>,
+    deferredRequest: async (endpointRoute: string, body: EndChatPayload) => {
+      await doRequest(endpointRoute, body, true);
+    },
   };
 };
 function storeSessionData(data: SessionDataStorage) {
@@ -155,7 +180,7 @@ class SessionDataHandler {
 
     let newTokenData: TokenResponse;
     try {
-      newTokenData = await contactBackend(store.getState().config)<TokenResponse>(
+      newTokenData = await contactBackend(store.getState().config).request<TokenResponse>(
         '/webchatAuthentication/refreshToken',
         {
           DeploymentKey: this._deploymentKey,
@@ -208,7 +233,7 @@ class SessionDataHandler {
       if (customerIdentity) {
         payload.Identity = customerIdentity;
       }
-      newTokenData = await contactBackend(config)<TokenResponse>('/webchatAuthentication/initWebchat', payload);
+      newTokenData = await contactBackend(config).request<TokenResponse>('/webchatAuthentication/initWebchat', payload);
     } catch (e) {
       logger.error('No results from server');
       throw Error('No results from server');

--- a/aselo-webchat-react-app/src/sessionDataHandler.ts
+++ b/aselo-webchat-react-app/src/sessionDataHandler.ts
@@ -77,7 +77,7 @@ export const contactBackend = ({ aseloBackendUrl, helplineCode }: ConfigState) =
       // eslint-disable-next-line dot-notation
       const { fetchLater } = window as any;
       if (fetchLater) {
-        console.info(`fetchLater support detected, using that.`);
+        logger.info(`fetchLater support detected, using that.`);
         fetchLater(fullUrl, {
           method: 'POST',
           headers,
@@ -85,7 +85,7 @@ export const contactBackend = ({ aseloBackendUrl, helplineCode }: ConfigState) =
         });
         return undefined;
       }
-      console.info(`No fetchLater support detected, falling back to fetch`);
+      logger.warn(`No fetchLater support detected, falling back to fetch`);
     }
     const response = await fetch(fullUrl, {
       method: 'POST',

--- a/aselo-webchat-react-app/src/utils/generateHeaders.test.ts
+++ b/aselo-webchat-react-app/src/utils/generateHeaders.test.ts
@@ -79,10 +79,7 @@ describe('Headers', () => {
         cookieEnabled: true,
         userTimezone: new Date().getTimezoneOffset(),
       });
-      expect(JSON.parse(headers[HEADER_SEC_DECODER])).toMatchObject({
-        audio: { decodingInfo: true },
-        video: { decodingInfo: true },
-      });
+      expect(JSON.parse(headers[HEADER_SEC_DECODER])).toBeDefined();
       expect(JSON.parse(headers[HEADER_SEC_WEBCHAT])).toMatchObject({
         loginTimestamp: 'TODAY',
       });
@@ -104,12 +101,6 @@ describe('Headers', () => {
           loginTimestamp: null,
         }),
       );
-      Object.defineProperty(navigator, 'mediaCapabilities', {
-        writable: true,
-        value: {
-          decodingInfo: jest.fn().mockRejectedValue(null),
-        },
-      });
       Object.defineProperty(navigator, 'userAgent', {
         writable: true,
         value: 'USER_AGENT_2',
@@ -131,10 +122,7 @@ describe('Headers', () => {
         cookieEnabled: DEFAULT_COOKIE_ENABLED,
         userTimezone: new Date().getTimezoneOffset(),
       });
-      expect(JSON.parse(headers[HEADER_SEC_DECODER])).toMatchObject({
-        audio: sampleDefaultCodecInfo,
-        video: sampleDefaultCodecInfo,
-      });
+      expect(JSON.parse(headers[HEADER_SEC_DECODER])).toBeDefined();
       expect(JSON.parse(headers[HEADER_SEC_WEBCHAT])).toMatchObject({
         loginTimestamp: DEFAULT_LOGIN_TIMESTAMP,
       });

--- a/aselo-webchat-react-app/src/utils/generateHeaders.ts
+++ b/aselo-webchat-react-app/src/utils/generateHeaders.ts
@@ -61,8 +61,11 @@ const getWebchatInfo = () => {
   };
 };
 
+let audio: MediaCapabilitiesInfo = DEFAULT_CODEC_INFO;
+let video: MediaCapabilitiesInfo = DEFAULT_CODEC_INFO;
+
 const getAudioVideoDecoders = async () => {
-  const audioDecorder = navigator.mediaCapabilities?.decodingInfo({
+  const audioDecoder = navigator.mediaCapabilities?.decodingInfo({
     type: 'file',
     audio: {
       contentType: 'audio/mp3',
@@ -71,7 +74,7 @@ const getAudioVideoDecoders = async () => {
       samplerate: 5200,
     },
   });
-  const videoDecorder = navigator.mediaCapabilities?.decodingInfo({
+  const videoDecoder = navigator.mediaCapabilities?.decodingInfo({
     type: 'file',
     audio: {
       contentType: 'audio/mp4',
@@ -80,42 +83,29 @@ const getAudioVideoDecoders = async () => {
       samplerate: 5200,
     },
   });
+  const [audioCapabilitiesResult, videoCapabilitiesResult]: Array<PromiseSettledResult<MediaCapabilitiesInfo>> =
+    await Promise.allSettled([audioDecoder, videoDecoder]);
 
-  return Promise.allSettled([audioDecorder, videoDecorder]).then(
-    (results: Array<PromiseSettledResult<MediaCapabilitiesInfo>>) => {
-      const allFullfied = results.every(result => result.status === 'fulfilled' && Boolean(result.value));
+  if (audioCapabilitiesResult.status === 'fulfilled' && Boolean(audioCapabilitiesResult.value)) {
+    audio = audioCapabilitiesResult.value;
+  }
 
-      let audio: MediaCapabilitiesInfo = DEFAULT_CODEC_INFO;
-      let video: MediaCapabilitiesInfo = DEFAULT_CODEC_INFO;
-
-      if (allFullfied) {
-        const _res = results as Array<PromiseFulfilledResult<MediaCapabilitiesInfo>>;
-
-        audio = _res[0].value;
-        video = _res[1].value;
-      }
-
-      return {
-        audio,
-        video,
-      };
-    },
-  );
+  if (videoCapabilitiesResult.status === 'fulfilled' && Boolean(videoCapabilitiesResult.value)) {
+    video = videoCapabilitiesResult.value;
+  }
 };
 
-// eslint-disable-next-line import/no-unused-modules
-export const generateSecurityHeaders = async (): Promise<SecurityHeadersType> => {
+getAudioVideoDecoders().then(() => null);
+
+export const generateSecurityHeaders = (): SecurityHeadersType => {
   const headers = {} as SecurityHeadersType;
-  return getAudioVideoDecoders().then(decoders => {
-    headers[HEADER_SEC_WEBCHAT] = JSON.stringify(getWebchatInfo());
-    headers[HEADER_SEC_USERSETTINGS] = JSON.stringify(getUserSpecificSettings());
-    headers[HEADER_SEC_DECODER] = JSON.stringify(decoders);
+  headers[HEADER_SEC_WEBCHAT] = JSON.stringify(getWebchatInfo());
+  headers[HEADER_SEC_USERSETTINGS] = JSON.stringify(getUserSpecificSettings());
+  headers[HEADER_SEC_DECODER] = JSON.stringify({ audio, video });
 
-    return headers;
-  });
+  return headers;
 };
 
-// eslint-disable-next-line import/no-unused-modules
 export const generateMixPanelHeaders = (): MixPanelHeadersType => {
   return {
     [HEADER_APP_VERSION]: process.env.APP_VERSION ?? '1.0.0',


### PR DESCRIPTION
## Description

Use fetchLater where available to make the endChat call on 'Quick Exit' clicks complete reliably

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P