### PR TITLE
fix: adjust chat capacity on pullTask [CHI-3984]

### DIFF
--- a/lambdas/account-scoped/src/worker/pullTask.ts
+++ b/lambdas/account-scoped/src/worker/pullTask.ts
@@ -14,36 +14,68 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { AccountSID } from '@tech-matters/twilio-types';
+import { AccountSID, WorkerSID } from '@tech-matters/twilio-types';
 import { getTwilioClient, getWorkspaceSid } from '@tech-matters/twilio-configuration';
 import { FlexValidatedHandler } from '../validation/flexToken';
 import { newOk } from '../Result';
 import { newHttpErrorResult, newMissingParameterResult } from '../httpErrors';
+import { adjustChatCapacity } from '../conversation/adjustChatCapacity';
+
+const PULL_ATTEMPT_TIMEOUT_MS = 5000;
+
+const delay = (ms: number) =>
+  new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
 
 export const pullTaskHandler: FlexValidatedHandler = async (
   { body: event },
   accountSid: AccountSID,
 ) => {
-  const { workerSid } = event as { workerSid?: string };
+  const { workerSid } = event as { workerSid?: WorkerSID };
 
   if (workerSid === undefined) {
     return newMissingParameterResult('workerSid');
   }
 
-  const client = await getTwilioClient(accountSid);
-  const workspaceSid = await getWorkspaceSid(accountSid);
+  try {
+    const client = await getTwilioClient(accountSid);
+    const workspaceSid = await getWorkspaceSid(accountSid);
 
-  const reservations = await client.taskrouter.v1
-    .workspaces(workspaceSid)
-    .workers(workerSid)
-    .reservations.list({ reservationStatus: 'pending' });
+    const { status } = await adjustChatCapacity(accountSid, {
+      workerSid,
+      adjustment: 'increaseUntilCapacityAvailable',
+    });
+    if (status !== 200) {
+      return newHttpErrorResult('Failed to provide available chat capacity', 400);
+    }
 
-  if (reservations.length === 0) {
+    const pullAttemptExpiry = Date.now() + PULL_ATTEMPT_TIMEOUT_MS;
+
+    while (Date.now() < pullAttemptExpiry) {
+      await delay(500);
+
+      const reservations = await client.taskrouter.v1
+        .workspaces(workspaceSid)
+        .workers(workerSid)
+        .reservations.list({ reservationStatus: 'pending' });
+
+      if (reservations.length > 0) {
+        const reservation = reservations[0];
+        console.debug('New task reserved for worker pulled:', reservation.taskSid);
+        // await reservation.update({ reservationStatus: 'accepted' });
+        return newOk({ taskPulled: reservation.taskSid });
+      }
+    }
+
     return newHttpErrorResult('No eligible queued task found to pull', 404);
+  } catch (err) {
+    return newHttpErrorResult(
+      err instanceof Error ? err.message : String(err),
+      500,
+      'Unknown error occurred',
+    );
+  } finally {
+    await adjustChatCapacity(accountSid, { workerSid, adjustment: 'setTo1' });
   }
-
-  const reservation = reservations[0];
-  await reservation.update({ reservationStatus: 'accepted' });
-
-  return newOk({ taskPulled: reservation.taskSid });
 };

--- a/lambdas/account-scoped/tests/unit/worker/pullTask.test.ts
+++ b/lambdas/account-scoped/tests/unit/worker/pullTask.test.ts
@@ -61,9 +61,9 @@ const mockReservation = {
 
 describe('pullTaskHandler', () => {
   let mockClient: any;
+  let dateSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    jest.useFakeTimers();
     jest.clearAllMocks();
     mockGetWorkspaceSid.mockResolvedValue(TEST_WORKSPACE_SID as any);
     mockAdjustChatCapacity.mockResolvedValue({ status: 200, message: 'ok' });
@@ -86,7 +86,7 @@ describe('pullTaskHandler', () => {
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    dateSpy?.mockRestore();
   });
 
   it('should return 400 when workerSid is missing', async () => {
@@ -130,12 +130,15 @@ describe('pullTaskHandler', () => {
       .workers()
       .reservations.list.mockResolvedValue([]);
 
-    const request = createMockRequest({ workerSid: TEST_WORKER_SID });
+    // Make Date.now() immediately exceed the timeout so the polling loop exits after first check
+    const now = Date.now();
+    dateSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(now) // initial: set pullAttemptExpiry = now + 5000
+      .mockReturnValue(now + 6000); // subsequent: already past expiry
 
-    // Run the handler and advance timers past the 5s timeout
-    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
-    await jest.runAllTimersAsync();
-    const result = await resultPromise;
+    const request = createMockRequest({ workerSid: TEST_WORKER_SID });
+    const result = await pullTaskHandler(request, TEST_ACCOUNT_SID);
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
@@ -150,10 +153,7 @@ describe('pullTaskHandler', () => {
 
   it('should return taskPulled when a pending reservation is found', async () => {
     const request = createMockRequest({ workerSid: TEST_WORKER_SID });
-
-    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
-    await jest.runAllTimersAsync();
-    const result = await resultPromise;
+    const result = await pullTaskHandler(request, TEST_ACCOUNT_SID);
 
     expect(isOk(result)).toBe(true);
     if (isOk(result)) {
@@ -178,14 +178,12 @@ describe('pullTaskHandler', () => {
     });
 
     const request = createMockRequest({ workerSid: TEST_WORKER_SID });
-    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
-    await jest.runAllTimersAsync();
-    const result = await resultPromise;
+    const result = await pullTaskHandler(request, TEST_ACCOUNT_SID);
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
       expect(result.error.statusCode).toBe(500);
-      expect(result.message).toContain('Twilio error');
+      expect(result.message).toBe('Unknown error occurred');
     }
     // setTo1 should still be called in finally
     expect(mockAdjustChatCapacity).toHaveBeenCalledWith(TEST_ACCOUNT_SID, {
@@ -196,9 +194,7 @@ describe('pullTaskHandler', () => {
 
   it('should use the workspace SID from configuration and query pending reservations for the worker', async () => {
     const request = createMockRequest({ workerSid: TEST_WORKER_SID });
-    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
-    await jest.runAllTimersAsync();
-    await resultPromise;
+    await pullTaskHandler(request, TEST_ACCOUNT_SID);
 
     expect(mockGetWorkspaceSid).toHaveBeenCalledWith(TEST_ACCOUNT_SID);
     expect(mockClient.taskrouter.v1.workspaces).toHaveBeenCalledWith(TEST_WORKSPACE_SID);
@@ -214,9 +210,7 @@ describe('pullTaskHandler', () => {
 
   it('should call adjustChatCapacity with increaseUntilCapacityAvailable before polling and setTo1 in finally', async () => {
     const request = createMockRequest({ workerSid: TEST_WORKER_SID });
-    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
-    await jest.runAllTimersAsync();
-    await resultPromise;
+    await pullTaskHandler(request, TEST_ACCOUNT_SID);
 
     expect(mockAdjustChatCapacity).toHaveBeenNthCalledWith(1, TEST_ACCOUNT_SID, {
       workerSid: TEST_WORKER_SID,

--- a/lambdas/account-scoped/tests/unit/worker/pullTask.test.ts
+++ b/lambdas/account-scoped/tests/unit/worker/pullTask.test.ts
@@ -16,6 +16,7 @@
 
 import { pullTaskHandler } from '../../../src/worker/pullTask';
 import { getTwilioClient, getWorkspaceSid } from '@tech-matters/twilio-configuration';
+import { adjustChatCapacity } from '../../../src/conversation/adjustChatCapacity';
 import { isErr, isOk } from '../../../src/Result';
 import { FlexValidatedHttpRequest } from '../../../src/validation/flexToken';
 import {
@@ -30,11 +31,18 @@ jest.mock('@tech-matters/twilio-configuration', () => ({
   getWorkspaceSid: jest.fn(),
 }));
 
+jest.mock('../../../src/conversation/adjustChatCapacity', () => ({
+  adjustChatCapacity: jest.fn(),
+}));
+
 const mockGetTwilioClient = getTwilioClient as jest.MockedFunction<
   typeof getTwilioClient
 >;
 const mockGetWorkspaceSid = getWorkspaceSid as jest.MockedFunction<
   typeof getWorkspaceSid
+>;
+const mockAdjustChatCapacity = adjustChatCapacity as jest.MockedFunction<
+  typeof adjustChatCapacity
 >;
 
 const createMockRequest = (body: any): FlexValidatedHttpRequest => ({
@@ -55,8 +63,10 @@ describe('pullTaskHandler', () => {
   let mockClient: any;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
     mockGetWorkspaceSid.mockResolvedValue(TEST_WORKSPACE_SID as any);
+    mockAdjustChatCapacity.mockResolvedValue({ status: 200, message: 'ok' });
 
     mockClient = {
       taskrouter: {
@@ -75,6 +85,10 @@ describe('pullTaskHandler', () => {
     mockGetTwilioClient.mockResolvedValue(mockClient as any);
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('should return 400 when workerSid is missing', async () => {
     const request = createMockRequest({});
     const result = await pullTaskHandler(request, TEST_ACCOUNT_SID);
@@ -86,35 +100,75 @@ describe('pullTaskHandler', () => {
     }
   });
 
-  it('should return 404 when no pending reservations are found', async () => {
-    mockClient.taskrouter.v1
-      .workspaces()
-      .workers()
-      .reservations.list.mockResolvedValue([]);
+  it('should return 400 when adjustChatCapacity fails to provide capacity', async () => {
+    mockAdjustChatCapacity.mockResolvedValue({
+      status: 412,
+      message: 'Reached the max capacity with no available capacity.',
+    });
 
     const request = createMockRequest({ workerSid: TEST_WORKER_SID });
     const result = await pullTaskHandler(request, TEST_ACCOUNT_SID);
 
     expect(isErr(result)).toBe(true);
     if (isErr(result)) {
-      expect(result.error.statusCode).toBe(404);
+      expect(result.error.statusCode).toBe(400);
     }
+    expect(mockAdjustChatCapacity).toHaveBeenCalledWith(TEST_ACCOUNT_SID, {
+      workerSid: TEST_WORKER_SID,
+      adjustment: 'increaseUntilCapacityAvailable',
+    });
+    // setTo1 should still be called in finally
+    expect(mockAdjustChatCapacity).toHaveBeenCalledWith(TEST_ACCOUNT_SID, {
+      workerSid: TEST_WORKER_SID,
+      adjustment: 'setTo1',
+    });
   });
 
-  it('should accept the first pending reservation and return taskPulled on success', async () => {
+  it('should return 404 when no pending reservations are found within the timeout', async () => {
+    mockClient.taskrouter.v1
+      .workspaces()
+      .workers()
+      .reservations.list.mockResolvedValue([]);
+
     const request = createMockRequest({ workerSid: TEST_WORKER_SID });
-    const result = await pullTaskHandler(request, TEST_ACCOUNT_SID);
+
+    // Run the handler and advance timers past the 5s timeout
+    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
+    await jest.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.statusCode).toBe(404);
+    }
+    // setTo1 should be called in finally even on 404
+    expect(mockAdjustChatCapacity).toHaveBeenCalledWith(TEST_ACCOUNT_SID, {
+      workerSid: TEST_WORKER_SID,
+      adjustment: 'setTo1',
+    });
+  });
+
+  it('should return taskPulled when a pending reservation is found', async () => {
+    const request = createMockRequest({ workerSid: TEST_WORKER_SID });
+
+    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
+    await jest.runAllTimersAsync();
+    const result = await resultPromise;
 
     expect(isOk(result)).toBe(true);
     if (isOk(result)) {
       expect(result.data.taskPulled).toBe(TEST_TASK_SID);
     }
-    expect(mockReservation.update).toHaveBeenCalledWith({
-      reservationStatus: 'accepted',
+    // reservation.update is commented out in the implementation
+    expect(mockReservation.update).not.toHaveBeenCalled();
+    // setTo1 should be called in finally
+    expect(mockAdjustChatCapacity).toHaveBeenCalledWith(TEST_ACCOUNT_SID, {
+      workerSid: TEST_WORKER_SID,
+      adjustment: 'setTo1',
     });
   });
 
-  it('should throw when Twilio client throws an error', async () => {
+  it('should return 500 when Twilio client throws an error', async () => {
     mockClient.taskrouter.v1.workspaces.mockReturnValue({
       workers: jest.fn().mockReturnValue({
         reservations: {
@@ -124,14 +178,27 @@ describe('pullTaskHandler', () => {
     });
 
     const request = createMockRequest({ workerSid: TEST_WORKER_SID });
-    await expect(pullTaskHandler(request, TEST_ACCOUNT_SID)).rejects.toThrow(
-      'Twilio error',
-    );
+    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
+    await jest.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.statusCode).toBe(500);
+      expect(result.message).toContain('Twilio error');
+    }
+    // setTo1 should still be called in finally
+    expect(mockAdjustChatCapacity).toHaveBeenCalledWith(TEST_ACCOUNT_SID, {
+      workerSid: TEST_WORKER_SID,
+      adjustment: 'setTo1',
+    });
   });
 
   it('should use the workspace SID from configuration and query pending reservations for the worker', async () => {
     const request = createMockRequest({ workerSid: TEST_WORKER_SID });
-    await pullTaskHandler(request, TEST_ACCOUNT_SID);
+    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
+    await jest.runAllTimersAsync();
+    await resultPromise;
 
     expect(mockGetWorkspaceSid).toHaveBeenCalledWith(TEST_ACCOUNT_SID);
     expect(mockClient.taskrouter.v1.workspaces).toHaveBeenCalledWith(TEST_WORKSPACE_SID);
@@ -142,6 +209,22 @@ describe('pullTaskHandler', () => {
       mockClient.taskrouter.v1.workspaces().workers().reservations.list,
     ).toHaveBeenCalledWith({
       reservationStatus: 'pending',
+    });
+  });
+
+  it('should call adjustChatCapacity with increaseUntilCapacityAvailable before polling and setTo1 in finally', async () => {
+    const request = createMockRequest({ workerSid: TEST_WORKER_SID });
+    const resultPromise = pullTaskHandler(request, TEST_ACCOUNT_SID);
+    await jest.runAllTimersAsync();
+    await resultPromise;
+
+    expect(mockAdjustChatCapacity).toHaveBeenNthCalledWith(1, TEST_ACCOUNT_SID, {
+      workerSid: TEST_WORKER_SID,
+      adjustment: 'increaseUntilCapacityAvailable',
+    });
+    expect(mockAdjustChatCapacity).toHaveBeenLastCalledWith(TEST_ACCOUNT_SID, {
+      workerSid: TEST_WORKER_SID,
+      adjustment: 'setTo1',
     });
   });
 });

--- a/lambdas/package-lock.json
+++ b/lambdas/package-lock.json
@@ -22287,7 +22287,7 @@
         "ts-jest": "^29.4.6",
         "ts-node": "^10.1.0",
         "typescript": "^4.3.5",
-        "uuid": "14.0.1"
+        "uuid": "^14.0.1"
       },
       "dependencies": {
         "@babel/code-frame": {

--- a/lambdas/package-lock.json
+++ b/lambdas/package-lock.json
@@ -22287,7 +22287,7 @@
         "ts-jest": "^29.4.6",
         "ts-node": "^10.1.0",
         "typescript": "^4.3.5",
-        "uuid": "^14.0.1"
+        "uuid": "14.0.1"
       },
       "dependencies": {
         "@babel/code-frame": {


### PR DESCRIPTION
## Description
The migration of `/pullTask` edpoint done in https://github.com/techmatters/flex-plugins/pull/3989 seemed to lack some of the original logic. This resulted in the feature for pulling tasks not working when the request was done against Twilio Lambda endpoint.

This PR fixes the issue by
- Adding a call to "increase chat capacity" (and decrease it accordingly).
- Polling for the workers reservation until a new one has been reserved. If that happened we assume a task was pulled and return.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3984)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P