### PR TITLE
fix: voicemail - race condition between contact creation and media attached [CHI-3992]

### DIFF
--- a/lambdas/account-scoped/src/hrm/createHrmContactTaskRouterListener.ts
+++ b/lambdas/account-scoped/src/hrm/createHrmContactTaskRouterListener.ts
@@ -28,7 +28,7 @@ import {
   postToInternalHrmEndpoint,
 } from './internalHrmRequest';
 import { isErr, isOk } from '@tech-matters/result-type';
-import { inferHrmAccountId } from './hrmAccountId';
+import { inferHrmAccountId, HrmAccountId } from './hrmAccountId';
 import { sanitizeIdentifierFromTask } from './sanitizeIdentifier';
 import { HrmContact } from '@tech-matters/hrm-types';
 import { populateHrmContactFormFromTaskByMappings } from './populateHrmContactFormFromTaskByMappings';
@@ -71,6 +71,62 @@ const BLANK_CONTACT: HrmContact = {
   conversationDuration: 0,
   csamReports: [],
   conversationMedia: [],
+};
+
+const addConversationMedia = async ({
+  accountSid,
+  channel,
+  callSid,
+  contactId,
+  hrmApiVersion,
+  hrmAccountId,
+}: {
+  accountSid: AccountSID;
+  channel: HrmContact['channel'];
+  contactId: HrmContact['id'];
+  callSid: string;
+  hrmAccountId: HrmAccountId;
+  hrmApiVersion: string;
+}) => {
+  console.info(
+    `Channel type is ${channel}, adding conversation media with call sid ${callSid}`,
+  );
+  const recordingResult = await getExternalRecordingS3Location({
+    accountSid,
+    callSid,
+  });
+
+  if (isErr(recordingResult)) {
+    return recordingResult;
+  }
+
+  const conversationMedia = [
+    {
+      storeType: 'S3',
+      storeTypeSpecificData: {
+        type: 'recording',
+        location: {
+          bucket: recordingResult.data.bucket,
+          key: recordingResult.data.key,
+        },
+      },
+    },
+  ];
+
+  const conversationMediaResult = await postToInternalHrmEndpoint<
+    HrmContact['conversationMedia'],
+    HrmContact
+  >(
+    hrmAccountId,
+    hrmApiVersion,
+    `contacts/${contactId}/conversationMedia`,
+    conversationMedia,
+  );
+  console.debug(
+    `Conversation media result ${conversationMediaResult.status} ${isOk(conversationMediaResult) ? JSON.stringify(conversationMediaResult.data) : JSON.stringify(conversationMediaResult.error)}`,
+  );
+
+  return conversationMediaResult;
 };
 
 export const handleEvent = async (
@@ -247,6 +303,17 @@ export const handleEvent = async (
   const savedTimeOfContactDate = parseISO(savedTimeOfContactString);
   console.info(`Created HRM contact with id ${id} for task ${taskSid}`);
 
+  if (channel === channelTypes.VOICEMAIL) {
+    await addConversationMedia({
+      accountSid,
+      callSid: taskAttributes.callSid,
+      channel,
+      contactId: id,
+      hrmAccountId,
+      hrmApiVersion,
+    });
+  }
+
   await patchTaskAttributes(accountSid, taskSid, currentTaskAttributes => ({
     ...currentTaskAttributes,
     contactId: id.toString(),
@@ -255,44 +322,6 @@ export const handleEvent = async (
       : null,
     timeOfContactMillis: savedTimeOfContactDate.getTime(),
   }));
-
-  if (channel === channelTypes.VOICEMAIL) {
-    console.info(
-      `Channel type is ${channel}, adding conversation media with call sid ${taskAttributes.callSid}`,
-    );
-    const recordingResult = await getExternalRecordingS3Location({
-      accountSid,
-      callSid: taskAttributes.callSid,
-    });
-
-    if (isOk(recordingResult)) {
-      const conversationMedia = [
-        {
-          storeType: 'S3',
-          storeTypeSpecificData: {
-            type: 'recording',
-            location: {
-              bucket: recordingResult.data.bucket,
-              key: recordingResult.data.key,
-            },
-          },
-        },
-      ];
-
-      const conversationMediaResult = await postToInternalHrmEndpoint<
-        HrmContact['conversationMedia'],
-        HrmContact
-      >(
-        hrmAccountId,
-        hrmApiVersion,
-        `contacts/${id}/conversationMedia`,
-        conversationMedia,
-      );
-      console.debug(
-        `Conversation media result ${conversationMediaResult.status} ${isOk(conversationMediaResult) ? JSON.stringify(conversationMediaResult.data) : JSON.stringify(conversationMediaResult.error)}`,
-      );
-    }
-  }
 };
 
 registerTaskRouterEventHandler([RESERVATION_ACCEPTED], handleEvent);


### PR DESCRIPTION
## Description
This PR fixes a bug that causes the voicemail audio fetch to fail.
The reason for this bug is that there is a race condition between the contact creation and the conversation media attachement in the backend.
Behavior before this PR:
- Contact is created.
- Task is updated with the contact id.
- Conversation media is attached.
2nd step causes the client to "fetch the contact from HRM". If the conversation media attachement is still in progress by the time the contact is loaded by Flex, the user can't access the voicemail recording.

The fix is to swap steps 2 and 3 so that conversation media is always attached before the task is updated. 

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3992)
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P