### PR TITLE
Add helpline shortcode to summary-service URL CHI-3885

### DIFF
--- a/plugin-hrm-form/src/hrmConfig.ts
+++ b/plugin-hrm-form/src/hrmConfig.ts
@@ -61,7 +61,7 @@ const readConfig = () => {
   }/lambda/twilio/account-scoped/${accountSid}`;
   const llmAssistantBaseUrl = `${
     process.env.REACT_APP_HRM_BASE_URL || manager.serviceConfiguration.attributes.hrm_base_url
-  }/lambda/ai/llm-service/${accountSid}`;
+  }/lambda/ai/llm-service/${accountSid}/${manager.serviceConfiguration.attributes.helpline_code}`;
   const resourcesConfiguredBaseUrl =
     process.env.REACT_APP_RESOURCES_BASE_URL || manager.serviceConfiguration.attributes.resources_base_url;
   const resourcesBaseUrl = resourcesConfiguredBaseUrl

--- a/plugin-hrm-form/src/hrmConfig.ts
+++ b/plugin-hrm-form/src/hrmConfig.ts
@@ -61,7 +61,7 @@ const readConfig = () => {
   }/lambda/twilio/account-scoped/${accountSid}`;
   const llmAssistantBaseUrl = `${
     process.env.REACT_APP_HRM_BASE_URL || manager.serviceConfiguration.attributes.hrm_base_url
-  }/lambda/ai/llm-service/${accountSid}/${manager.serviceConfiguration.attributes.helpline_code}`;
+  }/lambda/ai/llm-service/${accountSid}`;
   const resourcesConfiguredBaseUrl =
     process.env.REACT_APP_RESOURCES_BASE_URL || manager.serviceConfiguration.attributes.resources_base_url;
   const resourcesBaseUrl = resourcesConfiguredBaseUrl
@@ -135,6 +135,7 @@ const readConfig = () => {
     strings,
     llm: {
       assistantBaseUrl: llmAssistantBaseUrl,
+      helplineCode,
     },
     hrm: {
       accountSid,

--- a/plugin-hrm-form/src/services/llmAssistantService.ts
+++ b/plugin-hrm-form/src/services/llmAssistantService.ts
@@ -25,7 +25,7 @@ export const generateSummary = (
   contactId: string,
   currentChatTranscript: TranscriptForLlmAssistant,
 ): Promise<LlmAssistantSummary> => {
-  const { assistantBaseUrl } = getLlmConfig();
+  const { assistantBaseUrl, helplineCode } = getLlmConfig();
   const token = getValidToken();
   if (token instanceof Error) throw new ApiError(`Aborting request due to token issue: ${token.message}`, {}, token);
 
@@ -34,6 +34,6 @@ export const generateSummary = (
       Authorization: `Bearer ${token}`,
     },
     method: 'POST',
-    body: JSON.stringify({ transcript: currentChatTranscript }),
+    body: JSON.stringify({ transcript: currentChatTranscript, helpline: helplineCode }),
   });
 };


### PR DESCRIPTION
## Description
Adds the helpline shortcode to the summary-service request body so the LLM summary lambda can route prompts per helpline (Thai prompts for the TH helpline). `hrmConfig.ts` includes `helplineCode` in the `llm` config, and
`llmAssistantService.ts` sends it as `helpline` in the POST body alongside the transcript.

### Checklist
- [x] Corresponding issue has been opened (CHI-3885)
- [x] New tests added (N/A; small config change; prompt-routing tests are on the lambda)
- [x] Feature flags added (N/A)
- [x] Strings are localized (N/A: no user-facing strings)
- [ ] Tested for chat contacts (pending staging, after the lambda deploys, techmatters/aselo-ai#59)
- [ ] Tested for call contacts (pending staging, after the lambda deploys, techmatters/aselo-ai#59)

### Other Related Issues
techmatters/aselo-ai#59: the summary lambda that reads `helpline` from the body and selects the per-helpline prompt. They can deploy in any order. 

### Verification steps
After the lambda is deployed to the staging environment, trigger a summary on TH staging and confirm it is returned in Thai. Helplines without a matching prompt set fall back to the general prompt.



### AFTER YOU MERGE
1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P