### PR TITLE
fix: use defaultValue in form components [CHI-3875]

### DIFF
--- a/aselo-webchat-react-app/src/components/__tests__/PreEngagementFormPhase.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/PreEngagementFormPhase.test.tsx
@@ -605,9 +605,12 @@ describe('Pre Engagement Form Phase - validation', () => {
     expect(initAction.initSession).toHaveBeenCalled();
   });
 
-  it('uses preloaded redux values as form default values through getItem', () => {
+  it('uses preloaded redux values as form default values through getItem for all form input types', () => {
     const namePlaceholder = 'Your name';
     const emailPlaceholder = 'Your email';
+    const categoryPlaceholderLabel = 'Please select...';
+    const parentLabel = 'Country';
+    const dependentLabel = 'State';
     const store = createValidationStore(
       [
         {
@@ -627,19 +630,50 @@ describe('Pre Engagement Form Phase - validation', () => {
           type: FormInputType.Select,
           label: 'Choice',
           options: [
-            { value: '', label: 'Please select...' },
+            { value: '', label: categoryPlaceholderLabel },
             { value: 'opt1', label: 'Option 1' },
           ],
+        } as PreEngagementFormItem,
+        {
+          name: 'country',
+          type: FormInputType.Select,
+          label: parentLabel,
+          options: [
+            { value: '', label: 'Select country' },
+            { value: 'US', label: 'United States' },
+            { value: 'UK', label: 'United Kingdom' },
+          ],
+        } as PreEngagementFormItem,
+        {
+          name: 'state',
+          type: FormInputType.DependentSelect,
+          label: dependentLabel,
+          dependsOn: 'country',
+          options: {
+            US: [
+              { value: 'CA', label: 'California' },
+              { value: 'NY', label: 'New York' },
+            ],
+            UK: [{ value: 'ENG', label: 'England' }],
+          },
+        } as PreEngagementFormItem,
+        {
+          name: 'terms',
+          type: FormInputType.Checkbox,
+          label: 'Accept terms',
         } as PreEngagementFormItem,
       ],
       {
         name: { value: 'Alice', error: null, dirty: true },
         email: { value: 'alice@example.com', error: null, dirty: true },
         choice: { value: 'opt1', error: null, dirty: true },
+        country: { value: 'US', error: null, dirty: true },
+        state: { value: 'NY', error: null, dirty: true },
+        terms: { value: true, error: null, dirty: true },
       },
     );
 
-    const { getByPlaceholderText, getByRole } = render(
+    const { container, getByPlaceholderText } = render(
       <Provider store={store}>
         <PreEngagementFormPhase />
       </Provider>,
@@ -647,7 +681,10 @@ describe('Pre Engagement Form Phase - validation', () => {
 
     expect(getByPlaceholderText(namePlaceholder)).toHaveValue('Alice');
     expect(getByPlaceholderText(emailPlaceholder)).toHaveValue('alice@example.com');
-    expect(getByRole('combobox')).toHaveValue('opt1');
+    expect(container.querySelector('#choice')).toHaveValue('opt1');
+    expect(container.querySelector('#country')).toHaveValue('US');
+    expect(container.querySelector('#state')).toHaveValue('NY');
+    expect(container.querySelector('#terms')).toBeChecked();
   });
 
   it('validation errors are hidden before the first submit attempt even when the Redux state has an error', () => {

--- a/aselo-webchat-react-app/src/components/__tests__/PreEngagementFormPhase.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/PreEngagementFormPhase.test.tsx
@@ -605,6 +605,51 @@ describe('Pre Engagement Form Phase - validation', () => {
     expect(initAction.initSession).toHaveBeenCalled();
   });
 
+  it('uses preloaded redux values as form default values through getItem', () => {
+    const namePlaceholder = 'Your name';
+    const emailPlaceholder = 'Your email';
+    const store = createValidationStore(
+      [
+        {
+          name: 'name',
+          type: FormInputType.Input,
+          label: 'Name',
+          placeholder: namePlaceholder,
+        } as PreEngagementFormItem,
+        {
+          name: 'email',
+          type: FormInputType.Email,
+          label: 'Email',
+          placeholder: emailPlaceholder,
+        } as PreEngagementFormItem,
+        {
+          name: 'choice',
+          type: FormInputType.Select,
+          label: 'Choice',
+          options: [
+            { value: '', label: 'Please select...' },
+            { value: 'opt1', label: 'Option 1' },
+          ],
+        } as PreEngagementFormItem,
+      ],
+      {
+        name: { value: 'Alice', error: null, dirty: true },
+        email: { value: 'alice@example.com', error: null, dirty: true },
+        choice: { value: 'opt1', error: null, dirty: true },
+      },
+    );
+
+    const { getByPlaceholderText, getByRole } = render(
+      <Provider store={store}>
+        <PreEngagementFormPhase />
+      </Provider>,
+    );
+
+    expect(getByPlaceholderText(namePlaceholder)).toHaveValue('Alice');
+    expect(getByPlaceholderText(emailPlaceholder)).toHaveValue('alice@example.com');
+    expect(getByRole('combobox')).toHaveValue('opt1');
+  });
+
   it('validation errors are hidden before the first submit attempt even when the Redux state has an error', () => {
     // Pre-populate the store with a field that already has a validation error
     const store = createValidationStore(

--- a/aselo-webchat-react-app/src/components/forms/formInputs/Checkbox.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/Checkbox.tsx
@@ -26,7 +26,7 @@ type OwnProps = {
   definition: PreEngagementFormItem & { type: FormInputType.Checkbox };
   getItem: (inptuName: string) => PreEngagementDataItem;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
-  defaultValue?: string;
+  defaultValue?: PreEngagementDataItem['value'];
   showError?: boolean;
 };
 

--- a/aselo-webchat-react-app/src/components/forms/formInputs/DependentSelect.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/DependentSelect.tsx
@@ -30,13 +30,20 @@ type OwnProps = {
   getItem: (inptuName: string) => PreEngagementDataItem;
   setItemValue: (payload: { name: string; value: string | boolean }) => void;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
-  defaultValue?: string;
+  defaultValue?: PreEngagementDataItem['value'];
   showError?: boolean;
 };
 
 type Props = OwnProps;
 
-const DependentSelect: React.FC<Props> = ({ getItem, setItemValue, definition, handleChange, showError = true }) => {
+const DependentSelect: React.FC<Props> = ({
+  getItem,
+  // defaultValue,
+  setItemValue,
+  definition,
+  handleChange,
+  showError = true,
+}) => {
   const currentTranslations = useSelector(selectCurrentTranslations);
   const configuredLocalizeKey = localizeKey(currentTranslations);
   const { dependsOn, name, label, required, options } = definition;
@@ -79,6 +86,8 @@ const DependentSelect: React.FC<Props> = ({ getItem, setItemValue, definition, h
           onChange={e => handleChange({ name, value: e.target.value })}
           disabled={!dependsOnValue}
           value={value as string}
+          // value takes precedence and should be used
+          // defaultValue={typeof defaultValue === 'string' ? defaultValue : ''}
         >
           {buildOptions()}
         </SelectInput>

--- a/aselo-webchat-react-app/src/components/forms/formInputs/Input.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/Input.tsx
@@ -31,13 +31,13 @@ type OwnProps = {
   pattern?: RegExp;
   getItem: (inptuName: string) => PreEngagementDataItem;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
-  defaultValue?: string;
+  defaultValue?: PreEngagementDataItem['value'];
   showError?: boolean;
 };
 
 type Props = OwnProps;
 
-const InputText: React.FC<Props> = ({ definition, handleChange, getItem, showError = true }) => {
+const InputText: React.FC<Props> = ({ definition, defaultValue, handleChange, getItem, showError = true }) => {
   const currentTranslations = useSelector(selectCurrentTranslations);
   const configuredLocalizeKey = localizeKey(currentTranslations);
   const { name, label, placeholder, required } = definition;
@@ -64,6 +64,7 @@ const InputText: React.FC<Props> = ({ definition, handleChange, getItem, showErr
           hasError={Boolean(error && showError)}
           onBlur={e => handleChange({ name, value: e.target.value })}
           onChange={e => debouncedHandleChange({ name, value: e.target.value })}
+          defaultValue={typeof defaultValue === 'string' ? defaultValue : ''}
         />
       </Label>
       {error && showError && (

--- a/aselo-webchat-react-app/src/components/forms/formInputs/Select.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/Select.tsx
@@ -29,7 +29,7 @@ type OwnProps = {
   definition: PreEngagementFormItem & { type: FormInputType.Select };
   getItem: (inptuName: string) => PreEngagementDataItem;
   handleChange: (payload: { name: string; value: string | boolean }) => void;
-  defaultValue?: string;
+  defaultValue?: PreEngagementDataItem['value'];
   showError?: boolean;
 };
 
@@ -57,7 +57,7 @@ const Select: React.FC<Props> = ({ definition, getItem, defaultValue, handleChan
           id={name}
           hasError={Boolean(error && showError)}
           onChange={e => handleChange({ name, value: e.target.value })}
-          defaultValue={defaultValue}
+          defaultValue={typeof defaultValue === 'string' ? defaultValue : ''}
         >
           {buildOptions()}
         </SelectInput>

--- a/aselo-webchat-react-app/src/components/forms/formInputs/__tests__/Checkbox.test.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/__tests__/Checkbox.test.tsx
@@ -72,4 +72,12 @@ describe('Checkbox component', () => {
     fireEvent.click(checkbox);
     expect(handleChange).toHaveBeenCalledWith({ name: 'terms', value: true });
   });
+
+  it('uses defaultValue as the initial checked state', () => {
+    const { getByRole } = render(
+      <Checkbox definition={definition} handleChange={handleChange} getItem={getItem(noError)} defaultValue={true} />,
+    );
+
+    expect(getByRole('checkbox')).toBeChecked();
+  });
 });

--- a/aselo-webchat-react-app/src/components/forms/formInputs/__tests__/DependentSelect.test.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/__tests__/DependentSelect.test.tsx
@@ -115,6 +115,19 @@ describe('DependentSelect component', () => {
     expect(handleChange).toHaveBeenCalledWith({ name: 'state', value: 'NY' });
   });
 
+  it('uses redux-backed item value as the initial selected value', () => {
+    const { getByRole } = render(
+      <DependentSelect
+        definition={definition}
+        handleChange={handleChange}
+        getItem={makeGetItem(noError, 'US')}
+        setItemValue={setItemValue}
+      />,
+    );
+
+    expect(getByRole('combobox')).toHaveValue('CA');
+  });
+
   it('calls setItemValue to blank the dependent select when the dependee value changes', () => {
     const getItemWithUS = makeGetItem({ value: 'CA', error: null, dirty: false }, 'US');
     const getItemWithUK = makeGetItem({ value: 'CA', error: null, dirty: false }, 'UK');

--- a/aselo-webchat-react-app/src/components/forms/formInputs/__tests__/Input.test.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/__tests__/Input.test.tsx
@@ -81,6 +81,19 @@ describe('Input component', () => {
     expect(handleChange).toHaveBeenCalledWith({ name: 'friendlyName', value: 'John' });
   });
 
+  it('uses defaultValue as the initial input value', () => {
+    const { getByPlaceholderText } = render(
+      <InputText
+        definition={definition}
+        handleChange={handleChange}
+        getItem={getItem(noError)}
+        defaultValue="Prefilled name"
+      />,
+    );
+
+    expect(getByPlaceholderText('Enter your name')).toHaveValue('Prefilled name');
+  });
+
   describe('debounced onChange', () => {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/aselo-webchat-react-app/src/components/forms/formInputs/__tests__/Select.test.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/__tests__/Select.test.tsx
@@ -84,4 +84,12 @@ describe('Select component', () => {
     fireEvent.change(select, { target: { value: 'opt1' } });
     expect(handleChange).toHaveBeenCalledWith({ name: 'category', value: 'opt1' });
   });
+
+  it('uses defaultValue as the initial selected value', () => {
+    const { getByRole } = render(
+      <Select definition={definition} handleChange={handleChange} getItem={getItem(noError)} defaultValue="opt2" />,
+    );
+
+    expect(getByRole('combobox')).toHaveValue('opt2');
+  });
 });

--- a/aselo-webchat-react-app/src/components/forms/formInputs/index.tsx
+++ b/aselo-webchat-react-app/src/components/forms/formInputs/index.tsx
@@ -23,14 +23,14 @@ import { PreEngagementDataItem } from '../../../store/definitions';
 
 const generateFormItem = ({
   definition,
-  defaultValue = '',
+  defaultValue,
   handleChange,
   getItem,
   setItemValue,
   showError,
 }: {
   definition: PreEngagementFormItem;
-  defaultValue?: string | boolean;
+  defaultValue?: PreEngagementDataItem['value'];
   handleChange: (payload: { name: string; value: string | boolean }) => void;
   getItem: (inptuName: string) => PreEngagementDataItem;
   setItemValue: (payload: { name: string; value: string | boolean }) => void;
@@ -46,6 +46,7 @@ const generateFormItem = ({
           handleChange={handleChange}
           getItem={getItem}
           showError={showError}
+          defaultValue={defaultValue}
         />
       );
     case FormInputType.Select:
@@ -56,6 +57,7 @@ const generateFormItem = ({
           handleChange={handleChange}
           getItem={getItem}
           showError={showError}
+          defaultValue={defaultValue}
         />
       );
     case FormInputType.DependentSelect:
@@ -67,6 +69,7 @@ const generateFormItem = ({
           getItem={getItem}
           setItemValue={setItemValue}
           showError={showError}
+          defaultValue={defaultValue}
         />
       );
     case FormInputType.Checkbox:
@@ -77,6 +80,7 @@ const generateFormItem = ({
           handleChange={handleChange}
           getItem={getItem}
           showError={showError}
+          defaultValue={defaultValue}
         />
       );
     default:
@@ -84,7 +88,6 @@ const generateFormItem = ({
   }
 };
 
-// eslint-disable-next-line
 export const getDefaultValue = (def: PreEngagementFormItem) => {
   switch (def.type) {
     case FormInputType.Input:
@@ -114,15 +117,16 @@ export const generateForm = ({
 }) => {
   return (
     form &&
-    form.map(definition =>
-      generateFormItem({
+    form.map(definition => {
+      const defaultValue = getItem(definition.name).value ?? getDefaultValue(definition);
+      return generateFormItem({
         definition,
         handleChange,
-        defaultValue: getDefaultValue(definition),
+        defaultValue,
         getItem,
         setItemValue,
         showError: showError(definition.name),
-      }),
-    )
+      });
+    })
   );
 };


### PR DESCRIPTION
## Description
This PR fixes the bug described in the ticket by making use of the `defaultValue` property of the form generated components.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3875)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Verification steps
- Start development server (`npm run start:as_dev`).
- Open webchat, type some data in the forms and minimize it.
- Confirm the bug is not reproducible anymore.

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P