### PR TITLE
fix: twilio-iac scripts SSM & STS credentials interaction [CHI-3983]

### DIFF
--- a/scripts/src/helpers/ssm.ts
+++ b/scripts/src/helpers/ssm.ts
@@ -42,9 +42,6 @@ const getSsmConfig = async (): Promise<{
   region: string;
 }> => {
   console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
-  console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
-  console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
-  console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
   if (roleToAssume) {
     const sts = new STSClient();
     const timestamp = new Date().getTime();
@@ -56,11 +53,13 @@ const getSsmConfig = async (): Promise<{
 
     if (!stsResponse.Credentials) {
       logDebug('No credentials found');
+      console.log('>>>>>>>>>>> return 1')
       return {
         region: 'us-east-1',
       };
     }
 
+      console.log('>>>>>>>>>>> return 2')
     return {
       accessKeyId: stsResponse.Credentials.AccessKeyId,
       secretAccessKey: stsResponse.Credentials.SecretAccessKey,
@@ -69,12 +68,14 @@ const getSsmConfig = async (): Promise<{
     };
   }
 
+      console.log('>>>>>>>>>>> return 3')
   return {
     region: 'us-east-1',
   };
 };
 
 const getSsm = async () => {
+      console.log('>>>>>>>>>>> ssm?', Boolean(ssm))
   if (!ssm) {
     ssm = new SSMClient(await getSsmConfig());
   }
@@ -103,6 +104,7 @@ export const saveSSMParameter = async (
 
 export const getSSMParameter = async (name: string, usePrivilegedAccess = false) => {
   const ssmClient = await (usePrivilegedAccess ? getPrivilegedSsm() : getSsm());
+  console.log('>>>>>>>>>>> ssmClient', ssmClient.config)
   try {
     return await ssmClient.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
   } catch (e) {

--- a/scripts/src/helpers/ssm.ts
+++ b/scripts/src/helpers/ssm.ts
@@ -37,7 +37,6 @@ export const setRoleToAssume = (role: string) => {
 };
 
 const getSsmConfig = async (): Promise<Partial<SSMClientConfig>> => {
-  console.log('>>>>>>>>>>> roleToAssume', roleToAssume);
   if (roleToAssume) {
     const sts = new STSClient();
     const timestamp = new Date().getTime();
@@ -49,13 +48,11 @@ const getSsmConfig = async (): Promise<Partial<SSMClientConfig>> => {
 
     if (!stsResponse.Credentials) {
       logDebug('No credentials found');
-      console.log('>>>>>>>>>>> return 1');
       return {
         region: 'us-east-1',
       };
     }
 
-    console.log('>>>>>>>>>>> return 2');
     return {
       credentials: {
         accessKeyId: stsResponse.Credentials.AccessKeyId!,
@@ -66,14 +63,12 @@ const getSsmConfig = async (): Promise<Partial<SSMClientConfig>> => {
     };
   }
 
-  console.log('>>>>>>>>>>> return 3');
   return {
     region: 'us-east-1',
   };
 };
 
 const getSsm = async () => {
-  console.log('>>>>>>>>>>> ssm?', Boolean(ssm));
   if (!ssm) {
     ssm = new SSMClient(await getSsmConfig());
   }

--- a/scripts/src/helpers/ssm.ts
+++ b/scripts/src/helpers/ssm.ts
@@ -41,6 +41,10 @@ const getSsmConfig = async (): Promise<{
   sessionToken?: string;
   region: string;
 }> => {
+  console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
+  console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
+  console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
+  console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
   if (roleToAssume) {
     const sts = new STSClient();
     const timestamp = new Date().getTime();

--- a/scripts/src/helpers/ssm.ts
+++ b/scripts/src/helpers/ssm.ts
@@ -6,6 +6,7 @@ import {
   SSMClient,
   Tag,
   Parameter,
+  SSMClientConfig,
 } from '@aws-sdk/client-ssm';
 import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
 import { logDebug, logWarning } from './log';
@@ -35,13 +36,8 @@ export const setRoleToAssume = (role: string) => {
   roleToAssume = role;
 };
 
-const getSsmConfig = async (): Promise<{
-  accessKeyId?: string;
-  secretAccessKey?: string;
-  sessionToken?: string;
-  region: string;
-}> => {
-  console.log('>>>>>>>>>>> roleToAssume', roleToAssume)
+const getSsmConfig = async (): Promise<Partial<SSMClientConfig>> => {
+  console.log('>>>>>>>>>>> roleToAssume', roleToAssume);
   if (roleToAssume) {
     const sts = new STSClient();
     const timestamp = new Date().getTime();
@@ -53,29 +49,31 @@ const getSsmConfig = async (): Promise<{
 
     if (!stsResponse.Credentials) {
       logDebug('No credentials found');
-      console.log('>>>>>>>>>>> return 1')
+      console.log('>>>>>>>>>>> return 1');
       return {
         region: 'us-east-1',
       };
     }
 
-      console.log('>>>>>>>>>>> return 2')
+    console.log('>>>>>>>>>>> return 2');
     return {
-      accessKeyId: stsResponse.Credentials.AccessKeyId,
-      secretAccessKey: stsResponse.Credentials.SecretAccessKey,
-      sessionToken: stsResponse.Credentials.SessionToken,
+      credentials: {
+        accessKeyId: stsResponse.Credentials.AccessKeyId!,
+        secretAccessKey: stsResponse.Credentials.SecretAccessKey!,
+        sessionToken: stsResponse.Credentials.SessionToken,
+      },
       region: 'us-east-1',
     };
   }
 
-      console.log('>>>>>>>>>>> return 3')
+  console.log('>>>>>>>>>>> return 3');
   return {
     region: 'us-east-1',
   };
 };
 
 const getSsm = async () => {
-      console.log('>>>>>>>>>>> ssm?', Boolean(ssm))
+  console.log('>>>>>>>>>>> ssm?', Boolean(ssm));
   if (!ssm) {
     ssm = new SSMClient(await getSsmConfig());
   }
@@ -104,7 +102,6 @@ export const saveSSMParameter = async (
 
 export const getSSMParameter = async (name: string, usePrivilegedAccess = false) => {
   const ssmClient = await (usePrivilegedAccess ? getPrivilegedSsm() : getSsm());
-  console.log('>>>>>>>>>>> ssmClient', ssmClient.config)
   try {
     return await ssmClient.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
   } catch (e) {

--- a/twilio-iac/makefiles/terragrunt/setup.make
+++ b/twilio-iac/makefiles/terragrunt/setup.make
@@ -26,7 +26,7 @@ manage-ssm-secrets: verify-env ## Manage SSM secrets needed for the environment
   $(DEFAULT_ARGS) $(TG_ENV) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/python_tools/manageSecrets.py "$(HL_ENV)/$(HL)"
 
 # Accepts args via shell like
-# > make twilio-resources-import-account-defaults ARGS="--someFlag=value --anotherFlag=value2"
+# > make twilio-resources-import-account-defaults ARGS="--dryRun"
 twilio-resources-import-account-defaults: verify-env
 	docker run -it --rm \
   -v $(TF_PLUGIN_CACHE_HOST):$(TF_PLUGIN_CACHE_CONT) \

--- a/twilio-iac/makefiles/terragrunt/setup.make
+++ b/twilio-iac/makefiles/terragrunt/setup.make
@@ -25,10 +25,12 @@ manage-ssm-secrets: verify-env ## Manage SSM secrets needed for the environment
   -v $(TF_PLUGIN_CACHE_HOST):$(TF_PLUGIN_CACHE_CONT) \
   $(DEFAULT_ARGS) $(TG_ENV) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/python_tools/manageSecrets.py "$(HL_ENV)/$(HL)"
 
+# Accepts args via shell like
+# > make twilio-resources-import-account-defaults ARGS="--someFlag=value --anotherFlag=value2"
 twilio-resources-import-account-defaults: verify-env
 	docker run -it --rm \
   -v $(TF_PLUGIN_CACHE_HOST):$(TF_PLUGIN_CACHE_CONT) \
-  $(DEFAULT_ARGS) $(TG_ENV) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+  $(DEFAULT_ARGS) $(TG_ENV) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh $(ARGS)
 
 migrate-state: verify-env
 	docker run -it --rm \

--- a/twilio-iac/makefiles/terragrunt/setup.make
+++ b/twilio-iac/makefiles/terragrunt/setup.make
@@ -26,7 +26,7 @@ manage-ssm-secrets: verify-env ## Manage SSM secrets needed for the environment
   $(DEFAULT_ARGS) $(TG_ENV) $(DOCKER_IMAGE):$(TF_VER) $(TF_ROOT_PATH)/scripts/python_tools/manageSecrets.py "$(HL_ENV)/$(HL)"
 
 # Accepts args via shell like
-# > make twilio-resources-import-account-defaults ARGS="--dryRun"
+# > make twilio-resources-import-account-defaults ARGS="--dryRun --otherFlag=value"
 twilio-resources-import-account-defaults: verify-env
 	docker run -it --rm \
   -v $(TF_PLUGIN_CACHE_HOST):$(TF_PLUGIN_CACHE_CONT) \

--- a/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
@@ -5,4 +5,5 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 
-npm run twilioResources -- import-account-defaults --helplineShortCode="${HL}" --helplineEnvironment="${HL_ENV}" --stage="${MY_ENV}"
+# npm run twilioResources -- import-account-defaults --helplineShortCode="${HL}" --helplineEnvironment="${HL_ENV}" --stage="${MY_ENV}"
+npm run twilioResources -- import-account-defaults --helplineShortCode="${HL}" --helplineEnvironment="${HL_ENV}" --stage="${MY_ENV}" "$@"

--- a/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
+++ b/twilio-iac/scripts/deploy-scripts/terragrunt/twilioResourceImportAccountDefaults.sh
@@ -5,5 +5,4 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${script_dir}/../setup.sh
 
-# npm run twilioResources -- import-account-defaults --helplineShortCode="${HL}" --helplineEnvironment="${HL_ENV}" --stage="${MY_ENV}"
 npm run twilioResources -- import-account-defaults --helplineShortCode="${HL}" --helplineEnvironment="${HL_ENV}" --stage="${MY_ENV}" "$@"


### PR DESCRIPTION
## Description
This PR fixes the permissions issues seen in devops.

The cause is that the correct STS role is assumed when executing the scripts, but after upgrading to `@aws-sdk` v3, the credentials are expected in a different location for SSM client. This causes the devops instance to attempt running the commands with it's default role, which lacks the necessary permissions.

The fix is updating how the credentials from STS assumed role are given to the SSM client.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3983)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P