### PR TITLE
Fix issues with locating recordings caused by using a task retrieved via our endpoint rather than Flex

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/recordingsService.test.ts
+++ b/plugin-hrm-form/src/___tests__/services/recordingsService.test.ts
@@ -53,7 +53,7 @@ const makeVoiceTask = () =>
     taskSid: 'WTtest',
     sid: 'WRtest',
     status: 'assigned',
-    channelType: 'voice',
+    taskChannelUniqueName: 'voice',
     attributes: {
       conference: { participants: { worker: TEST_CALL_SID } },
     },

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -112,11 +112,11 @@ export const determineConversationMedia = async (
         },
       });
     }
-
-    if (!shouldGetExternalRecordingInfo(task)) return returnData;
-
     const externalRecordingInfo = await getExternalRecordingInfo(task);
     if (isFailureExternalRecordingInfo(externalRecordingInfo)) {
+      if (externalRecordingInfo.name === 'InvalidTask') {
+        return returnData;
+      }
       const error = `Failed to get external recording info: ${externalRecordingInfo.error}`;
       console.error(error, 'Task:', task);
       recordEvent('Backend Error: Get External Recording Info', {

--- a/plugin-hrm-form/src/services/recordingsService.ts
+++ b/plugin-hrm-form/src/services/recordingsService.ts
@@ -16,7 +16,6 @@
 
 import fetchProtectedApi from './fetchProtectedApi';
 import { getAseloFeatureFlags, getHrmConfig } from '../hrmConfig';
-import { isVoiceChannel } from '../states/DomainConstants';
 import { CustomITask, InMyBehalfITask, isOfflineContactTask, isTwilioTask } from '../types/types';
 
 export type ExternalRecordingInfoSuccess = {
@@ -45,9 +44,7 @@ export type ExternalRecordingInfo = ExternalRecordingInfoSuccess | ExternalRecor
 /* eslint-disable sonarjs/prefer-single-boolean-return */
 export const shouldGetExternalRecordingInfo = (task: CustomITask): task is InMyBehalfITask => {
   if (isOfflineContactTask(task)) return false;
-
-  const { channelType } = task;
-  if (!isVoiceChannel(channelType)) return false;
+  if (task.taskChannelUniqueName !== 'voice') return false;
 
   const { externalRecordingsEnabled } = getHrmConfig();
   return Boolean(externalRecordingsEnabled);

--- a/plugin-hrm-form/src/services/twilioTaskService.ts
+++ b/plugin-hrm-form/src/services/twilioTaskService.ts
@@ -113,8 +113,12 @@ export const getTaskAndReservations = async (taskSid: string): Promise<GetTaskAn
   };
   try {
     const res = await fetchProtectedApi(`/task/getTaskAndReservations`, body, { ...options, useTwilioLambda: true });
-    if (res?.task) {
-      res.task.status = res.task.status ?? res.task.assignmentStatus;
+    const { task } = res ?? {};
+    if (task) {
+      task.status = task.status ?? task.assignmentStatus;
+    }
+    if (typeof task.attributes === 'string') {
+      task.attributes = JSON.parse(task.attributes);
     }
     return res;
   } catch (error) {


### PR DESCRIPTION
## Description

Use taskChannelUniqueName to determine if the task is a voice task when retrieving an external recording
Ensure that tasks retrieved via getTaskAndReservations has it's attributes parsed, to align it more with a Flex task
Remove the double shouldGetExternalRecording

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [n/a] Tested for chat contacts
- [x] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P