### PR TITLE
CHI-3700: Propagate routing context to edit contact form

### DIFF
--- a/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
+++ b/plugin-hrm-form/src/components/contact/ContactDetailsHome.tsx
@@ -92,10 +92,9 @@ const ContactDetailsHome: React.FC<Props> = function ({
 }) {
   // Redux selectors
   const savedContact = useSelector((state: RootState) => selectContactStateByContactId(state, contactId)?.savedContact);
-  const isProfileRoute = useSelector((state: RootState) => {
-    const currentRoute = selectCurrentTopmostRouteForTask(state, task.taskSid);
-    return isRouteWithContext(currentRoute) && currentRoute?.context === 'profile';
-  });
+
+  const currentRoute = useSelector((state: RootState) => selectCurrentTopmostRouteForTask(state, task.taskSid));
+  const isProfileRoute = isRouteWithContext(currentRoute) && currentRoute?.context === 'profile';
   const definitionVersion = useSelector((state: RootState) => selectDefinitionVersionForContact(state, savedContact));
   const counselorsHash = useSelector((state: RootState) => selectCounselorsHash(state));
   const showRemovedFromCaseBanner = useSelector(
@@ -114,7 +113,19 @@ const ContactDetailsHome: React.FC<Props> = function ({
   const dispatch = useDispatch();
   const navigate = (
     form: keyof Pick<ContactRawJson, 'caseInformation' | 'callerInformation' | 'categories' | 'childInformation'>,
-  ) => dispatch(changeRoute({ route: 'contact', subroute: 'edit', id: contactId, form }, task.taskSid));
+  ) =>
+    dispatch(
+      changeRoute(
+        {
+          route: 'contact',
+          subroute: 'edit',
+          id: contactId,
+          form,
+          ...(isRouteWithContext(currentRoute) ? { context: currentRoute.context } : {}),
+        },
+        task.taskSid,
+      ),
+    );
   const createDraftCsamReport = () => dispatch(newCSAMReportActionForContact(contactId));
   const openProfileModal = id => {
     dispatch(newOpenModalAction({ route: 'profile', profileId: id, subroute: 'details' }, task.taskSid));


### PR DESCRIPTION
## Description

Navigation to the edit contact form was broken in some scenarios because the 'context' property of the route was not passed from the contact details view to the edit form

This PR ensures the context is propagated correctly

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P