### PR TITLE
CHI-3943: Pause recordings on task wrapup / completion as well as agent leaving conference

### DIFF
--- a/lambdas/account-scoped/src/conference/isAgentInConference.ts
+++ b/lambdas/account-scoped/src/conference/isAgentInConference.ts
@@ -14,14 +14,15 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import type { ParticipantInstance } from 'twilio/lib/rest/api/v2010/account/conference/participant';
+import { CallSid } from '@tech-matters/twilio-types';
 
 export const isAgentInConference = ({
   callSid,
   customerCallSid,
   participant,
 }: {
-  callSid: string;
-  customerCallSid: string;
+  callSid?: CallSid;
+  customerCallSid: CallSid;
   participant: ParticipantInstance;
 }): boolean => {
   console.debug('Checking if participant is an agent:', participant);
@@ -37,7 +38,7 @@ export const isAgentInConference = ({
     return false;
   }
 
-  if (participant.callSid === callSid) {
+  if (callSid && participant.callSid === callSid) {
     // This is the participant firing the event
     console.warn(
       `Participant ${participant.label} (${participant.callSid}) still in conference, despite leave event for them`,

--- a/lambdas/account-scoped/src/conference/isAgentInConference.ts
+++ b/lambdas/account-scoped/src/conference/isAgentInConference.ts
@@ -21,7 +21,7 @@ export const isAgentInConference = ({
   customerCallSid,
   participant,
 }: {
-  callSid?: CallSid;
+  callSid: CallSid;
   customerCallSid: CallSid;
   participant: ParticipantInstance;
 }): boolean => {
@@ -38,7 +38,7 @@ export const isAgentInConference = ({
     return false;
   }
 
-  if (callSid && participant.callSid === callSid) {
+  if (participant.callSid === callSid) {
     // This is the participant firing the event
     console.warn(
       `Participant ${participant.label} (${participant.callSid}) still in conference, despite leave event for them`,

--- a/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
+++ b/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
@@ -41,6 +41,7 @@ import {
   TASK_SYSTEM_DELETED,
   TASK_WRAPUP,
 } from '../taskrouter/eventTypes';
+import { retrieveFeatureFlags } from '../configuration/aseloConfiguration';
 
 const stopRecordingIfNotTransferring = async (
   client: Twilio,
@@ -163,12 +164,14 @@ const taskRouterEventHandler: TaskRouterEventHandler = async (
   accountSid: AccountSID,
   client: Twilio,
 ) => {
+  const { stop_recording_on_task_end: stopRecordingOnTaskEnd } =
+    await retrieveFeatureFlags(client);
   console.debug(
-    `[${accountSid}/${taskSid} - stopRecordingWhenLastAgentLeaves]  handler fired on ${eventType}.`,
+    `[${accountSid}/${taskSid} - stopRecordingWhenLastAgentLeaves]  handler fired on ${eventType} - feature flag set to ${stopRecordingOnTaskEnd}.`,
   );
 
   const { conference } = JSON.parse(attributesJson);
-  if (TaskChannelUniqueName === 'voice' && conference?.sid) {
+  if (stopRecordingOnTaskEnd && TaskChannelUniqueName === 'voice' && conference?.sid) {
     console.info(
       `[${accountSid}/${taskSid} - stopRecordingWhenLastAgentLeaves] ${eventType} on voice task with conference sid ${conference.sid}. Checking if recording needs to be stopped`,
     );

--- a/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
+++ b/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
@@ -36,7 +36,7 @@ import { Twilio } from 'twilio';
 import { EventFields } from '../taskrouter';
 import {
   TASK_CANCELED,
-  TASK_CREATED,
+  TASK_COMPLETED,
   TASK_DELETED,
   TASK_SYSTEM_DELETED,
   TASK_WRAPUP,

--- a/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
+++ b/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
@@ -46,14 +46,10 @@ const stopRecordingIfNotTransferring = async (
   client: Twilio,
   {
     conferenceSid,
-    callSid,
-    customerCallSid,
     taskSid,
     workspaceSid,
   }: {
     conferenceSid: ConferenceSid;
-    callSid?: CallSid;
-    customerCallSid: CallSid;
     taskSid: TaskSID;
     workspaceSid: WorkspaceSID;
   },
@@ -149,8 +145,6 @@ const conferenceStatusEventHandler: ConferenceStatusEventHandler = async (
   );
   await stopRecordingIfNotTransferring(client, {
     conferenceSid,
-    callSid,
-    customerCallSid,
     taskSid,
     workspaceSid,
   });
@@ -174,15 +168,13 @@ const taskRouterEventHandler: TaskRouterEventHandler = async (
   );
 
   const { conference } = JSON.parse(attributesJson);
-  const customerCallSid: CallSid = conference?.participants?.customer;
-  if (TaskChannelUniqueName === 'voice' && customerCallSid) {
+  if (TaskChannelUniqueName === 'voice' && conference?.sid) {
     console.info(
-      `[${accountSid}/${taskSid} - stopRecordingWhenLastAgentLeaves] ${eventType} on voice task with customer call sid ${customerCallSid}. Checking if recording needs to be stopped`,
+      `[${accountSid}/${taskSid} - stopRecordingWhenLastAgentLeaves] ${eventType} on voice task with conference sid ${conference.sid}. Checking if recording needs to be stopped`,
     );
     await stopRecordingIfNotTransferring(client, {
       taskSid,
       conferenceSid: conference.sid,
-      customerCallSid,
       workspaceSid,
     });
   }

--- a/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
+++ b/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
@@ -27,7 +27,6 @@ import {
 } from '../taskrouter/taskrouterEventHandler';
 import {
   AccountSID,
-  CallSid,
   ConferenceSid,
   TaskSID,
   WorkspaceSID,
@@ -75,7 +74,9 @@ const stopRecordingIfNotTransferring = async (
     conferenceRecordings.map(async recording => {
       try {
         if (['in-progress', 'processing'].includes(recording.status)) {
-          console.info(`Pausing recording ${recording.sid} for call ${recording.callSid} on conference ${conferenceSid}` );
+          console.info(
+            `Pausing recording ${recording.sid} for call ${recording.callSid} on conference ${conferenceSid}`,
+          );
           console.debug(recording);
           return await recording.update({
             status: 'paused', // 'stopped' not supported for conferences
@@ -141,7 +142,6 @@ const conferenceStatusEventHandler: ConferenceStatusEventHandler = async (
 
   console.info(
     `[${accountSid}/${taskSid}] No participants identified as Aselo agents still in conference ${conferenceSid}, candidate to stop recordings`,
-
   );
   await stopRecordingIfNotTransferring(client, {
     conferenceSid,
@@ -183,6 +183,6 @@ const taskRouterEventHandler: TaskRouterEventHandler = async (
 };
 
 registerTaskRouterEventHandler(
-  [TASK_WRAPUP, TASK_CREATED, TASK_CANCELED, TASK_DELETED, TASK_SYSTEM_DELETED],
+  [TASK_WRAPUP, TASK_COMPLETED, TASK_CANCELED, TASK_DELETED, TASK_SYSTEM_DELETED],
   taskRouterEventHandler,
 );

--- a/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
+++ b/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
@@ -21,35 +21,43 @@ import {
 import type RestException from 'twilio/lib/base/RestException';
 import { hasTaskControl } from '../transfer/hasTaskControl';
 import { isAgentInConference } from './isAgentInConference';
+import {
+  registerTaskRouterEventHandler,
+  TaskRouterEventHandler,
+} from '../taskrouter/taskrouterEventHandler';
+import {
+  AccountSID,
+  CallSid,
+  ConferenceSid,
+  TaskSID,
+  WorkspaceSID,
+} from '@tech-matters/twilio-types';
+import { Twilio } from 'twilio';
+import { EventFields } from '../taskrouter';
+import {
+  TASK_CANCELED,
+  TASK_CREATED,
+  TASK_DELETED,
+  TASK_SYSTEM_DELETED,
+  TASK_WRAPUP,
+} from '../taskrouter/eventTypes';
 
-const handler: ConferenceStatusEventHandler = async (event, _accountSid, client) => {
-  if (event.StatusCallbackEvent !== 'participant-leave') {
-    console.warn(
-      `stopRecordingWhenLastAgentLeave called for ${event.StatusCallbackEvent} on ${event.ConferenceSid}, should only be called for 'participant-leave'`,
-    );
-    return;
-  }
-  const {
-    ConferenceSid: conferenceSid,
-    CallSid: callSid,
-    CustomerCallSid: customerCallSid,
-    TaskSid: taskSid,
-    WorkspaceSid: workspaceSid,
-  } = event;
-  const remainingParticipants = await client.conferences
-    .get(conferenceSid)
-    .participants.list();
-  const agentStillInConference = remainingParticipants.some(participant =>
-    isAgentInConference({ callSid, customerCallSid, participant }),
-  );
-
-  if (agentStillInConference) {
-    return;
-  }
-
-  console.info(
-    `No participants identified as Aselo agents still in conference ${conferenceSid}, candidate to stop recordings`,
-  );
+const stopRecordingIfNotTransferring = async (
+  client: Twilio,
+  {
+    conferenceSid,
+    callSid,
+    customerCallSid,
+    taskSid,
+    workspaceSid,
+  }: {
+    conferenceSid: ConferenceSid;
+    callSid?: CallSid;
+    customerCallSid: CallSid;
+    taskSid: TaskSID;
+    workspaceSid: WorkspaceSID;
+  },
+) => {
   const isTaskInControl = await hasTaskControl({
     client,
     taskSid,
@@ -70,7 +78,7 @@ const handler: ConferenceStatusEventHandler = async (event, _accountSid, client)
     conferenceRecordings.map(async recording => {
       try {
         if (['in-progress', 'processing'].includes(recording.status)) {
-          console.debug(
+          console.info(
             `Pausing recording ${recording.sid} for call ${recording.callSid} on conference ${conferenceSid}`,
             recording,
           );
@@ -102,4 +110,85 @@ const handler: ConferenceStatusEventHandler = async (event, _accountSid, client)
   );
 };
 
-registerConferenceStatusEventHandler(['participant-leave'], handler);
+const conferenceStatusEventHandler: ConferenceStatusEventHandler = async (
+  event,
+  accountSid,
+  client,
+) => {
+  if (event.StatusCallbackEvent !== 'participant-leave') {
+    console.warn(
+      `stopRecordingWhenLastAgentLeave called for ${event.StatusCallbackEvent} on ${event.ConferenceSid}, should only be called for 'participant-leave'`,
+    );
+    return;
+  }
+  const {
+    ConferenceSid: conferenceSid,
+    CallSid: callSid,
+    CustomerCallSid: customerCallSid,
+    StatusCallbackEvent: statusCallbackEvent,
+    TaskSid: taskSid,
+    WorkspaceSid: workspaceSid,
+  } = event;
+
+  console.info(
+    `[${accountSid}/${taskSid}] ${statusCallbackEvent} on conference ${conferenceSid} for participant ${callSid} where customer is ${customerCallSid}. Checking if recording needs to be stopped`,
+  );
+  const remainingParticipants = await client.conferences
+    .get(conferenceSid)
+    .participants.list();
+  const agentStillInConference = remainingParticipants.some(participant =>
+    isAgentInConference({ callSid, customerCallSid, participant }),
+  );
+
+  if (agentStillInConference) {
+    return;
+  }
+
+  console.info(
+    `[${taskSid} - ] No participants identified as Aselo agents still in conference ${conferenceSid}, candidate to stop recordings`,
+  );
+  await stopRecordingIfNotTransferring(client, {
+    conferenceSid,
+    callSid,
+    customerCallSid,
+    taskSid,
+    workspaceSid,
+  });
+};
+
+registerConferenceStatusEventHandler(['participant-leave'], conferenceStatusEventHandler);
+
+const taskRouterEventHandler: TaskRouterEventHandler = async (
+  {
+    TaskSid: taskSid,
+    TaskAttributes: attributesJson,
+    WorkspaceSid: workspaceSid,
+    TaskChannelUniqueName,
+    EventType: eventType,
+  }: EventFields,
+  accountSid: AccountSID,
+  client: Twilio,
+) => {
+  console.debug(
+    `[${accountSid}/${taskSid} - stopRecordingWhenLastAgentLeaves]  handler fired on ${eventType}.`,
+  );
+
+  const { conference } = JSON.parse(attributesJson);
+  const customerCallSid: CallSid = conference?.participants?.customer;
+  if (TaskChannelUniqueName === 'voice' && customerCallSid) {
+    console.info(
+      `[${accountSid}/${taskSid} - stopRecordingWhenLastAgentLeaves] ${eventType} on voice task with customer call sid ${customerCallSid}. Checking if recording needs to be stopped`,
+    );
+    await stopRecordingIfNotTransferring(client, {
+      taskSid,
+      conferenceSid: conference.sid,
+      customerCallSid,
+      workspaceSid,
+    });
+  }
+};
+
+registerTaskRouterEventHandler(
+  [TASK_WRAPUP, TASK_CREATED, TASK_CANCELED, TASK_DELETED, TASK_SYSTEM_DELETED],
+  taskRouterEventHandler,
+);

--- a/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
+++ b/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
@@ -75,10 +75,8 @@ const stopRecordingIfNotTransferring = async (
     conferenceRecordings.map(async recording => {
       try {
         if (['in-progress', 'processing'].includes(recording.status)) {
-          console.info(
-            `Pausing recording ${recording.sid} for call ${recording.callSid} on conference ${conferenceSid}`,
-            recording,
-          );
+          console.info(`Pausing recording ${recording.sid} for call ${recording.callSid} on conference ${conferenceSid}` );
+          console.debug(recording);
           return await recording.update({
             status: 'paused', // 'stopped' not supported for conferences
           });

--- a/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
+++ b/lambdas/account-scoped/src/conference/stopRecordingWhenLastAgentLeaves.ts
@@ -142,7 +142,8 @@ const conferenceStatusEventHandler: ConferenceStatusEventHandler = async (
   }
 
   console.info(
-    `[${taskSid} - ] No participants identified as Aselo agents still in conference ${conferenceSid}, candidate to stop recordings`,
+    `[${accountSid}/${taskSid}] No participants identified as Aselo agents still in conference ${conferenceSid}, candidate to stop recordings`,
+
   );
   await stopRecordingIfNotTransferring(client, {
     conferenceSid,


### PR DESCRIPTION
## Description

In addition to the current check that pauses voice recordings if the last agent leaves the conference, the system will now also pause recording if a voice task is completed, wrapped up, cancelled or deleted and it does not occur as part of a transfer

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [x] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P