### PR TITLE
chore: add safeguards around missing post survey config [CHI-3916]

### DIFF
--- a/aselo-webchat-react-app/jest.config.js
+++ b/aselo-webchat-react-app/jest.config.js
@@ -30,6 +30,7 @@ module.exports = config => {
       },
       reporters: ['default', 'jest-junit'],
       testEnvironment: 'jsdom',
+      modulePaths: ['<rootDir>/node_modules'],
       transformIgnorePatterns: ['node_modules/(?!(@twilio-paste|@twilio/conversations))/'],
       collectCoverage: true,
       collectCoverageFrom: [

--- a/aselo-webchat-react-app/package-lock.json
+++ b/aselo-webchat-react-app/package-lock.json
@@ -26,6 +26,7 @@
         "googleapis-common": "6.0.3",
         "hrm-form-definitions": "file:../lambdas/packages/hrm-form-definitions",
         "jszip": "3.10.1",
+        "lodash": "^4.18.1",
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.2",
         "lodash.throttle": "^4.1.1",
@@ -7829,6 +7830,12 @@
         "@twilio-paste/design-tokens": "^10.0.0"
       }
     },
+    "node_modules/@twilio-paste/color-contrast-utils/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/@twilio-paste/combobox": {
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@twilio-paste/combobox/-/combobox-17.0.3.tgz",
@@ -7885,6 +7892,12 @@
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@twilio-paste/combobox/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/@twilio-paste/core": {
       "version": "21.5.0",
@@ -8094,6 +8107,12 @@
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@twilio-paste/data-grid/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/@twilio-paste/data-visualization-library": {
       "version": "6.1.0",
@@ -8416,6 +8435,12 @@
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@twilio-paste/file-uploader/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/@twilio-paste/flex": {
       "version": "9.0.1",
@@ -9324,6 +9349,12 @@
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@twilio-paste/react-textarea-autosize-library/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/@twilio-paste/reakit-library": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@twilio-paste/reakit-library/-/reakit-library-3.0.1.tgz",
@@ -9678,6 +9709,12 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
+      "license": "MIT"
+    },
+    "node_modules/@twilio-paste/style-props/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/@twilio-paste/styling-library": {
@@ -10218,6 +10255,12 @@
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@twilio-paste/utils/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/@twilio-paste/visual-picker": {
       "version": "3.0.2",
@@ -14770,13 +14813,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/cypress/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cypress/node_modules/supports-color": {
       "version": "8.1.1",
@@ -23338,9 +23374,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/aselo-webchat-react-app/package.json
+++ b/aselo-webchat-react-app/package.json
@@ -23,6 +23,7 @@
     "googleapis-common": "6.0.3",
     "hrm-form-definitions": "file:../lambdas/packages/hrm-form-definitions",
     "jszip": "3.10.1",
+    "lodash": "^4.18.1",
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.2",
     "lodash.throttle": "^4.1.1",

--- a/lambdas/account-scoped/src/channelCapture/channelCaptureHandlers.ts
+++ b/lambdas/account-scoped/src/channelCapture/channelCaptureHandlers.ts
@@ -677,7 +677,12 @@ const handlePostSurveyComplete = async ({
   const definition = await getCurrentDefinitionVersion({ accountSid });
   const postSurveyConfigSpecs = definition?.insights?.postSurveySpecs;
 
-  if (postSurveyConfigSpecs?.length) {
+  try {
+    if (!postSurveyConfigSpecs?.length) {
+      const errorMEssage = `No defined or invalid postSurveyConfigJson found for account ${accountSid}.`;
+      throw new Error(errorMEssage);
+    }
+
     const controlTaskAttributes = JSON.parse(controlTask.attributes);
 
     // parallel execution to save survey collected data in insights and hrm
@@ -697,13 +702,13 @@ const handlePostSurveyComplete = async ({
         hrmApiVersion,
       }),
     ]);
-
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error accessing to the post survey form definitions: ${message}`);
+  } finally {
     // As survey tasks will never be assigned to a worker, they'll be kept in pending state. A pending can't transition to completed state, so we cancel them here to raise a task.canceled taskrouter event (see functions/taskrouterListeners/janitorListener.ts)
     // This needs to be the last step so the new task attributes from saveSurveyInInsights make it to insights
     await controlTask.update({ assignmentStatus: 'canceled' });
-  } else {
-    const errorMEssage = `No defined or invalid postSurveyConfigJson found for account ${accountSid}.`;
-    console.info(`Error accessing to the post survey form definitions: ${errorMEssage}`);
   }
 };
 

--- a/lambdas/account-scoped/src/channelCapture/postSurveyListener.ts
+++ b/lambdas/account-scoped/src/channelCapture/postSurveyListener.ts
@@ -171,8 +171,8 @@ const triggerPostSurvey: TaskRouterEventHandler = async (
         const postSurveyConfigSpecs = definition?.insights?.postSurveySpecs;
 
         if (!postSurveyConfigSpecs?.length) {
-          const errorMEssage = `No defined or invalid postSurveyConfigJson found for account ${accountSid}.`;
-          throw new Error(errorMEssage);
+          const errorMessage = `No defined or invalid postSurveyConfigJson found for account ${accountSid}.`;
+          throw new Error(errorMessage);
         }
 
         const { channelSid, conversationSid, channelType, customChannelType } =

--- a/lambdas/account-scoped/src/channelCapture/postSurveyListener.ts
+++ b/lambdas/account-scoped/src/channelCapture/postSurveyListener.ts
@@ -22,7 +22,7 @@ import { AccountSID } from '@tech-matters/twilio-types';
 import { Twilio } from 'twilio';
 import { EventType, TASK_WRAPUP } from '../taskrouter/eventTypes';
 import { EventFields } from '../taskrouter';
-import { retrieveServiceConfigurationAttributes } from '../configuration/aseloConfiguration';
+import { retrieveServiceConfiguration } from '../configuration/aseloConfiguration';
 import {
   handleChannelCapture,
   HandleChannelCaptureParams,
@@ -35,6 +35,7 @@ import {
   getTwilioWorkspaceSid,
 } from '@tech-matters/twilio-configuration';
 import { getTranslation } from '../translations/translationLookup';
+import { getCurrentDefinitionVersion } from '../hrm/formDefinitionsCache';
 
 const GLOBAL_DEFAULT_LANGUAGE = 'en-US';
 
@@ -72,7 +73,7 @@ const isTriggerPostSurvey = ({
   return !isChatCaptureControlTask(taskAttributes);
 };
 
-export const postSurveyInitHandler = async ({
+const postSurveyInitHandler = async ({
   accountSid,
   channelType,
   chatServiceSid,
@@ -160,12 +161,20 @@ const triggerPostSurvey: TaskRouterEventHandler = async (
       console.log('taskAttributes', taskAttributes);
 
       // This task is a candidate to trigger post survey. Check feature flags for the account.
-      const serviceConfigAttributes =
-        await retrieveServiceConfigurationAttributes(client);
+      const serviceConfig = await retrieveServiceConfiguration(client);
+      const { attributes: serviceConfigAttributes } = serviceConfig;
       const { feature_flags: featureFlags, helplineLanguage } = serviceConfigAttributes;
       const { enable_post_survey: enablePostSurvey } = featureFlags;
 
       if (enablePostSurvey) {
+        const definition = await getCurrentDefinitionVersion({ accountSid });
+        const postSurveyConfigSpecs = definition?.insights?.postSurveySpecs;
+
+        if (!postSurveyConfigSpecs?.length) {
+          const errorMEssage = `No defined or invalid postSurveyConfigJson found for account ${accountSid}.`;
+          throw new Error(errorMEssage);
+        }
+
         const { channelSid, conversationSid, channelType, customChannelType } =
           taskAttributes;
 

--- a/lambdas/account-scoped/src/configuration/aseloConfiguration.ts
+++ b/lambdas/account-scoped/src/configuration/aseloConfiguration.ts
@@ -14,20 +14,35 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Twilio } from 'twilio';
+import type { ConfigurationInstance } from 'twilio/lib/rest/flexApi/v1/configuration';
+
+export const retrieveServiceConfiguration = async (
+  client: Twilio,
+): Promise<
+  Omit<ConfigurationInstance, 'attributes'> & {
+    attributes: Record<string, any> & {
+      feature_flags: Record<string, boolean | undefined>;
+    };
+  }
+> => {
+  const serviceConfig = await client.flexApi.v1.configuration.get().fetch();
+  return serviceConfig;
+};
 
 export const retrieveServiceConfigurationAttributes = async (
   client: Twilio,
 ): Promise<
   Record<string, any> & { feature_flags: Record<string, boolean | undefined> }
 > => {
-  const serviceConfig = await client.flexApi.v1.configuration.get().fetch();
+  const serviceConfig = await retrieveServiceConfiguration(client);
   return serviceConfig.attributes;
 };
 
 export const retrieveFeatureFlags = async (
   client: Twilio,
 ): Promise<Record<string, boolean | undefined>> => {
-  return (await retrieveServiceConfigurationAttributes(client)).feature_flags;
+  const serviceConfigAttributes = await retrieveServiceConfigurationAttributes(client);
+  return serviceConfigAttributes.feature_flags;
 };
 
 export type TaskRouterSkill =
@@ -47,6 +62,6 @@ export type TaskRouterSkill =
 export const retrieveServiceConfigurationTaskRouterSkills = async (
   client: Twilio,
 ): Promise<TaskRouterSkill[]> => {
-  const serviceConfig = await client.flexApi.v1.configuration.get().fetch();
+  const serviceConfig = await retrieveServiceConfiguration(client);
   return serviceConfig.taskrouterSkills;
 };

--- a/lambdas/account-scoped/src/conversation/janitorTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/conversation/janitorTaskRouterListener.ts
@@ -36,6 +36,7 @@ import { isChatCaptureControlTask } from '../channelCapture/channelCaptureHandle
 import { isAseloCustomChannel } from '../customChannels/aseloCustomChannels';
 import { getWorkspaceSid } from '@tech-matters/twilio-configuration';
 import { ChatChannelSID, ConversationSID } from '@tech-matters/twilio-types';
+import { getCurrentDefinitionVersion } from '../hrm/formDefinitionsCache';
 
 const isCleanupBotCapture = (
   eventType: EventType,
@@ -172,21 +173,28 @@ const janitorHandler: TaskRouterEventHandler = async (
     if (
       !(await isHandledByOtherListener(client, workspaceSid, taskSid, taskAttributes))
     ) {
-      if (!featureFlags.enable_post_survey) {
-        console.info(
-          `JanitorListener: deactivating conversation orchestration for account ${accountSid}, task ${taskSid}`,
-        );
-
-        await chatChannelJanitor(accountSid, {
-          channelSid: channelSid as ChatChannelSID,
-          conversationSid: conversationSid as ConversationSID,
-        });
-
-        console.info(
-          `JanitorListener: conversation orchestration deactivated for account ${accountSid}, task ${taskSid}`,
-        );
-        return;
+      if (featureFlags.enable_post_survey) {
+        const definition = await getCurrentDefinitionVersion({ accountSid });
+        const postSurveyConfigSpecs = definition?.insights?.postSurveySpecs;
+        // prevent janitor from cleanup if post survey is enabled and definition is valid
+        if (postSurveyConfigSpecs?.length) {
+          return;
+        }
       }
+
+      console.info(
+        `JanitorListener: deactivating conversation orchestration for account ${accountSid}, task ${taskSid}`,
+      );
+
+      await chatChannelJanitor(accountSid, {
+        channelSid: channelSid as ChatChannelSID,
+        conversationSid: conversationSid as ConversationSID,
+      });
+
+      console.info(
+        `JanitorListener: conversation orchestration deactivated for account ${accountSid}, task ${taskSid}`,
+      );
+      return;
     }
 
     console.info(

--- a/lambdas/account-scoped/src/conversation/janitorTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/conversation/janitorTaskRouterListener.ts
@@ -118,7 +118,7 @@ const janitorHandler: TaskRouterEventHandler = async (
 
     if (!['chat', 'survey'].includes(taskChannelUniqueName)) return;
 
-    console.info(
+    console.debug(
       `JanitorListener executing for account ${accountSid}, task ${taskSid}, event: ${eventType}`,
     );
 
@@ -141,7 +141,7 @@ const janitorHandler: TaskRouterEventHandler = async (
         conversationSid: conversationSid as ConversationSID,
       });
 
-      console.info(
+      console.debug(
         `JanitorListener: bot capture clean up finished for account ${accountSid}, task ${taskSid}`,
       );
       return;
@@ -156,7 +156,7 @@ const janitorHandler: TaskRouterEventHandler = async (
         taskAttributes,
       )
     ) {
-      console.info(
+      console.debug(
         `JanitorListener: handling custom channel clean up for account ${accountSid}, task ${taskSid}`,
       );
 
@@ -164,7 +164,7 @@ const janitorHandler: TaskRouterEventHandler = async (
         channelSid: taskAttributes.channelSid as ChatChannelSID,
       });
 
-      console.info(
+      console.debug(
         `JanitorListener: custom channel clean up finished for account ${accountSid}, task ${taskSid}`,
       );
       return;
@@ -182,7 +182,7 @@ const janitorHandler: TaskRouterEventHandler = async (
         }
       }
 
-      console.info(
+      console.debug(
         `JanitorListener: deactivating conversation orchestration for account ${accountSid}, task ${taskSid}`,
       );
 
@@ -191,13 +191,13 @@ const janitorHandler: TaskRouterEventHandler = async (
         conversationSid: conversationSid as ConversationSID,
       });
 
-      console.info(
+      console.debug(
         `JanitorListener: conversation orchestration deactivated for account ${accountSid}, task ${taskSid}`,
       );
       return;
     }
 
-    console.info(
+    console.debug(
       `JanitorListener finished successfully for account ${accountSid}, task ${taskSid}, event: ${eventType}`,
     );
   } catch (err) {

--- a/lambdas/account-scoped/tests/unit/conversation/janitorTaskRouterListener.test.ts
+++ b/lambdas/account-scoped/tests/unit/conversation/janitorTaskRouterListener.test.ts
@@ -34,6 +34,7 @@ import {
   TASK_DELETED,
   TASK_WRAPUP,
 } from '../../../src/taskrouter/eventTypes';
+import { getCurrentDefinitionVersion } from '../../../src/hrm/formDefinitionsCache';
 
 jest.mock('../../../src/conversation/chatChannelJanitor', () => ({
   chatChannelJanitor: jest.fn(),
@@ -64,6 +65,13 @@ const mockIsAseloCustomChannel = isAseloCustomChannel as jest.MockedFunction<
 jest.mock('@tech-matters/twilio-configuration', () => ({
   getWorkspaceSid: jest.fn().mockResolvedValue('WSut'),
 }));
+
+jest.mock('../../../src/hrm/formDefinitionsCache', () => ({
+  getCurrentDefinitionVersion: jest.fn(),
+}));
+const mockGetCurrentDefinitionVersion = getCurrentDefinitionVersion as jest.MockedFunction<
+  typeof getCurrentDefinitionVersion
+>;
 
 const newEventFields = (
   taskChannelUniqueName: string,
@@ -98,6 +106,7 @@ describe('janitorTaskRouterListener', () => {
     mockHasTaskControl.mockResolvedValue(true);
     mockIsChatCaptureControlTask.mockReturnValue(false);
     mockIsAseloCustomChannel.mockReturnValue(false);
+    mockGetCurrentDefinitionVersion.mockResolvedValue({} as any);
   });
 
   test('use_twilio_lambda_janitor flag not set - skips without calling chatChannelJanitor', async () => {
@@ -189,17 +198,37 @@ describe('janitorTaskRouterListener', () => {
     });
   });
 
-  test('deactivate conversation orchestration on TASK_WRAPUP with enable_post_survey=true - skips chatChannelJanitor', async () => {
+  test('deactivate conversation orchestration on TASK_WRAPUP with enable_post_survey=true and valid postSurveySpecs - skips chatChannelJanitor', async () => {
     client = newMockTwilioClientWithConfigurationAttributes({
       feature_flags: { use_twilio_lambda_janitor: true, enable_post_survey: true },
     });
     mockIsChatCaptureControlTask.mockReturnValue(false);
     mockHasTaskControl.mockResolvedValue(true);
     mockIsAseloCustomChannel.mockReturnValue(false);
+    mockGetCurrentDefinitionVersion.mockResolvedValue({
+      insights: { postSurveySpecs: [{ taskChannelUniqueName: 'survey' }] },
+    } as any);
 
     await handleEvent(newEventFields('chat', TASK_WRAPUP), TEST_ACCOUNT_SID, client);
 
     expect(mockChatChannelJanitor).not.toHaveBeenCalled();
+  });
+
+  test('deactivate conversation orchestration on TASK_WRAPUP with enable_post_survey=true and invalid postSurveySpecs - calls chatChannelJanitor', async () => {
+    client = newMockTwilioClientWithConfigurationAttributes({
+      feature_flags: { use_twilio_lambda_janitor: true, enable_post_survey: true },
+    });
+    mockIsChatCaptureControlTask.mockReturnValue(false);
+    mockHasTaskControl.mockResolvedValue(true);
+    mockIsAseloCustomChannel.mockReturnValue(false);
+    mockGetCurrentDefinitionVersion.mockResolvedValue({} as any);
+
+    await handleEvent(newEventFields('chat', TASK_WRAPUP), TEST_ACCOUNT_SID, client);
+
+    expect(mockChatChannelJanitor).toHaveBeenCalledWith(TEST_ACCOUNT_SID, {
+      channelSid: TEST_CHANNEL_SID,
+      conversationSid: TEST_CONVERSATION_SID,
+    });
   });
 
   test('TASK_WRAPUP but not in task control - skips chatChannelJanitor', async () => {

--- a/lambdas/account-scoped/tests/unit/conversation/janitorTaskRouterListener.test.ts
+++ b/lambdas/account-scoped/tests/unit/conversation/janitorTaskRouterListener.test.ts
@@ -69,9 +69,8 @@ jest.mock('@tech-matters/twilio-configuration', () => ({
 jest.mock('../../../src/hrm/formDefinitionsCache', () => ({
   getCurrentDefinitionVersion: jest.fn(),
 }));
-const mockGetCurrentDefinitionVersion = getCurrentDefinitionVersion as jest.MockedFunction<
-  typeof getCurrentDefinitionVersion
->;
+const mockGetCurrentDefinitionVersion =
+  getCurrentDefinitionVersion as jest.MockedFunction<typeof getCurrentDefinitionVersion>;
 
 const newEventFields = (
   taskChannelUniqueName: string,

--- a/lambdas/packages/hrm-form-definitions/form-definitions/as/v1/insights/postSurvey.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/as/v1/insights/postSurvey.json
@@ -1,2 +1,12 @@
 [
+  {
+    "insightsObject": "conversations",
+    "attributeName": "conversation_measure_6",
+    "questions": ["was_helpful"]
+  },
+  {
+    "insightsObject": "conversations",
+    "attributeName": "conversation_measure_7",
+    "questions": ["would_recommend"]
+  }
 ]

--- a/lambdas/packages/hrm-form-definitions/form-definitions/as/v1/insights/postSurvey.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/as/v1/insights/postSurvey.json
@@ -1,12 +1,2 @@
 [
-  {
-    "insightsObject": "conversations",
-    "attributeName": "conversation_measure_6",
-    "questions": ["was_helpful"]
-  },
-  {
-    "insightsObject": "conversations",
-    "attributeName": "conversation_measure_7",
-    "questions": ["would_recommend"]
-  }
 ]

--- a/lambdas/packages/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/lambdas/packages/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -41,7 +41,7 @@ import {
   OneToOneConfigSpec,
 } from './insightsConfig';
 import { LayoutVersion } from './layoutVersion';
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'lodash/cloneDeep';
 
 // Type representing the JSON form where single fields don't need to be wrapped in arrays
 type PrepopulateMappingJson = {

--- a/lambdas/packages/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/lambdas/packages/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -158,30 +158,128 @@ type IssueCategorizationTabModuleType = {
   [helpline: string]: CategoriesDefinition;
 };
 
+type DefinitionVersionFileToType = {
+  layoutVersion: LayoutVersion;
+  callerInformationTab: FormItemJsonDefinition[];
+  caseInformationTab: FormItemJsonDefinition[];
+  childInformationTab: FormItemJsonDefinition[];
+  issueCategorizationTab: IssueCategorizationTabModuleType;
+  contactlessTaskTab: DefinitionVersion['tabbedForms']['ContactlessTaskTab'];
+  callTypeButtons: CallTypeButtonsDefinitions;
+  helplineInformation: HelplineDefinitions;
+  caseSections: Record<string, CaseSectionTypeJsonEntry>;
+  cannedResponses: CannedResponsesDefinitions;
+  oneToOneConfigSpec: OneToOneConfigSpec;
+  oneToManyConfigSpecs: OneToManyConfigSpecs;
+  postSurveySpecs: LegacyOneToManyConfigSpec[];
+  caseFilters: DefinitionVersion['caseFilters'];
+  caseStatus: DefinitionVersion['caseStatus'];
+  caseOverview: DefinitionVersion['caseOverview'];
+  prepopulateKeys: DefinitionVersion['prepopulateKeys'];
+  prepopulateMappings: PrepopulateMappingJson;
+  referenceData: Record<string, any>;
+  blockedEmojis: string[];
+  profileSections: ProfileSectionDefinition[];
+  profileFlagDurations: ProfileFlagDurationDefinition[];
+  messages: LocalizedStringMap;
+  substitutions: LocalizedStringMap;
+  postSurveyMessages: Record<string, string>;
+  flexUiLocales: FlexUILocaleEntry[];
+  customLinks: DefinitionVersion['customLinks'];
+};
+
+// Placeholder for prepopulateKeys
+const prepopulateKeysEmpty: DefinitionVersion['prepopulateKeys'] = {
+  survey: { ChildInformationTab: [], CallerInformationTab: [] },
+  preEngagement: {
+    ChildInformationTab: [],
+    CallerInformationTab: [],
+    CaseInformationTab: [],
+  },
+};
+
+// Placeholder for prepopulateMappings
+const prepopulateMappingsEmpty: DefinitionVersion['prepopulateMappings'] = {
+  survey: {},
+  preEngagement: {},
+};
+
+const definitionVersionFileToLocation: {
+  [k in keyof DefinitionVersionFileToType]: {
+    location: string;
+    placeholder?: DefinitionVersionFileToType[k];
+  };
+} = {
+  layoutVersion: { location: 'LayoutDefinitions.json' },
+  callerInformationTab: { location: 'tabbedForms/CallerInformationTab.json' },
+  caseInformationTab: { location: 'tabbedForms/CaseInformationTab.json' },
+  childInformationTab: { location: 'tabbedForms/ChildInformationTab.json' },
+  issueCategorizationTab: { location: 'tabbedForms/IssueCategorizationTab.json' },
+  contactlessTaskTab: { location: 'tabbedForms/ContactlessTaskTab.json', placeholder: {} },
+  callTypeButtons: { location: 'CallTypeButtons.json' },
+  helplineInformation: { location: 'HelplineInformation.json' },
+  caseSections: { location: 'CaseSections.json' },
+  cannedResponses: { location: 'CannedResponses.json', placeholder: [] },
+  oneToOneConfigSpec: { location: 'insights/oneToOneConfigSpec.json' },
+  oneToManyConfigSpecs: { location: 'insights/oneToManyConfigSpecs.json' },
+  postSurveySpecs: { location: 'insights/postSurvey.json', placeholder: [] },
+  caseFilters: { location: 'CaseFilters.json' },
+  caseStatus: { location: 'CaseStatus.json' },
+  caseOverview: { location: 'caseForms/CaseOverview.json' },
+  prepopulateKeys: { location: 'PrepopulateKeys.json', placeholder: prepopulateKeysEmpty },
+  prepopulateMappings: {
+    location: 'PrepopulateMappings.json',
+    placeholder: prepopulateMappingsEmpty,
+  },
+  referenceData: { location: 'ReferenceData.json', placeholder: {} },
+  blockedEmojis: { location: 'BlockedEmojis.json', placeholder: [] },
+  profileSections: { location: 'profileForms/Sections.json', placeholder: [] },
+  profileFlagDurations: { location: 'profileForms/FlagDurations.json', placeholder: [] },
+  messages: { location: 'customStrings/Messages.json', placeholder: {} },
+  substitutions: { location: 'customStrings/Substitutions.json', placeholder: {} },
+  postSurveyMessages: { location: 'customStrings/postSurveyMessages.json', placeholder: {} },
+  flexUiLocales: { location: 'FlexUiLocales.json', placeholder: [] },
+  customLinks: { location: 'CustomLinks.json', placeholder: [] },
+};
+
+const definitionVersionFileKeys = Object.keys(
+  definitionVersionFileToLocation,
+) as (keyof DefinitionVersionFileToType)[];
+
+const loadDefinitionSingleFile =
+  (fetchDefinition: ReturnType<typeof buildFetchDefinition>['fetchDefinition']) =>
+  async <P extends keyof DefinitionVersionFileToType>({
+    file,
+  }: {
+    file: P;
+  }): Promise<DefinitionVersionFileToType[P]> => {
+    return fetchDefinition<DefinitionVersionFileToType[P]>(
+      definitionVersionFileToLocation[file].location,
+      definitionVersionFileToLocation[file].placeholder,
+    );
+  };
+
+const loadDefinitionAllFiles = async <K extends keyof DefinitionVersionFileToType>(
+  fetchDefinition: ReturnType<typeof buildFetchDefinition>['fetchDefinition'],
+): Promise<{ [P in K]: DefinitionVersionFileToType[P] }> => {
+  const entries = await Promise.all(
+    definitionVersionFileKeys.map(
+      async (file) => [file, await loadDefinitionSingleFile(fetchDefinition)({ file })] as const,
+    ),
+  );
+  // typecast is needed here because Object.fromEntries loses type info
+  return Object.fromEntries(entries) as { [P in K]: DefinitionVersionFileToType[P] };
+};
+
 export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion> {
   const { fetchDefinition } = buildFetchDefinition(baseUrl);
-
-  // Placeholder for prepopulateKeys
-  const prepopulateKeysEmpty: DefinitionVersion['prepopulateKeys'] = {
-    survey: { ChildInformationTab: [], CallerInformationTab: [] },
-    preEngagement: {
-      ChildInformationTab: [],
-      CallerInformationTab: [],
-      CaseInformationTab: [],
-    },
-  };
-
-  // Placeholder for prepopulateMappings
-  const prepopulateMappingsEmpty: DefinitionVersion['prepopulateMappings'] = {
-    survey: {},
-    preEngagement: {},
-  };
 
   const expandPrepopulateMappings = ({
     formSelector,
     ...sourceSets
   }: PrepopulateMappingJson): DefinitionVersion['prepopulateMappings'] => {
-    const expandedMapping: DefinitionVersion['prepopulateMappings'] = prepopulateMappingsEmpty;
+    const expandedMapping: DefinitionVersion['prepopulateMappings'] =
+      structuredClone(prepopulateMappingsEmpty);
     for (const [sourceSetName, sourceSetFields] of Object.entries(sourceSets)) {
       const targetObj =
         expandedMapping[
@@ -201,15 +299,7 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     return { ...expandedMapping, formSelector };
   };
 
-  /**
-   * Currently the following constants are order sensitive.
-   * It's very easy to make a human mistake and place one at the wrong order.
-   *
-   * TODO:
-   * We should come up with a function that resolves all promises concurrently and
-   * returns an object instead of an array.
-   */
-  const [
+  const {
     layoutVersion,
     callerInformationTab,
     caseInformationTab,
@@ -237,41 +327,8 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     postSurveyMessages,
     flexUiLocales,
     customLinks,
-  ] = await Promise.all([
-    fetchDefinition<LayoutVersion>('LayoutDefinitions.json'),
-    fetchDefinition<FormItemJsonDefinition[]>('tabbedForms/CallerInformationTab.json'),
-    fetchDefinition<FormItemJsonDefinition[]>('tabbedForms/CaseInformationTab.json'),
-    fetchDefinition<FormItemJsonDefinition[]>('tabbedForms/ChildInformationTab.json'),
-    fetchDefinition<IssueCategorizationTabModuleType>('tabbedForms/IssueCategorizationTab.json'),
-    fetchDefinition<DefinitionVersion['tabbedForms']['ContactlessTaskTab']>(
-      'tabbedForms/ContactlessTaskTab.json',
-      {},
-    ),
-    fetchDefinition<CallTypeButtonsDefinitions>('CallTypeButtons.json'),
-    fetchDefinition<HelplineDefinitions>('HelplineInformation.json'),
-    fetchDefinition<Record<string, CaseSectionTypeJsonEntry>>('CaseSections.json'),
-    fetchDefinition<CannedResponsesDefinitions>('CannedResponses.json', []),
-    fetchDefinition<OneToOneConfigSpec>('insights/oneToOneConfigSpec.json'),
-    fetchDefinition<OneToManyConfigSpecs>('insights/oneToManyConfigSpecs.json'),
-    fetchDefinition<LegacyOneToManyConfigSpec[]>('insights/postSurvey.json', []),
-    fetchDefinition<DefinitionVersion['caseFilters']>('CaseFilters.json'),
-    fetchDefinition<DefinitionVersion['caseStatus']>('CaseStatus.json'),
-    fetchDefinition<DefinitionVersion['caseOverview']>('caseForms/CaseOverview.json'),
-    fetchDefinition<DefinitionVersion['prepopulateKeys']>(
-      'PrepopulateKeys.json',
-      prepopulateKeysEmpty,
-    ),
-    fetchDefinition<PrepopulateMappingJson>('PrepopulateMappings.json', prepopulateMappingsEmpty),
-    fetchDefinition<Record<string, any>>('ReferenceData.json', {}),
-    fetchDefinition<string[]>('BlockedEmojis.json', []),
-    fetchDefinition<ProfileSectionDefinition[]>('profileForms/Sections.json', []),
-    fetchDefinition<ProfileFlagDurationDefinition[]>('profileForms/FlagDurations.json', []),
-    fetchDefinition<LocalizedStringMap>('customStrings/Messages.json', {}),
-    fetchDefinition<LocalizedStringMap>('customStrings/Substitutions.json', {}),
-    fetchDefinition<Record<string, string>>('customStrings/postSurveyMessages.json', {}),
-    fetchDefinition<FlexUILocaleEntry[]>('FlexUiLocales.json', []),
-    fetchDefinition<DefinitionVersion['customLinks']>('CustomLinks.json', []),
-  ] as const);
+  } = await loadDefinitionAllFiles(fetchDefinition);
+
   const expandedCaseSections: CaseSectionTypeDefinitions = await loadAndExpandCaseSections(
     caseSections,
     referenceData,
@@ -281,6 +338,7 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
   const defaultHelpline =
     helplineInformation.helplines.find((helpline: HelplineEntry) => helpline.default)?.value ||
     helplines[0].value;
+
   return {
     caseSectionTypes: expandedCaseSections,
     tabbedForms: {

--- a/lambdas/packages/hrm-form-definitions/src/formDefinition/loadDefinition.ts
+++ b/lambdas/packages/hrm-form-definitions/src/formDefinition/loadDefinition.ts
@@ -41,6 +41,7 @@ import {
   OneToOneConfigSpec,
 } from './insightsConfig';
 import { LayoutVersion } from './layoutVersion';
+import cloneDeep from 'lodash/cloneDeep'
 
 // Type representing the JSON form where single fields don't need to be wrapped in arrays
 type PrepopulateMappingJson = {
@@ -279,7 +280,7 @@ export async function loadDefinition(baseUrl: string): Promise<DefinitionVersion
     ...sourceSets
   }: PrepopulateMappingJson): DefinitionVersion['prepopulateMappings'] => {
     const expandedMapping: DefinitionVersion['prepopulateMappings'] =
-      structuredClone(prepopulateMappingsEmpty);
+      cloneDeep(prepopulateMappingsEmpty);
     for (const [sourceSetName, sourceSetFields] of Object.entries(sourceSets)) {
       const targetObj =
         expandedMapping[


### PR DESCRIPTION
## Description
This PR:
- Adds safeguards in the janitor task router listener to handle missing or invalid post survey configuration. When `enable_post_survey` is enabled, the janitor now checks that `postSurveySpecs` is a valid non-empty setting before skipping cleanup. If the configuration is missing or empty, the janitor closes the channel normally and pos survey is skipped.
- Reworks `loadDefinition` function (`lambdas/packages/hrm-form-definitions/src/formDefinition/loadDefinition.ts`) to avoid the "order dependency" we had. This change was done having in mind the idea of "fetching single files" rather than the entire form definition, but I wanted to keep the PR small-ish so that can be done in the future.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3916)
- [x] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues

None

### Verification steps

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P