### PR TITLE
CHI-3890: Fix default config location for Aselo Webchat.

### DIFF
--- a/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
+++ b/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
@@ -136,8 +136,7 @@ jobs:
           ;
           (function () {
             const rawSrc = document.currentScript.getAttribute('src');
-            const configUrl = `${rawSrc.substring(0, rawSrc.lastIndexOf('/'))}/config.json`;
-            const scriptTagData = { ...document.currentScript.dataset };
+            const configUrl = rawSrc.lastIndexOf('/') > -1 ? `${rawSrc.substring(0, rawSrc.lastIndexOf('/'))}/config.json` : './config.json';
             const legacyDisableMobileOptimizationAttribute = document.currentScript?.getAttribute('disable-mobile-optimization');
             const normalizedLegacyDisableMobileOptimizationAttribute = typeof legacyDisableMobileOptimizationAttribute === 'string'
               ? legacyDisableMobileOptimizationAttribute.trim().toLowerCase()

--- a/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
+++ b/.github/workflows/aselo-webchat-react-app-deploy-to-legacy-url.yml
@@ -135,6 +135,9 @@ jobs:
           cat >> aselo-chat-uncompressed.js << 'INIT_SCRIPT'
           ;
           (function () {
+            const rawSrc = document.currentScript.getAttribute('src');
+            const configUrl = `${rawSrc.substring(0, rawSrc.lastIndexOf('/'))}/config.json`;
+            const scriptTagData = { ...document.currentScript.dataset };
             const legacyDisableMobileOptimizationAttribute = document.currentScript?.getAttribute('disable-mobile-optimization');
             const normalizedLegacyDisableMobileOptimizationAttribute = typeof legacyDisableMobileOptimizationAttribute === 'string'
               ? legacyDisableMobileOptimizationAttribute.trim().toLowerCase()
@@ -142,7 +145,7 @@ jobs:
             const enableMobileOptimizations = typeof normalizedLegacyDisableMobileOptimizationAttribute === 'string'
               ? (!['', 'true'].includes(normalizedLegacyDisableMobileOptimizationAttribute)).toString()
               : undefined;
-            const scriptTagData = { enableMobileOptimizations, ...document.currentScript.dataset };
+            const scriptTagData = { configUrl, enableMobileOptimizations, ...document.currentScript.dataset };
             if (document.readyState === 'loading') {
               document.addEventListener('DOMContentLoaded', function () { window.Twilio.initChat(scriptTagData); });
             } else {

--- a/aselo-webchat-react-app/public/app.js
+++ b/aselo-webchat-react-app/public/app.js
@@ -15,7 +15,8 @@
  */
 // preserve relative path if one is used by pulling it with getAttribute not the src property
 const rawSrc = document.currentScript.getAttribute('src');
-const configUrl = `${rawSrc.substring(0, rawSrc.lastIndexOf('/'))}/config.json`;
+const configUrl =
+  rawSrc.lastIndexOf('/') > -1 ? `${rawSrc.substring(0, rawSrc.lastIndexOf('/'))}/config.json` : './config.json';
 const scriptTagData = { configUrl, ...document.currentScript.dataset };
 window.addEventListener('DOMContentLoaded', () => {
   Twilio.initChat(scriptTagData);

--- a/aselo-webchat-react-app/public/app.js
+++ b/aselo-webchat-react-app/public/app.js
@@ -13,7 +13,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-const scriptTagData = document.currentScript.dataset;
+// preserve relative path if one is used by pulling it with getAttribute not the src property
+const rawSrc = document.currentScript.getAttribute('src');
+const configUrl = `${rawSrc.substring(0, rawSrc.lastIndexOf('/'))}/config.json`;
+const scriptTagData = { configUrl, ...document.currentScript.dataset };
 window.addEventListener('DOMContentLoaded', () => {
   Twilio.initChat(scriptTagData);
 });

--- a/aselo-webchat-react-app/public/index.html
+++ b/aselo-webchat-react-app/public/index.html
@@ -28,7 +28,7 @@
   <link rel="shortcut icon" href="https://media.twiliocdn.com/sdk/js/webchat-v3/assets/favicon.ico">
   <title>Twilio Webchat React App</title>
   <link rel="stylesheet" href="./app.css">
-  <script defer src="./app.js"></script>
+  <script defer src="https://assets-staging.tl.techmatters.org/aselo-webchat-react-app/usnc/app.js/app.js"></script>
 </head>
 
 <body data-theme-pref="light-theme">

--- a/aselo-webchat-react-app/public/index.html
+++ b/aselo-webchat-react-app/public/index.html
@@ -28,7 +28,7 @@
   <link rel="shortcut icon" href="https://media.twiliocdn.com/sdk/js/webchat-v3/assets/favicon.ico">
   <title>Twilio Webchat React App</title>
   <link rel="stylesheet" href="./app.css">
-  <script defer src="https://assets-staging.tl.techmatters.org/aselo-webchat-react-app/usnc/app.js/app.js"></script>
+  <script defer src="/app.js"></script>
 </head>
 
 <body data-theme-pref="light-theme">

--- a/aselo-webchat-react-app/src/__tests__/index.test.tsx
+++ b/aselo-webchat-react-app/src/__tests__/index.test.tsx
@@ -33,6 +33,7 @@ global.fetch = mockFetch;
 const mockLogger = new WebChatLogger('InitWebChat');
 describe('Index', () => {
   const { initWebchat } = window.Twilio;
+  const originalConfigUrlEnv = process.env.REACT_APP_CONFIG_URL;
   beforeAll(() => {
     global.fetch = mockFetch;
 
@@ -47,6 +48,7 @@ describe('Index', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    process.env.REACT_APP_CONFIG_URL = originalConfigUrlEnv;
   });
 
   describe('initWebchat', () => {
@@ -83,6 +85,58 @@ describe('Index', () => {
           <WebchatWidget />
         </Provider>,
         expect.any(HTMLElement),
+      );
+    });
+
+    it('uses URL config param over environment and document config values', async () => {
+      const initConfigSpy = jest.spyOn(initActions, 'initConfigThunk');
+      process.env.REACT_APP_CONFIG_URL = '/env-config.json';
+
+      await initWebchat('/url-config.json', '/document-config.json', {});
+
+      expect(initConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configUrl: '/url-config.json',
+        }),
+      );
+    });
+
+    it('uses environment config URL when URL config param is empty', async () => {
+      const initConfigSpy = jest.spyOn(initActions, 'initConfigThunk');
+      process.env.REACT_APP_CONFIG_URL = '/env-config.json';
+
+      await initWebchat('', '/document-config.json', {});
+
+      expect(initConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configUrl: '/env-config.json',
+        }),
+      );
+    });
+
+    it('uses document config URL when environment config URL is empty', async () => {
+      const initConfigSpy = jest.spyOn(initActions, 'initConfigThunk');
+      process.env.REACT_APP_CONFIG_URL = '';
+
+      await initWebchat(null, '/document-config.json', {});
+
+      expect(initConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configUrl: '/document-config.json',
+        }),
+      );
+    });
+
+    it('uses default config URL when higher-precedence values are unset', async () => {
+      const initConfigSpy = jest.spyOn(initActions, 'initConfigThunk');
+      delete process.env.REACT_APP_CONFIG_URL;
+
+      await initWebchat(null, undefined, {});
+
+      expect(initConfigSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configUrl: './config.json',
+        }),
       );
     });
   });

--- a/aselo-webchat-react-app/src/__tests__/index.test.tsx
+++ b/aselo-webchat-react-app/src/__tests__/index.test.tsx
@@ -57,7 +57,7 @@ describe('Index', () => {
       const root = document.createElement('div');
       root.id = 'aselo-webchat-widget-root';
       document.body.appendChild(root);
-      await initWebchat(undefined, { deploymentKey: 'CV000000' });
+      await initWebchat(null, undefined, {});
 
       expect(renderSpy).toHaveBeenCalledWith(
         <Provider store={store}>
@@ -71,12 +71,11 @@ describe('Index', () => {
       const initConfigSpy = jest.spyOn(initActions, 'initConfigThunk');
       const renderSpy = jest.spyOn(reactDom, 'render');
 
-      const deploymentKey = 'CV000000';
-      await initWebchat(undefined, { deploymentKey });
+      await initWebchat(null, undefined, { defaultLocale: 'fr-FR' });
 
       expect(initConfigSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          overrides: expect.objectContaining({ deploymentKey }),
+          overrides: expect.objectContaining({ defaultLocale: 'fr-FR' }),
         }),
       );
       expect(renderSpy).toHaveBeenCalledWith(

--- a/aselo-webchat-react-app/src/index.tsx
+++ b/aselo-webchat-react-app/src/index.tsx
@@ -15,9 +15,14 @@ import { ConfigState } from './store/definitions';
 import { initLogger, getLogger } from './logger';
 import { initChat } from './initChat';
 
-const initWebchat = async (configLocation?: string | URL, overrides: Partial<ConfigState> = {}) => {
+const initWebchat = async (
+  paramConfigLocation: string | null,
+  documentConfigLocation?: string,
+  overrides: Partial<ConfigState> = {},
+) => {
   const logger = window.Twilio.getLogger(`InitWebChat`);
-  const configUrl = configLocation || process.env.REACT_APP_CONFIG_URL || './config.json';
+  const configUrl =
+    paramConfigLocation || process.env.REACT_APP_CONFIG_URL || documentConfigLocation || './config.json';
 
   await store.dispatch(initConfigThunk({ configUrl, overrides }) as any);
 

--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -53,7 +53,6 @@ export const initChat = (scriptTagData: Record<string, string | undefined>) => {
   const defaultLocale =
     // data-language attribute is supported for backwards compatibility, remove once webchat is fully migrated
     urlParams.get('locale') || scriptTagData.locale || scriptTagData.language;
-  const configUrl = urlParams.get('configUrl') ?? scriptTagData.configUrl?.toString() ?? undefined;
 
   const themeEl = document.querySelector('[data-theme-pref]');
   themeEl?.setAttribute('data-theme-pref', isLightTheme ? 'light-theme' : 'dark-theme');
@@ -72,7 +71,7 @@ export const initChat = (scriptTagData: Record<string, string | undefined>) => {
   }
 
   window.Twilio.initLogger('info');
-  window.Twilio.initWebchat(configUrl, {
+  window.Twilio.initWebchat(urlParams.get('configUrl'), scriptTagData.configUrl?.toString(), {
     theme: {
       isLight: isLightTheme,
       overrides: {


### PR DESCRIPTION
## Description
- Ensure legacy and new webchat deploys load the config file in the same location as the app.js script by default.
- Ensure config URL set in webpack env var overrides the one specified in the HTML page, but the one specified in the URL parameter overrides both

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P