### PR TITLE
Set use_twilio_lambda_to_transition_participants to "false" for all staging helplines

### DIFF
--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -29,6 +29,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "multipleOfficeSupport": true,

--- a/twilio-iac/helplines/br/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/br/configs/service-configuration/staging.json
@@ -8,6 +8,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/ca/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ca/configs/service-configuration/staging.json
@@ -9,6 +9,7 @@
       "use_twilio_lambda_for_iwf_reporting": true,
       "use_twilio_lambda_for_offline_contact_tasks": true,
       "use_twilio_lambda_janitor": true,
+      "use_twilio_lambda_to_transition_participants": false,
       "use_twilio_lambda_transfers": false
     },
     "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",

--- a/twilio-iac/helplines/cl/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/cl/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "pdfImagesSource": "https://tl-public-chat-cl-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/clhs/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/clhs/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",

--- a/twilio-iac/helplines/co/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/co/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/e2e/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/e2e/configs/service-configuration/common.json
@@ -14,6 +14,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "permissionConfig": "e2e",

--- a/twilio-iac/helplines/et/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/et/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false  
         },
         "previous_ui_version": {

--- a/twilio-iac/helplines/eumc/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/eumc/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
         "use_twilio_lambda_for_iwf_reporting": true,
         "use_twilio_lambda_for_offline_contact_tasks": true,
         "use_twilio_lambda_janitor": false,
+        "use_twilio_lambda_to_transition_participants": false,
         "use_twilio_lambda_transfers": false    
       },
       "previous_ui_version": {

--- a/twilio-iac/helplines/gy/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/gy/configs/service-configuration/staging.json
@@ -14,6 +14,7 @@
             "use_twilio_lambda_janitor": true,
             "use_twilio_lambda_transfers": true,
             "use_twilio_lambda_to_send_messages": true,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_media_urls": true,
             "use_twilio_lambda_worker_info": true,
             "use_twilio_lambda_to_issue_sync_token": true,

--- a/twilio-iac/helplines/hu/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/hu/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false    
         },
         "hrm_base_url": "https://hrm-staging-eu.tl.techmatters.org",

--- a/twilio-iac/helplines/in/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/in/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "helplineLanguage": "en-IN",

--- a/twilio-iac/helplines/jm/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/jm/configs/service-configuration/staging.json
@@ -9,6 +9,7 @@
       "use_twilio_lambda_for_iwf_reporting": true,
       "use_twilio_lambda_for_offline_contact_tasks": true,
       "use_twilio_lambda_janitor": false,
+      "use_twilio_lambda_to_transition_participants": false,
       "use_twilio_lambda_transfers": false
     },
     "pdfImagesSource": "https://tl-public-chat-jm-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/mt/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mt/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",

--- a/twilio-iac/helplines/mw/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/mw/configs/service-configuration/staging.json
@@ -7,6 +7,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "pdfImagesSource": "https://tl-public-chat-mw-stg.s3.amazonaws.com",

--- a/twilio-iac/helplines/nz/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/nz/configs/service-configuration/staging.json
@@ -8,6 +8,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/nzba/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/nzba/configs/service-configuration/staging.json
@@ -14,6 +14,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         }
     }

--- a/twilio-iac/helplines/ph/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ph/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "logo_url" : "https://aselo-logo.s3.amazonaws.com/200+transparent+background+no+TM+staging.png"

--- a/twilio-iac/helplines/sg/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/sg/configs/service-configuration/staging.json
@@ -9,6 +9,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "helpline_code": "sg",

--- a/twilio-iac/helplines/th/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/th/configs/service-configuration/staging.json
@@ -7,6 +7,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false,
             "enable_llm_summary": true
         },

--- a/twilio-iac/helplines/tz/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/tz/configs/service-configuration/staging.json
@@ -9,6 +9,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         }
     }

--- a/twilio-iac/helplines/ukmh/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/ukmh/configs/service-configuration/staging.json
@@ -17,6 +17,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         }
     }

--- a/twilio-iac/helplines/usch/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/usch/configs/service-configuration/staging.json
@@ -10,6 +10,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         }
     }

--- a/twilio-iac/helplines/uscr/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/uscr/configs/service-configuration/staging.json
@@ -10,6 +10,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         }
     }

--- a/twilio-iac/helplines/usnc/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/usnc/configs/service-configuration/staging.json
@@ -10,6 +10,7 @@
       "use_twilio_lambda_for_iwf_reporting": true,
       "use_twilio_lambda_for_offline_contact_tasks": true,
       "use_twilio_lambda_janitor": false,
+      "use_twilio_lambda_to_transition_participants": false,
       "use_twilio_lambda_transfers": false
     },
     "postStudioFlows": {

--- a/twilio-iac/helplines/usnm/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/usnm/configs/service-configuration/common.json
@@ -22,6 +22,7 @@
             "enable_voice_recordings": true,
             "enable_lambda_post_survey_processing": true,
             "use_prepopulate_mappings": true,
+            "use_twilio_lambda_to_transition_participants": false,
             "enable_hang_up_by_hrm_saving": true
         },
         "definitionVersion": "usnm-v1",

--- a/twilio-iac/helplines/usvc/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/usvc/configs/service-configuration/staging.json
@@ -10,6 +10,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         }
     }

--- a/twilio-iac/helplines/za/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/za/configs/service-configuration/staging.json
@@ -6,6 +6,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "previous_ui_version": {

--- a/twilio-iac/helplines/zw/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/zw/configs/service-configuration/staging.json
@@ -15,6 +15,7 @@
             "use_twilio_lambda_for_iwf_reporting": true,
             "use_twilio_lambda_for_offline_contact_tasks": true,
             "use_twilio_lambda_janitor": false,
+            "use_twilio_lambda_to_transition_participants": false,
             "use_twilio_lambda_transfers": false
         },
         "form_definitions_base_url": "https://assets-staging.tl.techmatters.org/form-definitions/",


### PR DESCRIPTION
For lambda migration testing, Remaining Task Router Handlers