### PR TITLE
filterCountryOrVoIP : adding hidden caller id

### DIFF
--- a/lambdas/account-scoped/src/voice/filterCountryOrVoIP.ts
+++ b/lambdas/account-scoped/src/voice/filterCountryOrVoIP.ts
@@ -25,6 +25,7 @@ const BLOCK_REASONS = {
   NON_US_COUNTRY: 'non_us_country',
   VOIP: 'voip',
   BLOCKED_CARRIER: 'blocked_carrier',
+  HIDDEN_CALLER_ID: 'hidden_caller_id',
 } as const;
 
 export const filterCountryOrVoIPHandler: AccountScopedHandler = async (
@@ -37,6 +38,17 @@ export const filterCountryOrVoIPHandler: AccountScopedHandler = async (
     return newErr({
       message: 'from parameter is missing',
       error: { statusCode: 400 },
+    });
+  }
+
+  if (from === 'Anonymous') {
+    console.info('filterCountryOrVoIP: Blocking anonymous call', {
+      accountSid,
+      from,
+    });
+    return newOk({
+      blockIncoming: true,
+      blockReason: BLOCK_REASONS.HIDDEN_CALLER_ID,
     });
   }
 

--- a/lambdas/account-scoped/src/voice/filterCountryOrVoIP.ts
+++ b/lambdas/account-scoped/src/voice/filterCountryOrVoIP.ts
@@ -41,8 +41,10 @@ export const filterCountryOrVoIPHandler: AccountScopedHandler = async (
     });
   }
 
-  if (from === 'Anonymous') {
-    console.info('filterCountryOrVoIP: Blocking anonymous call', {
+  const isE164PhoneNumber = /^\+[1-9]\d{1,14}$/.test(from);
+
+  if (!isE164PhoneNumber) {
+    console.info('filterCountryOrVoIP: Blocking call with non E164 number', {
       accountSid,
       from,
     });


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
It seems that in the US, people can hide their phone numbers by using *67

The  object that we receive in those cases starts like this:
```
"Called": "+18444271995",
      "ToState": "",
      "CallerCountry": "TH",
      "Direction": "inbound",
      "CallerState": "",
      "ToZip": "",
      "CallSid": "CA6c1bf2457532aadeac93c4617da9fca4",
      "To": "+18444271995",
      "CallerZip": "",
      "ToCountry": "US",
      "StirVerstat": "TN-Validation-Passed-A",
      "CallToken": "%7B%22parentCallInfoToken%22%3A%22eyJhbGciOiJFUzI1NiJ9.eyJjYWxsU2lkIjoiQ0E2YzFiZjI0NTc1MzJhYWRlYWM5M2M0NjE3ZGE5ZmNhNCIsImZyb20iOiJBbm9ueW1vdXMiLCJ0byI6IisxODQ0NDI3MTk5NSIsImlhdCI6IjE3ODc2ODQwODIifQ.zc-DIzA9bq7D7_iSkgrnViz1ENnJoQ96d6qA9lz_xmnqOjj8rT__v68vcbV44QCRFqhX_L4jjl9QkAQvZ56WcQ%22%2C%22identityHeaderTokens%22%3A%5B%5D%7D",
      "CalledZip": "",
      "ApiVersion": "2010-04-01",
      "CalledCity": "",
      "CallStatus": "ringing",
      "From": "Anonymous",
```

Previously our function filterCountryOrVoIP was detecting that as coming from another country ("TH") which is not actually true, so we want to handle this type of cases differently. 
So I've created a new block reason "HIDDEN_CALLER_ID" and the function now checks for that first, if "from" is a valid e164 number (instead of Anonymous, Restricted, etc).

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags added
- [ ] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P