### PR TITLE
Remove channels unused by certain helplines

### DIFF
--- a/twilio-iac/helplines/as/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/common.json
@@ -1,5 +1,16 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [
+            "voice",
+            "sms",
+            "web",
+            "whatsapp",
+            "facebook",
+            "instagram",
+            "line",
+            "telegram",
+            "voicemail"
+        ],
         "definitionVersion": "as-v1",
         "external_recordings_enabled": true,
         "enableExternalRecordings": true,

--- a/twilio-iac/helplines/as/configs/service-configuration/production.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/production.json
@@ -1,15 +1,5 @@
 {
     "attributes": {
-        "contacts_waiting_channels": [
-            "voice",
-            "sms",
-            "web",
-            "whatsapp",
-            "facebook",
-            "instagram",
-            "line",
-            "telegram"
-        ],
         "feature_flags": {
             "enable_lex": true,
             "enable_voice_recordings": true,

--- a/twilio-iac/helplines/as/configs/service-configuration/staging.json
+++ b/twilio-iac/helplines/as/configs/service-configuration/staging.json
@@ -1,16 +1,6 @@
 {
     "attributes": {
         "system_down" : false,
-        "contacts_waiting_channels": [
-            "voice",
-            "sms",
-            "web",
-            "whatsapp",
-            "facebook",
-            "instagram",
-            "line",
-            "telegram"
-        ],
         "feature_flags": {
             "enable_active_contact_header": true,
             "enable_assigned_skill_teams_view_filters": true,

--- a/twilio-iac/helplines/br/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/br/configs/service-configuration/common.json
@@ -1,6 +1,9 @@
 {
     "attributes": {
         "configuredLanguage": "pt-BR",
+        "contacts_waiting_channels": [
+            "facebook"
+        ],
         "definitionVersion": "br-v1",
         "feature_flags": {
             "enable_dual_write": true,

--- a/twilio-iac/helplines/e2e/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/e2e/configs/service-configuration/common.json
@@ -1,5 +1,16 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [
+            "voice",
+            "sms",
+            "web",
+            "whatsapp",
+            "facebook",
+            "instagram",
+            "line",
+            "telegram",
+            "voicemail"
+        ],
         "attributeUpdates": {
             "assets_bucket_url": "https://assets-development.tl.techmatters.org"
         },

--- a/twilio-iac/helplines/et/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/et/configs/service-configuration/common.json
@@ -1,5 +1,9 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [
+            "web",
+            "facebook"
+        ],
         "definitionVersion": "et-v1",
         "feature_flags": {
             "enable_lex": true

--- a/twilio-iac/helplines/in/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/in/configs/service-configuration/common.json
@@ -1,5 +1,6 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [],
         "definitionVersion": "in-v1",
         "feature_flags": {
             "enable_csam_clc_report": true,

--- a/twilio-iac/helplines/mt/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/mt/configs/service-configuration/common.json
@@ -5,9 +5,7 @@
             "web",
             "whatsapp",
             "facebook",
-            "twitter",
-            "instagram",
-            "line"
+            "instagram"
         ],
         "definitionVersion": "mt-v1",
         "feature_flags": {

--- a/twilio-iac/helplines/mw/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/mw/configs/service-configuration/common.json
@@ -1,5 +1,9 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [
+            "web",
+            "facebook"
+        ],
         "definitionVersion": "mw-v1",
         "feature_flags": {
             "enable_csam_report": true,

--- a/twilio-iac/helplines/ph/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/ph/configs/service-configuration/common.json
@@ -1,5 +1,8 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [
+            "facebook"
+        ],
         "definitionVersion": "ph-v1",
         "feature_flags": {
             "enable_lex": true,

--- a/twilio-iac/helplines/th/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/th/configs/service-configuration/common.json
@@ -1,5 +1,11 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [
+            "web",
+            "facebook",
+            "instagram",
+            "line"
+        ],
         "definitionVersion": "th-v1",
         "feature_flags": {
             "enable_manual_pulling": false

--- a/twilio-iac/helplines/zm/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/zm/configs/service-configuration/common.json
@@ -1,5 +1,11 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [
+            "voice",
+            "web",
+            "whatsapp",
+            "facebook"
+        ],
         "definitionVersion": "zm-v1",
         "feature_flags": {
             "enable_csam_report": true,

--- a/twilio-iac/helplines/zw/configs/service-configuration/common.json
+++ b/twilio-iac/helplines/zw/configs/service-configuration/common.json
@@ -1,5 +1,10 @@
 {
     "attributes": {
+        "contacts_waiting_channels": [
+            "voice",
+            "web",
+            "facebook"
+        ],
         "definitionVersion": "zw-v1",
         "feature_flags": {
         },


### PR DESCRIPTION
As we create more channels like voicemail and CAD (for LA CIRCLE / Motorola), we want to make sure these new channels don't show up in the Contacts Waiting queue area for our existing helplines.

Channel boxes are set as part of service configuration files, here's Childhelp's as an example: https://github.com/techmatters/flex-plugins/blob/master/twilio-iac/helplines/usch/configs/service-configuration/common.json

Default is just all channels available, and not all helplines have their individual channels set. 

I changed ~13 helplines' config files. I used helpline hcl files (twilio-iac/helplines/usch/staging.hcl) as a source of truth for which channels are actually configured.