### PR TITLE
CHI-3895: Add z-index: 100 css style to new div element added to contain Aselo webchat

### DIFF
--- a/aselo-webchat-react-app/src/initChat.ts
+++ b/aselo-webchat-react-app/src/initChat.ts
@@ -60,7 +60,7 @@ export const initChat = (scriptTagData: Record<string, string | undefined>) => {
   if (!root) {
     root = document.createElement('div');
     root.id = 'aselo-webchat-widget-root';
-
+    root.style.zIndex = '100';
     document.body.appendChild(root);
   }
   if (scriptTagData.zIndex !== undefined) {


### PR DESCRIPTION
## Description

In line with legacy webchat styling, if we automatically add a `<div / >` tag to contain the webchat widget because none with the reserved id tag exist, we will give it a CSS property of `z-index: 100` to ensure it floats on top of more web page layouts

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P