### PR TITLE
CHI-3981: Fix null checking for post survey logic in flex plugin

### DIFF
--- a/plugin-hrm-form/src/components/Conference/ConferenceMonitor/index.tsx
+++ b/plugin-hrm-form/src/components/Conference/ConferenceMonitor/index.tsx
@@ -31,7 +31,7 @@ type Props = TaskContextProps;
 const ConferenceMonitor: React.FC<Props> = ({ conference, task }) => {
   const isAgentOnConferenceWithOngoingCallPostStudioFlow = (participant: ConferenceParticipant) => {
     return (
-      getVoicePostStudioFlowSettings(task.queueSid as TaskQueueSID).flowTrigger === 'inProgressCall' &&
+      getVoicePostStudioFlowSettings(task.queueSid as TaskQueueSID)?.flowTrigger === 'inProgressCall' &&
       ['agent', 'worker', 'supervisor'].includes(participant.participantType)
     );
   };

--- a/plugin-hrm-form/src/postStudioFlow.ts
+++ b/plugin-hrm-form/src/postStudioFlow.ts
@@ -19,7 +19,7 @@ import { getHrmConfig } from './hrmConfig';
 
 export const getVoicePostStudioFlowSettings = (
   queueSid: TaskQueueSID,
-): ReturnType<typeof getHrmConfig>['postStudioFlows']['voice'] => {
+): ReturnType<typeof getHrmConfig>['postStudioFlows']['voice'] | undefined => {
   const { postStudioFlows } = getHrmConfig();
-  return postStudioFlows[queueSid] ?? postStudioFlows.voice;
+  return postStudioFlows?.[queueSid] ?? postStudioFlows?.voice;
 };


### PR DESCRIPTION
## Description

Null reference errors occur in some scenarios when post task studio flows are not configured, this should fix that

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P