### PR TITLE
TH: add generate summary button and Thai translations CHI-3976

### DIFF
--- a/lambdas/packages/hrm-form-definitions/form-definitions/th/v1/tabbedForms/CaseInformationTab.json
+++ b/lambdas/packages/hrm-form-definitions/form-definitions/th/v1/tabbedForms/CaseInformationTab.json
@@ -34,7 +34,52 @@
       "value": true,
       "message": "RequiredFieldError"
     },
-    "isPII": true
+    "isPII": true,
+    "rows": "40",
+    "additionalActions": [
+      {
+        "name": "generateSummary",
+        "label": "Generate Summary",
+        "type": "custom-contact-component",
+        "component": "generate-summary-button",
+        "saveable": false,
+        "props": {
+          "form": "caseInformation",
+          "item": "callSummary"
+        }
+      }
+    ]
+  },
+  {
+    "name": "summaryAccuracy",
+    "label": "[For AI Summary only] How accurate was the summary written by AI?",
+    "type": "select",
+    "options": [
+      {
+        "value": "Unknown",
+        "label": ""
+      },
+      {
+        "value": "Very accurate",
+        "label": "Very accurate"
+      },
+      {
+        "value": "Somewhat accurate",
+        "label": "Somewhat accurate"
+      },
+      {
+        "value": "Not accurate",
+        "label": "Not accurate"
+      }
+    ],
+    "isPII": false
+  },
+  {
+    "name": "summaryFeedback",
+    "label": "[For AI Summary only] Tell us more about your answer above.",
+    "type": "textarea",
+    "isPII": true,
+    "rows": "4"
   },
   {
     "name": "actionTaken",

--- a/plugin-hrm-form/src/translations/th.json
+++ b/plugin-hrm-form/src/translations/th.json
@@ -688,5 +688,13 @@
   "Forms-ResourceReferralsList-Add": "เพิ่ม",
   "Forms-ResourceReferralsList-Delete": "ลบ",
   "Forms-FileUpload-InvalidFileTypeError": "ประเภทไฟล์ไม่ถูกต้อง อนุญาตเฉพาะไฟล์ PNG, JPG, JPEG, PDF, DOC และ DOCX เท่านั้น",
-  "Forms-FileUpload-FileSizeError": "ไฟล์มีขนาดเกินขนาดสูงสุด"
+  "Forms-FileUpload-FileSizeError": "ไฟล์มีขนาดเกินขนาดสูงสุด",
+  "ContactForms-TextArea-GenerateSummary": "สร้างสรุป",
+  "ContactForms-TextArea-LoadingSummary": "กำลังโหลด",
+  "LlmAssistant-Notifications-SummaryGenerationError": "เกิดข้อผิดพลาดในการสร้างสรุป: {{errorMessage}}",
+  "[For AI Summary only] How accurate was the summary written by AI?": "[สำหรับสรุปโดยปัญญาประดิษฐ์ (AI) เท่านั้น] สรุปที่สร้างโดย AI มีความแม่นยำเพียงใด?",
+  "Very accurate": "แม่นยำมาก",
+  "Somewhat accurate": "แม่นยำพอสมควร",
+  "Not accurate": "ไม่แม่นยำ",
+  "[For AI Summary only] Tell us more about your answer above.": "[สำหรับสรุปโดยปัญญาประดิษฐ์ (AI) เท่านั้น] กรุณาระบุรายละเอียดเพิ่มเติมเกี่ยวกับคำตอบข้างต้น"
 }


### PR DESCRIPTION
## Description
Adds the Generate Summary button and summaryAccuracy/summaryFeedback fields to TH's CaseInformation tab, plus Thai translations for the button, loading, error, and feedback strings.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [x] Strings are localized
- [x] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
Follow-on to CHI-3885.

### Verification steps
Verified via hrm-form-definitions' schema validation tests (240/240 passing) and manual translation review against web/Wikipedia sources. Live browser rendering check against TH's form still pending.