### PR TITLE
Chatbot bug fix

### DIFF
--- a/lambdas/account-scoped/src/channelCapture/chatbotCallback.ts
+++ b/lambdas/account-scoped/src/channelCapture/chatbotCallback.ts
@@ -150,18 +150,6 @@ export const handleChatbotCallback: AccountScopedHandler = async (
       const twilioWorkspaceSid = await getWorkspaceSid(accountSid);
 
       const { lexResponse } = lexResult.data;
-      // If the session ended, we should unlock the channel to continue the Studio Flow
-      if (LexClient.isEndOfDialog(lexResponse)) {
-        await chatbotCallbackCleanup({
-          accountSid,
-          twilioClient,
-          conversation,
-          channel,
-          channelAttributes,
-          memory: LexClient.getBotMemory({ lexResponse }),
-          twilioWorkspaceSid,
-        });
-      }
 
       // TODO: unify with functions/channelCapture/channelCaptureHandlers.ts
       const messages = (lexResponse.messages || []).map(m => m.content || '');
@@ -183,6 +171,19 @@ export const handleChatbotCallback: AccountScopedHandler = async (
             xTwilioWebhookEnabled: 'true',
           });
         }
+      }
+      
+      // If the session ended, we should unlock the channel to continue the Studio Flow
+      if (LexClient.isEndOfDialog(lexResponse)) {
+        await chatbotCallbackCleanup({
+          accountSid,
+          twilioClient,
+          conversation,
+          channel,
+          channelAttributes,
+          memory: LexClient.getBotMemory({ lexResponse }),
+          twilioWorkspaceSid,
+        });
       }
 
       return newOk({});

--- a/lambdas/account-scoped/src/channelCapture/chatbotCallback.ts
+++ b/lambdas/account-scoped/src/channelCapture/chatbotCallback.ts
@@ -172,7 +172,7 @@ export const handleChatbotCallback: AccountScopedHandler = async (
           });
         }
       }
-      
+
       // If the session ended, we should unlock the channel to continue the Studio Flow
       if (LexClient.isEndOfDialog(lexResponse)) {
         await chatbotCallbackCleanup({

--- a/lambdas/account-scoped/src/channelCapture/chatbotCallback.ts
+++ b/lambdas/account-scoped/src/channelCapture/chatbotCallback.ts
@@ -150,6 +150,18 @@ export const handleChatbotCallback: AccountScopedHandler = async (
       const twilioWorkspaceSid = await getWorkspaceSid(accountSid);
 
       const { lexResponse } = lexResult.data;
+      // If the session ended, we should unlock the channel to continue the Studio Flow
+      if (LexClient.isEndOfDialog(lexResponse)) {
+        await chatbotCallbackCleanup({
+          accountSid,
+          twilioClient,
+          conversation,
+          channel,
+          channelAttributes,
+          memory: LexClient.getBotMemory({ lexResponse }),
+          twilioWorkspaceSid,
+        });
+      }
 
       // TODO: unify with functions/channelCapture/channelCaptureHandlers.ts
       const messages = (lexResponse.messages || []).map(m => m.content || '');
@@ -171,19 +183,6 @@ export const handleChatbotCallback: AccountScopedHandler = async (
             xTwilioWebhookEnabled: 'true',
           });
         }
-      }
-
-      // If the session ended, we should unlock the channel to continue the Studio Flow
-      if (LexClient.isEndOfDialog(lexResponse)) {
-        await chatbotCallbackCleanup({
-          accountSid,
-          twilioClient,
-          conversation,
-          channel,
-          channelAttributes,
-          memory: LexClient.getBotMemory({ lexResponse }),
-          twilioWorkspaceSid,
-        });
       }
 
       return newOk({});

--- a/lambdas/account-scoped/src/channelCapture/lexClient.ts
+++ b/lambdas/account-scoped/src/channelCapture/lexClient.ts
@@ -172,7 +172,10 @@ const getBotMemory = ({ lexResponse }: { lexResponse: RecognizeTextResponse }) =
   }
 
   return Object.entries(slots).reduce(
-    (accum, [q, { value }]) => ({ ...accum, [q]: value?.interpretedValue || '' }),
+    (accum, [q, slot]) => ({
+      ...accum,
+      [q]: slot?.value?.interpretedValue || '',
+    }),
     {} as LexMemory,
   );
 };

--- a/lambdas/account-scoped/src/studioFlow/postStudioFlowTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/studioFlow/postStudioFlowTaskRouterListener.ts
@@ -146,6 +146,7 @@ const triggerPostStudioFlow = async ({
               contactId,
               contactTaskSid: taskSid,
               taskQueueSid,
+              taskAttributes,
             },
             to: taskAttributes.from,
           });

--- a/lambdas/account-scoped/src/studioFlow/postStudioFlowTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/studioFlow/postStudioFlowTaskRouterListener.ts
@@ -146,7 +146,7 @@ const triggerPostStudioFlow = async ({
               contactId,
               contactTaskSid: taskSid,
               taskQueueSid,
-              taskAttributes,
+              taskLanguage: taskAttributes.language ?? '',
             },
             to: taskAttributes.from,
           });


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts
- [ ] 

This is a pretty small bug fix for the post survey chatbot when the user responded with an unrecognized response (slot value)

Here is an example where instead of Si  or No, I've responded "blah"
<img width="624" height="476" alt="{DD296EEB-22CE-479D-9E60-467D260FF0C6}" src="https://github.com/user-attachments/assets/a7ce0c11-dc14-4844-84d8-af3426f4db17" />

Basically the bot broke with error:
`026-08-13T18:38:57.402Z 170e032e-ec04-4d6c-a28d-cc5cd58037fb ERROR handler for path /lambda/twilio/account-scoped/AC5c77a3f308fe1361bc12b3a48b98f68d/channelCapture/chatbotCallback resulted in error Cannot read properties of null (reading 'value') { statusCode: 500, cause: TypeError: Cannot read properties of null (reading 'value') at /var/task/channelCapture/lexClient.js:109:55 at Array.reduce (<anonymous>) at Object.getBotMemory (/var/task/channelCapture/lexClient.js:109:34) at Object.handleChatbotCallback [as handler] (/var/task/channelCapture/chatbotCallback.js:127:51) at process.processTicksAndRejections (node:internal/process/task_queues:103:5) at async Runtime.handler (/var/task/index.js:70:28)`


The problem was this line (accum, [q, { value }]) => ({ ...accum, [q]: value?.interpretedValue || '' }), which was using {value} but in this case was null.

So I've changed it to the below (using AI help)
(accum, [q, slot]) => ({
      ...accum,
      [q]: slot?.value?.interpretedValue || '',
    }),

ChatGPT also suggested processing the messages first and then call the cleanup end point which I thought it was a good suggestion so I've added that as well.

I've tried this out and now it works:
<img width="562" height="466" alt="{B3D1AFD8-2E1D-4DAA-90EE-9F5F2E3D6D19}" src="https://github.com/user-attachments/assets/e2e79def-2c27-4b79-8c51-4287aaab92a4" />


### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P