### PR TITLE
CHI-3879: Implement missing legacy script attributes (2)

### DIFF
--- a/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
+++ b/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
@@ -136,7 +136,7 @@ jobs:
           ;
           (function () {
             const legacyDisableMobileOptimizationAttribute = document.currentScript?.getAttribute('disable-mobile-optimization');
-            const enableMobileOptimizations = typeof enableMobileOptimizations === 'string' ? !['', true, 'true'].some(value => value === legacyDisableMobileOptimizationAttribute) : undefined;
+            const enableMobileOptimizations = typeof legacyDisableMobileOptimizationAttribute === 'string' ? !['', true, 'true'].some(value => value === legacyDisableMobileOptimizationAttribute) : undefined;
             const scriptTagData = { enableMobileOptimizations, ...document.currentScript.dataset };
             if (document.readyState === 'loading') {
               document.addEventListener('DOMContentLoaded', function () { window.Twilio.initChat(scriptTagData); });

--- a/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
+++ b/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
@@ -136,7 +136,7 @@ jobs:
           ;
           (function () {
             const legacyDisableMobileOptimizationAttribute = document.currentScript?.getAttribute('disable-mobile-optimization');
-            const enableMobileOptimizations = typeof legacyDisableMobileOptimizationAttribute === 'string' ? !['', true, 'true'].some(value => value === legacyDisableMobileOptimizationAttribute) : undefined;
+            const enableMobileOptimizations = typeof legacyDisableMobileOptimizationAttribute === 'string' ? (!['', true, 'true'].some(value => value === legacyDisableMobileOptimizationAttribute)).toString() : undefined;
             const scriptTagData = { enableMobileOptimizations, ...document.currentScript.dataset };
             if (document.readyState === 'loading') {
               document.addEventListener('DOMContentLoaded', function () { window.Twilio.initChat(scriptTagData); });

--- a/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
+++ b/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
@@ -135,7 +135,9 @@ jobs:
           cat >> aselo-chat-uncompressed.js << 'INIT_SCRIPT'
           ;
           (function () {
-            const scriptTagData = document.currentScript.dataset;
+            const legacyDisableMobileOptimizationAttribute = document.currentScript?.getAttribute('disable-mobile-optimization');
+            const enableMobileOptimizations = typeof enableMobileOptimizations === 'string' ? !['', true, 'true'].some(value => value === legacyDisableMobileOptimizationAttribute) : undefined;
+            const scriptTagData = { enableMobileOptimizations, ...document.currentScript.dataset };
             if (document.readyState === 'loading') {
               document.addEventListener('DOMContentLoaded', function () { window.Twilio.initChat(scriptTagData); });
             } else {

--- a/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
+++ b/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
@@ -136,7 +136,12 @@ jobs:
           ;
           (function () {
             const legacyDisableMobileOptimizationAttribute = document.currentScript?.getAttribute('disable-mobile-optimization');
-            const enableMobileOptimizations = typeof legacyDisableMobileOptimizationAttribute === 'string' ? (!['', true, 'true'].some(value => value === legacyDisableMobileOptimizationAttribute)).toString() : undefined;
+            const normalizedLegacyDisableMobileOptimizationAttribute = typeof legacyDisableMobileOptimizationAttribute === 'string'
+              ? legacyDisableMobileOptimizationAttribute.trim().toLowerCase()
+              : undefined;
+            const enableMobileOptimizations = typeof normalizedLegacyDisableMobileOptimizationAttribute === 'string'
+              ? (!['', 'true'].includes(normalizedLegacyDisableMobileOptimizationAttribute)).toString()
+              : undefined;
             const scriptTagData = { enableMobileOptimizations, ...document.currentScript.dataset };
             if (document.readyState === 'loading') {
               document.addEventListener('DOMContentLoaded', function () { window.Twilio.initChat(scriptTagData); });

--- a/aselo-webchat-react-app/README.md
+++ b/aselo-webchat-react-app/README.md
@@ -133,7 +133,7 @@ Here's an example of how to use this config object in your `index.html` template
 window.addEventListener("load", () => {
     Twilio.initWebchat({
         deploymentKey: "CVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        alwaysOpen: true,
+        widgetAlwaysOpen: true,
         theme: {
             isLight: true
         }
@@ -142,7 +142,7 @@ window.addEventListener("load", () => {
 ```
 
 1. `deploymentKey` is a UUID with a fixed length. As a security enhancement, we have encapsulated **AccountSid** with **DeploymentKey**. An **AccountSid** has one-to-many relationship with **DeploymentKey**. This means, **AccountSid** is not any public entity anymore for webchat. Customers are to use **DeploymentKey** to initiate Webchat UI. For more info on how to create a **Deployment Key** refer to [this section](https://www.twilio.com/docs/flex/developer/conversations/webchat/security#deployment-key-shields-your-account-information)
-2. `alwaysOpen` Set this if you want the widget to only render in its open state, without the 'open / close' button. For more information refer to [this section](https://www.twilio.com/docs/flex/developer/conversations/webchat/setup#customize-webchat)
+2. `widgetAlwaysOpen` Set this if you want the widget to only render in its open state, without the 'open / close' button. For more information refer to [this section](https://www.twilio.com/docs/flex/developer/conversations/webchat/setup#customize-webchat)
 3. `theme` can be used to quickly customise the look and feel of the app. `theme.isLight` is a boolean to quickly toggle between the light and dark theme of Paste. For more information refer to [this section]([this section](https://www.twilio.com/docs/flex/developer/conversations/webchat/setup#customize-webchat)
 
 

--- a/aselo-webchat-react-app/configSrc/as/common.json
+++ b/aselo-webchat-react-app/configSrc/as/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "as",
   "enableRecaptcha": true,
   "captureIp": true,

--- a/aselo-webchat-react-app/configSrc/ca/common.json
+++ b/aselo-webchat-react-app/configSrc/ca/common.json
@@ -1794,5 +1794,5 @@
   "helplineCode": "ca",
   "enableRecaptcha": true,
   "captureIp": false,
-  "alwaysOpen": false
+  "widgetAlwaysOpen": false
 }

--- a/aselo-webchat-react-app/configSrc/clhs/common.json
+++ b/aselo-webchat-react-app/configSrc/clhs/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "defaultLocale": "es-CL",
   "definitionVersion": "clhs-v1",
   "helplineCode": "clhs",

--- a/aselo-webchat-react-app/configSrc/defaults.json
+++ b/aselo-webchat-react-app/configSrc/defaults.json
@@ -1,6 +1,6 @@
 {
   "deploymentKey": "CVxxx",
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "defaultLocale": "en-US",
   "quickExitUrl": "https://www.google.com"
 }

--- a/aselo-webchat-react-app/configSrc/e2e/common.json
+++ b/aselo-webchat-react-app/configSrc/e2e/common.json
@@ -4,6 +4,6 @@
     "maxFileSize": 16777216,
     "acceptedExtensions": ["jpg", "jpeg", "png", "amr", "mp3", "mp4", "pdf", "txt"]
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "e2e"
 }

--- a/aselo-webchat-react-app/configSrc/et/common.json
+++ b/aselo-webchat-react-app/configSrc/et/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "et",
   "enableRecaptcha": false,
   "captureIp": true

--- a/aselo-webchat-react-app/configSrc/jm/common.json
+++ b/aselo-webchat-react-app/configSrc/jm/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "jm",
   "captureIp": true,
   "contactIdentifierField": "ip"

--- a/aselo-webchat-react-app/configSrc/mt/common.json
+++ b/aselo-webchat-react-app/configSrc/mt/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "defaultLocale": "en-US",
   "helplineCode": "mt",
   "enableRecaptcha": false,

--- a/aselo-webchat-react-app/configSrc/nz/common.json
+++ b/aselo-webchat-react-app/configSrc/nz/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "defaultLocale": "en-NZ",
   "helplineCode": "nz",
   "enableRecaptcha": false,

--- a/aselo-webchat-react-app/configSrc/sg/common.json
+++ b/aselo-webchat-react-app/configSrc/sg/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "sg",
   "captureIp": true,
   "defaultLocale": "en-SG",

--- a/aselo-webchat-react-app/configSrc/tz/common.json
+++ b/aselo-webchat-react-app/configSrc/tz/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "tz",
   "captureIp": true,
   "definitionVersion": "tz-v1",

--- a/aselo-webchat-react-app/configSrc/ukmh/common.json
+++ b/aselo-webchat-react-app/configSrc/ukmh/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "ukmh",
   "captureIp": true,
   "definitionVersion": "ukmh-v1",

--- a/aselo-webchat-react-app/configSrc/usch/common.json
+++ b/aselo-webchat-react-app/configSrc/usch/common.json
@@ -1771,7 +1771,7 @@
   "helplineCode": "usch",
   "enableRecaptcha": false,
   "captureIp": true,
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "contactIdentifierField": "ip",
   "definitionVersion": "usch-v1"
 }

--- a/aselo-webchat-react-app/configSrc/uscr/common.json
+++ b/aselo-webchat-react-app/configSrc/uscr/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "uscr",
   "enableRecaptcha": false,
   "captureIp": true,

--- a/aselo-webchat-react-app/configSrc/usnc/common.json
+++ b/aselo-webchat-react-app/configSrc/usnc/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "usnc",
   "enableRecaptcha": false,
   "captureIp": true,

--- a/aselo-webchat-react-app/configSrc/usvc/common.json
+++ b/aselo-webchat-react-app/configSrc/usvc/common.json
@@ -4,11 +4,7 @@
     "maxFileSize": 16777216,
     "acceptedExtensions": ["jpg", "jpeg", "png", "amr", "mp3", "mp4", "pdf", "txt"]
   },
-  "emojiPicker": {
-    "enabled": true,
-    "blockedEmojis": []
-  },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "usvc",
   "enableRecaptcha": false,
   "definitionVersion": "usvc-v1",

--- a/aselo-webchat-react-app/configSrc/zm/common.json
+++ b/aselo-webchat-react-app/configSrc/zm/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "zm",
   "captureIp": true,
   "defaultLocale": "en-US",

--- a/aselo-webchat-react-app/configSrc/zw/common.json
+++ b/aselo-webchat-react-app/configSrc/zw/common.json
@@ -8,7 +8,7 @@
     "enabled": true,
     "blockedEmojis": []
   },
-  "alwaysOpen": false,
+  "widgetAlwaysOpen": false,
   "helplineCode": "zw",
   "enableRecaptcha": false,
   "captureIp": true,

--- a/aselo-webchat-react-app/public/index.html
+++ b/aselo-webchat-react-app/public/index.html
@@ -28,13 +28,13 @@
   <link rel="shortcut icon" href="https://media.twiliocdn.com/sdk/js/webchat-v3/assets/favicon.ico">
   <title>Twilio Webchat React App</title>
   <link rel="stylesheet" href="./app.css">
+  <script src="./app.js"></script>
 </head>
 
 <body data-theme-pref="light-theme">
   <noscript>
     You need to enable JavaScript to run this app.
   </noscript>
-  <script defer src="./app.js"></script>
 </body>
 
 </html>

--- a/aselo-webchat-react-app/public/index.html
+++ b/aselo-webchat-react-app/public/index.html
@@ -28,7 +28,7 @@
   <link rel="shortcut icon" href="https://media.twiliocdn.com/sdk/js/webchat-v3/assets/favicon.ico">
   <title>Twilio Webchat React App</title>
   <link rel="stylesheet" href="./app.css">
-  <script src="./app.js"></script>
+  <script defer src="./app.js"></script>
 </head>
 
 <body data-theme-pref="light-theme">

--- a/aselo-webchat-react-app/src/components/RootContainer.tsx
+++ b/aselo-webchat-react-app/src/components/RootContainer.tsx
@@ -54,7 +54,7 @@ export function RootContainer() {
     currentPhase: session.currentPhase,
     expanded: session.expanded,
   }));
-  const alwaysOpen = useSelector((state: AppState) => state.config.alwaysOpen);
+  const widgetAlwaysOpen = useSelector((state: AppState) => state.config.widgetAlwaysOpen);
   const { isMobileFullscreen } = useMobileOptimizations();
 
   return (
@@ -65,7 +65,7 @@ export function RootContainer() {
             {getPhaseComponent(currentPhase)}
           </Box>
         )}
-        {!alwaysOpen && <EntryPoint />}
+        {!widgetAlwaysOpen && <EntryPoint />}
       </Box>
     </Box>
   );

--- a/aselo-webchat-react-app/src/components/__tests__/RootContainer.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/RootContainer.test.tsx
@@ -50,7 +50,7 @@ describe('Root Container', () => {
     resetMockRedux({
       config: {
         ...BASE_MOCK_REDUX.config,
-        alwaysOpen: false,
+        widgetAlwaysOpen: false,
       },
     });
   });

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -24,25 +24,33 @@ import { LocaleString } from './store/definitions';
  * standard app.js bootstrap and the aselo-chat.min.js wrapper used for legacy URL
  * compatibility deploys.
  */
-export const initChat = (scriptTagData: Record<string, string | undefined>) => {
+export const initChat = (scriptTagData: Record<string, string | boolean | undefined>) => {
   const urlParams = new URLSearchParams(window.location.search);
   const theme = urlParams.get('theme') ?? scriptTagData.theme;
   const isLightTheme = theme !== 'dark';
   const color = urlParams.get('color') || scriptTagData.color;
+  const enableMobileOptimizationsUrlParam = urlParams.get('enableMobileOptimizations');
+  const enableMobileOptimizations = enableMobileOptimizationsUrlParam
+    ? Boolean(enableMobileOptimizationsUrlParam.toLowerCase() === 'true')
+    : scriptTagData.enableMobileOptimizations;
   const backgroundColor = urlParams.get('backgroundColor') || scriptTagData.backgroundColor;
   const alwaysOpen = urlParams.get('alwaysOpen');
   const defaultLocale =
     // data-language attribute is supported for backwards compatibility, remove once webchat is fully migrated
     urlParams.get('locale') || scriptTagData.locale || scriptTagData.language;
-  const configUrl = urlParams.get('configUrl') ?? scriptTagData.configUrl ?? undefined;
+  const configUrl = urlParams.get('configUrl') ?? scriptTagData.configUrl?.toString() ?? undefined;
 
   const themeEl = document.querySelector('[data-theme-pref]');
   themeEl?.setAttribute('data-theme-pref', isLightTheme ? 'light-theme' : 'dark-theme');
-
-  if (!document.getElementById('aselo-webchat-widget-root')) {
-    const root = document.createElement('div');
+  let root = document.getElementById('aselo-webchat-widget-root');
+  if (!root) {
+    root = document.createElement('div');
     root.id = 'aselo-webchat-widget-root';
+
     document.body.appendChild(root);
+  }
+  if (scriptTagData.zIndex) {
+    document.getElementById('aselo-webchat-widget-root')?.setAttribute('style', `z-index: ${scriptTagData.zIndex};`);
   }
 
   window.Twilio.initLogger('info');
@@ -58,5 +66,8 @@ export const initChat = (scriptTagData: Record<string, string | undefined>) => {
     },
     ...(alwaysOpen ? { alwaysOpen: alwaysOpen.toLowerCase() === 'true' } : {}),
     ...(defaultLocale ? { defaultLocale: defaultLocale as LocaleString } : {}),
+    ...(enableMobileOptimizations === undefined
+      ? {}
+      : { enableMobileOptimizations: enableMobileOptimizations as boolean }),
   });
 };

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -52,8 +52,11 @@ export const initChat = (scriptTagData: Record<string, string | boolean | undefi
 
     document.body.appendChild(root);
   }
-  if (scriptTagData.zIndex) {
-    document.getElementById('aselo-webchat-widget-root')?.setAttribute('style', `z-index: ${scriptTagData.zIndex};`);
+  if (scriptTagData.zIndex !== undefined) {
+    const parsedZIndex = Number.parseInt(String(scriptTagData.zIndex).trim(), 10);
+    if (Number.isFinite(parsedZIndex)) {
+      root.style.zIndex = String(parsedZIndex);
+    }
   }
 
   window.Twilio.initLogger('info');

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -16,6 +16,21 @@
 
 import { LocaleString } from './store/definitions';
 
+const extractBooleanFromUrlParamOrScriptDataAttributeSet = (
+  name: string,
+  scriptTagData: Record<string, string | undefined>,
+): boolean | undefined => {
+  const urlParam = new URLSearchParams(window.location.search).get(name);
+  if (urlParam) {
+    return Boolean(urlParam.toLowerCase() === 'true');
+  }
+  const scriptDataAttributeValue = scriptTagData[name];
+  if (scriptDataAttributeValue) {
+    return Boolean(scriptDataAttributeValue.toLowerCase() === 'true');
+  }
+  return undefined;
+};
+
 /**
  * Initialises the Aselo Webchat widget by reading configuration from URL parameters,
  * ensuring the widget root element exists, and calling Twilio.initWebchat.
@@ -24,20 +39,17 @@ import { LocaleString } from './store/definitions';
  * standard app.js bootstrap and the aselo-chat.min.js wrapper used for legacy URL
  * compatibility deploys.
  */
-export const initChat = (scriptTagData: Record<string, string | boolean | undefined>) => {
+export const initChat = (scriptTagData: Record<string, string | undefined>) => {
   const urlParams = new URLSearchParams(window.location.search);
   const theme = urlParams.get('theme') ?? scriptTagData.theme;
   const isLightTheme = theme !== 'dark';
   const color = urlParams.get('color') || scriptTagData.color;
-  const enableMobileOptimizationsUrlParam = urlParams.get('enableMobileOptimizations');
-  const enableMobileOptimizations = enableMobileOptimizationsUrlParam
-    ? Boolean(enableMobileOptimizationsUrlParam.toLowerCase() === 'true')
-    : scriptTagData.enableMobileOptimizations;
+  const enableMobileOptimizations = extractBooleanFromUrlParamOrScriptDataAttributeSet(
+    'enableMobileOptimizations',
+    scriptTagData,
+  );
   const backgroundColor = urlParams.get('backgroundColor') || scriptTagData.backgroundColor;
-  const widgetAlwaysOpenUrlParam = urlParams.get('widgetAlwaysOpen');
-  const widgetAlwaysOpen = widgetAlwaysOpenUrlParam
-    ? Boolean(widgetAlwaysOpenUrlParam.toLowerCase() === 'true')
-    : scriptTagData.widgetAlwaysOpen;
+  const widgetAlwaysOpen = extractBooleanFromUrlParamOrScriptDataAttributeSet('widgetAlwaysOpenUrl', scriptTagData);
   const defaultLocale =
     // data-language attribute is supported for backwards compatibility, remove once webchat is fully migrated
     urlParams.get('locale') || scriptTagData.locale || scriptTagData.language;

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -34,7 +34,10 @@ export const initChat = (scriptTagData: Record<string, string | boolean | undefi
     ? Boolean(enableMobileOptimizationsUrlParam.toLowerCase() === 'true')
     : scriptTagData.enableMobileOptimizations;
   const backgroundColor = urlParams.get('backgroundColor') || scriptTagData.backgroundColor;
-  const alwaysOpen = urlParams.get('alwaysOpen');
+  const widgetAlwaysOpenUrlParam = urlParams.get('widgetAlwaysOpen');
+  const widgetAlwaysOpen = widgetAlwaysOpenUrlParam
+    ? Boolean(widgetAlwaysOpenUrlParam.toLowerCase() === 'true')
+    : scriptTagData.widgetAlwaysOpen;
   const defaultLocale =
     // data-language attribute is supported for backwards compatibility, remove once webchat is fully migrated
     urlParams.get('locale') || scriptTagData.locale || scriptTagData.language;
@@ -64,7 +67,7 @@ export const initChat = (scriptTagData: Record<string, string | boolean | undefi
         textColors: { ...(color && { colorTextWeakest: color }) },
       },
     },
-    ...(alwaysOpen ? { alwaysOpen: alwaysOpen.toLowerCase() === 'true' } : {}),
+    ...(widgetAlwaysOpen === undefined ? {} : { widgetAlwaysOpen: widgetAlwaysOpen as boolean }),
     ...(defaultLocale ? { defaultLocale: defaultLocale as LocaleString } : {}),
     ...(enableMobileOptimizations === undefined
       ? {}

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -49,7 +49,7 @@ export const initChat = (scriptTagData: Record<string, string | undefined>) => {
     scriptTagData,
   );
   const backgroundColor = urlParams.get('backgroundColor') || scriptTagData.backgroundColor;
-  const widgetAlwaysOpen = extractBooleanFromUrlParamOrScriptDataAttributeSet('widgetAlwaysOpenUrl', scriptTagData);
+  const widgetAlwaysOpen = extractBooleanFromUrlParamOrScriptDataAttributeSet('widgetAlwaysOpen', scriptTagData);
   const defaultLocale =
     // data-language attribute is supported for backwards compatibility, remove once webchat is fully migrated
     urlParams.get('locale') || scriptTagData.locale || scriptTagData.language;

--- a/aselo-webchat-react-app/src/store/actions/__tests__/initActions.test.ts
+++ b/aselo-webchat-react-app/src/store/actions/__tests__/initActions.test.ts
@@ -256,16 +256,16 @@ describe('Actions', () => {
       expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: ACTION_LOAD_CONFIG_FAILURE }));
     });
 
-    it('triggers expanded true if alwaysOpen is set', async () => {
-      const dispatch = await runConfigThunk({ deploymentKey: 'CV000000', alwaysOpen: true });
+    it('triggers expanded true if widgetAlwaysOpen is set', async () => {
+      const dispatch = await runConfigThunk({ deploymentKey: 'CV000000', widgetAlwaysOpen: true });
       expect(dispatch).toHaveBeenCalledWith({
         type: ACTION_CHANGE_EXPANDED_STATUS,
         payload: { expanded: true },
       });
     });
 
-    it('triggers expanded false if alwaysOpen is not set', async () => {
-      const dispatch = await runConfigThunk({ deploymentKey: 'CV000000', alwaysOpen: false });
+    it('triggers expanded false if widgetAlwaysOpen is not set', async () => {
+      const dispatch = await runConfigThunk({ deploymentKey: 'CV000000', widgetAlwaysOpen: false });
       expect(dispatch).toHaveBeenCalledWith({
         type: ACTION_CHANGE_EXPANDED_STATUS,
         payload: { expanded: false },

--- a/aselo-webchat-react-app/src/store/actions/initActions.ts
+++ b/aselo-webchat-react-app/src/store/actions/initActions.ts
@@ -42,7 +42,7 @@ import type { AppState } from '../store';
 // export for testing
 export const getHelplineConfig = async ({ configUrl }: { configUrl: string | URL }) => {
   try {
-    const helplineConfigResponse = await fetch(configUrl);
+    const helplineConfigResponse = await fetch(configUrl.toString());
     if (!helplineConfigResponse.ok) {
       const errMsg = `Failed to load helpline specific config for Aselo Webchat from ${configUrl}, aborting load`;
       return { status: 'error', message: errMsg } as const;

--- a/aselo-webchat-react-app/src/store/actions/initActions.ts
+++ b/aselo-webchat-react-app/src/store/actions/initActions.ts
@@ -18,7 +18,6 @@ import { Client, ConnectionState } from '@twilio/conversations';
 import { AnyAction, Dispatch } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 import merge from 'lodash.merge';
-import { Logger } from 'loglevel';
 
 import { initMessagesListener } from './listeners/messagesListener';
 import { initParticipantsListener } from './listeners/participantsListener';
@@ -81,7 +80,7 @@ export const initConfigThunk = ({
         throw new Error(message);
       }
 
-      dispatch(changeExpandedStatus({ expanded: Boolean(webchatConfig.alwaysOpen) }));
+      dispatch(changeExpandedStatus({ expanded: Boolean(webchatConfig.widgetAlwaysOpen) }));
 
       sessionDataHandler.setRegion(webchatConfig.region);
       sessionDataHandler.setDeploymentKey(webchatConfig.deploymentKey);

--- a/aselo-webchat-react-app/src/store/definitions.ts
+++ b/aselo-webchat-react-app/src/store/definitions.ts
@@ -69,7 +69,7 @@ export type ConfigState = {
   emojiPicker?: EmojiPickerConfig;
   deploymentKey: string;
   region?: string;
-  alwaysOpen?: boolean;
+  widgetAlwaysOpen?: boolean;
   theme?: {
     isLight?: boolean;
     overrides?: Partial<GenericThemeShape>;


### PR DESCRIPTION
## Description

- implement data-z-index legacy script attribute
- implement disable-mobile-optimization script attribute for legacy deploys ONLY
- implement data-enable-mobile-optimizations to replace the above for new webchat deploys
- rename alwaysOpen to widgetAlwaysOpen, add support for setting it via a data-widget-always-open script attribute
- Ensure all the options can be set via script attribute OR url parameter for consistency (except legacy attributes we don't plan to support in the future, like data-z-index and disable-mobile-optimization)

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P