### PR TITLE
CHI-3876: Add optimistic locking support to patching attributes

### DIFF
--- a/lambdas/account-scoped/src/task/addCustomerExternalIdTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/task/addCustomerExternalIdTaskRouterListener.ts
@@ -17,7 +17,6 @@
 // eslint-disable-next-line prettier/prettier
 import {registerTaskRouterEventHandler, TaskRouterEventHandler} from '../taskrouter/taskrouterEventHandler';
 import { AccountSID, TaskSID } from '@tech-matters/twilio-types';
-import { Twilio } from 'twilio';
 import { TASK_CREATED, TASK_UPDATED } from '../taskrouter/eventTypes';
 import { EventFields } from '../taskrouter';
 import { patchTaskAttributes } from './patchTaskAttributes';
@@ -44,7 +43,6 @@ const isTaskRequiringExternalId = async (
 const addCustomerExternalId: TaskRouterEventHandler = async (
   event: EventFields,
   accountSid: AccountSID,
-  client: Twilio,
 ) => {
   const { TaskSid, TaskAttributes } = event;
   const taskSid = TaskSid as TaskSID;
@@ -53,13 +51,14 @@ const addCustomerExternalId: TaskRouterEventHandler = async (
     return;
   }
 
-  await patchTaskAttributes(client, accountSid, taskSid, originalAttributes => ({
+  const result = await patchTaskAttributes(accountSid, taskSid, originalAttributes => ({
     ...originalAttributes,
     customers: {
       ...originalAttributes.customers,
       external_id: taskSid,
     },
   }));
+  result.unwrap();
 };
 
 registerTaskRouterEventHandler([TASK_CREATED, TASK_UPDATED], addCustomerExternalId);

--- a/lambdas/account-scoped/src/task/addInitialHangUpByTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/task/addInitialHangUpByTaskRouterListener.ts
@@ -17,26 +17,26 @@
 // eslint-disable-next-line prettier/prettier
 import {registerTaskRouterEventHandler, TaskRouterEventHandler} from '../taskrouter/taskrouterEventHandler';
 import { AccountSID, TaskSID } from '@tech-matters/twilio-types';
-import { Twilio } from 'twilio';
 import { TASK_CREATED } from '../taskrouter/eventTypes';
 import { EventFields } from '../taskrouter';
 import { patchTaskAttributes } from './patchTaskAttributes';
+import {isErr} from "../Result";
 
 const addInitialHangUpBy: TaskRouterEventHandler = async (
   event: EventFields,
   accountSid: AccountSID,
-  client: Twilio,
 ) => {
   const { TaskSid } = event;
   const taskSid = TaskSid as TaskSID;
   if (event.TaskChannelUniqueName === 'voice') {
-    await patchTaskAttributes(client, accountSid, taskSid, originalAttributes => ({
+    const result = await patchTaskAttributes(accountSid, taskSid, originalAttributes => ({
       ...originalAttributes,
       conversations: {
         ...originalAttributes.conversations,
         hang_up_by: 'Customer',
       },
     }));
+    result.unwrap();
   }
 };
 

--- a/lambdas/account-scoped/src/task/addInitialHangUpByTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/task/addInitialHangUpByTaskRouterListener.ts
@@ -20,7 +20,7 @@ import { AccountSID, TaskSID } from '@tech-matters/twilio-types';
 import { TASK_CREATED } from '../taskrouter/eventTypes';
 import { EventFields } from '../taskrouter';
 import { patchTaskAttributes } from './patchTaskAttributes';
-import {isErr} from "../Result";
+import { isErr } from '../Result';
 
 const addInitialHangUpBy: TaskRouterEventHandler = async (
   event: EventFields,

--- a/lambdas/account-scoped/src/task/addInitialHangUpByTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/task/addInitialHangUpByTaskRouterListener.ts
@@ -15,7 +15,7 @@
  */
 
 // eslint-disable-next-line prettier/prettier
-import {registerTaskRouterEventHandler, TaskRouterEventHandler} from '../taskrouter/taskrouterEventHandler';
+import { registerTaskRouterEventHandler, TaskRouterEventHandler } from '../taskrouter/taskrouterEventHandler';
 import { AccountSID, TaskSID } from '@tech-matters/twilio-types';
 import { TASK_CREATED } from '../taskrouter/eventTypes';
 import { EventFields } from '../taskrouter';

--- a/lambdas/account-scoped/src/task/addInitialHangUpByTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/task/addInitialHangUpByTaskRouterListener.ts
@@ -20,7 +20,6 @@ import { AccountSID, TaskSID } from '@tech-matters/twilio-types';
 import { TASK_CREATED } from '../taskrouter/eventTypes';
 import { EventFields } from '../taskrouter';
 import { patchTaskAttributes } from './patchTaskAttributes';
-import { isErr } from '../Result';
 
 const addInitialHangUpBy: TaskRouterEventHandler = async (
   event: EventFields,

--- a/lambdas/account-scoped/src/task/patchTaskAttributes.ts
+++ b/lambdas/account-scoped/src/task/patchTaskAttributes.ts
@@ -115,7 +115,7 @@ export const patchTaskAttributes = async (
       `[${accountSid}/${taskSid}] patchTaskAttributes: no lastRequest found on httpClient after fetch, optimistic locking will not be applied.`,
     );
   } else {
-    version = typeof lastRequest.headers === 'object' ? lastRequest.headers.eTag : null;
+    version = typeof lastRequest.headers === 'object' ? lastRequest.headers.etag : null;
     if (!version) {
       console.warn(
         `[${accountSid}/${taskSid}] patchTaskAttributes: no eTag header found on lastRequest after fetch, optimistic locking will not be applied.`,

--- a/lambdas/account-scoped/src/task/patchTaskAttributes.ts
+++ b/lambdas/account-scoped/src/task/patchTaskAttributes.ts
@@ -108,17 +108,19 @@ export const patchTaskAttributes = async (
     }
   }
   // This is only safely the above fetch request if the client is private to this method
-  const { headers } = client.httpClient.lastRequest ?? {};
-  if (!client.httpClient.lastRequest) {
+  const lastRequest = client.httpClient.lastRequest;
+  let version: string | null = null;
+  if (!lastRequest) {
     console.warn(
       `[${accountSid}/${taskSid}] patchTaskAttributes: no lastRequest found on httpClient after fetch, optimistic locking will not be applied.`,
     );
-  }
-  const version = typeof headers === 'object' ? headers?.eTag : null;
-  if (client.httpClient.lastRequest && !version) {
-    console.warn(
-      `[${accountSid}/${taskSid}] patchTaskAttributes: no eTag header found on lastRequest after fetch, optimistic locking will not be applied.`,
-    );
+  } else {
+    version = typeof lastRequest.headers === 'object' ? lastRequest.headers.eTag : null;
+    if (!version) {
+      console.warn(
+        `[${accountSid}/${taskSid}] patchTaskAttributes: no eTag header found on lastRequest after fetch, optimistic locking will not be applied.`,
+      );
+    }
   }
 
   const taskAttributes = JSON.parse(task.attributes);

--- a/lambdas/account-scoped/src/task/patchTaskAttributes.ts
+++ b/lambdas/account-scoped/src/task/patchTaskAttributes.ts
@@ -108,17 +108,28 @@ export const patchTaskAttributes = async (
     }
   }
   // This is only safely the above fetch request if the client is private to this method
-  const lastRequest = client.httpClient.lastRequest;
+  const { lastResponse } = client.httpClient;
   let version: string | null = null;
-  if (!lastRequest) {
+  if (!lastResponse) {
     console.warn(
       `[${accountSid}/${taskSid}] patchTaskAttributes: no lastRequest found on httpClient after fetch, optimistic locking will not be applied.`,
     );
   } else {
-    version = typeof lastRequest.headers === 'object' ? lastRequest.headers.etag : null;
+    console.info(`lastResponse`, lastResponse);
+    console.info(`lastRequest.url`, client.httpClient.lastRequest?.url);
+    console.info(`lastResponse.status`, lastResponse.statusCode);
+    console.info(`lastResponse.headers`, lastResponse.headers);
+    if (typeof lastResponse.headers === 'object') {
+      for (const header of Object.entries(lastResponse.headers).map(
+        ([key, value]) => `${key}=${value}`,
+      )) {
+        console.info(`lastResponse header:`, header);
+      }
+    }
+    version = typeof lastResponse.headers === 'object' ? lastResponse.headers.etag : null;
     if (!version) {
       console.warn(
-        `[${accountSid}/${taskSid}] patchTaskAttributes: no eTag header found on lastRequest after fetch, optimistic locking will not be applied.`,
+        `[${accountSid}/${taskSid}] patchTaskAttributes: no etag header found on lastRequest after fetch, optimistic locking will not be applied.`,
       );
     }
   }

--- a/lambdas/account-scoped/src/task/patchTaskAttributes.ts
+++ b/lambdas/account-scoped/src/task/patchTaskAttributes.ts
@@ -15,29 +15,72 @@
  */
 
 import { AccountSID, TaskSID, WorkspaceSID } from '@tech-matters/twilio-types';
-import { Twilio } from 'twilio';
-import { getWorkspaceSid } from '@tech-matters/twilio-configuration';
+import { getTwilioClient, getWorkspaceSid } from '@tech-matters/twilio-configuration';
+import type RestException from 'twilio/lib/base/RestException';
+import { ErrorResult, newErr, newOk, Result } from '../Result';
 
-const logError = (
-  taskSid: TaskSID,
-  workspaceSid: WorkspaceSID,
-  step: 'fetch' | 'update',
-  errorInstance: Error,
-): void => {
-  const errorMessage = `Error at patchTaskAttributes: task with sid ${taskSid} does not exists in workspace ${workspaceSid} when trying to ${step} it.`;
-  console.error(errorMessage, errorInstance);
+const MAX_ATTEMPTS = 10;
+
+type ErrorResultPayload = {
+  accountSid: AccountSID;
+  taskSid: TaskSID;
+  errorInstance: Error;
+  step: 'fetch' | 'update';
+};
+
+type MissingTaskErrorResultPayload = ErrorResultPayload & {
+  workspaceSid: WorkspaceSID;
+};
+
+type PreconditionFailedErrorResultPayload = ErrorResultPayload & {
+  etag: string | null;
+  step: 'update';
+};
+
+const newErrorResult = <
+  T extends
+    | ErrorResultPayload
+    | MissingTaskErrorResultPayload
+    | PreconditionFailedErrorResultPayload,
+>(
+  payload: T,
+): ErrorResult<T> => {
+  const errorMessage = `[${payload.accountSid}/${payload.taskSid}] Error in patchTaskAttributes when trying to ${payload.step} it.`;
+  return newErr({
+    message: errorMessage,
+    error: payload,
+  });
+};
+
+const missingTaskError = (
+  payload: MissingTaskErrorResultPayload,
+): ErrorResult<MissingTaskErrorResultPayload> => {
+  const result = newErrorResult<MissingTaskErrorResultPayload>(payload);
+  const errorMessage = `[${payload.accountSid}/${payload.taskSid}] Error in patchTaskAttributes: task with sid does not exists in workspace ${payload.workspaceSid} when trying to ${payload.step} it.`;
+  console.error(errorMessage, payload.errorInstance);
+  result.message = errorMessage;
+  return result;
 };
 
 export const patchTaskAttributes = async (
-  client: Twilio,
   accountSid: AccountSID,
   taskSid: TaskSID,
   updatedAttributesGenerator: (
     originalTaskAttributes: Record<string, any>,
   ) => Record<string, any>,
-) => {
+  attemptsAlreadyMade = 0,
+): Promise<
+  Result<
+    | ErrorResultPayload
+    | MissingTaskErrorResultPayload
+    | PreconditionFailedErrorResultPayload,
+    undefined
+  >
+> => {
+  // Ensure we have a private Twilio client so the lastRequest check always returns the prior fetch request
+  const client = await getTwilioClient(accountSid);
   const workspaceSid: WorkspaceSID = await getWorkspaceSid(accountSid);
-  console.info('Adding external_id to task', taskSid);
+  console.info('Patching task', taskSid);
 
   if (!taskSid) throw new Error('TaskSid missing in event object');
 
@@ -45,10 +88,28 @@ export const patchTaskAttributes = async (
 
   try {
     task = await client.taskrouter.v1.workspaces(workspaceSid).tasks(taskSid).fetch();
-  } catch (err) {
-    logError(taskSid, workspaceSid, 'fetch', err as Error);
-    return;
+  } catch (error) {
+    const restError = error as RestException;
+    if (restError.status === 404) {
+      return missingTaskError({
+        accountSid,
+        taskSid,
+        workspaceSid,
+        step: 'fetch',
+        errorInstance: error as Error,
+      });
+    } else {
+      return newErrorResult({
+        accountSid,
+        taskSid,
+        step: 'fetch',
+        errorInstance: error as Error,
+      });
+    }
   }
+  // This is only safely the above fetch request if the client is private to this method
+  const { headers } = client.httpClient.lastRequest ?? {};
+  const version = typeof headers === 'object' ? headers.eTag : null;
 
   const taskAttributes = JSON.parse(task.attributes);
 
@@ -58,8 +119,48 @@ export const patchTaskAttributes = async (
     await client.taskrouter.v1
       .workspaces(workspaceSid)
       .tasks(taskSid)
-      .update({ attributes: JSON.stringify(newAttributes) });
-  } catch (err) {
-    logError(taskSid, workspaceSid, 'update', err as Error);
+      .update({
+        attributes: JSON.stringify(newAttributes),
+        ...(version ? { ifMatch: version } : {}),
+      });
+    return newOk(undefined);
+  } catch (error) {
+    const restError = error as RestException;
+    switch (restError.status) {
+      case 412:
+        if (attemptsAlreadyMade < MAX_ATTEMPTS) {
+          console.warn(
+            `Error 412 thrown, this usually indicates a mismatch in the ETag from the fetched task (${version}) and the one being updated, retry attempt ${attemptsAlreadyMade + 1} / ${MAX_ATTEMPTS}`,
+          );
+          return patchTaskAttributes(
+            accountSid,
+            taskSid,
+            updatedAttributesGenerator,
+            attemptsAlreadyMade + 1,
+          );
+        }
+        return newErrorResult({
+          accountSid,
+          taskSid,
+          etag: version,
+          step: 'update',
+          errorInstance: restError,
+        });
+      case 404:
+        return missingTaskError({
+          accountSid,
+          taskSid,
+          workspaceSid,
+          step: 'update',
+          errorInstance: restError,
+        });
+      default:
+        return newErrorResult({
+          accountSid,
+          taskSid,
+          step: 'update',
+          errorInstance: restError,
+        });
+    }
   }
 };

--- a/lambdas/account-scoped/src/task/patchTaskAttributes.ts
+++ b/lambdas/account-scoped/src/task/patchTaskAttributes.ts
@@ -109,7 +109,17 @@ export const patchTaskAttributes = async (
   }
   // This is only safely the above fetch request if the client is private to this method
   const { headers } = client.httpClient.lastRequest ?? {};
-  const version = typeof headers === 'object' ? headers.eTag : null;
+  if (!client.httpClient.lastRequest) {
+    console.warn(
+      `[${accountSid}/${taskSid}] patchTaskAttributes: no lastRequest found on httpClient after fetch, optimistic locking will not be applied.`,
+    );
+  }
+  const version = typeof headers === 'object' ? headers?.eTag : null;
+  if (client.httpClient.lastRequest && !version) {
+    console.warn(
+      `[${accountSid}/${taskSid}] patchTaskAttributes: no eTag header found on lastRequest after fetch, optimistic locking will not be applied.`,
+    );
+  }
 
   const taskAttributes = JSON.parse(task.attributes);
 

--- a/lambdas/account-scoped/src/task/patchTaskAttributes.ts
+++ b/lambdas/account-scoped/src/task/patchTaskAttributes.ts
@@ -115,13 +115,6 @@ export const patchTaskAttributes = async (
       `[${accountSid}/${taskSid}] patchTaskAttributes: no lastRequest found on httpClient after fetch, optimistic locking will not be applied.`,
     );
   } else {
-    if (typeof lastResponse.headers === 'object') {
-      for (const header of Object.entries(lastResponse.headers).map(
-        ([key, value]) => `${key}=${value}`,
-      )) {
-        console.info(`lastResponse header:`, header);
-      }
-    }
     version = typeof lastResponse.headers === 'object' ? lastResponse.headers.etag : null;
     if (!version) {
       console.warn(

--- a/lambdas/account-scoped/src/task/patchTaskAttributes.ts
+++ b/lambdas/account-scoped/src/task/patchTaskAttributes.ts
@@ -56,7 +56,7 @@ const missingTaskError = (
   payload: MissingTaskErrorResultPayload,
 ): ErrorResult<MissingTaskErrorResultPayload> => {
   const result = newErrorResult<MissingTaskErrorResultPayload>(payload);
-  const errorMessage = `[${payload.accountSid}/${payload.taskSid}] Error in patchTaskAttributes: task with sid does not exists in workspace ${payload.workspaceSid} when trying to ${payload.step} it.`;
+  const errorMessage = `[${payload.accountSid}/${payload.taskSid}] Error in patchTaskAttributes: task with sid ${payload.taskSid} does not exist in workspace ${payload.workspaceSid} when trying to ${payload.step} it.`;
   console.error(errorMessage, payload.errorInstance);
   result.message = errorMessage;
   return result;

--- a/lambdas/account-scoped/src/task/patchTaskAttributes.ts
+++ b/lambdas/account-scoped/src/task/patchTaskAttributes.ts
@@ -115,10 +115,6 @@ export const patchTaskAttributes = async (
       `[${accountSid}/${taskSid}] patchTaskAttributes: no lastRequest found on httpClient after fetch, optimistic locking will not be applied.`,
     );
   } else {
-    console.info(`lastResponse`, lastResponse);
-    console.info(`lastRequest.url`, client.httpClient.lastRequest?.url);
-    console.info(`lastResponse.status`, lastResponse.statusCode);
-    console.info(`lastResponse.headers`, lastResponse.headers);
     if (typeof lastResponse.headers === 'object') {
       for (const header of Object.entries(lastResponse.headers).map(
         ([key, value]) => `${key}=${value}`,

--- a/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
+++ b/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
@@ -74,7 +74,7 @@ describe('patchTaskAttributes', () => {
       },
       httpClient: {
         lastRequest: {
-          headers: { eTag: TEST_ETAG },
+          headers: { etag: TEST_ETAG },
         },
       },
     };
@@ -116,7 +116,7 @@ describe('patchTaskAttributes', () => {
       );
     });
 
-    it('should update without ifMatch when lastRequest headers contain no eTag', async () => {
+    it('should update without ifMatch when lastRequest headers contain no etag', async () => {
       mockClient.httpClient.lastRequest = {
         headers: { 'Content-Type': 'application/json' },
       };
@@ -126,18 +126,6 @@ describe('patchTaskAttributes', () => {
       expect(mockUpdate).toHaveBeenCalledWith(
         expect.not.objectContaining({ ifMatch: expect.anything() }),
       );
-    });
-
-    it('should log a warning when lastRequest headers contain no eTag', async () => {
-      mockClient.httpClient.lastRequest = {
-        headers: { 'Content-Type': 'application/json' },
-      };
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
-
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no eTag header'));
-      warnSpy.mockRestore();
     });
 
     it('should update without ifMatch when httpClient has no lastRequest', async () => {
@@ -148,25 +136,6 @@ describe('patchTaskAttributes', () => {
       expect(mockUpdate).toHaveBeenCalledWith(
         expect.not.objectContaining({ ifMatch: expect.anything() }),
       );
-    });
-
-    it('should log a warning when httpClient has no lastRequest', async () => {
-      mockClient.httpClient.lastRequest = null;
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
-
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no lastRequest'));
-      warnSpy.mockRestore();
-    });
-
-    it('should not log a warning when ETag is present', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
-
-      expect(warnSpy).not.toHaveBeenCalled();
-      warnSpy.mockRestore();
     });
 
     it('should fetch the task from the correct workspace', async () => {

--- a/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
+++ b/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
@@ -73,7 +73,7 @@ describe('patchTaskAttributes', () => {
         },
       },
       httpClient: {
-        lastRequest: {
+        lastResponse: {
           headers: { etag: TEST_ETAG },
         },
       },
@@ -116,8 +116,8 @@ describe('patchTaskAttributes', () => {
       );
     });
 
-    it('should update without ifMatch when lastRequest headers contain no etag', async () => {
-      mockClient.httpClient.lastRequest = {
+    it('should update without ifMatch when lastResponse headers contain no etag', async () => {
+      mockClient.httpClient.lastResponse = {
         headers: { 'Content-Type': 'application/json' },
       };
 
@@ -128,8 +128,8 @@ describe('patchTaskAttributes', () => {
       );
     });
 
-    it('should update without ifMatch when httpClient has no lastRequest', async () => {
-      mockClient.httpClient.lastRequest = null;
+    it('should update without ifMatch when httpClient has no lastResponse', async () => {
+      mockClient.httpClient.lastResponse = null;
 
       await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
 

--- a/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
+++ b/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
@@ -284,8 +284,8 @@ describe('patchTaskAttributes', () => {
     });
 
     it('should succeed after multiple 412 retries', async () => {
-      const retries = 5;
-      for (let i = 0; i < retries; i++) {
+      const failureCount = 5;
+      for (let i = 0; i < failureCount; i++) {
         mockUpdate.mockRejectedValueOnce(makeRestException(412));
       }
       mockUpdate.mockResolvedValueOnce({});
@@ -297,11 +297,11 @@ describe('patchTaskAttributes', () => {
       );
 
       expect(isOk(result)).toBe(true);
-      expect(mockUpdate).toHaveBeenCalledTimes(retries + 1);
+      expect(mockUpdate).toHaveBeenCalledTimes(failureCount + 1);
     });
 
     it('should return an error result after exhausting all retry attempts (412 on every attempt)', async () => {
-      // MAX_ATTEMPTS is 10, so there are 11 total attempts (initial + 10 retries)
+      // MAX_ATTEMPTS is 10; with 1 initial attempt plus 10 retries, 11 total calls are made before giving up
       const totalAttempts = 11;
       for (let i = 0; i < totalAttempts; i++) {
         mockFetch.mockResolvedValueOnce({ attributes: JSON.stringify(ORIGINAL_ATTRIBUTES) });

--- a/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
+++ b/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { patchTaskAttributes } from '../../../src/task/patchTaskAttributes';
+import { getTwilioClient, getWorkspaceSid } from '@tech-matters/twilio-configuration';
+import { isErr, isOk } from '../../../src/Result';
+import { TEST_ACCOUNT_SID, TEST_TASK_SID, TEST_WORKSPACE_SID } from '../../testTwilioValues';
+
+jest.mock('@tech-matters/twilio-configuration', () => ({
+  getTwilioClient: jest.fn(),
+  getWorkspaceSid: jest.fn(),
+}));
+
+const mockGetTwilioClient = getTwilioClient as jest.MockedFunction<typeof getTwilioClient>;
+const mockGetWorkspaceSid = getWorkspaceSid as jest.MockedFunction<typeof getWorkspaceSid>;
+
+const TEST_ETAG = '"abc123"';
+const ORIGINAL_ATTRIBUTES = { existingKey: 'original', anotherKey: 42 };
+const UPDATED_ATTRIBUTES = { existingKey: 'updated', anotherKey: 42, newKey: true };
+
+const makeRestException = (status: number): Error => {
+  const err = new Error(`HTTP ${status}`) as any;
+  err.status = status;
+  return err;
+};
+
+describe('patchTaskAttributes', () => {
+  let mockFetch: jest.Mock;
+  let mockUpdate: jest.Mock;
+  let mockClient: any;
+  let attributesGenerator: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    attributesGenerator = jest.fn().mockReturnValue(UPDATED_ATTRIBUTES);
+
+    mockFetch = jest.fn().mockResolvedValue({
+      attributes: JSON.stringify(ORIGINAL_ATTRIBUTES),
+    });
+    mockUpdate = jest.fn().mockResolvedValue({});
+
+    mockClient = {
+      taskrouter: {
+        v1: {
+          workspaces: jest.fn().mockReturnValue({
+            tasks: jest.fn().mockReturnValue({
+              fetch: mockFetch,
+              update: mockUpdate,
+            }),
+          }),
+        },
+      },
+      httpClient: {
+        lastRequest: {
+          headers: { eTag: TEST_ETAG },
+        },
+      },
+    };
+
+    mockGetTwilioClient.mockResolvedValue(mockClient as any);
+    mockGetWorkspaceSid.mockResolvedValue(TEST_WORKSPACE_SID as any);
+  });
+
+  describe('successful patch', () => {
+    it('should return an Ok result when fetch and update succeed', async () => {
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isOk(result)).toBe(true);
+    });
+
+    it('should call the updatedAttributesGenerator with the parsed task attributes', async () => {
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(attributesGenerator).toHaveBeenCalledWith(ORIGINAL_ATTRIBUTES);
+    });
+
+    it('should update the task with the generated attributes', async () => {
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ attributes: JSON.stringify(UPDATED_ATTRIBUTES) }),
+      );
+    });
+
+    it('should include ifMatch with the ETag from the fetch response', async () => {
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ ifMatch: TEST_ETAG }),
+      );
+    });
+
+    it('should update without ifMatch when lastRequest headers contain no eTag', async () => {
+      mockClient.httpClient.lastRequest = { headers: { 'Content-Type': 'application/json' } };
+
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.not.objectContaining({ ifMatch: expect.anything() }),
+      );
+    });
+
+    it('should update without ifMatch when httpClient has no lastRequest', async () => {
+      mockClient.httpClient.lastRequest = null;
+
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.not.objectContaining({ ifMatch: expect.anything() }),
+      );
+    });
+
+    it('should fetch the task from the correct workspace', async () => {
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(mockClient.taskrouter.v1.workspaces).toHaveBeenCalledWith(TEST_WORKSPACE_SID);
+      expect(
+        mockClient.taskrouter.v1.workspaces(TEST_WORKSPACE_SID).tasks,
+      ).toHaveBeenCalledWith(TEST_TASK_SID);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe('missing taskSid', () => {
+    it('should throw when taskSid is an empty string', async () => {
+      await expect(
+        patchTaskAttributes(TEST_ACCOUNT_SID, '' as any, attributesGenerator),
+      ).rejects.toThrow('TaskSid missing in event object');
+    });
+  });
+
+  describe('fetch errors', () => {
+    it('should return an error result when fetch throws a 404', async () => {
+      mockFetch.mockRejectedValue(makeRestException(404));
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.step).toBe('fetch');
+        expect(result.error.taskSid).toBe(TEST_TASK_SID);
+        expect(result.error.accountSid).toBe(TEST_ACCOUNT_SID);
+        expect((result.error as any).workspaceSid).toBe(TEST_WORKSPACE_SID);
+      }
+    });
+
+    it('should include workspaceSid in the error payload when fetch returns 404', async () => {
+      mockFetch.mockRejectedValue(makeRestException(404));
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect((result.error as any).workspaceSid).toBe(TEST_WORKSPACE_SID);
+      }
+    });
+
+    it('should return an error result when fetch throws a non-404 error', async () => {
+      mockFetch.mockRejectedValue(makeRestException(500));
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.step).toBe('fetch');
+        expect(result.error.taskSid).toBe(TEST_TASK_SID);
+      }
+    });
+
+    it('should not include workspaceSid in the error payload when fetch throws a non-404 error', async () => {
+      mockFetch.mockRejectedValue(makeRestException(500));
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect((result.error as any).workspaceSid).toBeUndefined();
+      }
+    });
+  });
+
+  describe('update errors', () => {
+    it('should return an error result when update throws a 404', async () => {
+      mockUpdate.mockRejectedValue(makeRestException(404));
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.step).toBe('update');
+        expect(result.error.taskSid).toBe(TEST_TASK_SID);
+        expect((result.error as any).workspaceSid).toBe(TEST_WORKSPACE_SID);
+      }
+    });
+
+    it('should return an error result when update throws a non-404/412 error', async () => {
+      mockUpdate.mockRejectedValue(makeRestException(500));
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.step).toBe('update');
+        expect(result.error.taskSid).toBe(TEST_TASK_SID);
+      }
+    });
+  });
+
+  describe('optimistic locking - 412 retry mechanism', () => {
+    it('should retry once when update returns 412 and succeed on second attempt', async () => {
+      mockUpdate
+        .mockRejectedValueOnce(makeRestException(412))
+        .mockResolvedValueOnce({});
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isOk(result)).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-fetch the task attributes on each retry attempt', async () => {
+      const firstAttributes = { key: 'first' };
+      const secondAttributes = { key: 'second' };
+
+      mockFetch
+        .mockResolvedValueOnce({ attributes: JSON.stringify(firstAttributes) })
+        .mockResolvedValueOnce({ attributes: JSON.stringify(secondAttributes) });
+
+      mockUpdate
+        .mockRejectedValueOnce(makeRestException(412))
+        .mockResolvedValueOnce({});
+
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(attributesGenerator).toHaveBeenNthCalledWith(1, firstAttributes);
+      expect(attributesGenerator).toHaveBeenNthCalledWith(2, secondAttributes);
+    });
+
+    it('should succeed after multiple 412 retries', async () => {
+      const retries = 5;
+      for (let i = 0; i < retries; i++) {
+        mockUpdate.mockRejectedValueOnce(makeRestException(412));
+      }
+      mockUpdate.mockResolvedValueOnce({});
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isOk(result)).toBe(true);
+      expect(mockUpdate).toHaveBeenCalledTimes(retries + 1);
+    });
+
+    it('should return an error result after exhausting all retry attempts (412 on every attempt)', async () => {
+      // MAX_ATTEMPTS is 10, so there are 11 total attempts (initial + 10 retries)
+      const totalAttempts = 11;
+      for (let i = 0; i < totalAttempts; i++) {
+        mockFetch.mockResolvedValueOnce({ attributes: JSON.stringify(ORIGINAL_ATTRIBUTES) });
+        mockUpdate.mockRejectedValueOnce(makeRestException(412));
+      }
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.step).toBe('update');
+        expect(result.error.taskSid).toBe(TEST_TASK_SID);
+        expect((result.error as any).etag).toBe(TEST_ETAG);
+      }
+    });
+
+    it('should include the ETag in the error payload when 412 retries are exhausted', async () => {
+      const totalAttempts = 11;
+      for (let i = 0; i < totalAttempts; i++) {
+        mockFetch.mockResolvedValueOnce({ attributes: JSON.stringify(ORIGINAL_ATTRIBUTES) });
+        mockUpdate.mockRejectedValueOnce(makeRestException(412));
+      }
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect((result.error as any).etag).toBe(TEST_ETAG);
+      }
+    });
+
+    it('should make exactly 11 fetch and update calls when all 10 retries are exhausted', async () => {
+      const totalAttempts = 11;
+      for (let i = 0; i < totalAttempts; i++) {
+        mockFetch.mockResolvedValueOnce({ attributes: JSON.stringify(ORIGINAL_ATTRIBUTES) });
+        mockUpdate.mockRejectedValueOnce(makeRestException(412));
+      }
+
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(mockFetch).toHaveBeenCalledTimes(totalAttempts);
+      expect(mockUpdate).toHaveBeenCalledTimes(totalAttempts);
+    });
+
+    it('should use ifMatch on retry attempts', async () => {
+      mockUpdate
+        .mockRejectedValueOnce(makeRestException(412))
+        .mockResolvedValueOnce({});
+
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(mockUpdate).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ ifMatch: TEST_ETAG }),
+      );
+    });
+  });
+
+  describe('error message content', () => {
+    it('should include accountSid and taskSid in error messages', async () => {
+      mockFetch.mockRejectedValue(makeRestException(500));
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.message).toContain(TEST_ACCOUNT_SID);
+        expect(result.message).toContain(TEST_TASK_SID);
+      }
+    });
+
+    it('should include workspaceSid in the error message when task is not found on fetch', async () => {
+      mockFetch.mockRejectedValue(makeRestException(404));
+
+      const result = await patchTaskAttributes(
+        TEST_ACCOUNT_SID,
+        TEST_TASK_SID,
+        attributesGenerator,
+      );
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.message).toContain(TEST_WORKSPACE_SID);
+      }
+    });
+  });
+});

--- a/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
+++ b/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
@@ -17,15 +17,23 @@
 import { patchTaskAttributes } from '../../../src/task/patchTaskAttributes';
 import { getTwilioClient, getWorkspaceSid } from '@tech-matters/twilio-configuration';
 import { isErr, isOk } from '../../../src/Result';
-import { TEST_ACCOUNT_SID, TEST_TASK_SID, TEST_WORKSPACE_SID } from '../../testTwilioValues';
+import {
+  TEST_ACCOUNT_SID,
+  TEST_TASK_SID,
+  TEST_WORKSPACE_SID,
+} from '../../testTwilioValues';
 
 jest.mock('@tech-matters/twilio-configuration', () => ({
   getTwilioClient: jest.fn(),
   getWorkspaceSid: jest.fn(),
 }));
 
-const mockGetTwilioClient = getTwilioClient as jest.MockedFunction<typeof getTwilioClient>;
-const mockGetWorkspaceSid = getWorkspaceSid as jest.MockedFunction<typeof getWorkspaceSid>;
+const mockGetTwilioClient = getTwilioClient as jest.MockedFunction<
+  typeof getTwilioClient
+>;
+const mockGetWorkspaceSid = getWorkspaceSid as jest.MockedFunction<
+  typeof getWorkspaceSid
+>;
 
 const TEST_ETAG = '"abc123"';
 const ORIGINAL_ATTRIBUTES = { existingKey: 'original', anotherKey: 42 };
@@ -109,7 +117,9 @@ describe('patchTaskAttributes', () => {
     });
 
     it('should update without ifMatch when lastRequest headers contain no eTag', async () => {
-      mockClient.httpClient.lastRequest = { headers: { 'Content-Type': 'application/json' } };
+      mockClient.httpClient.lastRequest = {
+        headers: { 'Content-Type': 'application/json' },
+      };
 
       await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
 
@@ -119,7 +129,9 @@ describe('patchTaskAttributes', () => {
     });
 
     it('should log a warning when lastRequest headers contain no eTag', async () => {
-      mockClient.httpClient.lastRequest = { headers: { 'Content-Type': 'application/json' } };
+      mockClient.httpClient.lastRequest = {
+        headers: { 'Content-Type': 'application/json' },
+      };
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
@@ -160,7 +172,9 @@ describe('patchTaskAttributes', () => {
     it('should fetch the task from the correct workspace', async () => {
       await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
 
-      expect(mockClient.taskrouter.v1.workspaces).toHaveBeenCalledWith(TEST_WORKSPACE_SID);
+      expect(mockClient.taskrouter.v1.workspaces).toHaveBeenCalledWith(
+        TEST_WORKSPACE_SID,
+      );
       expect(
         mockClient.taskrouter.v1.workspaces(TEST_WORKSPACE_SID).tasks,
       ).toHaveBeenCalledWith(TEST_TASK_SID);
@@ -279,9 +293,7 @@ describe('patchTaskAttributes', () => {
 
   describe('optimistic locking - 412 retry mechanism', () => {
     it('should retry once when update returns 412 and succeed on second attempt', async () => {
-      mockUpdate
-        .mockRejectedValueOnce(makeRestException(412))
-        .mockResolvedValueOnce({});
+      mockUpdate.mockRejectedValueOnce(makeRestException(412)).mockResolvedValueOnce({});
 
       const result = await patchTaskAttributes(
         TEST_ACCOUNT_SID,
@@ -302,9 +314,7 @@ describe('patchTaskAttributes', () => {
         .mockResolvedValueOnce({ attributes: JSON.stringify(firstAttributes) })
         .mockResolvedValueOnce({ attributes: JSON.stringify(secondAttributes) });
 
-      mockUpdate
-        .mockRejectedValueOnce(makeRestException(412))
-        .mockResolvedValueOnce({});
+      mockUpdate.mockRejectedValueOnce(makeRestException(412)).mockResolvedValueOnce({});
 
       await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
 
@@ -333,7 +343,9 @@ describe('patchTaskAttributes', () => {
       // MAX_ATTEMPTS is 10; with 1 initial attempt plus 10 retries, 11 total calls are made before giving up
       const totalAttempts = 11;
       for (let i = 0; i < totalAttempts; i++) {
-        mockFetch.mockResolvedValueOnce({ attributes: JSON.stringify(ORIGINAL_ATTRIBUTES) });
+        mockFetch.mockResolvedValueOnce({
+          attributes: JSON.stringify(ORIGINAL_ATTRIBUTES),
+        });
         mockUpdate.mockRejectedValueOnce(makeRestException(412));
       }
 
@@ -354,7 +366,9 @@ describe('patchTaskAttributes', () => {
     it('should include the ETag in the error payload when 412 retries are exhausted', async () => {
       const totalAttempts = 11;
       for (let i = 0; i < totalAttempts; i++) {
-        mockFetch.mockResolvedValueOnce({ attributes: JSON.stringify(ORIGINAL_ATTRIBUTES) });
+        mockFetch.mockResolvedValueOnce({
+          attributes: JSON.stringify(ORIGINAL_ATTRIBUTES),
+        });
         mockUpdate.mockRejectedValueOnce(makeRestException(412));
       }
 
@@ -373,7 +387,9 @@ describe('patchTaskAttributes', () => {
     it('should make exactly 11 fetch and update calls when all 10 retries are exhausted', async () => {
       const totalAttempts = 11;
       for (let i = 0; i < totalAttempts; i++) {
-        mockFetch.mockResolvedValueOnce({ attributes: JSON.stringify(ORIGINAL_ATTRIBUTES) });
+        mockFetch.mockResolvedValueOnce({
+          attributes: JSON.stringify(ORIGINAL_ATTRIBUTES),
+        });
         mockUpdate.mockRejectedValueOnce(makeRestException(412));
       }
 
@@ -384,9 +400,7 @@ describe('patchTaskAttributes', () => {
     });
 
     it('should use ifMatch on retry attempts', async () => {
-      mockUpdate
-        .mockRejectedValueOnce(makeRestException(412))
-        .mockResolvedValueOnce({});
+      mockUpdate.mockRejectedValueOnce(makeRestException(412)).mockResolvedValueOnce({});
 
       await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
 

--- a/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
+++ b/lambdas/account-scoped/tests/unit/task/patchTaskAttributes.test.ts
@@ -118,6 +118,16 @@ describe('patchTaskAttributes', () => {
       );
     });
 
+    it('should log a warning when lastRequest headers contain no eTag', async () => {
+      mockClient.httpClient.lastRequest = { headers: { 'Content-Type': 'application/json' } };
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no eTag header'));
+      warnSpy.mockRestore();
+    });
+
     it('should update without ifMatch when httpClient has no lastRequest', async () => {
       mockClient.httpClient.lastRequest = null;
 
@@ -126,6 +136,25 @@ describe('patchTaskAttributes', () => {
       expect(mockUpdate).toHaveBeenCalledWith(
         expect.not.objectContaining({ ifMatch: expect.anything() }),
       );
+    });
+
+    it('should log a warning when httpClient has no lastRequest', async () => {
+      mockClient.httpClient.lastRequest = null;
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no lastRequest'));
+      warnSpy.mockRestore();
+    });
+
+    it('should not log a warning when ETag is present', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await patchTaskAttributes(TEST_ACCOUNT_SID, TEST_TASK_SID, attributesGenerator);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
 
     it('should fetch the task from the correct workspace', async () => {


### PR DESCRIPTION
## Description

The bug in the linked ticket is _probably_ due to a combination of

- The `patchTaskAttributes` helper not supporting safe concurrent edits, 
- Task router handlers running concurrently
- setting hangUpBy and setting the external ID are both handlers that pach task attributes and run on task created 

This would fit with the fact that only call tasks are in the affected examples in the ticket, since chat tasks don't set the hangUpBy so wouldn't routinely risk concurrent editing

This PR adds optimistic lock check to patchTaskAttributes to ensure updates to task attributes are not lost when updated from 2 sources at the same time

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P