### PR TITLE
fix: wait lambda available before redirecting traffic

### DIFF
--- a/.github/workflows/twilio-lambda-deploy.yml
+++ b/.github/workflows/twilio-lambda-deploy.yml
@@ -154,9 +154,15 @@ jobs:
 
           LAMBDA_NAME=$(basename "./$SHORT_LAMBDA_NAME")
           LAMBDA="${{ inputs.environment }}-${{ matrix.region }}-$LAMBDA_NAME"
+
+          # Deploy and get new version
           OUTPUT=$(aws lambda update-function-code --function-name $LAMBDA --image-uri "$DOCKER_IMAGE" --publish)
           NEW_VERSION=$(echo "$OUTPUT" | jq -r '.Version')
 
+          # Wait until Lambda becomes available
+          aws lambda wait function-updated-v2 --function-name $LAMBDA --qualifier $NEW_VERSION
+
+          # Switch alias to redirect to new version
           ALIAS_EXISTS=$(aws lambda get-alias --function-name $LAMBDA --name live || echo "not_exists")
           if [ "$ALIAS_EXISTS" == "not_exists" ]; then
             aws lambda create-alias --function-name $LAMBDA --name live --function-version $NEW_VERSION


### PR DESCRIPTION
## Description
This PR introduces a wait command on the Lambda version to become "ready". This change ¿might? fix the 502 spikes we've been seeing on deploys.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P