### PR TITLE
CHI-3890: Use locale 'short time' formatting for message timestamps

### DIFF
--- a/aselo-webchat-react-app/src/components/MessageBubble.tsx
+++ b/aselo-webchat-react-app/src/components/MessageBubble.tsx
@@ -59,14 +59,12 @@ export const MessageBubble = ({
 }) => {
   const [read, setRead] = useState(false);
   const [isMouseDown, setIsMouseDown] = useState(false);
-  const { conversationsClient, participants, fileAttachmentConfig, currentTranslations } = useSelector(
-    (state: AppState) => ({
-      conversationsClient: state.chat.conversationsClient,
-      participants: state.chat.participants,
-      fileAttachmentConfig: state.config.fileAttachment,
-      currentTranslations: selectCurrentTranslations(state),
-    }),
-  );
+  const { conversationsClient, participants, fileAttachmentConfig } = useSelector((state: AppState) => ({
+    conversationsClient: state.chat.conversationsClient,
+    participants: state.chat.participants,
+    fileAttachmentConfig: state.config.fileAttachment,
+  }));
+  const currentTranslations = useSelector(selectCurrentTranslations);
   const messageRef = useRef<HTMLDivElement>(null);
 
   const belongsToCurrentUser = message.author === conversationsClient?.user.identity;
@@ -167,7 +165,10 @@ export const MessageBubble = ({
             </Text>
             <ScreenReaderOnly as="p">{`${translatedName} sent at`}</ScreenReaderOnly>
             <Text {...timeStampStyles} as="p">
-              {`${doubleDigit(message.dateCreated.getHours())}:${doubleDigit(message.dateCreated.getMinutes())}`}
+              {
+                // Use system locale rather than configured locale.
+                message.dateCreated.toLocaleTimeString([], { timeStyle: 'short' })
+              }
             </Text>
           </Flex>
           <Text as="p" {...bodyStyles}>

--- a/aselo-webchat-react-app/src/components/__tests__/MessageBubble.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/MessageBubble.test.tsx
@@ -75,10 +75,7 @@ jest.mock('../FilePreview', () => ({
 describe('Message Bubble', () => {
   const media = { filename: 'filename.jpg', contentType: 'image/jpeg', size: 1 } as Media;
   const media2 = { filename: 'filename2.jpg', contentType: 'image/jpeg', size: 1 } as Media;
-  const dateCreated = {
-    getHours: () => 0,
-    getMinutes: () => 0,
-  };
+  const dateCreated = new Date(2000, 0, 1, 0, 0);
   const messageCurrentUser = {
     index: 0,
     author: user1.identity,

--- a/aselo-webchat-react-app/src/components/__tests__/MessageBubble.test.tsx
+++ b/aselo-webchat-react-app/src/components/__tests__/MessageBubble.test.tsx
@@ -148,8 +148,9 @@ describe('Message Bubble', () => {
         updateFocus={jest.fn}
       />,
     );
-    const timestampText = '00:00'; // 0:0 is what getHours():getMinutes() will be
-
+    // This is a bit meh testing with the same code that generates the string in prod code
+    // But otherwise the test will fail if run in different locales
+    const timestampText = dateCreated.toLocaleTimeString([], { timeStyle: 'short' });
     expect(queryByText(timestampText)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Description

Replace manual time formatting with `toLocaleTimeString` call for message timestamps in Aselo Webchat

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P