### PR TITLE
CHI-3970: Fix incorrect null checking in getTaskAndReservations

### DIFF
--- a/plugin-hrm-form/src/services/twilioTaskService.ts
+++ b/plugin-hrm-form/src/services/twilioTaskService.ts
@@ -117,7 +117,7 @@ export const getTaskAndReservations = async (taskSid: string): Promise<GetTaskAn
     if (task) {
       task.status = task.status ?? task.assignmentStatus;
     }
-    if (typeof task.attributes === 'string') {
+    if (typeof task?.attributes === 'string') {
       task.attributes = JSON.parse(task.attributes);
     }
     return res;

--- a/plugin-hrm-form/src/services/twilioTaskService.ts
+++ b/plugin-hrm-form/src/services/twilioTaskService.ts
@@ -116,9 +116,9 @@ export const getTaskAndReservations = async (taskSid: string): Promise<GetTaskAn
     const { task } = res ?? {};
     if (task) {
       task.status = task.status ?? task.assignmentStatus;
-    }
-    if (typeof task?.attributes === 'string') {
-      task.attributes = JSON.parse(task.attributes);
+      if (typeof task.attributes === 'string') {
+        task.attributes = JSON.parse(task.attributes);
+      }
     }
     return res;
   } catch (error) {


### PR DESCRIPTION
## Description

Tighten up null checking to allow contacts without tasks to be finalised

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Feature flags added
- [n/a] Strings are localized
- [ ] Tested for chat contacts
- [ ] Tested for call contacts

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

See ticket

### AFTER YOU MERGE

1. Cut a release tag using the Github workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P