### PR TITLE
CHI-3922: Transition task to wrapping via Flex interactionswhen the endChat endpoint is used

### DIFF
--- a/lambdas/account-scoped/src/conversation/endChat.ts
+++ b/lambdas/account-scoped/src/conversation/endChat.ts
@@ -147,7 +147,7 @@ const updateTaskAssignmentStatus = async (
           .channels.get(flexInteractionChannelSid)
           .update({
             routing: {
-              status: 'wrapping',
+              status: 'wrapup',
             },
             status: 'closed',
           });

--- a/lambdas/account-scoped/src/conversation/endChat.ts
+++ b/lambdas/account-scoped/src/conversation/endChat.ts
@@ -30,6 +30,7 @@ import {
 } from '@tech-matters/twilio-configuration';
 import { lookupCustomMessage } from '../hrm/formDefinitionsCache';
 import { chatChannelJanitor } from './chatChannelJanitor';
+import { transitionAgentParticipants } from './interactionChannelParticipants';
 
 export type EndChatRequestBody = {
   channelSid?: ChatChannelSID;
@@ -136,7 +137,9 @@ const updateTaskAssignmentStatus = async (
         console.debug(
           `[endChat - ${accountSid} / ${conversationSid ?? channelSid}] wrapping up ${task.assignmentStatus} task ${taskSid} and returning a 'keep-alive' state`,
         );
-        await updateAssignmentStatus('wrapping');
+        const parsedAttributes = JSON.parse(task.attributes);
+        // This will transition the task to 'wrapping' state but also fix the conversation on the Flex side so the agent can view the portion of the conversation they were involved in, but not any subsequent messages, like the post survey.
+        await transitionAgentParticipants(client, parsedAttributes, 'closed');
         return 'keep-alive'; // keep the channel alive for post survey
       }
       // If the task is wrapping / complete, we assume the user is trying to end the post survey
@@ -239,22 +242,6 @@ export const handleEndChat: AccountScopedHandler = async (
         `[endChat - ${accountSid} / ${conversationSid}] Conversation cleanup required:`,
         channelCleanupRequired,
       );
-      const participantsList = await conversationContext.participants.list();
-      await Promise.all(
-        participantsList.map(async (p): Promise<boolean> => {
-          const { attributes, identity, sid } = p;
-          const participantAttributes = JSON.parse(attributes);
-          console.debug(
-            `[SENSITIVE] Checking participant ${sid} (${identity}) attributes :`,
-            participantAttributes,
-          );
-          if (participantAttributes.member_type !== 'guest') {
-            console.debug(`Removing participant ${sid} (${identity})`);
-            return p.remove();
-          }
-          return false;
-        }),
-      );
     } else {
       const channelContext = client.chat.v2.services
         .get(await getChatServiceSid(accountSid))
@@ -267,17 +254,6 @@ export const handleEndChat: AccountScopedHandler = async (
         accountSid,
         channelAttributes,
         body,
-      );
-
-      const channelMembers = await channelContext.members.list();
-      await Promise.all(
-        channelMembers.map(async m => {
-          if (JSON.parse(m.attributes).member_type !== 'guest') {
-            return m.remove();
-          }
-
-          return false;
-        }),
       );
     }
 

--- a/lambdas/account-scoped/src/conversation/endChat.ts
+++ b/lambdas/account-scoped/src/conversation/endChat.ts
@@ -31,7 +31,6 @@ import {
 import { lookupCustomMessage } from '../hrm/formDefinitionsCache';
 import { chatChannelJanitor } from './chatChannelJanitor';
 import { transitionAgentParticipants } from './interactionChannelParticipants';
-import type { InteractionChannelContextUpdateOptions } from 'twilio/lib/rest/flexApi/v1/interaction/interactionChannel';
 
 export type EndChatRequestBody = {
   channelSid?: ChatChannelSID;
@@ -135,22 +134,12 @@ const updateTaskAssignmentStatus = async (
         return 'cleanup'; // indicate that there's cleanup needed
       }
       case 'assigned': {
-        const { flexInteractionSid, flexInteractionChannelSid } = JSON.parse(
-          task.attributes,
-        );
         console.debug(
-          `[endChat - ${accountSid} / ${conversationSid ?? channelSid}] wrapping up ${task.assignmentStatus} task ${taskSid} and returning a 'keep-alive' state. Using interaction ${flexInteractionSid}, channel ${flexInteractionChannelSid} to orchestrate transition via the interactions API`,
+          `[endChat - ${accountSid} / ${conversationSid ?? channelSid}] wrapping up ${task.assignmentStatus} task ${taskSid} and returning a 'keep-alive' state`,
         );
+        const parsedAttributes = JSON.parse(task.attributes);
         // This will transition the task to 'wrapping' state but also fix the conversation on the Flex side so the agent can view the portion of the conversation they were involved in, but not any subsequent messages, like the post survey.
-        await client.flexApi.v1.interaction
-          .get(flexInteractionSid)
-          .channels.get(flexInteractionChannelSid)
-          .update({
-            routing: {
-              status: 'wrapup',
-            },
-            status: 'closed',
-          });
+        await transitionAgentParticipants(client, parsedAttributes, 'wrapup');
         return 'keep-alive'; // keep the channel alive for post survey
       }
       // If the task is wrapping / complete, we assume the user is trying to end the post survey

--- a/lambdas/account-scoped/src/conversation/endChat.ts
+++ b/lambdas/account-scoped/src/conversation/endChat.ts
@@ -31,6 +31,7 @@ import {
 import { lookupCustomMessage } from '../hrm/formDefinitionsCache';
 import { chatChannelJanitor } from './chatChannelJanitor';
 import { transitionAgentParticipants } from './interactionChannelParticipants';
+import type { InteractionChannelContextUpdateOptions } from 'twilio/lib/rest/flexApi/v1/interaction/interactionChannel';
 
 export type EndChatRequestBody = {
   channelSid?: ChatChannelSID;
@@ -134,12 +135,22 @@ const updateTaskAssignmentStatus = async (
         return 'cleanup'; // indicate that there's cleanup needed
       }
       case 'assigned': {
-        console.debug(
-          `[endChat - ${accountSid} / ${conversationSid ?? channelSid}] wrapping up ${task.assignmentStatus} task ${taskSid} and returning a 'keep-alive' state`,
+        const { flexInteractionSid, flexInteractionChannelSid } = JSON.parse(
+          task.attributes,
         );
-        const parsedAttributes = JSON.parse(task.attributes);
+        console.debug(
+          `[endChat - ${accountSid} / ${conversationSid ?? channelSid}] wrapping up ${task.assignmentStatus} task ${taskSid} and returning a 'keep-alive' state. Using interaction ${flexInteractionSid}, channel ${flexInteractionChannelSid} to orchestrate transition via the interactions API`,
+        );
         // This will transition the task to 'wrapping' state but also fix the conversation on the Flex side so the agent can view the portion of the conversation they were involved in, but not any subsequent messages, like the post survey.
-        await transitionAgentParticipants(client, parsedAttributes, 'closed');
+        await client.flexApi.v1.interaction
+          .get(flexInteractionSid)
+          .channels.get(flexInteractionChannelSid)
+          .update({
+            routing: {
+              status: 'wrapping',
+            },
+            status: 'closed',
+          });
         return 'keep-alive'; // keep the channel alive for post survey
       }
       // If the task is wrapping / complete, we assume the user is trying to end the post survey

--- a/lambdas/account-scoped/src/conversation/interactionChannelParticipants.ts
+++ b/lambdas/account-scoped/src/conversation/interactionChannelParticipants.ts
@@ -15,11 +15,12 @@
  */
 
 import { Twilio } from 'twilio';
+import { InteractionChannelParticipantStatus } from 'twilio/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelParticipant';
 
 export const transitionAgentParticipants = async (
   client: Twilio,
   taskAttributes: { flexInteractionSid?: string; flexInteractionChannelSid?: string },
-  targetStatus: string,
+  status: InteractionChannelParticipantStatus,
   interactionChannelParticipantSid?: string,
 ) => {
   const { flexInteractionSid, flexInteractionChannelSid } = taskAttributes;
@@ -42,7 +43,5 @@ export const transitionAgentParticipants = async (
       (!interactionChannelParticipantSid || p.sid === interactionChannelParticipantSid),
   );
 
-  await Promise.allSettled(
-    agentParticipants.map(p => p.update({ status: targetStatus as any })),
-  );
+  await Promise.allSettled(agentParticipants.map(p => p.update({ status })));
 };

--- a/lambdas/account-scoped/src/conversation/interactionChannelParticipants.ts
+++ b/lambdas/account-scoped/src/conversation/interactionChannelParticipants.ts
@@ -15,8 +15,7 @@
  */
 
 import { Twilio } from 'twilio';
-import { InteractionChannelParticipantStatus } from 'twilio/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelParticipant';
-
+import type { InteractionChannelParticipantStatus } from 'twilio/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelParticipant';
 export const transitionAgentParticipants = async (
   client: Twilio,
   taskAttributes: { flexInteractionSid?: string; flexInteractionChannelSid?: string },

--- a/lambdas/account-scoped/src/conversation/transitionAgentParticipants.ts
+++ b/lambdas/account-scoped/src/conversation/transitionAgentParticipants.ts
@@ -65,7 +65,7 @@ export const transitionAgentParticipantsHandler: FlexValidatedHandler = async (
     await transitionAgentParticipants(
       client,
       taskAttributes,
-      targetStatus,
+      targetStatus as any,
       interactionChannelParticipantSid,
     );
     return newOk({ message: 'Participants transitioned successfully' });


### PR DESCRIPTION
## Description

In order to ensure that the Flex side of a contact is orchestrated correctly, this PR changes the 'endChat' endpoint implementation used by the 'End Chat' button in the service user chat client.

Instead of using the taskrouter and conversations APIs directly to put their task into wrapping and removed them from the conversation, we use existing helpers to call the Flex Interactions API and transition agent participants into a 'closed' state

This should still transition the task to 'wrapping' , but instead of locking the flex user out of the whole conversation, which is what happens when they are removed as a participant, it should prevent them seeing any more messages sent after they go into a 'wrapping' state - exactly as if they had clicked the 'End Chat' button in the Flex UI

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [x] Tested for chat contacts
- [n/a] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket. Thoroughly regression test ending chats with and without post surveys

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P