### PR TITLE
CHI-3821: Mark Twilio Lambda logs sensitive

### DIFF
--- a/.github/workflows/global-production-release-tag.yml
+++ b/.github/workflows/global-production-release-tag.yml
@@ -14,7 +14,7 @@
 
 # Workflow to create a new production release from a given qa tag
 
-name: Create a production release
+name: Tag a production release
 
 # Controls when the action will run.
 on:
@@ -142,6 +142,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          slack-message: "`[Flex]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ needs.generate-release.outputs.qa-version }}` :rocket:."
+          slack-message: "`[Flex]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ inputs.tag-name }}` :rocket:."
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/global-qa-release-tag.yml
+++ b/.github/workflows/global-qa-release-tag.yml
@@ -14,7 +14,7 @@
 
 # Workflow to create a new pre-release with qa suffix
 
-name: Create a QA candidate release
+name: Tag a QA candidate release
 
 # Controls when the action will run.
 on:
@@ -165,7 +165,9 @@ jobs:
           MANIFEST=$(aws ecr batch-get-image --repository-name $REPOSITORY_NAME --image-ids imageTag="${{ github.ref_type }}.$REF_NAME_FOR_DOCKER_TAG" --output text --query 'images[].imageManifest')
           aws ecr put-image --repository-name $REPOSITORY_NAME --image-tag tag.${{ needs.generate-pre-release.outputs.qa-version }} --image-manifest "$MANIFEST"
   send-slack-message:
-    needs: tag-images
+    needs:
+      - tag-images
+      - generate-pre-release
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/twilio-lambda-deploy-all.yml
+++ b/.github/workflows/twilio-lambda-deploy-all.yml
@@ -72,7 +72,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     with:
-      send-slack-message: 'false'
       environment: ${{ inputs.environment }}
       lambda_path: ${{ matrix.lambda_path }}
 
@@ -84,4 +83,3 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     with:
       environment: ${{ inputs.environment }}
-      send-slack-message: 'false'

--- a/lambdas/account-scoped/src/conversation/createConversation.ts
+++ b/lambdas/account-scoped/src/conversation/createConversation.ts
@@ -86,7 +86,7 @@ export const createConversation = async (
       .update({ friendlyName: senderScreenName });
     const channelAttributes = JSON.parse((await conversationContext.fetch()).attributes);
 
-    console.debug('channelAttributes prior to update', channelAttributes);
+    console.debug('[SENSITIVE] channelAttributes prior to update', channelAttributes);
 
     await conversationContext.update({
       'timers.closed': CONVERSATION_CLOSE_TIMEOUT,

--- a/lambdas/account-scoped/src/hrm/createHrmContactTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/hrm/createHrmContactTaskRouterListener.ts
@@ -258,7 +258,8 @@ export const handleEvent = async (
     timeOfContactMillis: savedTimeOfContactDate.getTime(),
   };
   await taskContext.update({ attributes: JSON.stringify(updatedAttributes) });
-  console.info(`Set task ${taskSid} attributes:`, updatedAttributes);
+  console.info(`Set task ${taskSid} attributes`);
+  console.debug(`[SENSITIVE] Updated ${taskSid} attributes:`, updatedAttributes);
 };
 
 registerTaskRouterEventHandler([RESERVATION_ACCEPTED], handleEvent);

--- a/lambdas/account-scoped/src/hrm/getProfileFlagsForIdentifier.ts
+++ b/lambdas/account-scoped/src/hrm/getProfileFlagsForIdentifier.ts
@@ -47,9 +47,10 @@ export const handleGetProfileFlagsForIdentifier: AccountScopedHandler = async (
     }
     const identifier = identifierResult.unwrap();
     const profileFlagsByIdentifierPath = `profiles/identifier/${identifier}/flags`;
-    console.info(
-      `[${accountSid}] Getting profile flags for identifier ${identifier} from ${profileFlagsByIdentifierPath}`,
+    console.debug(
+      `[${accountSid}] Getting profile flags from ${profileFlagsByIdentifierPath}`,
     );
+    console.debug(`[SENSITIVE] [${accountSid}] For identifier ${identifier}`);
     const responseResult = await getFromInternalHrmEndpoint<{ name: string }[]>(
       accountSid, // We use the accountSid rather than the hrmAccountId because we can't infer the hrmAccountSid based on worker at this point
       hrmApiVersion,
@@ -63,7 +64,10 @@ export const handleGetProfileFlagsForIdentifier: AccountScopedHandler = async (
     }
     const responseBody = responseResult.unwrap();
     console.info(
-      `[${accountSid}] Profile flags for identifier ${identifier} from ${profileFlagsByIdentifierPath}`,
+      `[${accountSid}] Profile flags for identifier loaded from ${profileFlagsByIdentifierPath}`,
+    );
+    console.debug(
+      `[SENSITIVE] [${accountSid}] Profile flags for identifier ${identifier} from ${profileFlagsByIdentifierPath}`,
       responseBody,
     );
     return newOk({ flags: responseBody.map(flag => flag.name) });

--- a/lambdas/account-scoped/src/hrm/internalHrmRequest.ts
+++ b/lambdas/account-scoped/src/hrm/internalHrmRequest.ts
@@ -65,7 +65,7 @@ const requestFromInternalHrmEndpoint = async <TRequest, TResponse>(
       if (response.ok) {
         const hrmResponse = await response.json();
         console.info(`HRM responded ${response.status} to ${method} ${endpointUrl}`);
-        console.debug(`HRM response content:`, hrmResponse);
+        console.debug(`[SENSITIVE] HRM response content:`, hrmResponse);
         return newOk(hrmResponse as TResponse);
       }
       const bodyText = await response.text();

--- a/lambdas/account-scoped/src/hrm/populateHrmContactFormFromTaskByKeys.ts
+++ b/lambdas/account-scoped/src/hrm/populateHrmContactFormFromTaskByKeys.ts
@@ -51,7 +51,10 @@ const CUSTOM_MAPPERS: Record<string, MapperFunction> = {
 
         if (ageInt > maxAgeInt) return maxAge;
       } else {
-        console.error('Pre populate form error: no maxAge option provided.');
+        console.error(
+          `Pre populate form error: no maxAge option provided for normalising age '${age}'. Age options: `,
+          ageOptions,
+        );
       }
 
       return 'Unknown';
@@ -253,14 +256,15 @@ const populateInitialValues = async (
     ['ChildInformationTab', contact.rawJson.childInformation],
     ['CallerInformationTab', contact.rawJson.callerInformation],
   ];
-
-  const definitionsAndJsons: [FormItemDefinition[], Record<string, FormValue>][] =
-    await Promise.all(
-      tabNamesAndRawJsonSections.map(async ([tabbedFormsSection, rawJsonSection]) => [
+  type DefinitionAndJson = [FormItemDefinition[], Record<string, FormValue>];
+  const definitionsAndJsons: DefinitionAndJson[] = await Promise.all(
+    tabNamesAndRawJsonSections.map(
+      async ([tabbedFormsSection, rawJsonSection]): Promise<DefinitionAndJson> => [
         tabbedForms[tabbedFormsSection] as FormItemDefinition[],
         rawJsonSection,
-      ]),
-    );
+      ],
+    ),
+  );
   for (const [tabFormDefinition, rawJson] of definitionsAndJsons) {
     for (const formItemDefinition of tabFormDefinition) {
       rawJson[formItemDefinition.name] = getInitialValue(formItemDefinition);
@@ -291,7 +295,7 @@ const populateContactSection = async (
   ) => Record<string, FormValue>,
 ) => {
   console.debug('Keys', Array.from(keys));
-  console.debug('Using Values', valuesToPopulate);
+  console.debug('[SENSITIVE] Using Values', valuesToPopulate);
 
   if (keys.size > 0) {
     const childInformationTabDefinition =
@@ -394,12 +398,8 @@ export const populateHrmContactFormFromTaskByKeys = async ({
     return newOk(contact);
   } catch (err) {
     const error = err as Error;
-    console.error(
-      `Error prepopulating contact ${contact.id}`,
-      error,
-      'task attributes:',
-      taskAttributes,
-    );
+    console.error(`Error prepopulating contact ${contact.id}`, error);
+    console.error('[SENSITIVE] task attributes:', taskAttributes);
     return newErr({ error, message: error.message });
   }
 };

--- a/lambdas/account-scoped/src/hrm/populateHrmContactFormFromTaskByMappings.ts
+++ b/lambdas/account-scoped/src/hrm/populateHrmContactFormFromTaskByMappings.ts
@@ -255,13 +255,15 @@ const populateInitialValues = async (
     ['CallerInformationTab', contact.rawJson.callerInformation],
   ];
 
-  const definitionsAndJsons: [FormItemDefinition[], Record<string, FormValue>][] =
-    await Promise.all(
-      tabNamesAndRawJsonSections.map(async ([tabbedFormsSection, rawJsonSection]) => [
+  type DefinitionAndJson = [FormItemDefinition[], Record<string, FormValue>];
+  const definitionsAndJsons: DefinitionAndJson[] = await Promise.all(
+    tabNamesAndRawJsonSections.map(
+      async ([tabbedFormsSection, rawJsonSection]): Promise<DefinitionAndJson> => [
         tabbedForms[tabbedFormsSection] as FormItemDefinition[],
         rawJsonSection,
-      ]),
-    );
+      ],
+    ),
+  );
   for (const [tabFormDefinition, rawJson] of definitionsAndJsons) {
     for (const formItemDefinition of tabFormDefinition) {
       rawJson[formItemDefinition.name] = getInitialValue(formItemDefinition);
@@ -296,7 +298,7 @@ const populateContactSection = async (
   const targetFormName: ContactFormName = FORM_DEFINITION_MAP[targetFormDefinitionName];
   console.debug('Populating', targetFormName);
   console.debug('Mappings', mappings);
-  console.debug('Using Values', valuesToPopulate);
+  console.debug('[SENSITIVE] Using Values', valuesToPopulate);
   const target: HrmContactRawJson[ContactFormName] = contact.rawJson[targetFormName];
   const formMappings: Record<string, string[]> = {};
   // Convert mapping specification to a simple sourceKey -> formField of mappings that are valid for this form

--- a/lambdas/account-scoped/src/hrm/toggleSwitchboardQueue.ts
+++ b/lambdas/account-scoped/src/hrm/toggleSwitchboardQueue.ts
@@ -98,8 +98,8 @@ async function deleteSwitchboardStateDocument({
   client: Twilio;
   syncServiceSid: string;
 }) {
-  console.log(
-    `Deleting switchboard state document: ${JSON.stringify({ syncServiceSid }, null, 2)}`,
+  console.info(
+    `Deleting switchboard state document : ${syncServiceSid}/${SWITCHBOARD_STATE_DOCUMENT}`,
   );
 
   try {
@@ -129,7 +129,7 @@ async function deleteSwitchboardStateDocument({
     // If document doesn't exist, that's fine
     if (error.status === 404 || error.code === 20404) {
       const message = `Document may not exist, proceeding anyway: ${error instanceof Error ? error.message : String(error)}`;
-      console.log(message);
+      console.info(message);
       return newOk(false);
     }
 

--- a/lambdas/account-scoped/src/hrm/toggleSwitchboardQueue.ts
+++ b/lambdas/account-scoped/src/hrm/toggleSwitchboardQueue.ts
@@ -99,7 +99,7 @@ async function deleteSwitchboardStateDocument({
   syncServiceSid: string;
 }) {
   console.info(
-    `Deleting switchboard state document : ${syncServiceSid}/${SWITCHBOARD_STATE_DOCUMENT}`,
+    `Deleting switchboard state document: ${syncServiceSid}/${SWITCHBOARD_STATE_DOCUMENT}`,
   );
 
   try {

--- a/lambdas/account-scoped/src/index.ts
+++ b/lambdas/account-scoped/src/index.ts
@@ -53,7 +53,7 @@ const parseBody = ({
 
 export const handler = async (event: ALBEvent): Promise<ALBResult> => {
   console.info('twilio/account-scoped: Triggered by path:', event.path);
-  console.debug('twilio/account-scoped event:', JSON.stringify(event));
+  console.debug('[SENSITIVE] twilio/account-scoped event:', JSON.stringify(event));
   try {
     const request = {
       method: event.httpMethod,

--- a/lambdas/account-scoped/src/task/cancelOrRemoveTask.ts
+++ b/lambdas/account-scoped/src/task/cancelOrRemoveTask.ts
@@ -95,10 +95,10 @@ export const cancelOrRemoveTaskHandler: FlexValidatedHandler = async (
     await chatChannelJanitor(accountSid, taskAttributes);
   } catch (error) {
     console.error(
-      `Chat channel / conversation janitor failed completing task ${taskSid}, a stale channel / conversation is likely. Task attributes:`,
-      taskAttributes,
+      `Chat channel / conversation janitor failed completing task ${taskSid}, a stale channel / conversation is likely:`,
       error,
     );
+    console.error(`[SENSITIVE] Task attributes:`, taskAttributes);
   }
   return result;
 };

--- a/lambdas/account-scoped/src/task/completeTaskAssignment.ts
+++ b/lambdas/account-scoped/src/task/completeTaskAssignment.ts
@@ -101,10 +101,10 @@ export const completeTaskAssignmentHandler: FlexValidatedHandler = async (
     await chatChannelJanitor(accountSid, taskAttributes);
   } catch (error) {
     console.error(
-      `Chat channel / conversation janitor failed completing task ${taskSid}, a stale channel / conversation is likely. Task attributes:`,
-      taskAttributes,
+      `Chat channel / conversation janitor failed completing task ${taskSid}, a stale channel / conversation is likely.`,
       error,
     );
+    console.error(`[SENSITIVE] Task attributes:`, taskAttributes);
   }
   return result;
 };


### PR DESCRIPTION
## Description

- Mark the logs in Twilio Lambda that can potentially contain PHI / PII as sensitive so they aren't sent to Datadog, but are kept in Cloudwatch

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P