### PR TITLE
sjh/fix_aselo_webchat_prod_deploy

### DIFF
--- a/.github/workflows/global-production-release-tag.yml
+++ b/.github/workflows/global-production-release-tag.yml
@@ -65,7 +65,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           source-git-reference-type: ${{ github.ref_type }}
           source-git-reference: ${{ github.ref_name }}
-          target-git-tag: ${{ steps.create_pre_release.outputs.generated-pre-release-tag }}
+          target-git-tag: ${{ inputs.tag-name }}
 
   tag-images:
     needs: generate-release


### PR DESCRIPTION
## Description

- Fix aselo webchat prod tagging so that prod versions can be deployed

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P